### PR TITLE
Add telemetry burst mode

### DIFF
--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -165,3 +165,19 @@ uint8_t ICACHE_RAM_ATTR TLMratioEnumToValue(expresslrs_tlm_ratio_e enumval)
         return 0;
     }
 }
+
+uint16_t RateEnumToHz(expresslrs_RFrates_e eRate)
+{
+    switch(eRate)
+    {
+    case RATE_500HZ: return 500;
+    case RATE_250HZ: return 250;
+    case RATE_200HZ: return 200;
+    case RATE_150HZ: return 150;
+    case RATE_100HZ: return 100;
+    case RATE_50HZ: return 50;
+    case RATE_25HZ: return 25;
+    case RATE_4HZ: return 4;
+    default: return 1;
+    }
+}

--- a/src/src/common.h
+++ b/src/src/common.h
@@ -122,6 +122,7 @@ expresslrs_mod_settings_s *get_elrs_airRateConfig(int8_t index);
 expresslrs_rf_pref_params_s *get_elrs_RFperfParams(int8_t index);
 
 uint8_t ICACHE_RAM_ATTR TLMratioEnumToValue(expresslrs_tlm_ratio_e enumval);
+uint16_t RateEnumToHz(expresslrs_RFrates_e eRate);
 
 extern expresslrs_mod_settings_s *ExpressLRS_currAirRate_Modparams;
 extern expresslrs_rf_pref_params_s *ExpressLRS_currAirRate_RFperfParams;
@@ -129,6 +130,7 @@ extern uint8_t ExpressLRS_nextAirRateIndex;
 //extern expresslrs_mod_settings_s *ExpressLRS_nextAirRate;
 //extern expresslrs_mod_settings_s *ExpressLRS_prevAirRate;
 uint8_t ICACHE_RAM_ATTR enumRatetoIndex(expresslrs_RFrates_e rate);
+
 
 #define AUX1 5
 #define AUX2 6


### PR DESCRIPTION
Using `ENABLE_TELEMETRY`, the advanced telemetry sender splits its air time evenly between `ELRS_TELEMETRY_TYPE_LINK` and `ELRS_TELEMETRY_TYPE_DATA` type packets (apart from magic unicorn ratio). At higher packet rates, this provides an over-abundance of LINK_STATISTICS packets, updating at RATE / ratio / 2 or as fast as every 8ms for 500Hz / 1:2 ratio.

Instead of a simple flip flop between the two packet types, this patch changes the behavior to target sending roughly 2x LINK_STATISTICS per second, regardless of the rate and ratio. All other packet slots are used to "burst" transfer telemetry. For example, 500Hz with a 1:4 ratio in the old system would send 128 telemetry packets in 1024ms with the composition being 64 LINK_STATISTICS and 64 DATA type. After the patch, the RX will send just 2 LINK_STATISTICS packets and 126 DATA packets. This provides a substantial increase in effective advanced telemetry bandwidth.

**Minimum Throughput** - This patch does not go below a 1-to-1 ratio of LINK packets to DATA packets. If the rate / ratio means that fewer than 2 telemetry packets would be sent per second, the code will keep the current 1:1 cadence.

**Magic Unicorn Ratio** - The current code also has a special case for the 1:16 ratio, which sends 2x DATA packets for every 1x LINK packet. This occurs regardless of rate, which can starve lower rates for lack of LINK packets. This code has been removed in favor of the more fair burst slot allocation scheme. This means this code has already been tested! :-D The only difference is when it is activated and how many packets are sent.

**1024ms in One Second** - Ok you got me, there aren't 1024ms in a second. 512ms was chosen as the interval for the LINK packet due to many rate+ratio combinations falling just short of a 500ms interval so the extra 12ms delay allows a majority of the burst counts to be increased by 1 for an unnoticeable difference. It is especially beneficial at lower? ...higher? ...slower ratios where you get the bump from 2 to 3, shown here for 500Hz:
```
500 / 1:128 => 1 vs 1
500 / 1:64  => 3 vs 2
500 / 1:32  => 7 vs 6
500 / 1:16  => 15 vs 14
500 / 1:8   => 31 vs 30
500 / 1:4   => 63 vs 61
500 / 1:2   => 127 vs 124
```

**IRAM_ATTR** - I was careful to not add any code that needs IRAM_ATTR. All calculations can be done during loop(), and only a flag indicating the value needs to change is set in ISRs. It is possible that the code would be interrupted mid-switch, but that would only use the wrong burst rate for one cycle, which isn't mission critical especially considering the rate was just changed, so the user would expect some settling.

