### PR TITLE
Use all frequencies in FHSS randomised array

### DIFF
--- a/src/lib/FHSS/FHSS.cpp
+++ b/src/lib/FHSS/FHSS.cpp
@@ -68,7 +68,7 @@ void FHSSrandomiseFHSSsequence(long seed)
     // The 0 index is special - the 'sync' channel. The sync channel appears every
     // syncInterval hops. The other channels are randomly distributed between the
     // sync channels
-    const int SYNC_INTERVAL = NR_FHSS_ENTRIES -1;
+    const int SYNC_INTERVAL = NR_FHSS_ENTRIES;
 
     int nLeft = NR_FHSS_ENTRIES - 1; // how many channels are left to be allocated. Does not include the sync channel
     unsigned int prev = 0;           // needed to prevent repeats of the same index

--- a/src/lib/FHSS/FHSS.h
+++ b/src/lib/FHSS/FHSS.h
@@ -273,14 +273,8 @@ static inline uint32_t GetInitialFreq()
     return FHSSfreqs[0] - FreqCorrection;
 }
 
-static inline uint32_t FHSSgetCurrFreq()
-{
-    return FHSSfreqs[FHSSsequence[FHSSptr]] - FreqCorrection;
-}
-
 static inline uint32_t FHSSgetNextFreq()
 {
-    FHSSptr++;
-    return FHSSgetCurrFreq();
+    return FHSSfreqs[FHSSsequence[FHSSptr++]] - FreqCorrection;
 }
 

--- a/src/test/fhss_native/test_fhss.cpp
+++ b/src/test/fhss_native/test_fhss.cpp
@@ -9,10 +9,9 @@ void test_fhss_assignment(void)
 
     uint32_t initFreq = GetInitialFreq();
 
-    FHSSptr=255;
     for (unsigned int i = 0; i < 256; i++) {
         uint32_t freq = FHSSgetNextFreq();
-        if (i%(NR_FHSS_ENTRIES-1) == 0) {
+        if (i%NR_FHSS_ENTRIES == 0) {
             TEST_ASSERT_EQUAL(initFreq, freq);
         } else {
             TEST_ASSERT_NOT_EQUAL(initFreq, freq);
@@ -28,7 +27,7 @@ void test_fhss_unique(void)
 
     for (unsigned int i = 0; i < 256; i++) {
         uint32_t freq = FHSSgetNextFreq();
-        if (i%NR_FHSS_ENTRIES-1 == 0) {
+        if (i%NR_FHSS_ENTRIES == 0) {
             freqs.clear();
             freqs.insert(freq);
         } else {


### PR DESCRIPTION
This PR fixes the off-by-one error in the FHSS randomisation function, so that all frequencies are used before cycling back to the "master" channel (channel 0).

The unit test has been updated to reflect the fix, and an unused function was also removed.

NB: This is a change that will require a re-flash of both the RX and TX