### PR TITLE
CRC Unit tests and proper fix for CRC13

### DIFF
--- a/src/lib/CRC/crc.cpp
+++ b/src/lib/CRC/crc.cpp
@@ -53,7 +53,7 @@ uint16_t ICACHE_RAM_ATTR GENERIC_CRC13::calc(uint8_t *data, uint8_t len, uint16_
 {
     while (len--)
     {
-        crc = (crc >> 8) ^ crc13tab[(crc ^ (uint16_t) *data++) & 0x00FF];
+        crc = (crc << 8) ^ crc13tab[((crc >> 5) ^ (uint16_t) *data++) & 0x00FF];
     }    
     return crc & 0x1FFF;
 }
@@ -62,7 +62,7 @@ uint16_t ICACHE_RAM_ATTR GENERIC_CRC13::calc(volatile uint8_t *data, uint8_t len
 {
     while (len--)
     {
-        crc = (crc >> 8) ^ crc13tab[(crc ^ (uint16_t) *data++) & 0x00FF];
+        crc = (crc << 8) ^ crc13tab[((crc >> 5) ^ (uint16_t) *data++) & 0x00FF];
     }
     return crc & 0x1FFF;
 }

--- a/src/test/crc_native/test_crc.cpp
+++ b/src/test/crc_native/test_crc.cpp
@@ -1,0 +1,27 @@
+#include <cstdint>
+#include <unity.h>
+#include "ucrc_t.h"
+#include <crc.h>
+
+
+void test_crc(void)
+{
+    uint8_t bytes[] = {45, 46, 47, 48, 49, 50, 51};
+
+    uCRC_t ccrc = uCRC_t("CRC13", 13, 0x3d2f, 0, false, false, 0);
+    uint64_t crc = ccrc.get_raw_crc(bytes, 7, 0);
+
+    GENERIC_CRC13 ecrc = GENERIC_CRC13(0x1d2f);
+    uint16_t c = ecrc.calc(bytes, 7, 0);
+
+    TEST_ASSERT_EQUAL((int)(crc & 0x1FFF), c);
+}
+
+int main(int argc, char **argv)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_crc);
+    UNITY_END();
+
+    return 0;
+}

--- a/src/test/crc_native/test_crc.cpp
+++ b/src/test/crc_native/test_crc.cpp
@@ -4,7 +4,7 @@
 #include <crc.h>
 
 
-void test_crc(void)
+void test_crc13(void)
 {
     uint8_t bytes[] = {45, 46, 47, 48, 49, 50, 51};
 
@@ -17,10 +17,25 @@ void test_crc(void)
     TEST_ASSERT_EQUAL((int)(crc & 0x1FFF), c);
 }
 
