### PR TITLE
Fix NamimnoRC Voyager build

### DIFF
--- a/src/lib/DAC/DAC.h
+++ b/src/lib/DAC/DAC.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(TARGET_R9M_TX) || defined(TARGET_TX_ES915TX) || defined(TARGET_NAMIMNORC_VOYAGER_TX)
+#if defined(TARGET_R9M_TX) || defined(TARGET_TX_ES915TX) || defined(TARGET_NAMIMNORC_TX)
 
 #include "targets.h"
 #include <Wire.h>


### PR DESCRIPTION
The DAC header file was checking the wrong build flag.