### PR TITLE
Remove telemetry handling from 11bit mode

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -473,10 +473,6 @@ void ICACHE_RAM_ATTR UnpackChannelData_11bit()
     crsf.PackedRCdataOut.ch6 = BIT_to_CRSF(Radio.RXdataBuffer[6] & 0b00000010);
     crsf.PackedRCdataOut.ch7 = BIT_to_CRSF(Radio.RXdataBuffer[6] & 0b00000001);
 #endif
-#ifdef ENABLE_TELEMETRY
-    TelemetrySender.ConfirmCurrentPayload(Radio.RXdataBuffer[6] & 0b00000001);
-    crsf.PackedRCdataOut.ch7 = 0;
-#endif
 }
 
 void ICACHE_RAM_ATTR UnpackChannelData_10bit()

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -263,9 +263,6 @@ void ICACHE_RAM_ATTR Generate4ChannelData_11bit()
   Radio.TXdataBuffer[6] += CRSF_to_BIT(crsf.ChannelDataIn[6]) << 1;
   Radio.TXdataBuffer[6] += CRSF_to_BIT(crsf.ChannelDataIn[7]) << 0;
 #endif
-#ifdef ENABLE_TELEMETRY
-  Radio.TXdataBuffer[6] =  Radio.TXdataBuffer[6] & (~1 | TelemetryReceiver.GetCurrentConfirm());
-#endif
 }
 
 void ICACHE_RAM_ATTR GenerateMSPData()


### PR DESCRIPTION
You can only enable telemetry in hybrid mode according to the build-flags.