### PR TITLE
R9M Lite Pro DAC Outputs

### DIFF
--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -85,9 +85,29 @@ PowerLevels_e POWERMGNT::setPower(PowerLevels_e Power)
 #endif
 
 #ifdef TARGET_R9M_LITE_PRO_TX
-    Radio.SetOutputPower(0b0000);
-    CurrentPower = Power;
-    return CurrentPower;
+    switch (Power)
+    {
+    case PWR_100mW:
+        Radio.SetOutputPower(0b0101); //Needs to set PA5 DAC to 590mV & PA4 to 2.7V
+        CurrentPower = PWR_100mW;
+        break;
+    case PWR_250mW:
+        Radio.SetOutputPower(0b1000); //Needs to set PA5 DAC to 870mV & PA4 to 2.7V
+        CurrentPower = PWR_250mW;
+        break;
+    case PWR_500mW:
+        Radio.SetOutputPower(0b1100); //Needs to set PA5 DAC to 1.093V & PA4 to 2.7V
+        CurrentPower = PWR_500mW;
+        break;
+    case PWR_1000mW:
+        Radio.SetOutputPower(0b1111); //Needs to set PA5 DAC to 1.493V & PA4 to 2.7V
+        CurrentPower = PWR_1000mW;
+        break;
+    default:
+        CurrentPower = PWR_100mW;
+        Radio.SetOutputPower(0b0101); //Needs to set PA5 DAC to 590mV & PA4 to 2.7V
+        break;
+    }
 #endif
 
 #if defined(TARGET_100mW_MODULE) || defined(TARGET_R9M_LITE_TX)

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -88,24 +88,34 @@ PowerLevels_e POWERMGNT::setPower(PowerLevels_e Power)
     switch (Power)
     {
     case PWR_100mW:
-        Radio.SetOutputPower(0b0101); //Needs to set PA5 DAC to 590mV & PA4 to 2.7V
+        //Radio.SetOutputPower(0b0101); //Needs to set PA5 DAC to 590mV & PA4 to 2.7V
+        analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095
+        analogWrite(GPIO_PIN_RFamp_APC2, 732); //0-4095 100mW 590mV
         CurrentPower = PWR_100mW;
         break;
     case PWR_250mW:
-        Radio.SetOutputPower(0b1000); //Needs to set PA5 DAC to 870mV & PA4 to 2.7V
+        //Radio.SetOutputPower(0b1000); //Needs to set PA5 DAC to 870mV & PA4 to 2.7V
+        analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095
+        analogWrite(GPIO_PIN_RFamp_APC2, 1080); //0-4095 200mW 870mV
         CurrentPower = PWR_250mW;
         break;
     case PWR_500mW:
-        Radio.SetOutputPower(0b1100); //Needs to set PA5 DAC to 1.093V & PA4 to 2.7V
+        //Radio.SetOutputPower(0b1100); //Needs to set PA5 DAC to 1.093V & PA4 to 2.7V
+        analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095
+        analogWrite(GPIO_PIN_RFamp_APC2, 1356); //0-4095 500mW 1.093V
         CurrentPower = PWR_500mW;
         break;
     case PWR_1000mW:
-        Radio.SetOutputPower(0b1111); //Needs to set PA5 DAC to 1.493V & PA4 to 2.7V
+        //Radio.SetOutputPower(0b1111); //Needs to set PA5 DAC to 1.493V & PA4 to 2.7V
+        analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095
+        analogWrite(GPIO_PIN_RFamp_APC2, 1853); //0-4095 1W 1.493V
         CurrentPower = PWR_1000mW;
         break;
     default:
         CurrentPower = PWR_100mW;
-        Radio.SetOutputPower(0b0101); //Needs to set PA5 DAC to 590mV & PA4 to 2.7V
+        //Radio.SetOutputPower(0b0101); //Needs to set PA5 DAC to 590mV & PA4 to 2.7V
+        analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095
+        analogWrite(GPIO_PIN_RFamp_APC2, 732); //0-4095 100mW 590mV
         break;
     }
 #endif

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -41,6 +41,12 @@ void POWERMGNT::init()
 #ifdef TARGET_R9M_TX
     Serial.println("Init TARGET_R9M_TX DAC Driver");
 #endif
+#ifdef TARGET_R9M_LITE_PRO_TX
+    //initialize both 12 bit DACs
+    pinMode(GPIO_PIN_RFamp_APC1, OUTPUT);
+    pinMode(GPIO_PIN_RFamp_APC2, OUTPUT);
+    analogWriteResolution(12);
+#endif
 #ifdef GPIO_PIN_FAN_EN
     pinMode(GPIO_PIN_FAN_EN, OUTPUT);
 #endif
