### PR TITLE
Fixes compiler warnings and possible bug

### DIFF
--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -98,14 +98,7 @@ ICACHE_RAM_ATTR uint8_t enumRatetoIndex(expresslrs_RFrates_e rate)
             return i;
         }
     }
-    if (rate == RATE_500HZ)
-    {
-        return 0; // if we make it to here we didn't find the rate in the table to return the first index. 
-    }
-    else if (rate == RATE_25HZ)
-    {
-        return RATE_MAX;
-    }
+    return 0; // if we make it to here we didn't find the rate in the table to return the first index. 
 }
 
 expresslrs_mod_settings_s *ExpressLRS_currAirRate_Modparams;

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -169,7 +169,9 @@ uint32_t LastSyncPacket = 0;            //Time the last valid packet was recv
 uint32_t SendLinkStatstoFCintervalLastSent = 0;
 
 int16_t RFnoiseFloor; //measurement of the current RF noise floor
+#if defined(PRINT_RX_SCOREBOARD)
 static bool lastPacketCrcError;
+#endif
 ///////////////////////////////////////////////////////////////
 
 /// Variables for Sync Behaviour ////
@@ -753,7 +755,7 @@ void ICACHE_RAM_ATTR ProcessRFPacket()
         break;
     }
 
-    bool didFHSS = HandleFHSS();
+    HandleFHSS();
     HandleSendTelemetryResponse();
     LQCalc.add(); // Received a packet, that's the definition of LQ
 

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -883,13 +883,9 @@ void OnRFModePacket(mspPacket_t *packet)
   switch (rfMode)
   {
   case RATE_200HZ:
-    SetRFLinkRate(enumRatetoIndex(RATE_200HZ));
-    break;
   case RATE_100HZ:
-    SetRFLinkRate(enumRatetoIndex(RATE_100HZ));
-    break;
   case RATE_50HZ:
-    SetRFLinkRate(enumRatetoIndex(RATE_50HZ));
+    SetRFLinkRate(enumRatetoIndex((expresslrs_RFrates_e)rfMode));
     break;
   default:
     // Unsupported rate requested
@@ -904,36 +900,8 @@ void OnTxPowerPacket(mspPacket_t *packet)
   CHECK_PACKET_PARSING();
   Serial.println("TX setpower");
 
-  switch (txPower)
-  {
-  case PWR_10mW:
-    POWERMGNT.setPower(PWR_10mW);
-    break;
-  case PWR_25mW:
-    POWERMGNT.setPower(PWR_25mW);
-    break;
-  case PWR_50mW:
-    POWERMGNT.setPower(PWR_50mW);
-    break;
-  case PWR_100mW:
-    POWERMGNT.setPower(PWR_100mW);
-    break;
-  case PWR_250mW:
-    POWERMGNT.setPower(PWR_250mW);
-    break;
-  case PWR_500mW:
-    POWERMGNT.setPower(PWR_500mW);
-    break;
-  case PWR_1000mW:
-    POWERMGNT.setPower(PWR_1000mW);
-    break;
-  case PWR_2000mW:
-    POWERMGNT.setPower(PWR_2000mW);
-    break;
-  default:
-    // Unsupported power requested
-    break;
-  }
+  if (txPower < PWR_COUNT)
+    POWERMGNT.setPower((PowerLevels_e)txPower);
 }
 
 void OnTLMRatePacket(mspPacket_t *packet)


### PR DESCRIPTION
Our 1.0 shouldn't have stray compiler warnings, it should compile as clean as a hosed down seal! This PR fixes the three compiler warnings I've seen.

Note! One of these is actually a bug (gasp) I know can you believe it, the compiler warning you about a real problem? `enumRatetoIndex()` would return RATE_MAX as the index if you asked for RATE_25HZ and it didn't exist. Nothing checks this index to make sure it is valid (which RATE_MAX is not!) so if someone had the rate set to 25Hz, then recompiled with USE_500HZ active, their TX would do unknown things. Also, if a rate was requested that didn't exist, the function would return ?????, which could cause all sorts of problems.

I've changed it to just return the fastest rate, and later if we get around to callers actually error checking this value, we can change it to return RATE_MAX to indicate the error.

This actually compiles to be almost 80 bytes fewer code too, so win-win. 🎉

EDIT: There should be two commits with this but github is only showing one here? 🤔