### PR TITLE
Include RSSI2 in LINK telemetry, antenna in FC statistics

### DIFF
--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -34,6 +34,27 @@ PowerLevels_e POWERMGNT::currPower()
     return CurrentPower;
 }
 
+uint8_t POWERMGNT::currPowerAsCrsfPower()
+{
+    // Crossfire's power levels as defined in opentx:radio/src/telemetry/crossfire.cpp
+    //static const int32_t power_values[] = { 0, 10, 25, 100, 500, 1000, 2000, 250 };
+    const uint8_t CRSF_POWER_MAP[] ={
+        1, // PWR_10mW
+        2, // PWR_25mW
+        0, // PWR_50mW SAD!
+        3, // PWR_100mW
+        7, // PWR_250mW
+        4, //PWR_500mW
+        5, //PWR_1000mW
+        6 // PWR_2000mW
+    };
+    uint8_t pwr = (uint8_t)CurrentPower;
+    if (pwr < sizeof(CRSF_POWER_MAP)/sizeof(CRSF_POWER_MAP[0]))
+        return CRSF_POWER_MAP[pwr];
+    else
+        return 0;
+}
+
 void POWERMGNT::init()
 {
 #if DAC_IN_USE

--- a/src/lib/POWERMGNT/POWERMGNT.h
+++ b/src/lib/POWERMGNT/POWERMGNT.h
@@ -77,6 +77,7 @@ public:
     static PowerLevels_e incPower();
     static PowerLevels_e decPower();
     static PowerLevels_e currPower();
+    static uint8_t currPowerAsCrsfPower();
     static void setDefaultPower();
     static void init();
 };

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -178,21 +178,6 @@ void EnterBindingMode();
 void ExitBindingMode();
 void OnELRSBindMSP(mspPacket_t *packet);
 