@@ -85,37 +91,34 @@ PowerLevels_e POWERMGNT::setPower(PowerLevels_e Power)
 #endif
 
 #ifdef TARGET_R9M_LITE_PRO_TX
+    Radio.SetOutputPower(0b0000);
+    //Set DACs PA5 & PA4
     switch (Power)
     {
     case PWR_100mW:
-        //Radio.SetOutputPower(0b0101); //Needs to set PA5 DAC to 590mV & PA4 to 2.7V
-        analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095
-        analogWrite(GPIO_PIN_RFamp_APC2, 732); //0-4095 100mW 590mV
+        analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095 2.7V
+        analogWrite(GPIO_PIN_RFamp_APC2, 732); //0-4095  590mV
         CurrentPower = PWR_100mW;
         break;
     case PWR_250mW:
-        //Radio.SetOutputPower(0b1000); //Needs to set PA5 DAC to 870mV & PA4 to 2.7V
-        analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095
-        analogWrite(GPIO_PIN_RFamp_APC2, 1080); //0-4095 200mW 870mV
+        analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095 2.7V
+        analogWrite(GPIO_PIN_RFamp_APC2, 1080); //0-4095 870mV this is actually 200mw
         CurrentPower = PWR_250mW;
         break;
     case PWR_500mW:
-        //Radio.SetOutputPower(0b1100); //Needs to set PA5 DAC to 1.093V & PA4 to 2.7V
-        analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095
-        analogWrite(GPIO_PIN_RFamp_APC2, 1356); //0-4095 500mW 1.093V
+        analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095 2.7V
+        analogWrite(GPIO_PIN_RFamp_APC2, 1356); //0-4095 1.093V
         CurrentPower = PWR_500mW;
         break;
     case PWR_1000mW:
-        //Radio.SetOutputPower(0b1111); //Needs to set PA5 DAC to 1.493V & PA4 to 2.7V
-        analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095
-        analogWrite(GPIO_PIN_RFamp_APC2, 1853); //0-4095 1W 1.493V
+        analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095 2.7V
+        analogWrite(GPIO_PIN_RFamp_APC2, 1853); //0-4095 1.493V
         CurrentPower = PWR_1000mW;
         break;
     default:
         CurrentPower = PWR_100mW;
-        //Radio.SetOutputPower(0b0101); //Needs to set PA5 DAC to 590mV & PA4 to 2.7V
-        analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095
-        analogWrite(GPIO_PIN_RFamp_APC2, 732); //0-4095 100mW 590mV
+        analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095 2.7V
+        analogWrite(GPIO_PIN_RFamp_APC2, 732);  //0-4095 590mV
         break;
     }
 #endif

--- a/src/lib/POWERMGNT/POWERMGNT.h
+++ b/src/lib/POWERMGNT/POWERMGNT.h
@@ -12,16 +12,16 @@
 
 #ifdef TARGET_R9M_TX
 #ifdef R9M_UNLOCK_HIGHER_POWER
-#define MaxPower 6
+#define MaxPower PWR_1000mW
 #else
-#define MaxPower 4
+#define MaxPower PWR_250mW
 #endif
-#define DefaultPowerEnum 2
+#define DefaultPowerEnum PWR_50mW
 #endif
 
 #ifdef TARGET_R9M_LITE_PRO_TX
-#define MaxPower 6
-#define DefaultPowerEnum 3
+#define MaxPower PWR_1000mW
+#define DefaultPowerEnum PWR_100mW
 #endif
 
 #ifdef TARGET_100mW_MODULE
@@ -31,17 +31,17 @@
 
 #ifdef TARGET_1000mW_MODULE
 #define MaxPower 4
-#define DefaultPowerEnum 2
+#define DefaultPowerEnum 2 
 #endif
 
 #ifdef TARGET_R9M_LITE_TX
-#define MaxPower 2
-#define DefaultPowerEnum 2
+#define MaxPower PWR_50mW
+#define DefaultPowerEnum PWR_50mW
 #endif
 
 #ifdef TARGET_TX_ESP32_SX1280_V1
-#define MaxPower 0 // Output is actually 14mW
-#define DefaultPowerEnum 0
+#define MaxPower PWR_10mW // Output is actually 14mW
+#define DefaultPowerEnum PWR_10mW
 #endif
 
 #ifdef TARGET_TX_ESP32_E28_SX1280_V1

--- a/src/lib/POWERMGNT/POWERMGNT.h
+++ b/src/lib/POWERMGNT/POWERMGNT.h
@@ -20,8 +20,8 @@
 #endif
 
 #ifdef TARGET_R9M_LITE_PRO_TX
