### PR TITLE
rngN simplification

### DIFF
--- a/src/src/utils.cpp
+++ b/src/src/utils.cpp
@@ -3,8 +3,6 @@
 unsigned long seed = 0;
 
 // returns values between 0 and 0x7FFF
-// NB rngN depends on this output range, so if we change the
-// behaviour rngN will need updating
 long rng(void)
 {
     unsigned long m = 2147483648;
@@ -19,14 +17,10 @@ void rngSeed(long newSeed)
     seed = newSeed;
 }
 
-// returns 0 <= x < max where max <= 256
-// (actual upper limit is higher, but there is one and I haven't
-//  thought carefully about what it is)
+// returns 0 <= x < max
 unsigned int rngN(unsigned int max)
 {
-    unsigned long x = rng();
-    unsigned int result = (x * max) / RNG_MAX;
-    return result;
+    return rng() % max;
 }
 
 // 0..255 returned

--- a/src/src/utils.h
+++ b/src/src/utils.h
@@ -3,11 +3,9 @@
 // void  PrintRC()
 // }
 
-// the max value returned by rng
-#define RNG_MAX 0x7FFF
-
 extern unsigned long seed;
 
+// returns values between 0 and 0x7FFF
 long rng(void);
 
 void rngSeed(long newSeed);
@@ -16,5 +14,5 @@ long rng8Bit(void);
 // 0..31 returned
 long rng5Bit(void);
 
-// returns 0 <= x < n where n <= 256
+// returns 0 <= x < n
 unsigned int rngN(unsigned int upper);


### PR DESCRIPTION
Should behave exactly the same as before, without the possibility of overflowing