### PR TITLE
Properly process success/failure for _via_STLINK uploads

### DIFF
--- a/src/python/stlink.py
+++ b/src/python/stlink.py
@@ -65,11 +65,14 @@ def on_upload(source, target, env):
 
     BL_CMD, APP_CMD = get_commands(env, firmware_path)
 
+    retval = 0
     # flash bootloader
     if BL_CMD:
         print("Cmd: {}".format(BL_CMD))
-        env.Execute(BL_CMD)
+        retval = env.Execute(BL_CMD)
     # flash application
-    if APP_CMD:
+    if retval == 0 and APP_CMD:
         print("Cmd: {}".format(APP_CMD))
-        env.Execute(APP_CMD)
+        retval = env.Execute(APP_CMD)
+    return retval
+


### PR DESCRIPTION
When uploading via STLINK, the upload process always reports SUCCESS, which is great except sometimes it actually fails. jurgelenas reported this in #445, so this fixes that, and thanks to him for reporting.

I'm not sure if there any negative errno values that come out of STLINK-CLI, but a successful flash is 0 and "No target detected" and "No STLINK detected" is errno=2 and this catches those.