### PR TITLE
Initialise the config with pointer to eeprom

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -883,6 +883,7 @@ static void setupSerial()
 static void setupConfigAndPocCheck()
 {
     eeprom.Begin();
+    config.SetStorageProvider(&eeprom); // Pass pointer to the Config class for access to storage
     config.Load();
 
 #ifndef MY_UID


### PR DESCRIPTION
This bug was found while working on the WiFi changes.
The eeprom was not set in the config object so `Load` would fail. I'm surprised it didn't just fault.