-//////////////////////////////////////////////////////////////
-// flip to the other antenna
-// no-op if GPIO_PIN_ANTENNA_SELECT not defined
-#if defined(GPIO_PIN_ANTENNA_SELECT) && defined(USE_DIVERSITY)
-    void inline switchAntenna()
-    {
-
-
-        antenna = !antenna;
-        digitalWrite(GPIO_PIN_ANTENNA_SELECT, antenna);
-
-    }
-#endif
-
-
 void ICACHE_RAM_ATTR getRFlinkInfo()
 {
     int32_t rssiDBM0 = LPF_UplinkRSSI0.SmoothDataINT;
@@ -273,7 +258,6 @@ bool ICACHE_RAM_ATTR HandleSendTelemetryResponse()
     uint8_t packageIndex;
     static uint8_t telemetryDataCount = 0;
     #endif
-    uint8_t openTxRSSI;
     uint8_t modresult = (NonceRX + 1) % TLMratioEnumToValue(ExpressLRS_currAirRate_Modparams->TLMinterval);
 
     if ((connectionState == disconnected) || (ExpressLRS_currAirRate_Modparams->TLMinterval == TLM_RATIO_NO_TLM) || (alreadyTLMresp == true) || (modresult != 0))
@@ -430,6 +414,17 @@ void ICACHE_RAM_ATTR HWtimerCallbackTick() // this is 180 out of phase with the 
     uplinkLQ = LQCALC.getLQ();
     LQCALC.inc();
     crsf.RXhandleUARTout();
+}
+
+//////////////////////////////////////////////////////////////
+// flip to the other antenna
+// no-op if GPIO_PIN_ANTENNA_SELECT not defined
+static inline void switchAntenna()
+{
+#if defined(GPIO_PIN_ANTENNA_SELECT) && defined(USE_DIVERSITY)
+    antenna = !antenna;
+    digitalWrite(GPIO_PIN_ANTENNA_SELECT, antenna);
+#endif
 }
 
 static void ICACHE_RAM_ATTR updateDiversity()

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -195,9 +195,6 @@ void OnELRSBindMSP(mspPacket_t *packet);
 
 void ICACHE_RAM_ATTR getRFlinkInfo()
 {
-    //int8_t LastRSSI = Radio.LastPacketRSSI;
-    // int32_t rssiDBM = LPF_UplinkRSSI.update(Radio.LastPacketRSSI);
-
     int32_t rssiDBM0 = LPF_UplinkRSSI0.SmoothDataINT;
     int32_t rssiDBM1 = LPF_UplinkRSSI1.SmoothDataINT;
     switch (antenna) {
@@ -210,22 +207,17 @@ void ICACHE_RAM_ATTR getRFlinkInfo()
     }
 
     int32_t rssiDBM = (antenna == 0) ? rssiDBM0 : rssiDBM1;
-
-
     crsf.PackedRCdataOut.ch15 = UINT10_to_CRSF(map(constrain(rssiDBM, ExpressLRS_currAirRate_RFperfParams->RXsensitivity, -50),
                                                ExpressLRS_currAirRate_RFperfParams->RXsensitivity, -50, 0, 1023));
     crsf.PackedRCdataOut.ch14 = UINT10_to_CRSF(fmap(uplinkLQ, 0, 100, 0, 1023));
 
-    // our rssiDBM is currently in the range -128 to 98, but BF wants a value in the range
-    // 0 to 255 that maps to -1 * the negative part of the rssiDBM, so cap at 0.
-    // if (rssiDBM > 0)
-    //     rssiDBM = 0;
-
     if (rssiDBM0 > 0) rssiDBM0 = 0;
     if (rssiDBM1 > 0) rssiDBM1 = 0;
 
-    crsf.LinkStatistics.uplink_RSSI_1 = -rssiDBM0; // negate to match BF
+    // BetaFlight/iNav expect positive values for -dBm (e.g. -80dBm -> sent as 80)
+    crsf.LinkStatistics.uplink_RSSI_1 = -rssiDBM0;
     crsf.LinkStatistics.uplink_RSSI_2 = -rssiDBM1;
+    crsf.LinkStatistics.active_antenna = antenna;
     crsf.LinkStatistics.uplink_SNR = Radio.LastPacketSNR;
     crsf.LinkStatistics.uplink_Link_quality = uplinkLQ;
     crsf.LinkStatistics.rf_Mode = (uint8_t)RATE_4HZ - (uint8_t)ExpressLRS_currAirRate_Modparams->enum_rate;
@@ -302,18 +294,10 @@ bool ICACHE_RAM_ATTR HandleSendTelemetryResponse()
             #endif
             Radio.TXdataBuffer[1] = ELRS_TELEMETRY_TYPE_LINK;
 
-            // OpenTX hard codes "rssi" warnings to the LQ sensor for crossfire, so the
-            // rssi we send is for display only.
-            // OpenTX treats the rssi values as signed.
-
-            openTxRSSI = (antenna == 0) ? crsf.LinkStatistics.uplink_RSSI_1 : crsf.LinkStatistics.uplink_RSSI_2;
-            // truncate the range to fit into OpenTX's 8 bit signed value
-            if (openTxRSSI > 127)
-                openTxRSSI = 127;
-            // convert to 8 bit signed value in the negative range (-128 to 0)
-            openTxRSSI = 255 - openTxRSSI;
-            Radio.TXdataBuffer[2] = openTxRSSI;
-            Radio.TXdataBuffer[3] = 0;
+            // OpenTX RSSI as -dBm is fine and supports +dBm values as well
+            // but the value in linkstatistics is "positivized" (inverted polarity)
+            Radio.TXdataBuffer[2] = -crsf.LinkStatistics.uplink_RSSI_1;
+            Radio.TXdataBuffer[3] = -crsf.LinkStatistics.uplink_RSSI_2;
             Radio.TXdataBuffer[4] = crsf.LinkStatistics.uplink_SNR;
             Radio.TXdataBuffer[5] = crsf.LinkStatistics.uplink_Link_quality;
             Radio.TXdataBuffer[6] = 0;

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -170,6 +170,7 @@ void ICACHE_RAM_ATTR ProcessTLMpacket()
             crsf.LinkStatistics.uplink_RSSI_2 = Radio.RXdataBuffer[3];
             crsf.LinkStatistics.uplink_SNR = Radio.RXdataBuffer[4];
             crsf.LinkStatistics.uplink_Link_quality = Radio.RXdataBuffer[5];
+            crsf.LinkStatistics.uplink_TX_Power = POWERMGNT.currPowerAsCrsfPower();
             crsf.LinkStatistics.downlink_SNR = Radio.LastPacketSNR;
             crsf.LinkStatistics.downlink_RSSI = Radio.LastPacketRSSI;
             crsf.LinkStatistics.downlink_Link_quality = LPD_DownlinkLQ.update(LQCALC.getLQ()) + 1; // +1 fixes rounding issues with filter and makes it consistent with RX LQ Calculation

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -165,8 +165,9 @@ void ICACHE_RAM_ATTR ProcessTLMpacket()
     switch(TLMheader & ELRS_TELEMETRY_TYPE_MASK)
     {
         case ELRS_TELEMETRY_TYPE_LINK:
+            // RSSI received is signed, proper polarity (negative value = -dBm)
             crsf.LinkStatistics.uplink_RSSI_1 = Radio.RXdataBuffer[2];
-            crsf.LinkStatistics.uplink_RSSI_2 = 0;
+            crsf.LinkStatistics.uplink_RSSI_2 = Radio.RXdataBuffer[3];
             crsf.LinkStatistics.uplink_SNR = Radio.RXdataBuffer[4];
             crsf.LinkStatistics.uplink_Link_quality = Radio.RXdataBuffer[5];
             crsf.LinkStatistics.downlink_SNR = Radio.LastPacketSNR;


### PR DESCRIPTION
We have two free bytes in ELRS_TELEMETRY_TYPE_LINK which are currently just set to 0. Now that we have diversitification action, we should be including this information back to OpenTX, right? This uses one of those free bytes to include uplink_RSSI2. There's still one unused.

* There's a lot of extra code mucking about with the RSSI to flip the sign and avoid positive dBm values, but OpenTX handles signed values just fine so this isn't needed. The sign does need to be flipped vs BetaFlight though.
* Also sets the active_antenna value in the link statistics reported to FC. The active antenna is used in iNav so wheeeee it is fun to see the antenna flipping in the OSD. We send the byte, why not populate the byte?
* Adds the TX power to link statistics sent to OpenTX. Crossfire doesn't have a definition for 50mW so that still displays as 0 unfortunately, but 10, 25, 100, 250, 500, 1000, and 2000 show up.