### PR TITLE
Dynamically adjust StubbonSender timeout based on rate

### DIFF
--- a/src/lib/StubbornSender/stubborn_sender.h
+++ b/src/lib/StubbornSender/stubborn_sender.h
@@ -23,6 +23,7 @@ public:
     void GetCurrentPayload(uint8_t *packageIndex, uint8_t *count, uint8_t **currentData);
     void ConfirmCurrentPayload(bool telemetryConfirmValue);
     bool IsActive();
+    uint16_t GetMaxPacketsBeforeResync() const { return maxWaitCount; }
 private:
     uint8_t *data;
     uint8_t length;

--- a/src/lib/StubbornSender/stubborn_sender.h
+++ b/src/lib/StubbornSender/stubborn_sender.h
@@ -2,7 +2,8 @@
 
 #include <cstdint>
 
-#define WAIT_FOR_RESYNC 100
+// The number of times to resend the same package index before going to RESYNC
+#define SSENDER_MAX_MISSED_PACKETS 20
 
 typedef enum {
     SENDER_IDLE = 0,
@@ -17,19 +18,21 @@ class StubbornSender
 public:
     StubbornSender(uint8_t maxPackageIndex);
     void ResetState();
+    void UpdateTelemetryRate(uint16_t airRate, uint8_t tlmRatio, uint8_t tlmBurst);
     void SetDataToTransmit(uint8_t lengthToTransmit, uint8_t* dataToTransmit, uint8_t bytesPerCall);
     void GetCurrentPayload(uint8_t *packageIndex, uint8_t *count, uint8_t **currentData);
     void ConfirmCurrentPayload(bool telemetryConfirmValue);
     bool IsActive();
 private:
     uint8_t *data;
-    volatile uint8_t length;
-    volatile uint8_t bytesPerCall;
-    volatile uint8_t currentOffset;
-    volatile uint8_t currentPackage;
-    volatile bool waitUntilTelemetryConfirm;
-    volatile bool resetState;
-    volatile uint16_t waitCount;
-    volatile uint8_t maxPackageIndex;
-    volatile stubborn_sender_state_s senderState;
+    uint8_t length;
+    uint8_t bytesPerCall;
+    uint8_t currentOffset;
+    uint8_t currentPackage;
+    bool waitUntilTelemetryConfirm;
+    bool resetState;
+    uint16_t waitCount;
+    uint16_t maxWaitCount;
+    uint8_t maxPackageIndex;
+    stubborn_sender_state_s senderState;
 };

--- a/src/lib/StubbornSender/stubborn_sender.h
+++ b/src/lib/StubbornSender/stubborn_sender.h
@@ -35,5 +35,5 @@ private:
     uint16_t waitCount;
     uint16_t maxWaitCount;
     uint8_t maxPackageIndex;
-    stubborn_sender_state_s senderState;
+    volatile stubborn_sender_state_s senderState;
 };

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1040,7 +1040,7 @@ static void updateTelemetryBurst()
         --telemetryBurstMax;
     else
         telemetryBurstMax = 1;
-    Serial.print("TLMburst:"); Serial.println(telemetryBurstMax, DEC);
+    //Serial.print("TLMburst:"); Serial.println(telemetryBurstMax, DEC);
 
     // Notify the sender to adjust its expected throughput
     TelemetrySender.UpdateTelemetryRate(hz, ratiodiv, telemetryBurstMax);

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1040,6 +1040,10 @@ static void updateTelemetryBurst()
         --telemetryBurstMax;
     else
         telemetryBurstMax = 1;
+    Serial.print("TLMburst:"); Serial.println(telemetryBurstMax, DEC);
+
+    // Notify the sender to adjust its expected throughput
+    TelemetrySender.UpdateTelemetryRate(hz, ratiodiv, telemetryBurstMax);
 #endif
 }
 

--- a/src/test/stubborn_native/test_subborn.cpp
+++ b/src/test/stubborn_native/test_subborn.cpp
@@ -185,7 +185,7 @@ void test_stubborn_link_resyncs(void)
     receiver.SetDataToReceive(sizeof(buffer), buffer, 1);
 
     // wait for resync to happen
-    for(int i = 0; i < 101; i++)
+    for(int i = 0; i < sender.GetMaxPacketsBeforeResync() + 1; i++)
     {
         sender.GetCurrentPayload(&packageIndex, &maxLength, &data);
         TEST_ASSERT_EQUAL(3, packageIndex);


### PR DESCRIPTION
The timeout was set too low by mistake when merging MSP (changed it from 1000 to 100), so 1:64 and 1:128 rates were timing out before the ack came. Fixes #509 (theoretically, but tested)

Now the timeout scales from 40 packets at 1:2 to 5120 packets at 1:128. Note that 25Hz 1:128, StubbornSender will try for over 7 hours and 16 minutes to send the same telemetry item, but what do you expect over a **four bits per second** link?

I also removed the volatile flag from the member variables of StubbornSender. Sure, it is called from ISRs, but it is all accessed from the ISR except when idle, which is when the main loop will reload the data.