### PR TITLE
Fixes compiler warnings and possible bugs

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -45,7 +45,6 @@ volatile uint8_t CRSF::SerialInPacketLen = 0; // length of the CRSF packet as me
 volatile uint8_t CRSF::SerialInPacketPtr = 0; // index where we are reading/writing
 
 volatile uint16_t CRSF::ChannelDataIn[16] = {0};
-volatile uint16_t CRSF::ChannelDataInPrev[16] = {0};
 
 volatile inBuffer_U CRSF::inBuffer;
 
@@ -904,10 +903,6 @@ void ICACHE_RAM_ATTR CRSF::updateSwitchValues()
 
 void ICACHE_RAM_ATTR CRSF::GetChannelDataIn() // data is packed as 11 bits per channel
 {
-#define SERIAL_PACKET_OFFSET 3
-
-    memcpy((uint16_t *)ChannelDataInPrev, (uint16_t *)ChannelDataIn, 16); //before we write the new RC channel data copy the old data
-
     const volatile crsf_channels_t *rcChannels = &CRSF::inBuffer.asRCPacket_t.channels;
     ChannelDataIn[0] = (rcChannels->ch0);
     ChannelDataIn[1] = (rcChannels->ch1);

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -39,7 +39,6 @@ public:
     static HardwareSerial Port;
 
     static volatile uint16_t ChannelDataIn[16];
-    static volatile uint16_t ChannelDataInPrev[16]; // Contains the previous RC channel data RX side only
     static volatile uint16_t ChannelDataOut[16];
 
     // current and sent switch values

--- a/src/lib/FIFO/FIFO.cpp
+++ b/src/lib/FIFO/FIFO.cpp
@@ -29,11 +29,17 @@
  */
 #include "FIFO.h"
 
+#define BUILD_BUG_ON(condition) ((void)sizeof(char[1 - 2*!!(condition)]))
+
 FIFO::FIFO()
 {
     head = 0;
     tail = 0;
     numElements = 0;
+
+    // If the following line fails to compile, FIFO_SIZE is larger than
+    // numElements can hold
+    BUILD_BUG_ON(FIFO_SIZE >= (1 << (sizeof(numElements) * 8)));
 }
 
 FIFO::~FIFO()
@@ -42,7 +48,7 @@ FIFO::~FIFO()
 
 void ICACHE_RAM_ATTR FIFO::push(uint8_t data)
 {
-    if (numElements == (FIFO_SIZE-1))
+    if (numElements == FIFO_SIZE)
     {
         Serial.println("CRITICAL ERROR: Buffer full, will flush");
         this->flush();

--- a/src/lib/FIFO/FIFO.cpp
+++ b/src/lib/FIFO/FIFO.cpp
@@ -42,7 +42,7 @@ FIFO::~FIFO()
 
 void ICACHE_RAM_ATTR FIFO::push(uint8_t data)
 {
-    if (numElements == FIFO_SIZE)
+    if (numElements == (FIFO_SIZE-1))
     {
         Serial.println("CRITICAL ERROR: Buffer full, will flush");
         this->flush();

--- a/src/lib/FIFO/FIFO.h
+++ b/src/lib/FIFO/FIFO.h
@@ -33,7 +33,7 @@
 
 #include "targets.h"
 
-#define FIFO_SIZE 256
+#define FIFO_SIZE 255
 
 class FIFO
 {

--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -98,7 +98,9 @@ ICACHE_RAM_ATTR uint8_t enumRatetoIndex(expresslrs_RFrates_e rate)
             return i;
         }
     }
-    return 0; // if we make it to here we didn't find the rate in the table to return the first index. 
+    // If 25Hz selected and not available, return the slowest rate available
+    // else return the fastest rate available (500Hz selected but not available)
+    return (rate == RATE_25HZ) ? RATE_MAX - 1 : 0;
 }
 
 expresslrs_mod_settings_s *ExpressLRS_currAirRate_Modparams;

--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -98,14 +98,7 @@ ICACHE_RAM_ATTR uint8_t enumRatetoIndex(expresslrs_RFrates_e rate)
             return i;
         }
     }
-    if (rate == RATE_500HZ)
-    {
-        return 0; // if we make it to here we didn't find the rate in the table to return the first index. 
-    }
-    else if (rate == RATE_25HZ)
-    {
-        return RATE_MAX;
-    }
+    return 0; // if we make it to here we didn't find the rate in the table to return the first index. 
 }
 
 expresslrs_mod_settings_s *ExpressLRS_currAirRate_Modparams;

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -169,7 +169,9 @@ uint32_t LastSyncPacket = 0;            //Time the last valid packet was recv
 uint32_t SendLinkStatstoFCintervalLastSent = 0;
 
 int16_t RFnoiseFloor; //measurement of the current RF noise floor
