### PR TITLE
Moving OTA packet generation functions to OTA library

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -32,9 +32,6 @@ volatile bool CRSF::CRSFframeActive = false; //since we get a copy of the serial
 
 void inline CRSF::nullCallback(void) {}
 
-void (*CRSF::RCdataCallback1)() = &nullCallback; // null placeholder callback
-void (*CRSF::RCdataCallback2)() = &nullCallback; // null placeholder callback
-
 void (*CRSF::disconnected)() = &nullCallback; // called when CRSF stream is lost
 void (*CRSF::connected)() = &nullCallback;    // called when CRSF stream is regained
 
@@ -430,8 +427,6 @@ bool ICACHE_RAM_ATTR CRSF::ProcessPacket()
         CRSF::RCdataLastRecv = micros();
         GoodPktsCount++;
         GetChannelDataIn();
-        (RCdataCallback1)(); // run new RC data callback
-        (RCdataCallback2)(); // run new RC data callback
         return true;
     }
     return false;

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -48,9 +48,6 @@ public:
     // which switch should be sent in the next rc packet
     static uint8_t nextSwitchIndex;
 
-    static void (*RCdataCallback1)(); //function pointer for new RC data callback
-    static void (*RCdataCallback2)(); //function pointer for new RC data callback
-
     static void (*disconnected)();
     static void (*connected)();
 

--- a/src/lib/OTA/OTA.cpp
+++ b/src/lib/OTA/OTA.cpp
@@ -195,7 +195,7 @@ void ICACHE_RAM_ATTR UnpackChannelDataSeqSwitches(volatile uint8_t* Buffer, CRSF
 
 #if TARGET_TX or defined UNIT_TEST
 
-void ICACHE_RAM_ATTR Generate4ChannelData_11bit(volatile uint8_t* Buffer, CRSF *crsf, uint8_t addr)
+void ICACHE_RAM_ATTR Generate4ChannelData_10bit(volatile uint8_t* Buffer, CRSF *crsf, uint8_t addr)
 {
   uint8_t PacketHeaderAddr;
   PacketHeaderAddr = (addr << 2) | RC_DATA_PACKET;
@@ -204,32 +204,39 @@ void ICACHE_RAM_ATTR Generate4ChannelData_11bit(volatile uint8_t* Buffer, CRSF *
   Buffer[2] = ((crsf->ChannelDataIn[1]) >> 3);
   Buffer[3] = ((crsf->ChannelDataIn[2]) >> 3);
   Buffer[4] = ((crsf->ChannelDataIn[3]) >> 3);
-  Buffer[5] = ((crsf->ChannelDataIn[0] & 0b00000111) << 5) |
-                          ((crsf->ChannelDataIn[1] & 0b111) << 2) |
-                          ((crsf->ChannelDataIn[2] & 0b110) >> 1);
-  Buffer[6] = ((crsf->ChannelDataIn[2] & 0b001) << 7) |
-                          ((crsf->ChannelDataIn[3] & 0b111) << 4); // 4 bits left over for something else?
+  Buffer[5] = ((crsf->ChannelDataIn[0] & 0b110) << 5) |
+                           ((crsf->ChannelDataIn[1] & 0b110) << 3) |
+                           ((crsf->ChannelDataIn[2] & 0b110) << 1) |
+                           ((crsf->ChannelDataIn[3] & 0b110) >> 1);
 #ifdef One_Bit_Switches
-  Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[4]) << 3;
-  Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[5]) << 2;
-  Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[6]) << 1;
-  Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[7]) << 0;
+  Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[4]) << 7;
+  Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[5]) << 6;
+  Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[6]) << 5;
+  Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[7]) << 4;
+  Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[8]) << 3;
+  Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[9]) << 2;
+  Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[10]) << 1;
+  Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[11]) << 0;
 #endif
 }
 
 #elif TARGET_RX or defined UNIT_TEST
 
-void ICACHE_RAM_ATTR UnpackChannelData_11bit(volatile uint8_t* Buffer, CRSF *crsf)
+void ICACHE_RAM_ATTR UnpackChannelData_10bit(volatile uint8_t* Buffer, CRSF *crsf)
 {
-    crsf->PackedRCdataOut.ch0 = (Buffer[1] << 3) | ((Buffer[5] & 0b11100000) >> 5);
-    crsf->PackedRCdataOut.ch1 = (Buffer[2] << 3) | ((Buffer[5] & 0b00011100) >> 2);
-    crsf->PackedRCdataOut.ch2 = (Buffer[3] << 3) | ((Buffer[5] & 0b00000011) << 1) | (Buffer[6] & 0b10000000 >> 7);
-    crsf->PackedRCdataOut.ch3 = (Buffer[4] << 3) | ((Buffer[6] & 0b01110000) >> 4);
+    crsf->PackedRCdataOut.ch0 = (Buffer[1] << 3) | ((Buffer[5] & 0b11000000) >> 5);
+    crsf->PackedRCdataOut.ch1 = (Buffer[2] << 3) | ((Buffer[5] & 0b00110000) >> 3);
+    crsf->PackedRCdataOut.ch2 = (Buffer[3] << 3) | ((Buffer[5] & 0b00001100) >> 1);
+    crsf->PackedRCdataOut.ch3 = (Buffer[4] << 3) | ((Buffer[5] & 0b00000011) << 1);
 #ifdef One_Bit_Switches
-    crsf->PackedRCdataOut.ch4 = BIT_to_CRSF(Buffer[6] & 0b00001000);
-    crsf->PackedRCdataOut.ch5 = BIT_to_CRSF(Buffer[6] & 0b00000100);
-    crsf->PackedRCdataOut.ch6 = BIT_to_CRSF(Buffer[6] & 0b00000010);
-    crsf->PackedRCdataOut.ch7 = BIT_to_CRSF(Buffer[6] & 0b00000001);
+    crsf->PackedRCdataOut.ch4 = BIT_to_CRSF(Buffer[6] & 0b10000000);
+    crsf->PackedRCdataOut.ch5 = BIT_to_CRSF(Buffer[6] & 0b01000000);
+    crsf->PackedRCdataOut.ch6 = BIT_to_CRSF(Buffer[6] & 0b00100000);
+    crsf->PackedRCdataOut.ch7 = BIT_to_CRSF(Buffer[6] & 0b00010000);
+    crsf->PackedRCdataOut.ch8 = BIT_to_CRSF(Buffer[6] & 0b00001000);
+    crsf->PackedRCdataOut.ch9 = BIT_to_CRSF(Buffer[6] & 0b00000100);
+    crsf->PackedRCdataOut.ch10 = BIT_to_CRSF(Buffer[6] & 0b00000010);
+    crsf->PackedRCdataOut.ch11 = BIT_to_CRSF(Buffer[6] & 0b00000001);
 #endif
 }
 

