### PR TITLE
Enables buttonless passthrough bootloader for ESP8266 targets based on same xmodem protocol  

### DIFF
--- a/src/lib/Telemetry/telemetry.cpp
+++ b/src/lib/Telemetry/telemetry.cpp
@@ -1,7 +1,6 @@
 #include <cstdint>
 #include <cstring>
 #include "telemetry.h"
-#include <arduino.h>
 
 #if defined(UNIT_TEST)
 #include <iostream>

--- a/src/lib/Telemetry/telemetry.h
+++ b/src/lib/Telemetry/telemetry.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "targets.h"
 #include <cstdint>
 #include "crsf_protocol.h"
 
@@ -41,6 +42,8 @@ public:
     bool RXhandleUARTin(uint8_t data);
     void ResetState();
     bool ShouldCallBootloader();
+    uint32_t BootloaderFilesize();
+    void BootloaderMD5hash(uint8_t * buff);
     #ifdef ENABLE_TELEMETRY
     bool GetNextPayload(uint8_t* nextPayloadSize, uint8_t **payloadData);
     uint8_t* GetCurrentPayload();
@@ -57,4 +60,6 @@ private:
     volatile crsf_telemetry_package_t *telemetryPackageHead;
     uint8_t receivedPackages;
     bool callBootloader;
+    uint32_t bootloaderExpectedFilesize;
+    uint8_t bootloaderExpectedMD5hash[16];
 };

--- a/src/lib/XMODEM_SERVER/LICENSE
+++ b/src/lib/XMODEM_SERVER/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>

