### PR TITLE
Fixed MaxPower defines on POWERMGNT.h using enum items

### DIFF
--- a/src/lib/POWERMGNT/POWERMGNT.h
+++ b/src/lib/POWERMGNT/POWERMGNT.h
@@ -36,7 +36,11 @@
 #endif
 
 #ifdef TARGET_1000mW_MODULE
+#ifdef UNLOCK_HIGHER_POWER
 #define MaxPower PWR_1000mW
+#else
+#define MaxPower PWR_250mW
+#endif
 #define DefaultPowerEnum PWR_50mW
 #endif
 

--- a/src/lib/POWERMGNT/POWERMGNT.h
+++ b/src/lib/POWERMGNT/POWERMGNT.h
@@ -51,8 +51,8 @@
 #endif
 
 #ifdef TARGET_TX_ESP32_E28_SX1280_V1
-#define MaxPower PWR_10mW
-#define DefaultPowerEnum PWR_10mW
+#define MaxPower PWR_500mW
+#define DefaultPowerEnum PWR_50mW
 #endif
 
 #ifdef TARGET_TX_ESP32_LORA1280F27

--- a/src/lib/POWERMGNT/POWERMGNT.h
+++ b/src/lib/POWERMGNT/POWERMGNT.h
@@ -21,8 +21,8 @@
 
 
 #ifdef TARGET_TX_GHOST
-#define MaxPower 4
-#define DefaultPowerEnum 2
+#define MaxPower PWR_250mW
+#define DefaultPowerEnum PWR_50mW
 #endif
 
 #ifdef TARGET_R9M_LITE_PRO_TX
@@ -31,13 +31,13 @@
 #endif
 
 #ifdef TARGET_100mW_MODULE
-#define MaxPower 2
-#define DefaultPowerEnum 2
+#define MaxPower PWR_100mW
+#define DefaultPowerEnum PWR_50mW
 #endif
 
 #ifdef TARGET_1000mW_MODULE
-#define MaxPower 4
-#define DefaultPowerEnum 2 
+#define MaxPower PWR_1000mW
+#define DefaultPowerEnum PWR_50mW
 #endif
 
 #ifdef TARGET_R9M_LITE_TX
@@ -51,13 +51,13 @@
 #endif
 
 #ifdef TARGET_TX_ESP32_E28_SX1280_V1
-#define MaxPower 4
-#define DefaultPowerEnum 2
+#define MaxPower PWR_10mW
+#define DefaultPowerEnum PWR_10mW
 #endif
 
 #ifdef TARGET_TX_ESP32_LORA1280F27
-#define MaxPower 4
-#define DefaultPowerEnum 2
+#define MaxPower PWR_500mW
+#define DefaultPowerEnum PWR_50mW
 #endif
 
 typedef enum

--- a/src/lib/POWERMGNT/POWERMGNT.h
+++ b/src/lib/POWERMGNT/POWERMGNT.h
@@ -31,7 +31,7 @@
 #endif
 
 #ifdef TARGET_100mW_MODULE
-#define MaxPower PWR_100mW
+#define MaxPower PWR_50mW
 #define DefaultPowerEnum PWR_50mW
 #endif
 
@@ -55,7 +55,7 @@
 #endif
 
 #ifdef TARGET_TX_ESP32_E28_SX1280_V1
-#define MaxPower PWR_500mW
+#define MaxPower PWR_250mW
 #define DefaultPowerEnum PWR_50mW
 #endif
 

--- a/src/lib/POWERMGNT/POWERMGNT.h
+++ b/src/lib/POWERMGNT/POWERMGNT.h
@@ -60,7 +60,7 @@
 #endif
 
 #ifdef TARGET_TX_ESP32_LORA1280F27
-#define MaxPower PWR_500mW
+#define MaxPower PWR_250mW
 #define DefaultPowerEnum PWR_50mW
 #endif
 


### PR DESCRIPTION
There was a misalignment between the `PowerLevels_e` enum values and the value used on `MaxPower` defines. Especially for the `TARGET_1000mW_MODULE` where the define was 4 (250mW) but it should be 6 (1000mW).
To mitigate other risks of error I changed all the numeric values to enum items. In this way it is easier to maintain and add new targets.