### PR TITLE
Add Happy Model RX targets

### DIFF
--- a/src/platformio.ini
+++ b/src/platformio.ini
@@ -246,6 +246,12 @@ upload_flags =
 [env:HappyModel_TX_ES915TX_via_stock_BL]
 extends = env:HappyModel_TX_ES915TX_via_STLINK
 
+[env:HappyModel_RX_ES915RX_via_STLINK]
+extends = env:Frsky_RX_R9MM_R9MINI_via_STLINK
+
+[env:HappyModel_RX_ES915RX_via_BetaflightPassthrough]
+extends = env:Frsky_RX_R9MM_R9MINI_via_STLINK
+
 [env:DIY_900_TX_TTGO_V1_SX127x_via_UART]
 extends = env_common_esp32
 build_flags =


### PR DESCRIPTION
Extends the R9MM targets for STLINK and Passthrough for the Happy Model RX