--- a/src/lib/XMODEM_SERVER/README.md
+++ b/src/lib/XMODEM_SERVER/README.md
@@ -1,0 +1,51 @@
+# Asynchonous XModem Receiver
+Build status: [![GitHub Actions](https://github.com/AndreRenaud/async_xmodem/workflows/Build%20and%20Test/badge.svg)](https://github.com/AndreRenaud/async_xmodem/actions)
+
+This is a minimal C implementation of the 
+[XModem](https://en.wikipedia.org/wiki/XMODEM) transfer protocol.
+It is designed to be used in bare-metal embedded systems with no
+underlying operating system. It is asynchonous (non-blocking), and
+all data is either directly supplied or sent out via callbacks,
+with no OS-level dependencies. It does not allocate any dynamic memory,
+using only 164B (1080B if large packet sizes are used) of memory while
+the transfer is in progress, with a very shallow stack (3-calls deep
+maximum). It is approximately 1kB of ARM-thumb2 compiled code.
+
+## Usage
+This is a simple single .c & .h file, designed to be directly imported into
+most existing code bases without issue.
+
+For most usage, there are four functions which are of interest
+* `xmodem_server_init` - initialise the state, and provide the callback for
+transmitting individual response bytes
+* `xmodem_server_rx_byte` - insert a byte of incoming data into the server
+(typically from a UART)
+* `xmodem_server_process` - check for timeouts, and extract the next packet
+if available
+* `xmodem_server_is_done` - indicates when the transfer is completed
+* `xmodem_server_get_state` - get the specific state of the transfer
+(including success/failure)
+
+## Example
+```c
+struct xmodem_server xdm;
+
+xmodem_server_init(&xdm, uart_tx_char, NULL);
+while (!xmodem_server_is_done(&xdm)) {
+	uint8_t resp[XMODEM_MAX_PACKET_SIZE];
+	uint32_t block_nr;
+	int rx_data_len;
+
+	if (uart_has_data())
+		xmodem_server_rx_byte(uart_read());
+	rx_data_len = xmodem_server_process(&xdm, resp, &block_nr, ms_time());
+	if (rx_data_len > 0)
+		handle_incoming_packet(resp, rx_data_len, block_nr);
+}
+if (xmodem_server_get_state(&xdm) == XMODEM_STATE_FAILURE)
+	handle_transfer_failure();
+```
+
+## License
+This code is licensed using the [Unlicense](https://unlicense.org/) - do
+what you want with it.

--- a/src/lib/XMODEM_SERVER/xmodem_server.c
+++ b/src/lib/XMODEM_SERVER/xmodem_server.c
@@ -1,0 +1,190 @@
+#include <string.h>
+
+#include "xmodem_server.h"
+
+/* XMODEM protocol constants */
+#define XMODEM_SOH 0x01
+#define XMODEM_STX 0x02
+#define XMODEM_EOT 0x04
+#define XMODEM_ACK 0x06
+#define XMODEM_NACK 0x15
+#define XMODEM_CAN 0x18
+
+// How many milliseconds do we have to wait for a packet to arrive before
+// we send a NAK & restart the transfer
+#define XMODEM_PACKET_TIMEOUT 1000
+
+// How many errors during the transfer before we just fail
+// TODO: Could this be configurable
+#define XMODEM_MAX_ERRORS 10
+
+static const char *state_name(xmodem_server_state state) {
+	#define XDMSTAT(a) case XMODEM_STATE_ ##a: return #a
+	switch(state) {
+		XDMSTAT(START);
+		XDMSTAT(SOH);
+		XDMSTAT(BLOCK_NUM);
+		XDMSTAT(BLOCK_NEG);
+		XDMSTAT(DATA);
+		XDMSTAT(CRC0);
+		XDMSTAT(CRC1);
+		XDMSTAT(PROCESS_PACKET);
+		XDMSTAT(SUCCESSFUL);
+		XDMSTAT(FAILURE);
+		default: return "UNKNOWN";
+	}
+	#undef XDMSTAT
+}
+
+uint16_t xmodem_server_crc(uint16_t crc, uint8_t byte)
+{
+	crc = crc ^ ((uint16_t)byte) << 8;
+	for (int i = 8; i > 0; i--) {
+		if (crc & 0x8000)
+			crc = crc << 1 ^ 0x1021;
+		else
+			crc = crc << 1;
+	}
+	return crc;
+}
+
+bool xmodem_server_rx_byte(struct xmodem_server *xdm, uint8_t byte) {
+	switch (xdm->state) {
+	case XMODEM_STATE_START:
+	case XMODEM_STATE_SOH:
+		if (byte == XMODEM_SOH) {
+			xdm->state = XMODEM_STATE_BLOCK_NUM;
+			xdm->packet_size = 128;
+#if XMODEM_MAX_PACKET_SIZE == 1024
+		} else if (byte == XMODEM_STX) {
+			xdm->state = XMODEM_STATE_BLOCK_NUM;
+			xdm->packet_size = 1024;
+#endif			
+		} else if (byte == XMODEM_EOT) {
+			xdm->state = XMODEM_STATE_SUCCESSFUL;
+			xdm->tx_byte(xdm, XMODEM_ACK, xdm->cb_data);
+		}
+		break;
+	case XMODEM_STATE_BLOCK_NUM:
+		if (byte == ((xdm->block_num + 1) & 0xff)) {
+			xdm->state = XMODEM_STATE_BLOCK_NEG;
+			xdm->repeating = false;
+		} else if (byte == (xdm->block_num & 0xff)) {
+			xdm->state = XMODEM_STATE_BLOCK_NEG;
+			xdm->repeating = true;
+		} else if (byte == XMODEM_SOH || byte == XMODEM_STX) {
+			xdm->state = XMODEM_STATE_BLOCK_NUM;
+		} else {
+			xdm->state = XMODEM_STATE_SOH;
+		}
+		break;
+
+	case XMODEM_STATE_BLOCK_NEG: {
+		uint8_t neg_block = ~(xdm->block_num + 1) & 0xff;
+		if (xdm->repeating)
+			neg_block = (~xdm->block_num) & 0xff;
+		if (byte == neg_block) {
+			xdm->packet_pos = 0;
+			xdm->state = XMODEM_STATE_DATA;
+		} else if (byte == XMODEM_SOH || byte == XMODEM_STX) {
+			xdm->state = XMODEM_STATE_BLOCK_NUM;
+		} else {
+			xdm->state =XMODEM_STATE_SOH;
+		}
+		break;
+	}
+	case XMODEM_STATE_DATA:
+		xdm->packet_data[xdm->packet_pos++] = byte;
+		if (xdm->packet_pos >= xdm->packet_size)
+			xdm->state = XMODEM_STATE_CRC0;
+		break;
+
+	case XMODEM_STATE_CRC0:
+		xdm->crc = ((uint16_t)byte) << 8;
+		xdm->state = XMODEM_STATE_CRC1;
+		break;
+
+	case XMODEM_STATE_CRC1: {
+		uint16_t crc = 0;
+		xdm->crc |= byte;
+		for (int i = 0; i < xdm->packet_size; i++)
+			crc = xmodem_server_crc(crc, xdm->packet_data[i]);
+		if (crc != xdm->crc) {
+			xdm->error_count++;
+			xdm->state = XMODEM_STATE_SOH;
+			xdm->tx_byte(xdm, XMODEM_NACK, xdm->cb_data);
+		} else if (xdm->repeating) {
+			//xdm->tx_byte(xdm, XMODEM_ACK, xdm->cb_data);
+			xdm->state = XMODEM_STATE_SOH;
+		} else {
+			xdm->state = XMODEM_STATE_PROCESS_PACKET;
+		}
+		break;
+	}
+
+	default:
+		break;
+	}
+
+	return (xdm->state == XMODEM_STATE_PROCESS_PACKET);
+}
+
+const char *xmodem_server_state_name(const struct xmodem_server *xdm)
+{
+	return state_name(xdm->state);
+}
+
+int xmodem_server_init(struct xmodem_server *xdm, xmodem_tx_byte tx_byte, void *cb_data) {
+	if (!tx_byte)
+		return -1;
+	memset(xdm, 0, sizeof(*xdm));
+	xdm->tx_byte = tx_byte;
+	xdm->cb_data = cb_data;
+
+	xdm->tx_byte(xdm, 'C', xdm->cb_data);
+
+	return 0;
+}
+
+xmodem_server_state xmodem_server_get_state(const struct xmodem_server *xdm) {
+	return xdm->state;
+}
+
+bool xmodem_server_is_done(const struct xmodem_server *xdm) {
+	return xdm->state == XMODEM_STATE_SUCCESSFUL || xdm->state == XMODEM_STATE_FAILURE;
+}
+
+int xmodem_server_process(struct xmodem_server *xdm, uint8_t *packet, uint32_t *block_num, int64_t ms_time) {
+	if (xmodem_server_is_done(xdm))
+		return 0;
+	// Avoid confusion with 0 default value
+	if (ms_time == 0)
+		ms_time = 1;
+	// Initialise our timer
+	if (xdm->last_event_time == 0)
+		xdm->last_event_time = ms_time;
+	if (xdm->state == XMODEM_STATE_START && ms_time - xdm->last_event_time > 500) {
+		xdm->tx_byte(xdm, 'C', xdm->cb_data);
+		xdm->last_event_time = ms_time;
+	}
+	if (ms_time - xdm->last_event_time > XMODEM_PACKET_TIMEOUT) {
+		xdm->error_count++;
+		xdm->state = XMODEM_STATE_SOH;
+		xdm->tx_byte(xdm, XMODEM_NACK, xdm->cb_data);
+		xdm->last_event_time = ms_time;
+	}
+	if (xdm->error_count >= XMODEM_MAX_ERRORS) {
+		xdm->state = XMODEM_STATE_FAILURE;
+		xdm->tx_byte(xdm, XMODEM_CAN, xdm->cb_data);
+		xdm->last_event_time = ms_time;
+	}
+	if (xdm->state != XMODEM_STATE_PROCESS_PACKET)
+		return 0;
+	xdm->last_event_time = ms_time;
+	memcpy(packet, xdm->packet_data, xdm->packet_size);
+	*block_num = xdm->block_num;
+	xdm->block_num++;
+	xdm->state = XMODEM_STATE_SOH;
+	xdm->tx_byte(xdm, XMODEM_ACK, xdm->cb_data);
+	return xdm->packet_size;
+}

--- a/src/lib/XMODEM_SERVER/xmodem_server.h
+++ b/src/lib/XMODEM_SERVER/xmodem_server.h
@@ -1,0 +1,127 @@
+/**
+ * Implementation of the receiver side of the XModem data transfer protocol
+ * This implementation has been done as an asynchronous system, so there
+ * are no blocking read calls.
+ * It does not allocate any dynamic memory, using only ~160B of memory
+ * while the transfer is in progress
+ */
+#ifndef XMODEM_SERVER_H
+#define XMODEM_SERVER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/**
+ * Original XModem only supports 128B transfers, but Xmodem-1k supports up to
+ * 1k transfers. This is automatically detected by the presense of the STX
+ * instead of the SOH character as the transfer start.
+ * This must be defined to either 128 or 1024. Unless memory usage is a concern,
+ * this should be left at 1024
+ */
+#ifndef XMODEM_MAX_PACKET_SIZE
+#define XMODEM_MAX_PACKET_SIZE 1024
+#endif
+
+/**
+ * The different states that the internal xmodem state machine may be in
+ */
+typedef enum {
+	XMODEM_STATE_START,
+	XMODEM_STATE_SOH,
+	XMODEM_STATE_BLOCK_NUM,
+	XMODEM_STATE_BLOCK_NEG,
+	XMODEM_STATE_DATA,
+	XMODEM_STATE_CRC0,
+	XMODEM_STATE_CRC1,
+	XMODEM_STATE_PROCESS_PACKET,
+	XMODEM_STATE_SUCCESSFUL,
+	XMODEM_STATE_FAILURE,
+
+	XMODEM_STATE_COUNT,
+} xmodem_server_state;
+
+struct xmodem_server;
+
+/**
+ * Callback function to transmit a byte to the xmodem client
+ */
+typedef void (*xmodem_tx_byte)(struct xmodem_server *xdm, uint8_t byte, void *cb_data);
+
+/**
+ * This contains the state for the xmodem server.
+ * None of its contents should be accessed directly, this structure
+ * should be considered opaque
+ */
+struct xmodem_server {
+	xmodem_server_state state; // What state are we in?
+	uint8_t packet_data[XMODEM_MAX_PACKET_SIZE]; // Incoming packet data
+	int packet_pos; // Where are we up to in this packet
+	uint16_t crc; // Whatis the expected CRC of the incoming packet
+	uint16_t packet_size; // Are we receiving 128B or 1K packets?
+	bool repeating; // Are we receiving a packet that we've already processed?
+	int64_t last_event_time; // When did we last do something interesting?
+	uint32_t block_num; // What block are we up to?
+	uint32_t error_count; // How many errors have we seen?
+	xmodem_tx_byte tx_byte;
+	void *cb_data;
+};
+
+/**
+ * Initialise the internal xmodem server state
+ * @param xdm Xmodem server state area to initialise
+ * @param tx_byte callback to be called for ACK/NACK bytes
+ * @param cb_data user-supplied pointer to be supplied to the tx_byte function
+ * @return < 0 on failure, >= 0 on success
+ */
+int xmodem_server_init(struct xmodem_server *xdm, xmodem_tx_byte tx_byte, void *cb_data);
+
+/**
+ * Send a single byte to the xmodem state machine
+ * @returns true if a packet is now available for processing, false if more data is needed
+ */
+bool xmodem_server_rx_byte(struct xmodem_server *xdm, uint8_t byte);
+
+/**
+ * Determine the current state of the xmodem transfer
+ */
+xmodem_server_state xmodem_server_get_state(const struct xmodem_server *xdm);
+
+/**
+ * Returns a human readable version of the current state
+ */
+const char *xmodem_server_state_name(const struct xmodem_server *xdm);
+
+/**
+ * Utility function for extending the XModem 16-bit CRC calculate by
+ * one byte.
+ * Note: This function should not normally be need to be called explicitly,
+ * it is provided to make writing test cases easier
+ */
+uint16_t xmodem_server_crc(uint16_t crc, uint8_t byte);
+
+/**
+ * Process the internal state and determine if there is a full packet ready
+ * This function should be called periodically to correctly process timeouts
+ * @param xdm xmodem_server state
+ * @param packet Area to store the next decoded packet. Must be at least XMODEM_MAX_PACKET_SIZE long. xdm->packet_size bytes will be copied in here
+ * @param block_num Area to store the 0-based index of the extracted block
+ * @param ms_time Current time in milliseconds (used to determine timeouts)
+ * @return Number of bytes of data copied into 'packet' (either 128, or 1024), or 0 if no new packet is available
+ */
+int xmodem_server_process(struct xmodem_server *xdm, uint8_t *packet, uint32_t *block_num, int64_t ms_time);
+
+/**
+ * Determine if the transfer is complete (success or failure)
+ * @return true if the transfer has been finished, false otherwise
+ */
+bool xmodem_server_is_done(const struct xmodem_server *xdm);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/python/crc.py
+++ b/src/python/crc.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+# Inspired by: https://www.youtube.com/watch?v=izG7qT0EpBw
+# The CRC values are verified using: https://crccalc.com/
+# https://gist.github.com/Lauszus/6c787a3bc26fea6e842dfb8296ebd630#file-crc-py
+
+def reflect_data(x, width):
+    # See: https://stackoverflow.com/a/20918545
+    if width == 8:
+        x = ((x & 0x55) << 1) | ((x & 0xAA) >> 1)
+        x = ((x & 0x33) << 2) | ((x & 0xCC) >> 2)
+        x = ((x & 0x0F) << 4) | ((x & 0xF0) >> 4)
+    elif width == 16:
+        x = ((x & 0x5555) << 1) | ((x & 0xAAAA) >> 1)
+        x = ((x & 0x3333) << 2) | ((x & 0xCCCC) >> 2)
+        x = ((x & 0x0F0F) << 4) | ((x & 0xF0F0) >> 4)
+        x = ((x & 0x00FF) << 8) | ((x & 0xFF00) >> 8)
+    elif width == 32:
+        x = ((x & 0x55555555) << 1) | ((x & 0xAAAAAAAA) >> 1)
+        x = ((x & 0x33333333) << 2) | ((x & 0xCCCCCCCC) >> 2)
+        x = ((x & 0x0F0F0F0F) << 4) | ((x & 0xF0F0F0F0) >> 4)
+        x = ((x & 0x00FF00FF) << 8) | ((x & 0xFF00FF00) >> 8)
+        x = ((x & 0x0000FFFF) << 16) | ((x & 0xFFFF0000) >> 16)
+    else:
+        raise ValueError('Unsupported width')
+    return x
+
+def crc_poly(data, n, poly, crc=0, ref_in=False, ref_out=False, xor_out=0):
+    g = 1 << n | poly  # Generator polynomial
+
+    # Loop over the data
+    for d in data:
+        # Reverse the input byte if the flag is true
+        if ref_in:
+            d = reflect_data(d, 8)
+
+        # XOR the top byte in the CRC with the input byte
+        crc ^= d << (n - 8)
+
+        # Loop over all the bits in the byte
+        for _ in range(8):
+            # Start by shifting the CRC, so we can check for the top bit
+            crc <<= 1
+
+            # XOR the CRC if the top bit is 1
+            if crc & (1 << n):
+                crc ^= g
+
+    # Reverse the output if the flag is true
+    if ref_out:
+        crc = reflect_data(crc, n)
+
+    # Return the CRC value
+    return crc ^ xor_out
+
+msg = b'Hi!'
+
+# CRC-8
+crc = crc_poly(msg, 8, 0x07)
+# print(hex(crc), '{0:08b}'.format(crc))
+assert crc == 0x78
+
+# CRC-8/ITU
+crc = crc_poly(msg, 8, 0x07, xor_out=0x55)
+# print(hex(crc), '{0:08b}'.format(crc))
+assert crc == 0x2D
+
+# CRC-8/DARC
+crc = crc_poly(msg, 8, 0x39, ref_in=True, ref_out=True)
+# print(hex(crc), '{0:08b}'.format(crc))
+assert crc == 0x94
+
+# CRC-16/XMODEM
+crc = crc_poly(msg, 16, 0x1021)
+# print(hex(crc), '{0:016b}'.format(crc))
+assert crc == 0x31FD
+
+# CRC-16/MAXIM
+crc = crc_poly(msg, 16, 0x8005, ref_in=True, ref_out=True, xor_out=0xFFFF)
+# print(hex(crc), '{0:016b}'.format(crc))
+assert crc == 0xA191
+
+# CRC-16/USB
+crc = crc_poly(msg, 16, 0x8005, crc=0xFFFF, ref_in=True, ref_out=True, xor_out=0xFFFF)
+# print(hex(crc), '{0:016b}'.format(crc))
+assert crc == 0x61E0
+
+# CRC-32/BZIP2
+crc = crc_poly(msg, 32, 0x04C11DB7, crc=0xFFFFFFFF, xor_out=0xFFFFFFFF)
+# print(hex(crc), '{0:032b}'.format(crc))
+assert crc == 0x9523B4B4
+
+# CRC-32C
+crc = crc_poly(msg, 32, 0x1EDC6F41, crc=0xFFFFFFFF, ref_in=True, ref_out=True, xor_out=0xFFFFFFFF)
+# print(hex(crc), '{0:032b}'.format(crc))
+assert crc == 0x43AC6E72
+
+# CRC-32/XFER
+crc = crc_poly(msg, 32, 0x000000AF)
+# print(hex(crc), '{0:032b}'.format(crc))
+assert crc == 0x2E83E24F
+
+# CRC-32/MPEG-2
+crc = crc_poly(msg, 32, 0x04C11DB7, crc=0xFFFFFFFF)
+# print(hex(crc), '{0:032b}'.format(crc))
+assert crc == 0x6ADC4B4B

--- a/src/src/ESP8266_xmodem_update.h
+++ b/src/src/ESP8266_xmodem_update.h
@@ -1,0 +1,113 @@
+#include <Arduino.h>
+#include "targets.h"
+#include "telemetry.h"
+#include "xmodem_server.h"
+
+extern bool LED;
+extern Telemetry telemetry;
+
+#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#include "SX127xDriver.h"
+extern SX127xDriver Radio;
+#elif defined(Regulatory_Domain_ISM_2400)
+#include "SX1280Driver.h"
+extern SX1280Driver Radio;
+#else
+#error "Radio configuration is not valid!"
+#endif
+
+void array_to_string(byte array[], unsigned int len, char buffer[])
+{
+    for (unsigned int i = 0; i < len; i++)
+    {
+        byte nib1 = (array[i] >> 4) & 0x0f;
+        byte nib2 = (array[i] >> 0) & 0x0f;
+        buffer[i*2+0] = nib1  < 0xa ? '0' + nib1  : 'a' + nib1  - 0xa;
+        buffer[i*2+1] = nib2  < 0xa ? '0' + nib2  : 'a' + nib2  - 0xa;
+    }
+    buffer[len*2] = '\0';
+}
+
+void esp8266_xmodem_tx(struct xmodem_server *xdm, uint8_t byte, void *cb_data)
+{
+    (void)xdm;
+    Serial.write(byte);
+}
+
+void esp8266_xmodem_updater()
+{
+    Radio.End();
+
+    for (uint8_t i = 0; i < 5; i++)
+    {
+        Serial.println("ESP8266 XMODEM BOOTLOADER"); // tell script we got into bootloader
+    }
+
+    //uint32_t uploadSize = telemetry.BootloaderFilesize() ; // didn't seem to work, assign max size instead
+    uint32_t maxSketchSpace = (ESP.getFreeSketchSpace() - 0x1000) & 0xFFFFF000;
+
+    uint8_t md5_bytes[16] = {0};
+    char md5_str[32] = "";
+    telemetry.BootloaderMD5hash(md5_bytes);
+    array_to_string(md5_bytes, sizeof(md5_bytes), md5_str);
+
+    if (!Update.setMD5(md5_str))
+    {
+        Serial.println("MD5 ERROR");
+        Update.printError(Serial);
+        return;
+    }
+
+    if (!Update.begin(maxSketchSpace, U_FLASH))
+    { //start with max available size
+        Serial.println("UPDATE FAILURE (BEGIN)");
+        Update.printError(Serial);
+        return;
+    }
+
+    struct xmodem_server xdm;
+    xmodem_server_init(&xdm, esp8266_xmodem_tx, NULL);
+
+    while (!xmodem_server_is_done(&xdm))
+    {
+        uint8_t resp[XMODEM_MAX_PACKET_SIZE] = {0};
+        uint32_t block_nr = 0;
+        uint32_t rx_data_len = 0;
+
+        if (Serial.available())
+        {
+            xmodem_server_rx_byte(&xdm, Serial.read());
+        }
+
+        rx_data_len = xmodem_server_process(&xdm, resp, &block_nr, millis());
+
+        if (rx_data_len > 0)
+        {
+            if ((uint32_t)Update.write(resp, rx_data_len) == rx_data_len)
+            {
+                #ifdef GPIO_PIN_LED
+                digitalWrite(GPIO_PIN_LED, LED ^ GPIO_LED_RED_INVERTED);
+                #endif
+                LED = !LED;
+            }
+        }
+    }
+
+    delay(100);
+
+    if (xmodem_server_get_state(&xdm) != XMODEM_STATE_SUCCESSFUL)
+    {
+        Serial.println("UPDATE FAILURE (XMODEM)");
+        ESP.restart();
+    }
+
+    if (Update.end(true)) // force update since uploadSize < maxSketchSpace
+    {
+        Serial.println("UPDATE SUCCESS");
+        ESP.restart();
+    }
+    else
+    {
+        Serial.println("UPDATE FAILURE (GENERIC)");
+    }
+}

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -100,6 +100,8 @@ CRSF crsf(CRSF_TX_SERIAL);
     // Maximum ms between LINK_STATISTICS packets for determining burst max
     #define TELEM_MIN_LINK_INTERVAL 512U
 #endif
+    uint8_t *nextPayload = 0;
+    uint8_t nextPlayloadSize = 0;
 
 StubbornReceiver MspReceiver(ELRS_MSP_MAX_PACKAGES);
 uint8_t MspData[ELRS_MSP_BUFFER];
@@ -1146,6 +1148,7 @@ void setup()
     {
         Serial.print("MD5:");
         Serial.println(ESP.getSketchMD5());
+        wifiOff();
     }
 #endif
 
@@ -1161,7 +1164,6 @@ void setup()
     Serial.println("Setting 2.4GHz Mode");
 #endif
 
-    wifiOff();
     ws2812Blink();
     setupBindingFromConfig();
 
@@ -1192,10 +1194,8 @@ void setup()
 
 void loop()
 {
-    #ifdef ENABLE_TELEMETRY
-    uint8_t *nextPayload = 0;
-    uint8_t nextPlayloadSize = 0;
-    #endif
+    nextPayload = 0;
+    nextPlayloadSize = 0;
 
     if (hwTimer.running == false)
     {

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -137,7 +137,7 @@ uint32_t ConsiderConnGoodMillis = 1000; // minimum time before we can consider a
 bool lowRateMode = false;
 
 // LED Blinking state
-static bool LED = false;
+bool LED = false;
 static uint8_t LEDPulseCounter;
 static uint32_t LEDLastUpdate;
 

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -38,6 +38,7 @@ platform_packages =
     mcspr/toolchain-xtensa@~5.100200.201223
     framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git#0049090
 board = esp8285
+board_build.ldscript = eagle.flash.1m64.ld
 build_flags =
 	-D PLATFORM_ESP8266=1
 	-D VTABLES_IN_FLASH=1

--- a/src/targets/diy_2400.ini
+++ b/src/targets/diy_2400.ini
@@ -57,10 +57,10 @@ src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 [env:DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough]
 extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART
 upload_protocol = custom
-upload_speed = 115200
+upload_speed = 420000
 upload_command =
 	python "$PROJECT_DIR/python/BFinitPassthrough.py" $UPLOAD_SPEED
-	python "$PROJECT_DIR/python/esptool-3.0/esptool.py" --no-stub -b $UPLOAD_SPEED -c esp8266 --before no_reset --after soft_reset write_flash 0x0000 "$SOURCE"
+	python "$PROJECT_DIR/python/UARTupload.py" $SOURCE
 
 [env:DIY_2400_RX_ESP8285_SX1280_via_WIFI]
 extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART

--- a/src/targets/diy_900.ini
+++ b/src/targets/diy_900.ini
@@ -58,10 +58,10 @@ src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 [env:DIY_900_RX_ESP8285_SX127x_via_BetaflightPassthrough]
 extends = env:DIY_900_RX_ESP8285_SX127x_via_UART
 upload_protocol = custom
-upload_speed = 115200
+upload_speed = 420000
 upload_command =
 	python "$PROJECT_DIR/python/BFinitPassthrough.py" $UPLOAD_SPEED
-	python "$PROJECT_DIR/python/esptool-3.0/esptool.py" --no-stub -b $UPLOAD_SPEED -c esp8266 --before no_reset --after soft_reset write_flash 0x0000 "$SOURCE"
+	python "$PROJECT_DIR/python/UARTupload.py" $SOURCE
 
 [env:DIY_900_RX_ESP8285_SX127x_via_WIFI]
 extends = env:DIY_900_RX_ESP8285_SX127x_via_UART


### PR DESCRIPTION
new bootloader init sequence  <0xEC><len><0x32><0x0A><uint32_t size><uint8_t md5_hash[16]><crc>
which contains expected filesize and md5 hash
(legacy still works) 

Updated xmodem.py file

Tested to not break existing stm32 upload method. 