### PR TITLE
Change DIVERSITY to switch on last packet missed, not last last packet

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -234,7 +234,7 @@ void SetRFLinkRate(uint8_t index) // Set speed of RF link (hz)
 
     ExpressLRS_currAirRate_Modparams = ModParams;
     ExpressLRS_currAirRate_RFperfParams = RFperf;
-    ExpressLRS_nextAirRateIndex = index; // presumably we just handled this 
+    ExpressLRS_nextAirRateIndex = index; // presumably we just handled this
     telemBurstValid = false;
 }
 
@@ -448,36 +448,44 @@ static void ICACHE_RAM_ATTR updateDiversity()
     int32_t otherRSSI = (antenna == 0) ? LPF_UplinkRSSI1.SmoothDataINT : LPF_UplinkRSSI0.SmoothDataINT;
 
     //if rssi dropped by the amount of DIVERSITY_ANTENNA_RSSI_TRIGGER
-        if ((rssi < (prevRSSI - DIVERSITY_ANTENNA_RSSI_TRIGGER) ) && antennaRSSIDropTrigger >= DIVERSITY_ANTENNA_INTERVAL){
-
+    if ((rssi < (prevRSSI - DIVERSITY_ANTENNA_RSSI_TRIGGER)) && antennaRSSIDropTrigger >= DIVERSITY_ANTENNA_INTERVAL)
+    {
         switchAntenna();
         antennaLQDropTrigger = 1;
         antennaRSSIDropTrigger = 0;
-        } else if(rssi > prevRSSI || antennaRSSIDropTrigger < DIVERSITY_ANTENNA_INTERVAL){
-                prevRSSI = rssi;
-                antennaRSSIDropTrigger++;
-            }
+    }
+    else if (rssi > prevRSSI || antennaRSSIDropTrigger < DIVERSITY_ANTENNA_INTERVAL)
+    {
+        prevRSSI = rssi;
+        antennaRSSIDropTrigger++;
+    }
+
     // if we didn't get a packet switch the antenna
-    if (((!LQCalc.previousIsSet()) && antennaLQDropTrigger == 0)) {
-
+    if (!LQCalc.currentIsSet() && antennaLQDropTrigger == 0)
+    {
         switchAntenna();
         antennaLQDropTrigger = 1;
         antennaRSSIDropTrigger = 0;
-    } else if (antennaLQDropTrigger >= DIVERSITY_ANTENNA_INTERVAL) {
+    }
+    else if (antennaLQDropTrigger >= DIVERSITY_ANTENNA_INTERVAL)
+    {
         // We switched antenna on the previous packet, so we now have relatively fresh rssi info for both antennas.
         // We can compare the rssi values and see if we made things better or worse when we switched
-
-        if (rssi < otherRSSI) {
+        if (rssi < otherRSSI)
+        {
             // things got worse when we switched, so change back.
-
             switchAntenna();
             antennaLQDropTrigger = 1;
             antennaRSSIDropTrigger = 0;
-        } else {
+        }
+        else
+        {
             // all good, we can stay on the current antenna. Clear the flag.
             antennaLQDropTrigger = 0;
         }
-    } else if (antennaLQDropTrigger > 0){
+    }
+    else if (antennaLQDropTrigger > 0)
+    {
         antennaLQDropTrigger ++;
     }
 #endif
@@ -1185,7 +1193,7 @@ void loop()
     #endif
 
     if ((connectionState != disconnected) && (ExpressLRS_nextAirRateIndex != ExpressLRS_currAirRate_Modparams->index)){ // forced change
-        SetRFLinkRate(ExpressLRS_nextAirRateIndex); 
+        SetRFLinkRate(ExpressLRS_nextAirRateIndex);
         LostConnection();
         LastSyncPacket = millis();           // reset this variable to stop rf mode switching and add extra time
         RFmodeLastCycled = millis();         // reset this variable to stop rf mode switching and add extra time


### PR DESCRIPTION
The Diversity code checks `LQCalc.previousIsSet()` to determine if the last packet was missed, but that is actually the last last packet if it is called from the Tock ISR. The only change in this code is

`LQCalc.previousIsSet()` => `LQCalc.currentIsSet()`

The rest is just fixing the whitespace because it was all outta whack.