-#define MaxPower 0
-#define DefaultPowerEnum 0
+#define MaxPower 6
+#define DefaultPowerEnum 3
 #endif
 
 #ifdef TARGET_100mW_MODULE

--- a/src/src/targets.h
+++ b/src/src/targets.h
@@ -254,17 +254,16 @@ https://github.com/jaxxzer
 #define GPIO_PIN_LED_RED        PB3  // Red LED
 #define GPIO_PIN_LED_RED        PB4  // Blue LED
 
-#define GPIO_PIN_DEBUG_RX    	PA3  // inverted UART JR
-#define GPIO_PIN_DEBUG_TX    	PA2  // inverted UART JR
+#define GPIO_PIN_DEBUG_RX    	  PA3  // inverted UART JR
+#define GPIO_PIN_DEBUG_TX      	PA2  // inverted UART JR
 
-#define GPIO_PIN_VRF1			PA7  // 26SU Switch RF1
-#define GPIO_PIN_VRF2			PB1  // 26SU Switch RF2
-#define GPIO_PIN_SWR			 PA0  // SWR ADC1_IN1
+#define BUFFER_OE               PB2  //CONFIRMED
+#define GPIO_PIN_VRF1			        PA7  // 26SU Switch RF1
+#define GPIO_PIN_VRF2			        PB1  // 26SU Switch RF2
+#define GPIO_PIN_SWR			         PA0  // SWR ADC1_IN1
 
-//#define GPIO_PIN_EEPROM_DATA     PB8 //2Kb EEPROM ST M95160
-//#define GPIO_PIN_EEPROM_CLOCK    PB9 //2Kb EEPROM ST M95160
-
-#define BUFFER_OE               UNDEF_PIN  //CONFIRMED
+//#define GPIO_PIN_EEPROM_DATA    PB8 //2Kb EEPROM ST M95160
+//#define GPIO_PIN_EEPROM_CLOCK   PB9 //2Kb EEPROM ST M95160
 
 #endif
 

--- a/src/src/targets.h
+++ b/src/src/targets.h
@@ -233,8 +233,8 @@ https://github.com/jaxxzer
 #endif
 
 #ifdef TARGET_R9M_LITE_PRO_TX
-//#define GPIO_PIN_RFamp_APC1           PA4  //2.7V
-//#define GPIO_PIN_RFamp_APC2           PA5  //100mW@590mV, 200mW@870mV, 500mW@1.093V, 1W@1.493V
+#define GPIO_PIN_RFamp_APC1           PA4  //2.7V
+#define GPIO_PIN_RFamp_APC2           PA5  //100mW@590mV, 200mW@870mV, 500mW@1.093V, 1W@1.493V
 #define GPIO_PIN_RFswitch_CONTROL     PA6  // confirmed  //HIGH = RX, LOW = TX
 
 #define GPIO_PIN_NSS            PB12 // confirmed

--- a/src/src/targets.h
+++ b/src/src/targets.h
@@ -245,21 +245,24 @@ https://github.com/jaxxzer
 #define GPIO_PIN_MISO           PB14
 #define GPIO_PIN_SCK            PB13
 #define GPIO_PIN_RST            PA9  // NRESET
-#define GPIO_PIN_RX_ENABLE      PC13 // need to confirm
+#define GPIO_PIN_RX_ENABLE      UNDEF_PIN   // NOT USED ON THIS TARGET
 #define GPIO_PIN_SDA            PB7
 #define GPIO_PIN_SCL            PB6
-#define GPIO_PIN_RCSIGNAL_RX    PB11 // not yet confirmed
-#define GPIO_PIN_RCSIGNAL_TX    PB10 // not yet confirmed
+#define GPIO_PIN_RCSIGNAL_RX    PB11 // s.port inverter
+#define GPIO_PIN_RCSIGNAL_TX    PB10 // s.port inverter
 #define GPIO_PIN_LED_GREEN      PA15 // Green LED
 #define GPIO_PIN_LED_RED        PB3  // Red LED
 #define GPIO_PIN_LED_RED        PB4  // Blue LED
 
-#define GPIO_PIN_DEBUG_RX    	PA3  // not yet confirmed
-#define GPIO_PIN_DEBUG_TX    	PA2  // not yet confirmed
+#define GPIO_PIN_DEBUG_RX    	PA3  // inverted UART JR
+#define GPIO_PIN_DEBUG_TX    	PA2  // inverted UART JR
 
