### PR TITLE
Spam sync packets on rf param change

### DIFF
--- a/src/lib/HWTIMER/STM32_hwTimer.h
+++ b/src/lib/HWTIMER/STM32_hwTimer.h
@@ -15,11 +15,15 @@ public:
     static volatile bool isTick;
     static volatile int32_t PhaseShift;
     static volatile int32_t FreqOffset;
+    static volatile uint32_t PauseDuration;
     static bool running;
+    static bool isPaused;
+    static bool PauseReq;
     static bool alreadyInit;
 
     static void init();
     static void stop();
+    static void pause(uint32_t duration);
     static void resume();
     static void callback(void);
     static void updateInterval(uint32_t newTimerInterval);
@@ -29,6 +33,7 @@ public:
     static void phaseShift(int32_t newPhaseShift);
 
     static void inline nullCallback(void);
+    static void PauseDoneCallback(void);
     static void (*callbackTick)();
     static void (*callbackTock)();
 };

--- a/src/lib/HWTIMER/STM32_hwTimer.h
+++ b/src/lib/HWTIMER/STM32_hwTimer.h
@@ -17,8 +17,6 @@ public:
     static volatile int32_t FreqOffset;
     static volatile uint32_t PauseDuration;
     static bool running;
-    static bool isPaused;
-    static bool PauseReq;
     static bool alreadyInit;
 
     static void init();
@@ -33,7 +31,6 @@ public:
     static void phaseShift(int32_t newPhaseShift);
 
     static void inline nullCallback(void);
-    static void PauseDoneCallback(void);
     static void (*callbackTick)();
     static void (*callbackTock)();
 };

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -71,6 +71,7 @@ void POWERMGNT::init()
     pinMode(GPIO_PIN_RF_AMP_EN, OUTPUT);
     digitalWrite(GPIO_PIN_RF_AMP_EN, HIGH);
 #endif
+    CurrentPower = PWR_COUNT;
 }
 
 void POWERMGNT::setDefaultPower()
