### PR TITLE
Add developer defines

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -7,3 +7,4 @@
 python/__pycache__/
 *.pyc
 user_defines.txt
+developer_defines.txt

--- a/src/python/build_flags.py
+++ b/src/python/build_flags.py
@@ -64,7 +64,13 @@ def parse_flags(path):
     except IOError:
         print("File '%s' does not exist" % path)
 
-parse_flags("user_defines.txt")
+developer_defines_filename = "developer_defines.txt"
+user_defines_filename = "user_defines.txt"
+if os.path.isfile(developer_defines_filename):
+    configuration_filename = developer_defines_filename
+else:
+    configuration_filename = user_defines_filename
+parse_flags(configuration_filename)
 
 print("build flags: %s" % env['BUILD_FLAGS'])
 


### PR DESCRIPTION
When developing, the user_defines.txt must be modified with user-specifics to test. This can be annoying since we do not want to push those changes to the repo. This merge allows developers to create a copy of the user_defines.txt file, named developer_defines.txt, which is also in the .gitignore so it will never be accidentally added to a commit and won't annoy people by being in the list of modified files.