### PR TITLE
fix SYNC_INTERVAL

### DIFF
--- a/src/src/FHSS.cpp
+++ b/src/src/FHSS.cpp
@@ -69,7 +69,7 @@ void FHSSrandomiseFHSSsequence()
     // The 0 index is special - the 'sync' channel. The sync channel appears every
     // syncInterval hops. The other channels are randomly distributed between the
     // sync channels
-    const int SYNC_INTERVAL = NR_FHSS_ENTRIES -1;
+    const int SYNC_INTERVAL = NR_FHSS_ENTRIES;
 
     int nLeft = NR_FHSS_ENTRIES - 1; // how many channels are left to be allocated. Does not include the sync channel
     unsigned int prev = 0;           // needed to prevent repeats of the same index


### PR DESCRIPTION
Corrects the spacing between sync freq in the hop sequence.