### PR TITLE
Improve sync behaviour again

### DIFF
--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -12,10 +12,10 @@ expresslrs_mod_settings_s ExpressLRS_AirRateConfig[RATE_MAX] = {
     {3, RATE_25HZ, SX127x_BW_500_00_KHZ, SX127x_SF_9, SX127x_CR_4_7, 40000, TLM_RATIO_NO_TLM, 4, 10}};
 
 expresslrs_rf_pref_params_s ExpressLRS_AirRateRFperf[RATE_MAX] = {
-    {0, RATE_200HZ, -112, 4380, 3500, 2500, 2000, 5000},
-    {1, RATE_100HZ, -117, 8770, 3500, 2500, 2000, 5000},
-    {2, RATE_50HZ, -120, 17540, 5000, 2500, 2000, 5000},
-    {3, RATE_25HZ, -123, 17540, 5000, 4000, 2000, 5000}};
+    {0, RATE_200HZ, -112, 4380, 3000, 2500, 2000, 4000},
+    {1, RATE_100HZ, -117, 8770, 3500, 2500, 2000, 4000},
+    {2, RATE_50HZ, -120, 17540, 4000, 2500, 2000, 4000},
+    {3, RATE_25HZ, -123, 17540, 6000, 4000, 2000, 4000}};
 #endif
 
 #if defined(Regulatory_Domain_ISM_2400)
@@ -31,10 +31,10 @@ expresslrs_mod_settings_s ExpressLRS_AirRateConfig[RATE_MAX] = {
     {3, RATE_50HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF9, SX1280_LORA_CR_LI_4_6, 20000, TLM_RATIO_NO_TLM, 4, 12}};
 
 expresslrs_rf_pref_params_s ExpressLRS_AirRateRFperf[RATE_MAX] = {
-    {0, RATE_500HZ, -105, 4380, 3500, 1000, 2000, 5000},
-    {1, RATE_250HZ, -108, 4380, 3500, 2500, 2000, 5000},
-    {2, RATE_150HZ, -112, 8770, 3500, 2500, 2000, 5000},
-    {3, RATE_50HZ, -117, 17540, 5000, 2500, 2000, 5000}};
+    {0, RATE_500HZ, -105, 1507, 2500, 2500, 2000, 4000},
+    {1, RATE_250HZ, -108, 3300, 3000, 2500, 2000, 4000},
+    {2, RATE_150HZ, -112, 5871, 3500, 2500, 2000, 4000},
+    {3, RATE_50HZ, -117, 18443, 4000, 2500, 2000, 4000}};
 #else
 expresslrs_mod_settings_s ExpressLRS_AirRateConfig[RATE_MAX] = {
     {0, RATE_250HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF6, SX1280_LORA_CR_LI_4_7, 4000, TLM_RATIO_1_64, 4, 14},
@@ -43,10 +43,10 @@ expresslrs_mod_settings_s ExpressLRS_AirRateConfig[RATE_MAX] = {
     {3, RATE_25HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF10, SX1280_LORA_CR_LI_4_6, 40000, TLM_RATIO_NO_TLM, 4, 12}};
 
 expresslrs_rf_pref_params_s ExpressLRS_AirRateRFperf[RATE_MAX] = {
-    {0, RATE_250HZ, -108, 4380, 3500, 2500, 2000, 5000},
-    {1, RATE_150HZ, -112, 8770, 3500, 2500, 2000, 5000},
-    {2, RATE_50HZ, -117, 17540, 5000, 2500, 2000, 5000},
-    {3, RATE_25HZ, -120, 36886, 5000, 4000, 2000, 5000}};
+    {0, RATE_250HZ, -108, 3300, 3000, 2500, 2000, 4000},
+    {1, RATE_150HZ, -112, 5871, 3500, 2500, 2000, 4000},
+    {2, RATE_50HZ, -117, 18443, 4000, 2500, 2000, 4000},
+    {3, RATE_25HZ, -120, 35625, 6000, 4000, 2000, 4000}};
 #endif
 
 #endif

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -233,7 +233,8 @@ void SetRFLinkRate(uint8_t index) // Set speed of RF link (hz)
     hwTimer.updateInterval(ModParams->interval);
     Radio.Config(ModParams->bw, ModParams->sf, ModParams->cr, GetInitialFreq(), ModParams->PreambleLen, bool(UID[5] & 0x01));
 
