### PR TITLE
Always init msp receiver

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1142,9 +1142,9 @@ void setup()
     telemetry.ResetState();
     #ifdef ENABLE_TELEMETRY
     TelemetrySender.ResetState();
+    #endif
     MspReceiver.ResetState();
     MspReceiver.SetDataToReceive(ELRS_MSP_BUFFER, MspData, ELRS_MSP_BYTES_PER_CALL);
-    #endif
     Radio.RXnb();
     crsf.Begin();
     hwTimer.init();


### PR DESCRIPTION
if it's only done when telemetry is enabled the bind feature does not work.

Resolves #541 