@@ -80,6 +81,9 @@ void POWERMGNT::setDefaultPower()
 
 PowerLevels_e POWERMGNT::setPower(PowerLevels_e Power)
 {
+    if (Power == CurrentPower)
+        return CurrentPower;
+
     if (Power > MaxPower)
     {
         Power = (PowerLevels_e)MaxPower;

--- a/src/lib/POWERMGNT/POWERMGNT.h
+++ b/src/lib/POWERMGNT/POWERMGNT.h
@@ -62,8 +62,8 @@ typedef enum
     PWR_250mW = 4,
     PWR_500mW = 5,
     PWR_1000mW = 6,
-    PWR_2000mW = 7
-
+    PWR_2000mW = 7,
+    PWR_COUNT = 8
 } PowerLevels_e;
 
 class POWERMGNT

--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -14,8 +14,8 @@ expresslrs_mod_settings_s ExpressLRS_AirRateConfig[RATE_MAX] = {
 expresslrs_rf_pref_params_s ExpressLRS_AirRateRFperf[RATE_MAX] = {
     {0, RATE_200HZ, -112, 4380, 3500, 2500, 2000, 5000},
     {1, RATE_100HZ, -117, 8770, 3500, 2500, 2000, 5000},
-    {2, RATE_50HZ, -120, 17540, 3500, 2500, 2000, 5000},
-    {3, RATE_25HZ, -123, 17540, 3500, 4000, 2000, 5000}};
+    {2, RATE_50HZ, -120, 17540, 5000, 2500, 2000, 5000},
+    {3, RATE_25HZ, -123, 17540, 5000, 4000, 2000, 5000}};
 #endif
 
 #if defined(Regulatory_Domain_ISM_2400)
@@ -34,7 +34,7 @@ expresslrs_rf_pref_params_s ExpressLRS_AirRateRFperf[RATE_MAX] = {
     {0, RATE_500HZ, -105, 4380, 3500, 1000, 2000, 5000},
     {1, RATE_250HZ, -108, 4380, 3500, 2500, 2000, 5000},
     {2, RATE_150HZ, -112, 8770, 3500, 2500, 2000, 5000},
-    {3, RATE_50HZ, -117, 17540, 3500, 2500, 2000, 5000}};
+    {3, RATE_50HZ, -117, 17540, 5000, 2500, 2000, 5000}};
 #else
 expresslrs_mod_settings_s ExpressLRS_AirRateConfig[RATE_MAX] = {
     {0, RATE_250HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF6, SX1280_LORA_CR_LI_4_7, 4000, TLM_RATIO_1_64, 4, 14},
@@ -45,8 +45,8 @@ expresslrs_mod_settings_s ExpressLRS_AirRateConfig[RATE_MAX] = {
 expresslrs_rf_pref_params_s ExpressLRS_AirRateRFperf[RATE_MAX] = {
     {0, RATE_250HZ, -108, 4380, 3500, 2500, 2000, 5000},
     {1, RATE_150HZ, -112, 8770, 3500, 2500, 2000, 5000},
-    {2, RATE_50HZ, -117, 17540, 3500, 2500, 2000, 5000},
-    {3, RATE_25HZ, -120, 36886, 3500, 4000, 2000, 5000}};
+    {2, RATE_50HZ, -117, 17540, 5000, 2500, 2000, 5000},
+    {3, RATE_25HZ, -120, 36886, 5000, 4000, 2000, 5000}};
 #endif
 
 #endif
@@ -104,6 +104,9 @@ ICACHE_RAM_ATTR uint8_t enumRatetoIndex(expresslrs_RFrates_e rate)
 
 expresslrs_mod_settings_s *ExpressLRS_currAirRate_Modparams;
 expresslrs_rf_pref_params_s *ExpressLRS_currAirRate_RFperfParams;
+
+expresslrs_mod_settings_s *ExpressLRS_nextAirRate_Modparams;
+expresslrs_rf_pref_params_s *ExpressLRS_nextAirRate_RFperfParams;
 
 uint8_t ExpressLRS_nextAirRateIndex = 0;
 

--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -105,9 +105,6 @@ ICACHE_RAM_ATTR uint8_t enumRatetoIndex(expresslrs_RFrates_e rate)
 expresslrs_mod_settings_s *ExpressLRS_currAirRate_Modparams;
 expresslrs_rf_pref_params_s *ExpressLRS_currAirRate_RFperfParams;
 
-expresslrs_mod_settings_s *ExpressLRS_nextAirRate_Modparams;
-expresslrs_rf_pref_params_s *ExpressLRS_nextAirRate_RFperfParams;
-
 uint8_t ExpressLRS_nextAirRateIndex = 0;
 
 connectionState_e connectionState = disconnected;

--- a/src/src/common.h
+++ b/src/src/common.h
@@ -133,8 +133,6 @@ uint16_t RateEnumToHz(expresslrs_RFrates_e eRate);
 
 extern expresslrs_mod_settings_s *ExpressLRS_currAirRate_Modparams;
 extern expresslrs_rf_pref_params_s *ExpressLRS_currAirRate_RFperfParams;
-extern expresslrs_mod_settings_s *ExpressLRS_nextAirRate_Modparams;
-extern expresslrs_rf_pref_params_s *ExpressLRS_nextAirRate_RFperfParams;
 extern uint8_t ExpressLRS_nextAirRateIndex;
 //extern expresslrs_mod_settings_s *ExpressLRS_nextAirRate;
 //extern expresslrs_mod_settings_s *ExpressLRS_prevAirRate;

--- a/src/src/common.h
+++ b/src/src/common.h
@@ -133,6 +133,8 @@ uint16_t RateEnumToHz(expresslrs_RFrates_e eRate);
 
 extern expresslrs_mod_settings_s *ExpressLRS_currAirRate_Modparams;
 extern expresslrs_rf_pref_params_s *ExpressLRS_currAirRate_RFperfParams;
+extern expresslrs_mod_settings_s *ExpressLRS_nextAirRate_Modparams;
+extern expresslrs_rf_pref_params_s *ExpressLRS_nextAirRate_RFperfParams;
 extern uint8_t ExpressLRS_nextAirRateIndex;
 //extern expresslrs_mod_settings_s *ExpressLRS_nextAirRate;
 //extern expresslrs_mod_settings_s *ExpressLRS_prevAirRate;

--- a/src/src/config.cpp
+++ b/src/src/config.cpp
@@ -35,31 +35,6 @@ TxConfig::Commit()
     m_modified = false;
 }
 