+void test_crc8(void)
+{
+    // Size of a CRSF
+    uint8_t bytes[] = {45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55};
+
+    uCRC_t ccrc = uCRC_t("CRC8", 8, 0x107, 0, false, false, 0);
+    uint64_t crc = ccrc.get_raw_crc(bytes, 7, 0);
+
+    GENERIC_CRC8 ecrc = GENERIC_CRC8(0x07);
+    uint16_t c = ecrc.calc(bytes, 7);
+
+    TEST_ASSERT_EQUAL((int)(crc & 0xFF), c);
+}
+
 int main(int argc, char **argv)
 {
     UNITY_BEGIN();
-    RUN_TEST(test_crc);
+    RUN_TEST(test_crc13);
+    RUN_TEST(test_crc8);
     UNITY_END();
 
     return 0;

--- a/src/test/crc_native/ucrc_t.cpp
+++ b/src/test/crc_native/ucrc_t.cpp
@@ -1,0 +1,224 @@
+/*
+ * ucrc_t.cpp
+ *
+ *
+ * version 1.3
+ *
+ *
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2015, Koynov Stas - skojnov@yandex.ru
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "ucrc_t.h"
+#include <cstdio>
+#include <errno.h>
+
+uCRC_t::uCRC_t(const std::string &Name, uint8_t Bits, uint64_t Poly, uint64_t Init, bool RefIn, bool RefOut, uint64_t XorOut) : name(Name),
+                                                                                                                                poly(Poly),
+                                                                                                                                init(Init),
+                                                                                                                                xor_out(XorOut),
+                                                                                                                                bits(Bits),
+                                                                                                                                ref_in(RefIn),
+                                                                                                                                ref_out(RefOut)
+{
+    init_class();
+}
+
+uCRC_t::uCRC_t(uint8_t Bits, uint64_t Poly, uint64_t Init, bool RefIn, bool RefOut, uint64_t XorOut) : poly(Poly),
+                                                                                                       init(Init),
+                                                                                                       xor_out(XorOut),
+                                                                                                       bits(Bits),
+                                                                                                       ref_in(RefIn),
+                                                                                                       ref_out(RefOut)
+{
+    init_class();
+}
+
+uint64_t uCRC_t::get_check() const
+{
+    const uint8_t data[] = {0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39};
+
+    return get_crc(data, sizeof(data));
+}
+
+int uCRC_t::set_bits(uint8_t new_value)
+{
+    if ((new_value < 1) || (new_value > 64))
+        return -1; //error
+
+    bits = new_value;
+    init_class();
+
+    return 0; //good job
+}
+
+uint64_t uCRC_t::get_crc(const void *data, size_t len) const
+{
+    uint64_t crc = get_raw_crc(data, len, crc_init);
+
+    return get_final_crc(crc);
+}
+
+int uCRC_t::get_crc(uint64_t &crc, const char *file_name) const
+{
+    char buf[4096];
+
+    return get_crc(crc, file_name, buf, sizeof(buf));
+}
+
+int uCRC_t::get_crc(uint64_t &crc, const char *file_name, void *buf, size_t size_buf) const
+{
+    std::ifstream ifs(file_name, std::ios_base::binary);
+
+    if (!ifs || !buf || !size_buf)
+    {
+        errno = EINVAL;
+        return -1;
+    }
+
+    return get_crc(crc, ifs, buf, size_buf);
+}
+
+int uCRC_t::get_crc(uint64_t &crc, std::ifstream &ifs, void *buf, size_t size_buf) const
+{
+    crc = crc_init;
+
+    while (ifs)
+    {
+        ifs.read(static_cast<char *>(buf), size_buf);
+        crc = get_raw_crc(buf, ifs.gcount(), crc);
+    }
+
+    crc = get_final_crc(crc);
+
+    return (ifs.rdstate() & std::ios_base::badbit); //return 0 if all good
+}
+
+uint64_t uCRC_t::get_raw_crc(const void *data, size_t len, uint64_t crc) const
+{
+    const uint8_t *buf = static_cast<const uint8_t *>(data);
+
+    if (bits > 8)
+    {
+        if (ref_in)
+            while (len--)
+                crc = (crc >> 8) ^ crc_table[(crc ^ *buf++) & 0xff];
+        else
+            while (len--)
+                crc = (crc << 8) ^ crc_table[((crc >> shift) ^ *buf++) & 0xff];
+    }
+    else
+    {
+        if (ref_in)
+            while (len--)
+                crc = crc_table[(crc ^ *buf++) & 0xff];
+        else
+            while (len--)
+                crc = crc_table[((crc << shift) ^ *buf++) & 0xff];
+    }
+
+    return crc;
+}
+
+uint64_t uCRC_t::get_final_crc(uint64_t raw_crc) const
+{
+    if (ref_out ^ ref_in)
+        raw_crc = reflect(raw_crc, bits);
+
+    raw_crc ^= xor_out;
+    raw_crc &= crc_mask; //for CRC not power 2
+
+    return raw_crc;
+}
+
+uint64_t uCRC_t::reflect(uint64_t data, uint8_t num_bits) const
+{
+    uint64_t reflection = 0;
+
+    while (num_bits--)
+    {
+        reflection = (reflection << 1) | (data & 1);
+        data >>= 1;
+    }
+
+    return reflection;
+}
+
+void uCRC_t::init_crc_table()
+{
+    //Calculation of the standard CRC table for byte.
+    for (int i = 0; i < 256; i++)
+    {
+
+        uint64_t crc = 0;
+
+        for (uint8_t mask = 0x80; mask; mask >>= 1)
+        {
+
+            if (i & mask)
+                crc ^= top_bit;
+
+            if (crc & top_bit)
+            {
+                crc <<= 1;
+                crc ^= poly;
+            }
+            else
+                crc <<= 1;
+        }
+
+        crc &= crc_mask; //for CRC not power 2
+
+        if (ref_in)
+            crc_table[reflect(i, 8)] = reflect(crc, bits);
+        else
+            crc_table[i] = crc;
+    }
+}
+
+void uCRC_t::init_class()
+{
+    top_bit = (uint64_t)1 << (bits - 1);
+    crc_mask = ((top_bit - 1) << 1) | 1;
+
+    if (bits > 8)
+        shift = (bits - 8);
+    else
+        shift = (8 - bits);
+
+    if (ref_in)
+        crc_init = reflect(init, bits);
+    else
+        crc_init = init;
+
+    init_crc_table();
+}

--- a/src/test/crc_native/ucrc_t.h
+++ b/src/test/crc_native/ucrc_t.h
@@ -1,0 +1,136 @@
+/*
+ * ucrc_t.h
+ *
+ *
+ * version 1.3
+ *
+ *
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2015, Koynov Stas - skojnov@yandex.ru
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ * more details see https://github.com/KoynovStas/uCRC_t
+ *
+ */
+
+#ifndef UCRC_T_H
+#define UCRC_T_H
+
+#include <stdint.h>
+#include <string>
+#include <fstream> // for std::ifstream
+#include <ios>     // for std::ios_base, etc.
+
+class uCRC_t
+{
+
+public:
+    explicit uCRC_t(const std::string &Name = "CRC-32",
+                    uint8_t Bits = 32,
+                    uint64_t Poly = 0x04c11db7,
+                    uint64_t Init = 0xffffffff,
+                    bool RefIn = true,
+                    bool RefOut = true,
+                    uint64_t XorOut = 0xffffffff);
+
+    explicit uCRC_t(uint8_t Bits,
+                    uint64_t Poly,
+                    uint64_t Init,
+                    bool RefIn,
+                    bool RefOut,
+                    uint64_t XorOut);
+
+    std::string name;
+
+    // get param CRC
+    uint8_t get_bits() const { return bits; }
+    uint64_t get_poly() const { return poly; }
+    uint64_t get_init() const { return init; }
+    uint64_t get_xor_out() const { return xor_out; }
+    bool get_ref_in() const { return ref_in; }
+    bool get_ref_out() const { return ref_out; }
+
+    uint64_t get_crc_init() const { return crc_init; } //crc_init = reflect(init, bits) if RefIn, else = init
+    uint64_t get_top_bit() const { return top_bit; }
+    uint64_t get_crc_mask() const { return crc_mask; }
+    uint64_t get_check() const; //crc for ASCII string "123456789" (i.e. 313233... (hexadecimal)).
+
+    // set param CRC
+    int set_bits(uint8_t new_value);
+    void set_poly(uint64_t new_value)
+    {
+        poly = new_value;
+        init_class();
+    }
+    void set_init(uint64_t new_value)
+    {
+        init = new_value;
+        init_class();
+    }
+    void set_ref_in(bool new_value)
+    {
+        ref_in = new_value;
+        init_class();
+    }
+    void set_ref_out(bool new_value) { ref_out = new_value; }
+    void set_xor_out(uint64_t new_value) { xor_out = new_value; }
+
+    // Calculate methods
+    uint64_t get_crc(const void *data, size_t len) const;
+    int get_crc(uint64_t &crc, const char *file_name) const;
+    int get_crc(uint64_t &crc, const char *file_name, void *buf, size_t size_buf) const;
+
+    // Calculate for chunks of data
+    uint64_t get_raw_crc(const void *data, size_t len, uint64_t crc) const; //for first byte crc = crc_init (must be)
+    uint64_t get_final_crc(uint64_t raw_crc) const;
+
+private:
+    uint64_t poly;
+    uint64_t init;
+    uint64_t xor_out;
+    uint64_t crc_init; //crc_init = reflect(init, bits) if RefIn, else = init
+    uint64_t top_bit;
+    uint64_t crc_mask;
+    uint64_t crc_table[256];
+
+    uint8_t bits;
+    uint8_t shift;
+    bool ref_in;
+    bool ref_out;
+
+    uint64_t reflect(uint64_t data, uint8_t num_bits) const;
+    void init_crc_table();
+    void init_class();
+
+    int get_crc(uint64_t &crc, std::ifstream &ifs, void *buf, size_t size_buf) const;
+};
+
+#endif // UCRC_T_H


### PR DESCRIPTION
Added a more complete implementation of CRC1-64 in a unit test so we can verify the CRC8 and CRC13 implementations used in the code proper.

Made fixes to CRC13 after the test showed that the output was not correct.