### PR TITLE
Extend CRC test to use random data

### DIFF
--- a/src/src/common.h
+++ b/src/src/common.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#ifndef UNIT_TEST
+
 #include "FHSS.h"
 
 #if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
@@ -9,6 +11,8 @@
 #if defined(Regulatory_Domain_ISM_2400)
 #include "SX1280Driver.h"
 #endif
+
+#endif // UNIT_TEST
 
 extern uint8_t BindingUID[6];
 extern uint8_t UID[6];
@@ -80,6 +84,8 @@ typedef struct expresslrs_rf_pref_params_s
 
 } expresslrs_rf_pref_params_s;
 
+#ifndef UNIT_TEST
+
 #if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
 #define RATE_MAX 4
 #define RATE_DEFAULT 0
@@ -118,6 +124,7 @@ typedef struct expresslrs_mod_settings_s
 
 #endif
 
+
 expresslrs_mod_settings_s *get_elrs_airRateConfig(int8_t index);
 expresslrs_rf_pref_params_s *get_elrs_RFperfParams(int8_t index);
 
@@ -131,6 +138,7 @@ extern uint8_t ExpressLRS_nextAirRateIndex;
 //extern expresslrs_mod_settings_s *ExpressLRS_prevAirRate;
 uint8_t ICACHE_RAM_ATTR enumRatetoIndex(expresslrs_RFrates_e rate);
 
+#endif // UNIT_TEST
 
 #define AUX1 5
 #define AUX2 6

