### PR TITLE
Change monitor baud rate to match TX debug rate

### DIFF
--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -7,7 +7,7 @@ framework = arduino
 extra_scripts =
 	pre:python/build_flags.py
 	python/build_env_setup.py
-monitor_speed = 420000
+monitor_speed = 460800
 monitor_dtr = 0
 monitor_rts = 0
 


### PR DESCRIPTION
`tx_main.cpp` initialises the debug UART on the TX at `460800` baud, which doesn't match the monitor rate specified in the `common.ini`. This means monitor doesn't work at the correct baud.