-    cycleInterval = (1.1*NR_FHSS_ENTRIES*ModParams->FHSShopInterval*ModParams->interval)/100;
+    //wait for 110% of time it takes to cycle through all freqs. 
+    cycleInterval = (11*NR_FHSS_ENTRIES*ModParams->FHSShopInterval*ModParams->interval)/10; 
 
     ExpressLRS_currAirRate_Modparams = ModParams;
     ExpressLRS_currAirRate_RFperfParams = RFperf;

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -774,9 +774,8 @@ void ICACHE_RAM_ATTR ProcessRFPacket()
     (void)didFHSS; // silence compiler warning
 #endif /* Regulatory_Domain_ISM_2400 */
 
-    // Slow down FAST_SYNC if we're not connected, and also will hold
-    // longer for the first cycle after disconnecting since it is likely
-    // we'll reconnect on this rate again
+    // Extend sync duration since we've received a packet at this rate
+    // but do not extend it indefinitely
     RFmodeCycleDivisor = 1;
 
     doneProcessing = micros();

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -233,8 +233,8 @@ void SetRFLinkRate(uint8_t index) // Set speed of RF link (hz)
     hwTimer.updateInterval(ModParams->interval);
     Radio.Config(ModParams->bw, ModParams->sf, ModParams->cr, GetInitialFreq(), ModParams->PreambleLen, bool(UID[5] & 0x01));
 
-    //wait for 110% of time it takes to cycle through all freqs. 
-    cycleInterval = (11*NR_FHSS_ENTRIES*ModParams->FHSShopInterval*ModParams->interval)/10; 
+    // Wait for 110% of time it takes to cycle through all freqs
+    cycleInterval = ((uint32_t)11U * NR_FHSS_ENTRIES * ModParams->FHSShopInterval * ModParams->interval) / 1000;
 
     ExpressLRS_currAirRate_Modparams = ModParams;
     ExpressLRS_currAirRate_RFperfParams = RFperf;

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -175,7 +175,7 @@ static bool lastPacketCrcError;
 ///////////////////////////////////////////////////////////////
 
 /// Variables for Sync Behaviour ////
-uint32_t cycleInterval;
+uint32_t cycleInterval; // in ms
 uint32_t RFmodeLastCycled = 0;
 #define RFmodeCycleDivisorFastMode 10
 uint8_t RFmodeCycleDivisor;
@@ -233,7 +233,7 @@ void SetRFLinkRate(uint8_t index) // Set speed of RF link (hz)
     hwTimer.updateInterval(ModParams->interval);
     Radio.Config(ModParams->bw, ModParams->sf, ModParams->cr, GetInitialFreq(), ModParams->PreambleLen, bool(UID[5] & 0x01));
 
-    // Wait for 110% of time it takes to cycle through all freqs
+    // Wait for 110% of time it takes to cycle through all freqs in FHSS table (in ms)
     cycleInterval = ((uint32_t)11U * NR_FHSS_ENTRIES * ModParams->FHSShopInterval * ModParams->interval) / 1000;
 
     ExpressLRS_currAirRate_Modparams = ModParams;

--- a/src/user_defines.txt
+++ b/src/user_defines.txt
@@ -31,9 +31,6 @@
 
 ### PERFORMANCE OPTIONS: ###
 
-#Improves Inital Syncing/Binding Speed (Currently Experimental)
--DFAST_SYNC
-
 #unlocks >250mw output power for R9M and Happy Model ES915TX (Fan mod suggested: https://github.com/AlessandroAU/ExpressLRS/wiki/R9M-Fan-Mod-Cover)
 #-DUNLOCK_HIGHER_POWER
 
@@ -42,7 +39,7 @@
 -DFEATURE_OPENTX_SYNC
 #-DFEATURE_OPENTX_SYNC_AUTOTUNE
 
-#-DLOCK_ON_FIRST_CONNECTION
+-DLOCK_ON_FIRST_CONNECTION
 
 ### COMPATIBILITY OPTIONS: ###
 


### PR DESCRIPTION
There have been a few complaints about syncing taking too long at lower packet rates, this pr address that. The following is changed:

Remove FAST_SYNC #idef 
dynamically calculate minimum time needed to dwell on a rate to be guaranteed to get a valid packet and trigger additional sync waiting time. 

Make LOCK_ON_FIRST_CONNECTION on as default. 

Tweak connected sync packet interval from 5000ms to 4000ms when connected. 

Fix incorrect OTA entries in ExpressLRS_AirRateRFperf[] array. 