### PR TITLE
Fix BetaFlight passthrough

### DIFF
--- a/src/targets/diy_2400.ini
+++ b/src/targets/diy_2400.ini
@@ -58,8 +58,8 @@ src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART
 upload_protocol = custom
 upload_command =
-	python $PROJECT_DATA_DIR/../python/BFinitPassthrough.py $UPLOAD_SPEED
-	python $PROJECT_DATA_DIR/../python/esptool-3.0/esptool.py --no-stub -b $UPLOAD_SPEED -c esp8266 --before no_reset --after soft_reset write_flash 0x0000 $SOURCE
+	python "$PROJECT_DIR/python/BFinitPassthrough.py" $UPLOAD_SPEED
+	python "$PROJECT_DIR/python/esptool-3.0/esptool.py" --no-stub -b $UPLOAD_SPEED -c esp8266 --before no_reset --after soft_reset write_flash 0x0000 $SOURCE
 
 [env:DIY_2400_RX_ESP8285_SX1280_via_WIFI]
 extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART

--- a/src/targets/diy_900.ini
+++ b/src/targets/diy_900.ini
@@ -57,8 +57,8 @@ src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 extends = env:DIY_900_RX_ESP8285_SX127x_via_UART
 upload_protocol = custom
 upload_command =
-	python $PROJECT_DATA_DIR/../python/BFinitPassthrough.py $UPLOAD_SPEED
-	python $PROJECT_DATA_DIR/../python/esptool-3.0/esptool.py --no-stub -b $UPLOAD_SPEED -c esp8266 --before no_reset --after soft_reset write_flash 0x0000 $SOURCE
+	python "$PROJECT_DIR/python/BFinitPassthrough.py" $UPLOAD_SPEED
+	python "$PROJECT_DIR/python/esptool-3.0/esptool.py" --no-stub -b $UPLOAD_SPEED -c esp8266 --before no_reset --after soft_reset write_flash 0x0000 $SOURCE
 
 [env:DIY_900_RX_ESP8285_SX127x_via_WIFI]
 extends = env:DIY_900_RX_ESP8285_SX127x_via_UART

--- a/src/targets/neutronrc_900.ini
+++ b/src/targets/neutronrc_900.ini
@@ -21,8 +21,8 @@ src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 extends = env:NeutronRC_900_RX_via_UART
 upload_protocol = custom
 upload_command =
-	python $PROJECT_DATA_DIR/../python/BFinitPassthrough.py $UPLOAD_SPEED
-	python $PROJECT_DATA_DIR/../python/esptool-3.0/esptool.py --no-stub -b $UPLOAD_SPEED -c esp8266 --before no_reset --after soft_reset write_flash 0x0000 $SOURCE
+	python "$PROJECT_DIR/python/BFinitPassthrough.py" $UPLOAD_SPEED
+	python "$PROJECT_DIR/python/esptool-3.0/esptool.py" --no-stub -b $UPLOAD_SPEED -c esp8266 --before no_reset --after soft_reset write_flash 0x0000 $SOURCE
 
 [env:NeutronRC_900_RX_via_WIFI]
 extends = env:NeutronRC_900_RX_via_UART


### PR DESCRIPTION
Seems there is a problem with paths that have a space in the project directory, so we have to quote the paths for the upload commands. The problem with using the previous `PROJECT_DATA_DIR` is that there was no `data` directory and quoting the path caused then shell to have a problem so we have to use the `PROJECT_DIR` instead.