--- a/src/lib/OTA/OTA.cpp
+++ b/src/lib/OTA/OTA.cpp
@@ -215,8 +215,7 @@ void ICACHE_RAM_ATTR GenerateChannelData10bit(volatile uint8_t* Buffer, CRSF *cr
                            ((crsf->ChannelDataIn[1] & 0b110) << 3) |
                            ((crsf->ChannelDataIn[2] & 0b110) << 1) |
                            ((crsf->ChannelDataIn[3] & 0b110) >> 1);
-#ifdef One_Bit_Switches
-  Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[4]) << 7;
+  Buffer[6] = CRSF_to_BIT(crsf->ChannelDataIn[4]) << 7;
   Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[5]) << 6;
   Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[6]) << 5;
   Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[7]) << 4;
@@ -224,7 +223,6 @@ void ICACHE_RAM_ATTR GenerateChannelData10bit(volatile uint8_t* Buffer, CRSF *cr
   Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[9]) << 2;
   Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[10]) << 1;
   Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[11]) << 0;
-#endif
 }
 
 #elif TARGET_RX or defined UNIT_TEST
@@ -235,7 +233,6 @@ void ICACHE_RAM_ATTR UnpackChannelData10bit(volatile uint8_t* Buffer, CRSF *crsf
     crsf->PackedRCdataOut.ch1 = (Buffer[2] << 3) | ((Buffer[5] & 0b00110000) >> 3);
     crsf->PackedRCdataOut.ch2 = (Buffer[3] << 3) | ((Buffer[5] & 0b00001100) >> 1);
     crsf->PackedRCdataOut.ch3 = (Buffer[4] << 3) | ((Buffer[5] & 0b00000011) << 1);
-#ifdef One_Bit_Switches
     crsf->PackedRCdataOut.ch4 = BIT_to_CRSF(Buffer[6] & 0b10000000);
     crsf->PackedRCdataOut.ch5 = BIT_to_CRSF(Buffer[6] & 0b01000000);
     crsf->PackedRCdataOut.ch6 = BIT_to_CRSF(Buffer[6] & 0b00100000);
@@ -244,7 +241,6 @@ void ICACHE_RAM_ATTR UnpackChannelData10bit(volatile uint8_t* Buffer, CRSF *crsf
     crsf->PackedRCdataOut.ch9 = BIT_to_CRSF(Buffer[6] & 0b00000100);
     crsf->PackedRCdataOut.ch10 = BIT_to_CRSF(Buffer[6] & 0b00000010);
     crsf->PackedRCdataOut.ch11 = BIT_to_CRSF(Buffer[6] & 0b00000001);
-#endif
 }
 
 #endif

--- a/src/lib/OTA/OTA.cpp
+++ b/src/lib/OTA/OTA.cpp
@@ -10,6 +10,7 @@
 
 #if defined HYBRID_SWITCHES_8 or defined UNIT_TEST
 
+#if TARGET_TX or defined UNIT_TEST
 /**
  * Hybrid switches packet encoding for sending over the air
  *
@@ -53,6 +54,7 @@ void ICACHE_RAM_ATTR GenerateChannelDataHybridSwitch8(volatile uint8_t* Buffer, 
   crsf->setSentSwitch(nextSwitchIndex, value);
 }
 
+#elif TARGET_RX or defined UNIT_TEST
 /**
  * Hybrid switches decoding of over the air data
  *
@@ -106,10 +108,12 @@ void ICACHE_RAM_ATTR UnpackChannelDataHybridSwitches8(volatile uint8_t* Buffer, 
     }
 }
 
+#endif
 #endif // HYBRID_SWITCHES_8
 
 #if defined SEQ_SWITCHES or defined UNIT_TEST
 
+#if TARGET_TX or defined UNIT_TEST
 /**
  * Sequential switches packet encoding
  *
@@ -141,6 +145,7 @@ void ICACHE_RAM_ATTR GenerateChannelDataSeqSwitch(volatile uint8_t* Buffer, CRSF
   crsf->setSentSwitch(nextSwitchIndex, value);
 }
 
+#elif TARGET_RX or defined UNIT_TEST
 /**
  * Sequential switches decoding of over the air packet
  *
@@ -183,4 +188,5 @@ void ICACHE_RAM_ATTR UnpackChannelDataSeqSwitches(volatile uint8_t* Buffer, CRSF
             break;
     }
 }
+#endif
 #endif // SEQ_SWITCHES

--- a/src/lib/OTA/OTA.cpp
+++ b/src/lib/OTA/OTA.cpp
@@ -26,9 +26,9 @@
  * Outputs: Radio.TXdataBuffer, side-effects the sentSwitch value
  */
 #ifdef ENABLE_TELEMETRY
-void ICACHE_RAM_ATTR GenerateChannelData(volatile uint8_t* Buffer, CRSF *crsf, uint8_t addr, bool TelemetryStatus)
+void ICACHE_RAM_ATTR GenerateChannelDataHybridSwitch8(volatile uint8_t* Buffer, CRSF *crsf, uint8_t addr, bool TelemetryStatus)
 #else
-void ICACHE_RAM_ATTR GenerateChannelData(volatile uint8_t* Buffer, CRSF *crsf, uint8_t addr)
+void ICACHE_RAM_ATTR GenerateChannelDataHybridSwitch8(volatile uint8_t* Buffer, CRSF *crsf, uint8_t addr)
 #endif
 {
   uint8_t PacketHeaderAddr;
@@ -72,7 +72,7 @@ void ICACHE_RAM_ATTR GenerateChannelData(volatile uint8_t* Buffer, CRSF *crsf, u
  * Input: Buffer
  * Output: crsf->PackedRCdataOut
  */
-void ICACHE_RAM_ATTR UnpackChannelData(volatile uint8_t* Buffer, CRSF *crsf)
+void ICACHE_RAM_ATTR UnpackChannelDataHybridSwitch8(volatile uint8_t* Buffer, CRSF *crsf)
 {
     // The analog channels
     crsf->PackedRCdataOut.ch0 = (Buffer[1] << 3) | ((Buffer[5] & 0b11000000) >> 5);
@@ -129,7 +129,7 @@ void ICACHE_RAM_ATTR UnpackChannelData(volatile uint8_t* Buffer, CRSF *crsf)
  * we take the lowest indexed one and send that, hence lower indexed switches have
  * higher priority in the event that several are changed at once.
  */
-void ICACHE_RAM_ATTR GenerateChannelData(volatile uint8_t* Buffer, CRSF *crsf, uint8_t addr)
+void ICACHE_RAM_ATTR GenerateChannelDataSeqSwitch(volatile uint8_t* Buffer, CRSF *crsf, uint8_t addr)
 {
   uint8_t PacketHeaderAddr;
   PacketHeaderAddr = (addr << 2) | RC_DATA_PACKET;
@@ -158,7 +158,7 @@ void ICACHE_RAM_ATTR GenerateChannelData(volatile uint8_t* Buffer, CRSF *crsf, u
  *
  * Seq switches uses 10 bits for ch3, 3 bits for the switch index and 2 bits for the switch value
  */
-void ICACHE_RAM_ATTR UnpackChannelData(volatile uint8_t* Buffer, CRSF *crsf)
+void ICACHE_RAM_ATTR UnpackChannelDataSeqSwitch(volatile uint8_t* Buffer, CRSF *crsf)
 {
     crsf->PackedRCdataOut.ch0 = (Buffer[1] << 3) | ((Buffer[5] & 0b11100000) >> 5);
     crsf->PackedRCdataOut.ch1 = (Buffer[2] << 3) | ((Buffer[5] & 0b00011100) >> 2);
@@ -202,7 +202,7 @@ void ICACHE_RAM_ATTR UnpackChannelData(volatile uint8_t* Buffer, CRSF *crsf)
 
 #if TARGET_TX or defined UNIT_TEST
 
-void ICACHE_RAM_ATTR GenerateChannelData(volatile uint8_t* Buffer, CRSF *crsf, uint8_t addr)
+void ICACHE_RAM_ATTR GenerateChannelData10bit(volatile uint8_t* Buffer, CRSF *crsf, uint8_t addr)
 {
   uint8_t PacketHeaderAddr;
   PacketHeaderAddr = (addr << 2) | RC_DATA_PACKET;
@@ -229,7 +229,7 @@ void ICACHE_RAM_ATTR GenerateChannelData(volatile uint8_t* Buffer, CRSF *crsf, u
 
 #elif TARGET_RX or defined UNIT_TEST
 
-void ICACHE_RAM_ATTR UnpackChannelData(volatile uint8_t* Buffer, CRSF *crsf)
+void ICACHE_RAM_ATTR UnpackChannelData10bit(volatile uint8_t* Buffer, CRSF *crsf)
 {
     crsf->PackedRCdataOut.ch0 = (Buffer[1] << 3) | ((Buffer[5] & 0b11000000) >> 5);
     crsf->PackedRCdataOut.ch1 = (Buffer[2] << 3) | ((Buffer[5] & 0b00110000) >> 3);

--- a/src/lib/OTA/OTA.cpp
+++ b/src/lib/OTA/OTA.cpp
@@ -236,3 +236,41 @@ void ICACHE_RAM_ATTR UnpackChannelData_11bit(volatile uint8_t* Buffer, CRSF *crs
 #endif
 
 #endif // !HYBRID_SWITCHES_8 and !SEQ_SWITCHES
+
+void ICACHE_RAM_ATTR GenerateMSPData(volatile uint8_t* Buffer, mspPacket_t *msp, uint8_t addr)
+{
+  uint8_t PacketHeaderAddr;
+  PacketHeaderAddr = (addr << 2) + MSP_DATA_PACKET;
+  Buffer[0] = PacketHeaderAddr;
+  Buffer[1] = msp->function;
+  Buffer[2] = msp->payloadSize;
+  Buffer[3] = 0;
+  Buffer[4] = 0;
+  Buffer[5] = 0;
+  Buffer[6] = 0;
+  if (msp->payloadSize <= 4)
+  {
+    msp->payloadReadIterator = 0;
+    for (int i = 0; i < msp->payloadSize; i++)
+    {
+      Buffer[3 + i] = msp->readByte();
+    }
+  }
+  else
+  {
+    Serial.println("Unable to send MSP command. Packet too long.");
+  }
+}
+
+void ICACHE_RAM_ATTR UnpackMSPData(volatile uint8_t* Buffer, mspPacket_t *msp)
+{
+    msp->reset();
+    msp->makeCommand();
+    msp->flags = 0;
+    msp->function = Buffer[1];
+    msp->addByte(Buffer[3]);
+    msp->addByte(Buffer[4]);
+    msp->addByte(Buffer[5]);
+    msp->addByte(Buffer[6]);
+}
+

--- a/src/lib/OTA/OTA.h
+++ b/src/lib/OTA/OTA.h
@@ -15,15 +15,21 @@
 
 #if defined HYBRID_SWITCHES_8 or defined UNIT_TEST
 
+#if TARGET_TX or defined UNIT_TEST
 void GenerateChannelDataHybridSwitch8(volatile uint8_t* Buffer, CRSF *crsf, uint8_t addr, bool TelemetryStatus);
+#elif TARGET_RX or defined UNIT_TEST
 void UnpackChannelDataHybridSwitches8(volatile uint8_t* Buffer, CRSF *crsf);
+#endif
 
 #endif // HYBRID_SWITCHES_8
 
 #if defined SEQ_SWITCHES or defined UNIT_TEST
 
+#if TARGET_TX or defined UNIT_TEST
 void ICACHE_RAM_ATTR GenerateChannelDataSeqSwitch(volatile uint8_t* Buffer, CRSF *crsf, uint8_t addr);
+#elif TARGET_RX or defined UNIT_TEST
 void UnpackChannelDataSeqSwitches(volatile uint8_t* Buffer, CRSF *crsf);
+#endif
 
 #endif // SEQ_SWITCHES
 

--- a/src/lib/OTA/OTA.h
+++ b/src/lib/OTA/OTA.h
@@ -33,5 +33,14 @@ void UnpackChannelDataSeqSwitches(volatile uint8_t* Buffer, CRSF *crsf);
 
 #endif // SEQ_SWITCHES
 
+#if (!defined HYBRID_SWITCHES_8 and !defined SEQ_SWITCHES) or defined UNIT_TEST
+
+#if TARGET_TX or defined UNIT_TEST
+void ICACHE_RAM_ATTR Generate4ChannelData_11bit(volatile uint8_t* Buffer, CRSF *crsf, uint8_t addr);
+#elif TARGET_RX or defined UNIT_TEST
+void ICACHE_RAM_ATTR UnpackChannelData_11bit(volatile uint8_t* Buffer, CRSF *crsf);
+#endif
+
+#endif // !HYBRID_SWITCHES_8 and !SEQ_SWITCHES
 
 #endif // H_OTA

--- a/src/lib/OTA/OTA.h
+++ b/src/lib/OTA/OTA.h
@@ -13,35 +13,16 @@
 #define TLM_PACKET 0b11
 #define SYNC_PACKET 0b10
 
-#if defined HYBRID_SWITCHES_8 or defined UNIT_TEST
-
 #if TARGET_TX or defined UNIT_TEST
-void GenerateChannelDataHybridSwitch8(volatile uint8_t* Buffer, CRSF *crsf, uint8_t addr, bool TelemetryStatus);
-#elif TARGET_RX or defined UNIT_TEST
-void UnpackChannelDataHybridSwitches8(volatile uint8_t* Buffer, CRSF *crsf);
+#ifdef ENABLE_TELEMETRY
+void GenerateChannelData(volatile uint8_t* Buffer, CRSF *crsf, uint8_t addr, bool TelemetryStatus);
+#else
+void GenerateChannelData(volatile uint8_t* Buffer, CRSF *crsf, uint8_t addr);
 #endif
-
-#endif // HYBRID_SWITCHES_8
-
-#if defined SEQ_SWITCHES or defined UNIT_TEST
-
-#if TARGET_TX or defined UNIT_TEST
-void ICACHE_RAM_ATTR GenerateChannelDataSeqSwitch(volatile uint8_t* Buffer, CRSF *crsf, uint8_t addr);
-#elif TARGET_RX or defined UNIT_TEST
-void UnpackChannelDataSeqSwitches(volatile uint8_t* Buffer, CRSF *crsf);
 #endif
-
-#endif // SEQ_SWITCHES
-
-#if (!defined HYBRID_SWITCHES_8 and !defined SEQ_SWITCHES) or defined UNIT_TEST
-
-#if TARGET_TX or defined UNIT_TEST
-void ICACHE_RAM_ATTR Generate4ChannelData_10bit(volatile uint8_t* Buffer, CRSF *crsf, uint8_t addr);
-#elif TARGET_RX or defined UNIT_TEST
-void ICACHE_RAM_ATTR UnpackChannelData_10bit(volatile uint8_t* Buffer, CRSF *crsf);
+#if TARGET_RX or defined UNIT_TEST
+void UnpackChannelData(volatile uint8_t* Buffer, CRSF *crsf);
 #endif
-
-#endif // !HYBRID_SWITCHES_8 and !SEQ_SWITCHES
 
 void ICACHE_RAM_ATTR GenerateMSPData(volatile uint8_t* Buffer, mspPacket_t *msp, uint8_t addr);
 void ICACHE_RAM_ATTR UnpackMSPData(volatile uint8_t* Buffer, mspPacket_t *msp);

--- a/src/lib/OTA/OTA.h
+++ b/src/lib/OTA/OTA.h
@@ -43,4 +43,7 @@ void ICACHE_RAM_ATTR UnpackChannelData_11bit(volatile uint8_t* Buffer, CRSF *crs
 
 #endif // !HYBRID_SWITCHES_8 and !SEQ_SWITCHES
 
+void ICACHE_RAM_ATTR GenerateMSPData(volatile uint8_t* Buffer, mspPacket_t *msp, uint8_t addr);
+void ICACHE_RAM_ATTR UnpackMSPData(volatile uint8_t* Buffer, mspPacket_t *msp);
+
 #endif // H_OTA

--- a/src/lib/OTA/OTA.h
+++ b/src/lib/OTA/OTA.h
@@ -26,16 +26,7 @@ void ICACHE_RAM_ATTR UnpackChannelDataHybridSwitch8(volatile uint8_t* Buffer, CR
 #endif
 #endif
 
-#if defined SEQ_SWITCHES or defined UNIT_TEST
-#if TARGET_TX or defined UNIT_TEST
-void ICACHE_RAM_ATTR GenerateChannelDataSeqSwitch(volatile uint8_t* Buffer, CRSF *crsf, uint8_t addr);
-#endif
-#if TARGET_RX or defined UNIT_TEST
-void ICACHE_RAM_ATTR UnpackChannelDataSeqSwitch(volatile uint8_t* Buffer, CRSF *crsf);
-#endif
-#endif
-
-#if (!defined HYBRID_SWITCHES_8 and !defined SEQ_SWITCHES) or defined UNIT_TEST
+#if !defined HYBRID_SWITCHES_8 or defined UNIT_TEST
 #if TARGET_TX or defined UNIT_TEST
 void ICACHE_RAM_ATTR GenerateChannelData10bit(volatile uint8_t* Buffer, CRSF *crsf, uint8_t addr);
 #endif
@@ -47,9 +38,6 @@ void ICACHE_RAM_ATTR UnpackChannelData10bit(volatile uint8_t* Buffer, CRSF *crsf
 #if defined HYBRID_SWITCHES_8
 #define GenerateChannelData GenerateChannelDataHybridSwitch8
 #define UnpackChannelData UnpackChannelDataHybridSwitch8
-#elif defined SEQ_SWITCHES
-#define GenerateChannelData GenerateChannelDataSeqSwitch
-#define UnpackChannelData UnpackChannelDataSeqSwitch
 #else
 #define GenerateChannelData GenerateChannelData10bit
 #define UnpackChannelData UnpackChannelData10bit

--- a/src/lib/OTA/OTA.h
+++ b/src/lib/OTA/OTA.h
@@ -13,15 +13,46 @@
 #define TLM_PACKET 0b11
 #define SYNC_PACKET 0b10
 
+#if defined HYBRID_SWITCHES_8 or defined UNIT_TEST
 #if TARGET_TX or defined UNIT_TEST
 #ifdef ENABLE_TELEMETRY
-void GenerateChannelData(volatile uint8_t* Buffer, CRSF *crsf, uint8_t addr, bool TelemetryStatus);
+void ICACHE_RAM_ATTR GenerateChannelDataHybridSwitch8(volatile uint8_t* Buffer, CRSF *crsf, uint8_t addr, bool TelemetryStatus);
 #else
-void GenerateChannelData(volatile uint8_t* Buffer, CRSF *crsf, uint8_t addr);
+void ICACHE_RAM_ATTR GenerateChannelDataHybridSwitch8(volatile uint8_t* Buffer, CRSF *crsf, uint8_t addr);
 #endif
 #endif
 #if TARGET_RX or defined UNIT_TEST
-void UnpackChannelData(volatile uint8_t* Buffer, CRSF *crsf);
+void ICACHE_RAM_ATTR UnpackChannelDataHybridSwitch8(volatile uint8_t* Buffer, CRSF *crsf);
+#endif
+#endif
+
+#if defined SEQ_SWITCHES or defined UNIT_TEST
+#if TARGET_TX or defined UNIT_TEST
+void ICACHE_RAM_ATTR GenerateChannelDataSeqSwitch(volatile uint8_t* Buffer, CRSF *crsf, uint8_t addr);
+#endif
+#if TARGET_RX or defined UNIT_TEST
+void ICACHE_RAM_ATTR UnpackChannelDataSeqSwitch(volatile uint8_t* Buffer, CRSF *crsf);
+#endif
+#endif
+
+#if (!defined HYBRID_SWITCHES_8 and !defined SEQ_SWITCHES) or defined UNIT_TEST
+#if TARGET_TX or defined UNIT_TEST
+void ICACHE_RAM_ATTR GenerateChannelData10bit(volatile uint8_t* Buffer, CRSF *crsf, uint8_t addr);
+#endif
+#if TARGET_RX or defined UNIT_TEST
+void ICACHE_RAM_ATTR UnpackChannelData10bit(volatile uint8_t* Buffer, CRSF *crsf);
+#endif
+#endif
+
+#if defined HYBRID_SWITCHES_8
+#define GenerateChannelData GenerateChannelDataHybridSwitch8
+#define UnpackChannelData UnpackChannelDataHybridSwitch8
+#elif defined SEQ_SWITCHES
+#define GenerateChannelData GenerateChannelDataSeqSwitch
+#define UnpackChannelData UnpackChannelDataSeqSwitch
+#else
+#define GenerateChannelData GenerateChannelData10bit
+#define UnpackChannelData UnpackChannelData10bit
 #endif
 
 void ICACHE_RAM_ATTR GenerateMSPData(volatile uint8_t* Buffer, mspPacket_t *msp, uint8_t addr);

--- a/src/lib/OTA/OTA.h
+++ b/src/lib/OTA/OTA.h
@@ -36,9 +36,9 @@ void UnpackChannelDataSeqSwitches(volatile uint8_t* Buffer, CRSF *crsf);
 #if (!defined HYBRID_SWITCHES_8 and !defined SEQ_SWITCHES) or defined UNIT_TEST
 
 #if TARGET_TX or defined UNIT_TEST
-void ICACHE_RAM_ATTR Generate4ChannelData_11bit(volatile uint8_t* Buffer, CRSF *crsf, uint8_t addr);
+void ICACHE_RAM_ATTR Generate4ChannelData_10bit(volatile uint8_t* Buffer, CRSF *crsf, uint8_t addr);
 #elif TARGET_RX or defined UNIT_TEST
-void ICACHE_RAM_ATTR UnpackChannelData_11bit(volatile uint8_t* Buffer, CRSF *crsf);
+void ICACHE_RAM_ATTR UnpackChannelData_10bit(volatile uint8_t* Buffer, CRSF *crsf);
 #endif
 
 #endif // !HYBRID_SWITCHES_8 and !SEQ_SWITCHES

--- a/src/src/common.h
+++ b/src/src/common.h
@@ -11,8 +11,6 @@
 #include "SX1280Driver.h"
 #endif
 
-#define One_Bit_Switches
-
 extern uint8_t BindingUID[6];
 extern uint8_t UID[6];
 extern uint8_t MasterUID[6];

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -518,16 +518,10 @@ void ICACHE_RAM_ATTR ProcessRFPacket()
     switch (type)
     {
     case RC_DATA_PACKET: //Standard RC Data Packet
-        #if defined SEQ_SWITCHES
-        UnpackChannelDataSeqSwitches(Radio.RXdataBuffer, &crsf);
-        #elif defined HYBRID_SWITCHES_8
-        UnpackChannelDataHybridSwitches8(Radio.RXdataBuffer, &crsf);
+        UnpackChannelData(Radio.RXdataBuffer, &crsf);
         #ifdef ENABLE_TELEMETRY
         telemetryConfirmValue = Radio.RXdataBuffer[6] & (1 << 7);
         TelemetrySender.ConfirmCurrentPayload(telemetryConfirmValue);
-        #endif
-        #else
-        UnpackChannelData_10bit(Radio.RXdataBuffer, &crsf);
         #endif
         if (connectionState == connected)
         {

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -461,20 +461,6 @@ void GotConnection()
 #endif
 }
 
-void ICACHE_RAM_ATTR UnpackChannelData_11bit()
-{
-    crsf.PackedRCdataOut.ch0 = (Radio.RXdataBuffer[1] << 3) + ((Radio.RXdataBuffer[5] & 0b11100000) >> 5);
-    crsf.PackedRCdataOut.ch1 = (Radio.RXdataBuffer[2] << 3) + ((Radio.RXdataBuffer[5] & 0b00011100) >> 2);
-    crsf.PackedRCdataOut.ch2 = (Radio.RXdataBuffer[3] << 3) + ((Radio.RXdataBuffer[5] & 0b00000011) << 1) + (Radio.RXdataBuffer[6] & 0b10000000 >> 7);
-    crsf.PackedRCdataOut.ch3 = (Radio.RXdataBuffer[4] << 3) + ((Radio.RXdataBuffer[6] & 0b01110000) >> 4);
-#ifdef One_Bit_Switches
-    crsf.PackedRCdataOut.ch4 = BIT_to_CRSF(Radio.RXdataBuffer[6] & 0b00001000);
-    crsf.PackedRCdataOut.ch5 = BIT_to_CRSF(Radio.RXdataBuffer[6] & 0b00000100);
-    crsf.PackedRCdataOut.ch6 = BIT_to_CRSF(Radio.RXdataBuffer[6] & 0b00000010);
-    crsf.PackedRCdataOut.ch7 = BIT_to_CRSF(Radio.RXdataBuffer[6] & 0b00000001);
-#endif
-}
-
 void ICACHE_RAM_ATTR UnpackMSPData()
 {
     mspPacket_t packet;
@@ -563,7 +549,7 @@ void ICACHE_RAM_ATTR ProcessRFPacket()
         TelemetrySender.ConfirmCurrentPayload(telemetryConfirmValue);
         #endif
         #else
-        UnpackChannelData_11bit();
+        UnpackChannelData_11bit(Radio.RXdataBuffer, &crsf);
         #endif
         if (connectionState == connected)
         {

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -461,28 +461,6 @@ void GotConnection()
 #endif
 }
 
-void ICACHE_RAM_ATTR UnpackMSPData()
-{
-    mspPacket_t packet;
-    packet.reset();
-    packet.makeCommand();
-    packet.flags = 0;
-    packet.function = Radio.RXdataBuffer[1];
-    packet.addByte(Radio.RXdataBuffer[3]);
-    packet.addByte(Radio.RXdataBuffer[4]);
-    packet.addByte(Radio.RXdataBuffer[5]);
-    packet.addByte(Radio.RXdataBuffer[6]);
-
-    if (packet.function == MSP_ELRS_BIND)
-    {
-        OnELRSBindMSP(&packet);
-    }
-    else
-    {
-        crsf.sendMSPFrameToFC(&packet);
-    }
-}
-
 void ICACHE_RAM_ATTR ProcessRFPacket()
 {
     beginProcessing = micros();
@@ -558,7 +536,16 @@ void ICACHE_RAM_ATTR ProcessRFPacket()
         break;
 
     case MSP_DATA_PACKET:
-        UnpackMSPData();
+        mspPacket_t packet;
+        UnpackMSPData(Radio.RXdataBuffer, &packet);
+        if (packet.function == MSP_ELRS_BIND)
+        {
+            OnELRSBindMSP(&packet);
+        }
+        else
+        {
+            crsf.sendMSPFrameToFC(&packet);
+        }
         break;
 
     case TLM_PACKET: //telemetry packet from master

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -475,14 +475,6 @@ void ICACHE_RAM_ATTR UnpackChannelData_11bit()
 #endif
 }
 
-void ICACHE_RAM_ATTR UnpackChannelData_10bit()
-{
-    crsf.PackedRCdataOut.ch0 = UINT10_to_CRSF((Radio.RXdataBuffer[1] << 2) + ((Radio.RXdataBuffer[5] & 0b11000000) >> 6));
-    crsf.PackedRCdataOut.ch1 = UINT10_to_CRSF((Radio.RXdataBuffer[2] << 2) + ((Radio.RXdataBuffer[5] & 0b00110000) >> 4));
-    crsf.PackedRCdataOut.ch2 = UINT10_to_CRSF((Radio.RXdataBuffer[3] << 2) + ((Radio.RXdataBuffer[5] & 0b00001100) >> 2));
-    crsf.PackedRCdataOut.ch3 = UINT10_to_CRSF((Radio.RXdataBuffer[4] << 2) + ((Radio.RXdataBuffer[5] & 0b00000011) >> 0));
-}
-
 void ICACHE_RAM_ATTR UnpackMSPData()
 {
     mspPacket_t packet;

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -527,7 +527,7 @@ void ICACHE_RAM_ATTR ProcessRFPacket()
         TelemetrySender.ConfirmCurrentPayload(telemetryConfirmValue);
         #endif
         #else
-        UnpackChannelData_11bit(Radio.RXdataBuffer, &crsf);
+        UnpackChannelData_10bit(Radio.RXdataBuffer, &crsf);
         #endif
         if (connectionState == connected)
         {

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -197,17 +197,6 @@ void ICACHE_RAM_ATTR ProcessTLMpacket()
     }
 }
 
-void ICACHE_RAM_ATTR CheckChannels5to8Change()
-{ //check if channels 5 to 8 have new data (switch channels)
-  for (int i = 4; i < 8; i++)
-  {
-    if (crsf.ChannelDataInPrev[i] != crsf.ChannelDataIn[i])
-    {
-      Channels5to8Changed = true;
-    }
-  }
-}
-
 void ICACHE_RAM_ATTR GenerateSyncPacketData()
 {
   uint8_t PacketHeaderAddr;
@@ -613,9 +602,6 @@ void setup()
   Radio.RXdoneCallback = &RXdoneISR;
   Radio.TXdoneCallback = &TXdoneISR;
 
-#ifndef One_Bit_Switches
-  crsf.RCdataCallback1 = &CheckChannels5to8Change;
-#endif
   crsf.connected = &UARTconnected; // it will auto init when it detects UART connection
   crsf.disconnected = &UARTdisconnected;
   crsf.RecvParameterUpdate = &ParamUpdateReq;

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -228,31 +228,6 @@ void ICACHE_RAM_ATTR GenerateSyncPacketData()
   Radio.TXdataBuffer[6] = UID[5];
 }
 
-void ICACHE_RAM_ATTR GenerateMSPData()
-{
-  uint8_t PacketHeaderAddr;
-  PacketHeaderAddr = (DeviceAddr << 2) + MSP_DATA_PACKET;
-  Radio.TXdataBuffer[0] = PacketHeaderAddr;
-  Radio.TXdataBuffer[1] = MSPPacket.function;
-  Radio.TXdataBuffer[2] = MSPPacket.payloadSize;
-  Radio.TXdataBuffer[3] = 0;
-  Radio.TXdataBuffer[4] = 0;
-  Radio.TXdataBuffer[5] = 0;
-  Radio.TXdataBuffer[6] = 0;
-  if (MSPPacket.payloadSize <= 4)
-  {
-    MSPPacket.payloadReadIterator = 0;
-    for (int i = 0; i < MSPPacket.payloadSize; i++)
-    {
-      Radio.TXdataBuffer[3 + i] = MSPPacket.readByte();
-    }
-  }
-  else
-  {
-    Serial.println("Unable to send MSP command. Packet too long.");
-  }
-}
-
 void ICACHE_RAM_ATTR SetRFLinkRate(uint8_t index) // Set speed of RF link (hz)
 {
   Serial.println("set rate");
@@ -349,7 +324,7 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
   {
     if ((millis() > (MSP_PACKET_SEND_INTERVAL + MSPPacketLastSent)) && MSPPacketSendCount)
     {
-      GenerateMSPData();
+      GenerateMSPData(Radio.TXdataBuffer, &MSPPacket, DeviceAddr);
       MSPPacketLastSent = millis();
       MSPPacketSendCount--;
 

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -228,21 +228,6 @@ void ICACHE_RAM_ATTR GenerateSyncPacketData()
   Radio.TXdataBuffer[6] = UID[5];
 }
 
-void ICACHE_RAM_ATTR Generate4ChannelData_10bit()
-{
-  uint8_t PacketHeaderAddr;
-  PacketHeaderAddr = (DeviceAddr << 2) + RC_DATA_PACKET;
-  Radio.TXdataBuffer[0] = PacketHeaderAddr;
-  Radio.TXdataBuffer[1] = ((CRSF_to_UINT10(crsf.ChannelDataIn[0]) & 0b1111111100) >> 2);
-  Radio.TXdataBuffer[2] = ((CRSF_to_UINT10(crsf.ChannelDataIn[1]) & 0b1111111100) >> 2);
-  Radio.TXdataBuffer[3] = ((CRSF_to_UINT10(crsf.ChannelDataIn[2]) & 0b1111111100) >> 2);
-  Radio.TXdataBuffer[4] = ((CRSF_to_UINT10(crsf.ChannelDataIn[3]) & 0b1111111100) >> 2);
-  Radio.TXdataBuffer[5] = ((CRSF_to_UINT10(crsf.ChannelDataIn[0]) & 0b0000000011) << 6) +
-                          ((CRSF_to_UINT10(crsf.ChannelDataIn[1]) & 0b0000000011) << 4) +
-                          ((CRSF_to_UINT10(crsf.ChannelDataIn[2]) & 0b0000000011) << 2) +
-                          ((CRSF_to_UINT10(crsf.ChannelDataIn[3]) & 0b0000000011) << 0);
-}
-
 void ICACHE_RAM_ATTR Generate4ChannelData_11bit()
 {
   uint8_t PacketHeaderAddr;

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -344,7 +344,7 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
       #elif defined SEQ_SWITCHES
       GenerateChannelDataSeqSwitch(Radio.TXdataBuffer, &crsf, DeviceAddr);
       #else
-      Generate4ChannelData_11bit(Radio.TXdataBuffer, &crsf, DeviceAddr);
+      Generate4ChannelData_10bit(Radio.TXdataBuffer, &crsf, DeviceAddr);
       #endif
     }
   }

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -228,28 +228,6 @@ void ICACHE_RAM_ATTR GenerateSyncPacketData()
   Radio.TXdataBuffer[6] = UID[5];
 }
 
-void ICACHE_RAM_ATTR Generate4ChannelData_11bit()
-{
-  uint8_t PacketHeaderAddr;
-  PacketHeaderAddr = (DeviceAddr << 2) + RC_DATA_PACKET;
-  Radio.TXdataBuffer[0] = PacketHeaderAddr;
-  Radio.TXdataBuffer[1] = ((crsf.ChannelDataIn[0]) >> 3);
-  Radio.TXdataBuffer[2] = ((crsf.ChannelDataIn[1]) >> 3);
-  Radio.TXdataBuffer[3] = ((crsf.ChannelDataIn[2]) >> 3);
-  Radio.TXdataBuffer[4] = ((crsf.ChannelDataIn[3]) >> 3);
-  Radio.TXdataBuffer[5] = ((crsf.ChannelDataIn[0] & 0b00000111) << 5) +
-                          ((crsf.ChannelDataIn[1] & 0b111) << 2) +
-                          ((crsf.ChannelDataIn[2] & 0b110) >> 1);
-  Radio.TXdataBuffer[6] = ((crsf.ChannelDataIn[2] & 0b001) << 7) +
-                          ((crsf.ChannelDataIn[3] & 0b111) << 4); // 4 bits left over for something else?
-#ifdef One_Bit_Switches
-  Radio.TXdataBuffer[6] += CRSF_to_BIT(crsf.ChannelDataIn[4]) << 3;
-  Radio.TXdataBuffer[6] += CRSF_to_BIT(crsf.ChannelDataIn[5]) << 2;
-  Radio.TXdataBuffer[6] += CRSF_to_BIT(crsf.ChannelDataIn[6]) << 1;
-  Radio.TXdataBuffer[6] += CRSF_to_BIT(crsf.ChannelDataIn[7]) << 0;
-#endif
-}
-
 void ICACHE_RAM_ATTR GenerateMSPData()
 {
   uint8_t PacketHeaderAddr;
@@ -391,7 +369,7 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
       #elif defined SEQ_SWITCHES
       GenerateChannelDataSeqSwitch(Radio.TXdataBuffer, &crsf, DeviceAddr);
       #else
-      Generate4ChannelData_11bit();
+      Generate4ChannelData_11bit(Radio.TXdataBuffer, &crsf, DeviceAddr);
       #endif
     }
   }

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -335,16 +335,10 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
     }
     else
     {
-      #if defined HYBRID_SWITCHES_8
       #ifdef ENABLE_TELEMETRY
-      GenerateChannelDataHybridSwitch8(Radio.TXdataBuffer, &crsf, DeviceAddr, TelemetryReceiver.GetCurrentConfirm());
+      GenerateChannelData(Radio.TXdataBuffer, &crsf, DeviceAddr, TelemetryReceiver.GetCurrentConfirm());
       #else
-      GenerateChannelDataHybridSwitch8(Radio.TXdataBuffer, &crsf, DeviceAddr, false);
-      #endif
-      #elif defined SEQ_SWITCHES
-      GenerateChannelDataSeqSwitch(Radio.TXdataBuffer, &crsf, DeviceAddr);
-      #else
-      Generate4ChannelData_10bit(Radio.TXdataBuffer, &crsf, DeviceAddr);
+      GenerateChannelData(Radio.TXdataBuffer, &crsf, DeviceAddr);
       #endif
     }
   }


### PR DESCRIPTION
This commit is just a little bit of moving code around after a comment en the development chat.
I'd also like to start adding some unit test code that checks packet sizes and mapping functions to ensure that generate/unpack pairs are symmetric.

- #ifdef guards around TX/RX code to shrink flash size
- Remove unused 10-bit functions
- Move 11-bit mode (one-bit switches) to OTA library
- Move MSP packing/unpacking into OTA library
- Using bitwise or is faster than addition ~3% increase in performance of hybrid generation function.