-// Getters
-uint32_t
-TxConfig::GetRate()
-{
-    return m_config.rate;
-}
-
-uint32_t
-TxConfig::GetTlm()
-{
-    return m_config.tlm;
-}
-
-uint32_t
-TxConfig::GetPower()
-{
-    return m_config.power;
-}
-
-bool
-TxConfig::IsModified()
-{
-    return m_modified;
-}
-
 // Setters
 void
 TxConfig::SetRate(uint32_t rate)
@@ -144,35 +119,6 @@ RxConfig::Commit()
     m_eeprom->Commit();
 
     m_modified = false;
-}
-
-// Getters
-bool
-RxConfig::GetIsBound()
-{
-    #ifdef MY_UID
-        return true;
-    #else
-        return m_config.isBound;
-    #endif
-}
-
-uint8_t*
-RxConfig::GetUID()
-{
-    return m_config.uid;
-}
-
-uint8_t
-RxConfig::GetPowerOnCounter()
-{
-    return m_config.powerOnCounter;
-}
-
-bool
-RxConfig::IsModified()
-{
-    return m_modified;
 }
 
 // Setters

--- a/src/src/config.h
+++ b/src/src/config.h
@@ -21,10 +21,10 @@ public:
     void Commit();
 
     // Getters
-    uint32_t GetRate();
-    uint32_t GetTlm();
-    uint32_t GetPower();
-    bool     IsModified();
+    uint32_t GetRate() const { return m_config.rate; }
+    uint32_t GetTlm() const { return m_config.tlm; }
+    uint32_t GetPower() const { return m_config.power; }
+    bool     IsModified() const { return m_modified; }
 
     // Setters
     void SetRate(uint32_t rate);
@@ -55,10 +55,16 @@ public:
     void Commit();
 
     // Getters