--- a/src/test/crc_native/test_crc.cpp
+++ b/src/test/crc_native/test_crc.cpp
@@ -41,13 +41,14 @@ void test_crc13_implementation_compatibility(void)
 // This test will fail as 6 bits is over our HD fro CRC13
 void test_crc13_flip6(void)
 {
+    GENERIC_CRC13 ccrc = GENERIC_CRC13(ELRS_CRC13_POLY);
+
     for (int x=0 ; x<1000 ; x++) {
         uint8_t bytes[7];
         for (int i = 0; i < sizeof(bytes); i++)
             bytes[i] = random() % 255;
         bytes[0] &= 0b11;
 
-        GENERIC_CRC13 ccrc = GENERIC_CRC13(ELRS_CRC13_POLY);
         uint16_t c = ccrc.calc(bytes, 7, 0);
 
         // Flip 5 random bits
@@ -56,9 +57,7 @@ void test_crc13_flip6(void)
             bytes[pos/8] ^= 1 << (pos % 8);
         }
 
-        GENERIC_CRC13 ecrc = GENERIC_CRC13(ELRS_CRC13_POLY);
-        uint16_t e = ecrc.calc(bytes, 7, 0);
-
+        uint16_t e = ccrc.calc(bytes, 7, 0);
         TEST_ASSERT_NOT_EQUAL_MESSAGE(c, e, genMsg(bytes, sizeof(bytes)));
 
         // Flip all the bits one after the other
@@ -69,9 +68,7 @@ void test_crc13_flip6(void)
                 pos += 6;
             bytes[pos / 8] ^= 1 << (pos % 8);
 
-            GENERIC_CRC13 ecrc = GENERIC_CRC13(ELRS_CRC13_POLY);
-            uint16_t e = ecrc.calc(bytes, 7, 0);
-
+            uint16_t e = ccrc.calc(bytes, 7, 0);
             if (c == e)
             {
                 fprintf(stderr, "False +ve %s\n", genMsg(bytes, sizeof(bytes)));
@@ -85,6 +82,8 @@ void test_crc13_flip6(void)
 
 void test_crc13_flip5(void)
 {
+    GENERIC_CRC13 ccrc = GENERIC_CRC13(ELRS_CRC13_POLY);
+
     for (int x = 0; x < NUM_ITERATIONS; x++)
     {
         uint8_t bytes[7];
@@ -92,7 +91,6 @@ void test_crc13_flip5(void)
             bytes[i] = random() % 255;
         bytes[0] &= 0b11;
 
-        GENERIC_CRC13 ccrc = GENERIC_CRC13(ELRS_CRC13_POLY);
         uint16_t c = ccrc.calc(bytes, 7, 0);
 
         // Flip 4 random bits
@@ -113,9 +111,7 @@ void test_crc13_flip5(void)
                 pos += 6;
             bytes[pos / 8] ^= 1 << (pos % 8);
 
-            GENERIC_CRC13 ecrc = GENERIC_CRC13(0x1d2f);
-            uint16_t e = ecrc.calc(bytes, 7, 0);
-
+            uint16_t e = ccrc.calc(bytes, 7, 0);
             if (c == e)
             {
                 fprintf(stderr, "False +ve %s\n", genMsg(bytes, sizeof(bytes)));

--- a/src/test/crc_native/test_crc.cpp
+++ b/src/test/crc_native/test_crc.cpp
@@ -22,7 +22,36 @@ void test_crc13(void)
         sprintf(hex, "%02x ", bytes[i]);
         strcat(buf, hex);
     }
-    TEST_ASSERT_EQUAL_INT_MESSAGE((int)(crc & 0x1FFF), c, buf);
+    TEST_ASSERT_EQUAL_MESSAGE((int)(crc & 0x1FFF), c, buf);
+}
+
+void test_crc13_flip6(void)
+{
+    uint8_t bytes[7];
+    for (int i = 0; i < sizeof(bytes); i++)
+        bytes[i] = random() % 255;
+
+    GENERIC_CRC13 ccrc = GENERIC_CRC13(0x1d2f);
+    uint16_t c = ccrc.calc(bytes, 7, 0);
+
+    // Flip 6 random bits
+    for (int i=0 ; i<6 ; i++) {
+        int pos = random() % 52;
+        bytes[pos/8] ^= 1 << (pos % 8);
+    }
+
+    GENERIC_CRC13 ecrc = GENERIC_CRC13(0x1d2f);
+    uint16_t e = ecrc.calc(bytes, 7, 0);
+
+    char buf[80];
+    char hex[4];
+    sprintf(buf, "bytes ");
+    for (int i = 0; i < sizeof(bytes); i++)
+    {
+        sprintf(hex, "%02x ", bytes[i]);
+        strcat(buf, hex);
+    }
+    TEST_ASSERT_NOT_EQUAL_MESSAGE(c, e, buf);
 }
 
 void test_crc8(void)
@@ -46,13 +75,14 @@ void test_crc8(void)
         sprintf(hex, "%02x ", bytes[i]);
         strcat(buf, hex);
     }
-    TEST_ASSERT_EQUAL_INT_MESSAGE((int)(crc & 0xFF), c, buf);
+    TEST_ASSERT_EQUAL_MESSAGE((int)(crc & 0xFF), c, buf);
 }
 
 int main(int argc, char **argv)
 {
     UNITY_BEGIN();
     RUN_TEST(test_crc13);
+    RUN_TEST(test_crc13_flip6);
     RUN_TEST(test_crc8);
     UNITY_END();
 

--- a/src/test/crc_native/test_crc.cpp
+++ b/src/test/crc_native/test_crc.cpp
@@ -3,10 +3,11 @@
 #include "ucrc_t.h"
 #include <crc.h>
 
-
 void test_crc13(void)
 {
-    uint8_t bytes[] = {45, 46, 47, 48, 49, 50, 51};
+    uint8_t bytes[7];
+    for (int i = 0; i < sizeof(bytes); i++)
+        bytes[i] = random() % 255;
 
     uCRC_t ccrc = uCRC_t("CRC13", 13, 0x3d2f, 0, false, false, 0);
     uint64_t crc = ccrc.get_raw_crc(bytes, 7, 0);
@@ -14,13 +15,22 @@ void test_crc13(void)
     GENERIC_CRC13 ecrc = GENERIC_CRC13(0x1d2f);
     uint16_t c = ecrc.calc(bytes, 7, 0);
 
-    TEST_ASSERT_EQUAL((int)(crc & 0x1FFF), c);
+    char buf[80];
+    char hex[4];
+    sprintf(buf, "bytes ");
+    for (int i=0 ; i<sizeof(bytes) ; i++) {
+        sprintf(hex, "%02x ", bytes[i]);
+        strcat(buf, hex);
+    }
+    TEST_ASSERT_EQUAL_INT_MESSAGE((int)(crc & 0x1FFF), c, buf);
 }
 
 void test_crc8(void)
 {
-    // Size of a CRSF
-    uint8_t bytes[] = {45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55};
+    // Size of a CRSF packet
+    uint8_t bytes[11];
+    for (int i = 0; i < sizeof(bytes); i++)
+        bytes[i] = random() % 255;
 
     uCRC_t ccrc = uCRC_t("CRC8", 8, 0x107, 0, false, false, 0);
     uint64_t crc = ccrc.get_raw_crc(bytes, 7, 0);
@@ -28,7 +38,15 @@ void test_crc8(void)
     GENERIC_CRC8 ecrc = GENERIC_CRC8(0x07);
     uint16_t c = ecrc.calc(bytes, 7);
 
-    TEST_ASSERT_EQUAL((int)(crc & 0xFF), c);
+    char buf[80];
+    char hex[4];
+    sprintf(buf, "bytes ");
+    for (int i = 0; i < sizeof(bytes); i++)
+    {
+        sprintf(hex, "%02x ", bytes[i]);
+        strcat(buf, hex);
+    }
+    TEST_ASSERT_EQUAL_INT_MESSAGE((int)(crc & 0xFF), c, buf);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
Use random data when testing the CRC routines.
If they fail it will print the bytes used for calculating this CRC so we can fix if needed.
I have run this in a loop for 1 million times without any errors in the CRC code. I think we're good 😄 
