### PR TITLE
adds GENERIC_CRC13 and parity lib

### DIFF
--- a/src/lib/CRC/crc.cpp
+++ b/src/lib/CRC/crc.cpp
@@ -2,15 +2,12 @@
 
 GENERIC_CRC8::GENERIC_CRC8(uint8_t poly)
 {
-    poly = (poly << 1) + 1; // Correct Koopman formatting https://users.ece.cmu.edu/~koopman/crc/
-    uint32_t i;
-    uint8_t j;
     uint8_t crc;
 
-    for (i = 0; i < crclen; i++)
+    for (uint16_t i = 0; i < crclen; i++)
     {
         crc = i;
-        for (j = 0; j < 8; j++)
+        for (uint8_t j = 0; j < 8; j++)
         {
             crc = (crc << 1) ^ ((crc & 0x80) ? poly : 0);
         }
@@ -21,7 +18,7 @@ GENERIC_CRC8::GENERIC_CRC8(uint8_t poly)
 uint8_t ICACHE_RAM_ATTR GENERIC_CRC8::calc(uint8_t *data, uint8_t len)
 {
     uint8_t crc = 0;
-    for (uint8_t i = 0; i < len; i++)
+    while (len--)
     {
         crc = crc8tab[crc ^ *data++];
     }
@@ -31,45 +28,41 @@ uint8_t ICACHE_RAM_ATTR GENERIC_CRC8::calc(uint8_t *data, uint8_t len)
 uint8_t ICACHE_RAM_ATTR GENERIC_CRC8::calc(volatile uint8_t *data, uint8_t len)
 {
     uint8_t crc = 0;
-    for (uint8_t i = 0; i < len; i++)
+    while (len--)
     {
         crc = crc8tab[crc ^ *data++];
     }
     return crc;
 }
 
-GENERIC_CRC16::GENERIC_CRC16(uint16_t poly)
+GENERIC_CRC13::GENERIC_CRC13(uint16_t poly)
 {
-    poly = (poly << 1) + 1; // Correct Koopman formatting https://users.ece.cmu.edu/~koopman/crc/
-    uint32_t i;
-    uint8_t j;
     uint16_t crc;
-
-    for (i = 0; i < crclen; i++)
+    for (uint16_t i = 0; i < crclen; i++)
     {
         crc = i << 8;
-        for (j = 0; j < 8; j++)
+        for (uint8_t j = 0; j < 8; j++)
         {
-            crc = (crc << 1) ^ ((crc & 0x8000) ? poly : 0);
+            crc = (crc << 1) ^ ((crc & 0x1000) ? poly : 0);
         }
-        crc16tab[i] = crc;
+        crc13tab[i] = crc;
     }
 }
 
-uint16_t ICACHE_RAM_ATTR GENERIC_CRC16::calc(uint8_t *data, uint8_t len, uint16_t crc)
+uint16_t ICACHE_RAM_ATTR GENERIC_CRC13::calc(uint8_t *data, uint8_t len, uint16_t crc)
 {
-    for (uint8_t i = 0; i < len; i++)
+    while (len--)
     {
-        crc = (crc >> 8) ^ crc16tab[(crc ^ (uint16_t) *data++) & 0x00FF];
+        crc = (crc >> 8) ^ crc13tab[(crc ^ (uint16_t) *data++) & 0x00FF];
     }    
     return crc;
 }
 
-uint16_t ICACHE_RAM_ATTR GENERIC_CRC16::calc(volatile uint8_t *data, uint8_t len, uint16_t crc)
+uint16_t ICACHE_RAM_ATTR GENERIC_CRC13::calc(volatile uint8_t *data, uint8_t len, uint16_t crc)
 {
-    for (uint8_t i = 0; i < len; i++)
+    while (len--)
     {
-        crc = (crc >> 8) ^ crc16tab[(crc ^ (uint16_t) *data++) & 0x00FF];
+        crc = (crc >> 8) ^ crc13tab[(crc ^ (uint16_t) *data++) & 0x00FF];
     }
     return crc;
 }
@@ -77,7 +70,7 @@ uint16_t ICACHE_RAM_ATTR GENERIC_CRC16::calc(volatile uint8_t *data, uint8_t len
 uint8_t ICACHE_RAM_ATTR getParity(uint8_t *data, uint8_t len)
 {
     uint8_t parity = 0;
-    for (uint8_t i = 0; i < len; i++)
+    while (len--)
     {
         parity ^= __builtin_parity(*data++);
     }
@@ -87,7 +80,7 @@ uint8_t ICACHE_RAM_ATTR getParity(uint8_t *data, uint8_t len)
 uint8_t ICACHE_RAM_ATTR getParity(volatile uint8_t *data, uint8_t len)
 {
     uint8_t parity = 0;
-    for (uint8_t i = 0; i < len; i++)
+    while (len--)
     {
         parity ^= __builtin_parity(*data++);
     }

--- a/src/lib/CRC/crc.cpp
+++ b/src/lib/CRC/crc.cpp
@@ -2,6 +2,7 @@
 
 GENERIC_CRC8::GENERIC_CRC8(uint8_t poly)
 {
+    poly = (poly << 1) + 1; // Correct Koopman formatting https://users.ece.cmu.edu/~koopman/crc/
     uint32_t i;
     uint8_t j;
     uint8_t crc;
@@ -35,4 +36,60 @@ uint8_t ICACHE_RAM_ATTR GENERIC_CRC8::calc(volatile uint8_t *data, uint8_t len)
         crc = crc8tab[crc ^ *data++];
     }
     return crc;
+}
+
+GENERIC_CRC16::GENERIC_CRC16(uint16_t poly)
+{
+    poly = (poly << 1) + 1; // Correct Koopman formatting https://users.ece.cmu.edu/~koopman/crc/
+    uint32_t i;
+    uint8_t j;
+    uint16_t crc;
+
+    for (i = 0; i < crclen; i++)
+    {
+        crc = i << 8;
+        for (j = 0; j < 8; j++)
+        {
+            crc = (crc << 1) ^ ((crc & 0x8000) ? poly : 0);
+        }
+        crc16tab[i] = crc;
+    }
+}
+
+uint16_t ICACHE_RAM_ATTR GENERIC_CRC16::calc(uint8_t *data, uint8_t len, uint16_t crc)
+{
+    for (uint8_t i = 0; i < len; i++)
+    {
+        crc = (crc >> 8) ^ crc16tab[(crc ^ (uint16_t) *data++) & 0x00FF];
+    }    
+    return crc;
+}
+
+uint16_t ICACHE_RAM_ATTR GENERIC_CRC16::calc(volatile uint8_t *data, uint8_t len, uint16_t crc)
+{
+    for (uint8_t i = 0; i < len; i++)
+    {
+        crc = (crc >> 8) ^ crc16tab[(crc ^ (uint16_t) *data++) & 0x00FF];
+    }
+    return crc;
+}
+
+uint8_t ICACHE_RAM_ATTR getParity(uint8_t *data, uint8_t len)
+{
+    uint8_t parity = 0;
+    for (uint8_t i = 0; i < len; i++)
+    {
+        parity ^= __builtin_parity(*data++);
+    }
+    return parity;
+}
+
+uint8_t ICACHE_RAM_ATTR getParity(volatile uint8_t *data, uint8_t len)
+{
+    uint8_t parity = 0;
+    for (uint8_t i = 0; i < len; i++)
+    {
+        parity ^= __builtin_parity(*data++);
+    }
+    return parity;
 }

--- a/src/lib/CRC/crc.h
+++ b/src/lib/CRC/crc.h
@@ -15,3 +15,18 @@ public:
     uint8_t calc(uint8_t *data, uint8_t len);
     uint8_t calc(volatile uint8_t *data, uint8_t len);
 };
+
+class GENERIC_CRC16
+{
+private:
+    uint16_t crc16tab[crclen];
+    uint16_t crcpoly;
+
+public:
+    GENERIC_CRC16(uint16_t poly);
+    uint16_t calc(uint8_t *data, uint8_t len, uint16_t crc);
+    uint16_t calc(volatile uint8_t *data, uint8_t len, uint16_t crc);
+};
+
+uint8_t getParity(uint8_t *data, uint8_t len);
+uint8_t getParity(volatile uint8_t *data, uint8_t len);

--- a/src/lib/CRC/crc.h
+++ b/src/lib/CRC/crc.h
@@ -16,14 +16,14 @@ public:
     uint8_t calc(volatile uint8_t *data, uint8_t len);
 };
 
-class GENERIC_CRC16
+class GENERIC_CRC13
 {
 private:
-    uint16_t crc16tab[crclen];
+    uint16_t crc13tab[crclen];
     uint16_t crcpoly;
 
 public:
-    GENERIC_CRC16(uint16_t poly);
+    GENERIC_CRC13(uint16_t poly);
     uint16_t calc(uint8_t *data, uint8_t len, uint16_t crc);
     uint16_t calc(volatile uint8_t *data, uint8_t len, uint16_t crc);
 };

--- a/src/src/common.h
+++ b/src/src/common.h
@@ -144,4 +144,6 @@ uint8_t ICACHE_RAM_ATTR enumRatetoIndex(expresslrs_RFrates_e rate);
 #define AUX8 12
 
 //ELRS SPECIFIC OTA CRC
+//Koopman formatting https://users.ece.cmu.edu/~koopman/crc/
 #define ELRS_CRC_POLY 0x83
+#define ELRS_CRC13_POLY 0x1E97

--- a/src/src/common.h
+++ b/src/src/common.h
@@ -145,5 +145,5 @@ uint8_t ICACHE_RAM_ATTR enumRatetoIndex(expresslrs_RFrates_e rate);
 
 //ELRS SPECIFIC OTA CRC
 //Koopman formatting https://users.ece.cmu.edu/~koopman/crc/
-#define ELRS_CRC_POLY 0x83
-#define ELRS_CRC13_POLY 0x1E97
+#define ELRS_CRC_POLY 0x07 // 0x83
+#define ELRS_CRC13_POLY 0x1D2F // 0x1E97


### PR DESCRIPTION
A second PR will follow after https://github.com/ExpressLRS/ExpressLRS/pull/417 is merged.  This PR only adds the libs and the second PR will mod the OTA packet to use crc13+parity to replace the current crc8 and device address.