-    bool     GetIsBound();
-    uint8_t* GetUID();
-    uint8_t  GetPowerOnCounter();
-    bool     IsModified();
+    bool     GetIsBound() const {
+        #ifdef MY_UID
+            return true;
+        #else
+            return m_config.isBound;
+        #endif
+    }
+    const uint8_t* GetUID() const { return m_config.uid; }
+    uint8_t  GetPowerOnCounter() const { return m_config.powerOnCounter; }
+    bool     IsModified() const { return m_modified; }
 
     // Setters
     void SetIsBound(bool isBound);

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -897,7 +897,7 @@ static void setupBindingFromConfig()
     if (config.GetIsBound())
     {
         Serial.println("RX has been bound previously, reading the UID from eeprom...");
-        uint8_t* storedUID = config.GetUID();
+        const uint8_t* storedUID = config.GetUID();
         for (uint8_t i = 0; i < UID_LEN; ++i)
         {
             UID[i] = storedUID[i];

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1108,7 +1108,7 @@ void loop()
         RFmodeLastCycled = millis();         // reset this variable to stop rf mode switching
         Serial.println("Air rate change req via sync");
         SetRFLinkRate(ExpressLRS_nextAirRateIndex);
-        LQCalc.reset();
+        //LQCalc.reset();
         crsf.sendLinkStatisticsToFC();
         delay(100);
         crsf.sendLinkStatisticsToFC(); // need to send twice, not sure why, seems like a BF bug?

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -716,8 +716,6 @@ void ICACHE_RAM_ATTR ProcessRFPacket()
              if (ExpressLRS_currAirRate_Modparams->index != (expresslrs_tlm_ratio_e)indexIN)
              { // change link parameters if required
                 ExpressLRS_nextAirRateIndex = indexIN;
-                Serial.println(ExpressLRS_nextAirRateIndex);
-                Serial.println(indexIN);
              }
 
              if (NonceRX != Radio.RXdataBuffer[2] || FHSSgetCurrIndex() != Radio.RXdataBuffer[1])

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1103,7 +1103,9 @@ void loop()
 
     if ((connectionState != disconnected) && (ExpressLRS_nextAirRateIndex != ExpressLRS_currAirRate_Modparams->index)){ // forced change
         LostConnection();
+        RFmodeCycleDivisor = 1;
         LastSyncPacket = millis();           // reset this variable to stop rf mode switching
+        RFmodeLastCycled = millis();         // reset this variable to stop rf mode switching
         Serial.println("Air rate change req via sync");
         SetRFLinkRate(ExpressLRS_nextAirRateIndex);
         LQCalc.reset();

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -203,7 +203,7 @@ void ICACHE_RAM_ATTR GenerateSyncPacketData()
 #ifdef HYBRID_SWITCHES_8
   #define SwitchEncMode 0b01
 #else
-  define SwitchEncMode 0b00
+  #define SwitchEncMode 0b00
 #endif
   uint8_t Index;
   uint8_t TLMrate;

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -324,11 +324,13 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
   bool skipSync = false;
 #endif
 
+  uint8_t NonceFHSSresult = NonceTX % ExpressLRS_currAirRate_Modparams->FHSShopInterval;
+
   if ((syncSpamRequested || (millis() - rfModeLastChangedMS < syncSpamAResidualTimeMS)) && Radio.currFreq == GetInitialFreq())
   {
     GenerateSyncPacketData();
   }
-  else if ((!skipSync) && ((millis() > (SyncPacketLastSent + SyncInterval)) && (Radio.currFreq == GetInitialFreq()) && ((NonceTX) % ExpressLRS_currAirRate_Modparams->FHSShopInterval != 0))) // sync just after we changed freqs (helps with hwTimer.init() being in sync from the get go)
+  else if ((!skipSync) && ((millis() > (SyncPacketLastSent + SyncInterval)) && (Radio.currFreq == GetInitialFreq()) && (NonceFHSSresult == 1 || NonceFHSSresult == 2))) // don't sync just after we changed freqs (helps with hwTimer.init() being in sync from the get go)
   {
     GenerateSyncPacketData();
   }

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -213,7 +213,7 @@ void ICACHE_RAM_ATTR GenerateSyncPacketData()
   if (syncSpamRequested)
   {
     Index = (ExpressLRS_nextAirRate_Modparams->index & 0b11);
-    TLMrate = (ExpressLRS_nextAirRate_Modparams->TLMinterval & 0b111);
+    TLMrate = 0; // this helps get the link back online quicker because the RX is less likely to miss pkts, this will overridden shortly after link change anyway. 
   }
   else
   {

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -91,7 +91,7 @@ mspPacket_t MSPPacket;
 
 ////////////SYNC PACKET/////////
 /// sync packet spamming on mode change vars ///
-#define syncSpamAResidualTimeMS 500 // we spam some more after rate change to help link get up to speed
+#define syncSpamAResidualTimeMS 1500 // we spam some more after rate change to help link get up to speed
 #define syncSpamAmount 3
 uint8_t syncSpamCounter = 0;
 uint32_t rfModeLastChangedMS = 0;


### PR DESCRIPTION
I'm not very happy with how the logic works and it feels ugly so please suggest improvements.

Basically, when a RFparam is changed it will send 5 sync packets to the RX before doing the change, the RX will also hop to a different rfmode if needed when it gets these packets. This makes switching rates super fast and allows you to change rates even with -LOCK_ON_FIRST_CONNECTION enabled. 