### PR TITLE
Split telemetry sending

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -269,7 +269,7 @@ void ICACHE_RAM_ATTR HandleFHSS()
     }
 }
 
-void ICACHE_RAM_ATTR HandleSendTelemetryResponse()
+void SendTelemetryResponse()
 {
     #ifdef ENABLE_TELEMETRY
     uint8_t *data;
@@ -278,17 +278,6 @@ void ICACHE_RAM_ATTR HandleSendTelemetryResponse()
     static uint8_t telemetryDataCount = 0;
     #endif
     uint8_t openTxRSSI;
-
-    if ((connectionState == disconnected) || (ExpressLRS_currAirRate_Modparams->TLMinterval == TLM_RATIO_NO_TLM) || (alreadyTLMresp == true))
-    {
-        return; // don't bother sending tlm if disconnected or TLM is off
-    }
-
-    uint8_t modresult = (NonceRX + 1) % TLMratioEnumToValue(ExpressLRS_currAirRate_Modparams->TLMinterval);
-    if (modresult != 0)
-    {
-        return;
-    }
 
     alreadyTLMresp = true;
 
@@ -348,6 +337,22 @@ void ICACHE_RAM_ATTR HandleSendTelemetryResponse()
     Radio.TXdataBuffer[7] = crc;
     Radio.TXnb(Radio.TXdataBuffer, 8);
     return;
+}
+
+void ICACHE_RAM_ATTR HandleSendTelemetryResponse()
+{
+    if ((connectionState == disconnected) || (ExpressLRS_currAirRate_Modparams->TLMinterval == TLM_RATIO_NO_TLM) || (alreadyTLMresp == true))
+    {
+        return; // don't bother sending tlm if disconnected or TLM is off
+    }
+
+    uint8_t modresult = (NonceRX + 1) % TLMratioEnumToValue(ExpressLRS_currAirRate_Modparams->TLMinterval);
+    if (modresult != 0)
+    {
+        return;
+    }
+
+    SendTelemetryResponse();
 }
 
 void ICACHE_RAM_ATTR HandleFreqCorr(bool value)


### PR DESCRIPTION
Move the actual sending code into a new non-IRAM function and leave the code that checks if we need to send telemetry in IRAM. This will give us a little more headroom in the IRAM race 😄 .