### PR TITLE
adds crcr14

### DIFF
--- a/src/lib/CRC/crc.cpp
+++ b/src/lib/CRC/crc.cpp
@@ -35,54 +35,34 @@ uint8_t ICACHE_RAM_ATTR GENERIC_CRC8::calc(volatile uint8_t *data, uint8_t len)
     return crc;
 }
 
-GENERIC_CRC13::GENERIC_CRC13(uint16_t poly)
+GENERIC_CRC14::GENERIC_CRC14(uint16_t poly)
 {
     uint16_t crc;
     for (uint16_t i = 0; i < crclen; i++)
     {
-        crc = i << (13 - 8);
+        crc = i << (14 - 8);
         for (uint8_t j = 0; j < 8; j++)
         {
-            crc = (crc << 1) ^ ((crc & 0x1000) ? poly : 0);
+            crc = (crc << 1) ^ ((crc & 0x2000) ? poly : 0);
         }
-        crc13tab[i] = crc;
+        crc14tab[i] = crc;
     }
 }
 
-uint16_t ICACHE_RAM_ATTR GENERIC_CRC13::calc(uint8_t *data, uint8_t len, uint16_t crc)
+uint16_t ICACHE_RAM_ATTR GENERIC_CRC14::calc(uint8_t *data, uint8_t len, uint16_t crc)
 {
     while (len--)
     {
-        crc = (crc << 8) ^ crc13tab[((crc >> 5) ^ (uint16_t) *data++) & 0x00FF];
+        crc = (crc << 8) ^ crc14tab[((crc >> 6) ^ (uint16_t) *data++) & 0x00FF];
     }    
-    return crc & 0x1FFF;
+    return crc & 0x3FFF;
 }
 
-uint16_t ICACHE_RAM_ATTR GENERIC_CRC13::calc(volatile uint8_t *data, uint8_t len, uint16_t crc)
+uint16_t ICACHE_RAM_ATTR GENERIC_CRC14::calc(volatile uint8_t *data, uint8_t len, uint16_t crc)
 {
     while (len--)
     {
-        crc = (crc << 8) ^ crc13tab[((crc >> 5) ^ (uint16_t) *data++) & 0x00FF];
+        crc = (crc << 8) ^ crc14tab[((crc >> 6) ^ (uint16_t) *data++) & 0x00FF];
     }
-    return crc & 0x1FFF;
-}
-
-uint8_t ICACHE_RAM_ATTR getParity(uint8_t *data, uint8_t len)
-{
-    uint8_t parity = 0;
-    while (len--)
-    {
-        parity ^= __builtin_parity(*data++);
-    }
-    return parity;
-}
-
-uint8_t ICACHE_RAM_ATTR getParity(volatile uint8_t *data, uint8_t len)
-{
-    uint8_t parity = 0;
-    while (len--)
-    {
-        parity ^= __builtin_parity(*data++);
-    }
-    return parity;
+    return crc & 0x3FFF;
 }

--- a/src/lib/CRC/crc.h
+++ b/src/lib/CRC/crc.h
@@ -16,17 +16,14 @@ public:
     uint8_t calc(volatile uint8_t *data, uint8_t len);
 };
 
-class GENERIC_CRC13
+class GENERIC_CRC14
 {
 private:
-    uint16_t crc13tab[crclen];
+    uint16_t crc14tab[crclen];
     uint16_t crcpoly;
 
 public:
-    GENERIC_CRC13(uint16_t poly);
+    GENERIC_CRC14(uint16_t poly);
     uint16_t calc(uint8_t *data, uint8_t len, uint16_t crc);
     uint16_t calc(volatile uint8_t *data, uint8_t len, uint16_t crc);
 };
-
-uint8_t getParity(uint8_t *data, uint8_t len);
-uint8_t getParity(volatile uint8_t *data, uint8_t len);

--- a/src/src/common.h
+++ b/src/src/common.h
@@ -152,4 +152,4 @@ uint8_t ICACHE_RAM_ATTR enumRatetoIndex(expresslrs_RFrates_e rate);
 //ELRS SPECIFIC OTA CRC
 //Koopman formatting https://users.ece.cmu.edu/~koopman/crc/
 #define ELRS_CRC_POLY 0x07 // 0x83
-#define ELRS_CRC13_POLY 0x1D2F // 0x1E97
+#define ELRS_CRC14_POLY 0x2E57 // 0x372B

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -64,7 +64,7 @@ const uint8_t thisCommit[6] = {LATEST_COMMIT};
 
 /// define some libs to use ///
 hwTimer hwTimer;
-GENERIC_CRC13 ota_crc(ELRS_CRC13_POLY);
+GENERIC_CRC14 ota_crc(ELRS_CRC14_POLY);
 CRSF crsf;
 POWERMGNT POWERMGNT;
 MSP msp;
@@ -119,15 +119,7 @@ uint8_t baseMac[6];
 
 void ICACHE_RAM_ATTR ProcessTLMpacket()
 {
-  if (getParity(Radio.RXdataBuffer, 8))
-  {
-      #ifndef DEBUG_SUPPRESS
-      Serial.println("Parity error on RF packet");
-      #endif
-      return;
-  }
-
-  uint16_t inCRC = (((uint16_t)Radio.RXdataBuffer[0] & 0b11111000) << 5) | Radio.RXdataBuffer[7];
+  uint16_t inCRC = (((uint16_t)Radio.RXdataBuffer[0] & 0b11111100) << 6) | Radio.RXdataBuffer[7];
   
   Radio.RXdataBuffer[0] &= 0b11;
   uint16_t calculatedCRC = ota_crc.calc(Radio.RXdataBuffer, 7, CRCInitializer);
@@ -324,13 +316,8 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
 
   ///// Next, Calculate the CRC and put it into the buffer /////
   uint16_t crc = ota_crc.calc(Radio.TXdataBuffer, 7, CRCInitializer);
-  Radio.TXdataBuffer[0] |= (crc >> 5) & 0b11111000;
+  Radio.TXdataBuffer[0] |= (crc >> 6) & 0b11111100;
   Radio.TXdataBuffer[7] = crc & 0xFF;
-
-  if (getParity(Radio.TXdataBuffer, 8))
-  {
-    Radio.TXdataBuffer[0] |= 0b00000100;
-  }
 
   Radio.TXnb(Radio.TXdataBuffer, 8);
 }


### PR DESCRIPTION
@pkendall64 identified with testing that the crc already contains parity.  So we can replace the crc13 with a crc14.  It has the same HD but the percentage of false positives for packets with 6, 8, etc flipped bits decrease by nearly an order of magnitude.

https://discord.com/channels/596350022191415318/733424557636976692/833524818941837322