-#define GPIO_PIN_VRF1			PA7  // 26SU Sample RF1
-#define GPIO_PIN_VRF2			PB1  // 26SU Sample RF2
-#define GPIO_PIN_SWR			PA0  // SWR? ADC1_IN1
+#define GPIO_PIN_VRF1			PA7  // 26SU Switch RF1
+#define GPIO_PIN_VRF2			PB1  // 26SU Switch RF2
+#define GPIO_PIN_SWR			 PA0  // SWR ADC1_IN1
+
+//#define GPIO_PIN_EEPROM_DATA     PB8 //2Kb EEPROM ST M95160
+//#define GPIO_PIN_EEPROM_CLOCK    PB9 //2Kb EEPROM ST M95160
 
 #define BUFFER_OE               UNDEF_PIN  //CONFIRMED
 

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -47,13 +47,6 @@ R9DAC R9DAC;
 #endif
 const uint8_t thisCommit[6] = {LATEST_COMMIT};
 
-#if defined(TARGET_R9M_LITE_PRO_TX)
-//#define HAL_DAC_MODULE_ENABLED //this may need to be enabled in the Arduino stm32h7xx_hal_conf.h file
-pinMode(GPIO_PIN_RFamp_APC1, OUTPUT); //I'm sure this does not belong here
-pinMode(GPIO_PIN_RFamp_APC2, OUTPUT); //I'm sure this does not belong here
-analogWriteResolution(12); //I'm sure this does not belong here
-#endif
-
 //// CONSTANTS ////
 #define RX_CONNECTION_LOST_TIMEOUT 3000 // After 1500ms of no TLM response consider that slave has lost connection
 #define MSP_PACKET_SEND_INTERVAL 200
@@ -548,6 +541,13 @@ void setup()
     pinMode(GPIO_PIN_LED_GREEN, OUTPUT);
     pinMode(GPIO_PIN_LED_RED, OUTPUT);
     digitalWrite(GPIO_PIN_LED_GREEN, HIGH);
+  
+#if defined(TARGET_R9M_LITE_PRO_TX)
+//#define HAL_DAC_MODULE_ENABLED //this may need to be enabled in the Arduino stm32h7xx_hal_conf.h file
+pinMode(GPIO_PIN_RFamp_APC1, OUTPUT); //I'm sure this does not belong here
+pinMode(GPIO_PIN_RFamp_APC2, OUTPUT); //I'm sure this does not belong here
+analogWriteResolution(12); //I'm sure this does not belong here
+#endif
 
 #ifdef USE_ESP8266_BACKPACK
     HardwareSerial(USART1);

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -47,6 +47,13 @@ R9DAC R9DAC;
 #endif
 const uint8_t thisCommit[6] = {LATEST_COMMIT};
 
+#if defined(TARGET_R9M_LITE_PRO_TX)
+//#define HAL_DAC_MODULE_ENABLED //this may need to be enabled in the Arduino stm32h7xx_hal_conf.h file
+pinMode(GPIO_PIN_RFamp_APC1, OUTPUT); //I'm sure this does not belong here
+pinMode(GPIO_PIN_RFamp_APC2, OUTPUT); //I'm sure this does not belong here
+analogWriteResolution(12); //I'm sure this does not belong here
+#endif
+
 //// CONSTANTS ////
 #define RX_CONNECTION_LOST_TIMEOUT 3000 // After 1500ms of no TLM response consider that slave has lost connection
 #define MSP_PACKET_SEND_INTERVAL 200

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -541,13 +541,6 @@ void setup()
     pinMode(GPIO_PIN_LED_GREEN, OUTPUT);
     pinMode(GPIO_PIN_LED_RED, OUTPUT);
     digitalWrite(GPIO_PIN_LED_GREEN, HIGH);
-  
-#if defined(TARGET_R9M_LITE_PRO_TX)
-//#define HAL_DAC_MODULE_ENABLED //this may need to be enabled in the Arduino stm32h7xx_hal_conf.h file
-pinMode(GPIO_PIN_RFamp_APC1, OUTPUT); //I'm sure this does not belong here
-pinMode(GPIO_PIN_RFamp_APC2, OUTPUT); //I'm sure this does not belong here
-analogWriteResolution(12); //I'm sure this does not belong here
-#endif
 
 #ifdef USE_ESP8266_BACKPACK
     HardwareSerial(USART1);


### PR DESCRIPTION
This "should" be enough to get the Lite Pro working but I'm sure there is a better way to do it.

I'm not sure what the function Radio.SetOutputPower is actually doing. I think its the actual power output of the SX1276?

I couldn't find where GPIO_PIN_RFamp_APC1 or GPIO_PIN_RFamp_APC2 were actually used other than the R9M's I2C DAC lib.

#326 