### PR TITLE
Upgrade ESP8266 framework to allow larger IRAM

### DIFF
--- a/src/include/targets.h
+++ b/src/include/targets.h
@@ -15,11 +15,10 @@
 #ifdef PLATFORM_STM32
 #define ICACHE_RAM_ATTR //nothing//
 #else
-#ifndef ICACHE_RAM_ATTR //fix to allow both esp32 and esp8266 to use ICACHE_RAM_ATTR for mapping to IRAM
+#undef ICACHE_RAM_ATTR //fix to allow both esp32 and esp8266 to use ICACHE_RAM_ATTR for mapping to IRAM
 #define ICACHE_RAM_ATTR IRAM_ATTR
 #endif
-#endif
-
+ 
 #ifdef TARGET_TTGO_LORA_V1_AS_TX
 #define GPIO_PIN_NSS 18
 #define GPIO_PIN_BUSY           -1 // NOT USED ON THIS TARGET

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -34,13 +34,17 @@ lib_deps = NeoPixelBus
 
 # ------------------------- COMMON ESP82xx DEFINITIONS -----------------
 [env_common_esp82xx]
-platform = espressif8266@2.2.3
-platform_packages = toolchain-xtensa@2.40802.200502
+platform = espressif8266
+platform_packages = 
+    mcspr/toolchain-xtensa@~5.100200.201223
+    framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
 board = esp8285
 upload_speed = 921600
 build_flags =
 	-D PLATFORM_ESP8266=1
 	-D VTABLES_IN_FLASH=1
+	-D MMU_IRAM_SIZE=0xC000
+	-D MMU_ICACHE_SIZE=0x4000
 	-O2
 board_build.f_cpu = 80000000L
 src_filter = ${common_env_data.src_filter} -<ESP32*.*> -<STM32*.*> -<WS281B*.*>

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -34,10 +34,10 @@ lib_deps = NeoPixelBus
 
 # ------------------------- COMMON ESP82xx DEFINITIONS -----------------
 [env_common_esp82xx]
-platform = espressif8266
+platform = espressif8266@2.6.3
 platform_packages = 
     mcspr/toolchain-xtensa@~5.100200.201223
-    framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
+    framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git#0049090
 board = esp8285
 upload_speed = 921600
 build_flags =


### PR DESCRIPTION
This allows changes to MMU_IRAM_SIZE from 32kb (0x8000) to 48kb (0xC000) but also reduces ICACHE from 32kb to 16kb.
 