+#if defined(PRINT_RX_SCOREBOARD)
 static bool lastPacketCrcError;
+#endif
 ///////////////////////////////////////////////////////////////
 
 /// Variables for Sync Behaviour ////
@@ -753,7 +755,7 @@ void ICACHE_RAM_ATTR ProcessRFPacket()
         break;
     }
 
-    bool didFHSS = HandleFHSS();
+    HandleFHSS();
     HandleSendTelemetryResponse();
     LQCalc.add(); // Received a packet, that's the definition of LQ
 

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -755,7 +755,7 @@ void ICACHE_RAM_ATTR ProcessRFPacket()
         break;
     }
 
-    HandleFHSS();
+    bool didFHSS = HandleFHSS();
     HandleSendTelemetryResponse();
     LQCalc.add(); // Received a packet, that's the definition of LQ
 
@@ -765,6 +765,8 @@ void ICACHE_RAM_ATTR ProcessRFPacket()
         HandleFreqCorr(Radio.GetFrequencyErrorbool()); //corrects for RX freq offset
         Radio.SetPPMoffsetReg(FreqCorrection);         //as above but corrects a different PPM offset based on freq error
     }
+#else
+    (void)didFHSS; // silence compiler warning
 #endif /* Regulatory_Domain_ISM_2400 */
 
     doneProcessing = micros();

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -883,13 +883,9 @@ void OnRFModePacket(mspPacket_t *packet)
   switch (rfMode)
   {
   case RATE_200HZ:
-    SetRFLinkRate(enumRatetoIndex(RATE_200HZ));
-    break;
   case RATE_100HZ:
-    SetRFLinkRate(enumRatetoIndex(RATE_100HZ));
-    break;
   case RATE_50HZ:
-    SetRFLinkRate(enumRatetoIndex(RATE_50HZ));
+    SetRFLinkRate(enumRatetoIndex((expresslrs_RFrates_e)rfMode));
     break;
   default:
     // Unsupported rate requested
@@ -904,36 +900,8 @@ void OnTxPowerPacket(mspPacket_t *packet)
   CHECK_PACKET_PARSING();
   Serial.println("TX setpower");
 
-  switch (txPower)
-  {
-  case PWR_10mW:
-    POWERMGNT.setPower(PWR_10mW);
-    break;
-  case PWR_25mW:
-    POWERMGNT.setPower(PWR_25mW);
-    break;
-  case PWR_50mW:
-    POWERMGNT.setPower(PWR_50mW);
-    break;
-  case PWR_100mW:
-    POWERMGNT.setPower(PWR_100mW);
-    break;
-  case PWR_250mW:
-    POWERMGNT.setPower(PWR_250mW);
-    break;
-  case PWR_500mW:
-    POWERMGNT.setPower(PWR_500mW);
-    break;
-  case PWR_1000mW:
-    POWERMGNT.setPower(PWR_1000mW);
-    break;
-  case PWR_2000mW:
-    POWERMGNT.setPower(PWR_2000mW);
-    break;
-  default:
-    // Unsupported power requested
-    break;
-  }
+  if (txPower < PWR_COUNT)
+    POWERMGNT.setPower((PowerLevels_e)txPower);
 }
 
 void OnTLMRatePacket(mspPacket_t *packet)


### PR DESCRIPTION
Our 1.0 shouldn't have stray compiler warnings, it should compile as clean as a hosed down seal! This PR fixes the three compiler warnings I've seen.

Note! One of these is actually a bug (gasp) I know can you believe it, the compiler warning you about a real problem? `enumRatetoIndex()` would return RATE_MAX as the index if you asked for RATE_25HZ and it didn't exist. Nothing checks this index to make sure it is valid (which RATE_MAX is not!) so if someone had the rate set to 25Hz, then recompiled with USE_500HZ active, their TX would do unknown things. Also, if a rate was requested that didn't exist, the function would return ?????, which could cause all sorts of problems.

I've changed it to just return the fastest rate, and later if we get around to callers actually error checking this value, we can change it to return RATE_MAX to indicate the error.

This actually compiles to be almost 80 bytes fewer code too, so win-win. 🎉

Other fixes
* Fixes a bug in `FIFO::push()` where it will never detect that it is full due to overflowing the uint8 it uses to check against 256. Thanks to @pkendall64 
* Removes the `CRSF::ChannelDataInPrev` which isn't used, and the memcpy() which fails to fill it properly.