Increased bandwidth - Burst shows how many DATA packets will be sent for every LINK packet, and BW is the change in effective advanced telemetry bandwidth.
```
Rate=500 Ratio=1:128 int=256 PPS=3.906 Burst=1 BW 78bps=>78bps
Rate=500 Ratio=1:64 int=128 PPS=7.812 Burst=3 BW 156bps=>234bps
Rate=500 Ratio=1:32 int=64 PPS=15.625 Burst=7 BW 312bps=>547bps
Rate=500 Ratio=1:16 int=32 PPS=31.250 Burst=15 BW 625bps=>1172bps
Rate=500 Ratio=1:8 int=16 PPS=62.500 Burst=31 BW 1250bps=>2422bps
Rate=500 Ratio=1:4 int=8 PPS=125.000 Burst=63 BW 2500bps=>4922bps
Rate=500 Ratio=1:2 int=4 PPS=250.000 Burst=127 BW 5000bps=>9922bps
Rate=250 Ratio=1:128 int=512 PPS=1.953 Burst=1 BW 39bps=>39bps
Rate=250 Ratio=1:64 int=256 PPS=3.906 Burst=1 BW 78bps=>78bps
Rate=250 Ratio=1:32 int=128 PPS=7.812 Burst=3 BW 156bps=>234bps
Rate=250 Ratio=1:16 int=64 PPS=15.625 Burst=7 BW 312bps=>547bps
Rate=250 Ratio=1:8 int=32 PPS=31.250 Burst=15 BW 625bps=>1172bps
Rate=250 Ratio=1:4 int=16 PPS=62.500 Burst=31 BW 1250bps=>2422bps
Rate=250 Ratio=1:2 int=8 PPS=125.000 Burst=63 BW 2500bps=>4922bps
Rate=200 Ratio=1:128 int=640 PPS=1.562 Burst=1 BW 31bps=>31bps
Rate=200 Ratio=1:64 int=320 PPS=3.125 Burst=1 BW 62bps=>62bps
Rate=200 Ratio=1:32 int=160 PPS=6.250 Burst=2 BW 125bps=>167bps
Rate=200 Ratio=1:16 int=80 PPS=12.500 Burst=5 BW 250bps=>417bps
Rate=200 Ratio=1:8 int=40 PPS=25.000 Burst=11 BW 500bps=>917bps
Rate=200 Ratio=1:4 int=20 PPS=50.000 Burst=24 BW 1000bps=>1920bps
Rate=200 Ratio=1:2 int=10 PPS=100.000 Burst=50 BW 2000bps=>3922bps
Rate=150 Ratio=1:128 int=853 PPS=1.172 Burst=1 BW 23bps=>23bps
Rate=150 Ratio=1:64 int=426 PPS=2.344 Burst=1 BW 47bps=>47bps
Rate=150 Ratio=1:32 int=213 PPS=4.688 Burst=1 BW 94bps=>94bps
Rate=150 Ratio=1:16 int=106 PPS=9.375 Burst=3 BW 188bps=>281bps
Rate=150 Ratio=1:8 int=53 PPS=18.750 Burst=8 BW 375bps=>667bps
Rate=150 Ratio=1:4 int=26 PPS=37.500 Burst=18 BW 750bps=>1421bps
Rate=150 Ratio=1:2 int=13 PPS=75.000 Burst=37 BW 1500bps=>2921bps
Rate=100 Ratio=1:128 int=1280 PPS=0.781 Burst=1 BW 16bps=>16bps
Rate=100 Ratio=1:64 int=640 PPS=1.562 Burst=1 BW 31bps=>31bps
Rate=100 Ratio=1:32 int=320 PPS=3.125 Burst=1 BW 62bps=>62bps
Rate=100 Ratio=1:16 int=160 PPS=6.250 Burst=2 BW 125bps=>167bps
Rate=100 Ratio=1:8 int=80 PPS=12.500 Burst=5 BW 250bps=>417bps
Rate=100 Ratio=1:4 int=40 PPS=25.000 Burst=11 BW 500bps=>917bps
Rate=100 Ratio=1:2 int=20 PPS=50.000 Burst=24 BW 1000bps=>1920bps
Rate=50 Ratio=1:128 int=2560 PPS=0.391 Burst=1 BW 8bps=>8bps
Rate=50 Ratio=1:64 int=1280 PPS=0.781 Burst=1 BW 16bps=>16bps
Rate=50 Ratio=1:32 int=640 PPS=1.562 Burst=1 BW 31bps=>31bps
Rate=50 Ratio=1:16 int=320 PPS=3.125 Burst=1 BW 62bps=>62bps
Rate=50 Ratio=1:8 int=160 PPS=6.250 Burst=2 BW 125bps=>167bps
Rate=50 Ratio=1:4 int=80 PPS=12.500 Burst=5 BW 250bps=>417bps
Rate=50 Ratio=1:2 int=40 PPS=25.000 Burst=11 BW 500bps=>917bps
Rate=25 Ratio=1:128 int=5120 PPS=0.195 Burst=1 BW 4bps=>4bps
Rate=25 Ratio=1:64 int=2560 PPS=0.391 Burst=1 BW 8bps=>8bps
Rate=25 Ratio=1:32 int=1280 PPS=0.781 Burst=1 BW 16bps=>16bps
Rate=25 Ratio=1:16 int=640 PPS=1.562 Burst=1 BW 31bps=>31bps
Rate=25 Ratio=1:8 int=320 PPS=3.125 Burst=1 BW 62bps=>62bps
Rate=25 Ratio=1:4 int=160 PPS=6.250 Burst=2 BW 125bps=>167bps
Rate=25 Ratio=1:2 int=80 PPS=12.500 Burst=5 BW 250bps=>417bps
```
Summarizing where improvements are seen:
* 500Hz - Any ratio above 1:128
* 250Hz - Any ratio above 1:64
* 200Hz - Any ratio above 1:64
* 150Hz - Any ratio above 1:32
* 100Hz - Any ratio above 1:32
* 50Hz - Any ratio above 1:16
* 25Hz - Any ratio above 1:8
 
This patch increases or maintains bandwidth across the board, except for 50Hz 1:16 and 25Hz 1:16, which were over-sending DATA packets and starving LINK packets