### PR TITLE
Check firmware target on WiFi based TX/RX and BFPassthrough RX

### DIFF
--- a/src/python/BFinitPassthrough.py
+++ b/src/python/BFinitPassthrough.py
@@ -131,7 +131,7 @@ def reset_to_bootloader(args):
     flash_target = re.sub("_VIA_.*", "", args.target.upper())
     if rx_target == "":
         dbg_print("Cannot detect RX target, blindly flashing!")
-    if rx_target != flash_target:
+    elif rx_target != flash_target:
         raise WrongTargetSelected("Wrong target selected your RX is '%s', trying to flash '%s'" % (rx_target, flash_target))
     elif flash_target != "":
         dbg_print("Verified RX target '%s'" % (flash_target))

--- a/src/python/BFinitPassthrough.py
+++ b/src/python/BFinitPassthrough.py
@@ -129,9 +129,12 @@ def reset_to_bootloader(args):
     s.flush()
     rx_target = rl.read_line().strip()
     flash_target = re.sub("_VIA_.*", "", args.target.upper())
-    dbg_print("RX Target '%s', trying to flash '%s'" % (rx_target, flash_target))
-    if flash_target != "" and rx_target != flash_target:
+    if rx_target == "":
+        dbg_print("Cannot detect RX target, blindly flashing!")
+    if rx_target != flash_target:
         raise WrongTargetSelected("Wrong target selected your RX is '%s', trying to flash '%s'" % (rx_target, flash_target))
+    elif flash_target != "":
+        dbg_print("Verified RX target '%s'" % (flash_target))
     time.sleep(.5)
     s.close()
 
@@ -162,4 +165,8 @@ if __name__ == '__main__':
         dbg_print(str(err))
 
     if args.reset_to_bl:
-        reset_to_bootloader(args)
+        try:
+            reset_to_bootloader(args)
+        except WrongTargetSelected as err:
+            dbg_print(str(err))
+            exit(-1)

--- a/src/python/UARTupload.py
+++ b/src/python/UARTupload.py
@@ -20,7 +20,7 @@ def dbg_print(line=''):
     return
 
 
-def uart_upload(port, filename, baudrate, ghst=False, key=None):
+def uart_upload(port, filename, baudrate, ghst=False, key=None, target=""):
     half_duplex = False
 
     dbg_print("=================== FIRMWARE UPLOAD ===================\n")
@@ -139,6 +139,13 @@ def uart_upload(port, filename, baudrate, ghst=False, key=None):
                         gotBootloader = True
                         break
 
+                    elif "_RX_" in line:
+                        flash_target = re.sub("_VIA_.*", "", target.upper())
+                        if line != flash_target:
+                            raise Exception("Wrong target selected your RX is '%s', trying to flash '%s'" % (line, flash_target))
+                        elif flash_target != "":
+                            dbg_print("Verified RX target '%s'" % flash_target)
+
             dbg_print("    Got into bootloader after: %u attempts\n" % currAttempt)
 
             # sanity check! Make sure the bootloader is started
@@ -223,7 +230,7 @@ def on_upload(source, target, env):
                 envkey = flag.split("=")[1]
 
     try:
-        uart_upload(upload_port, firmware_path, upload_speed, ghst, key=envkey)
+        uart_upload(upload_port, firmware_path, upload_speed, ghst, key=envkey, target=env['PIOENV'])
     except Exception as e:
         dbg_print("{0}\n".format(e))
         return -1

--- a/src/python/build_flags.py
+++ b/src/python/build_flags.py
@@ -105,6 +105,7 @@ def get_git_sha():
 process_flags("user_defines.txt")
 process_flags("super_defines.txt") # allow secret super_defines to override user_defines
 build_flags.append("-DLATEST_COMMIT=" + get_git_sha())
+build_flags.append("-DTARGET_NAME=" + re.sub("_VIA_.*", "", env['PIOENV'].upper()))
 condense_flags()
 
 env['BUILD_FLAGS'] = build_flags

--- a/src/python/serials_find.py
+++ b/src/python/serials_find.py
@@ -40,6 +40,7 @@ def serial_ports():
             ports.extend(glob.glob('/dev/ttyUSB*'))
         elif platform.startswith('darwin'):
             ports = glob.glob('/dev/tty.usbmodem*')
+            ports.extend(glob.glob('/dev/tty.SLAB*'))
         else:
             raise Exception('Unsupported platform')
 

--- a/src/src/ESP32_WebUpdate.cpp
+++ b/src/src/ESP32_WebUpdate.cpp
@@ -27,6 +27,12 @@ extern CRSF crsf;
 
 #include "ESP32_WebUpdate.h"
 
+#define QUOTE(arg) #arg
+#define STR(macro) QUOTE(macro)
+const unsigned char target_name[] = "\xBE\xEF\xCA\xFE" STR(TARGET_NAME);
+uint8_t target_seen = 0;
+uint8_t target_pos = 0;
+
 const char *ssid = "ExpressLRS TX Module"; // The name of the Wi-Fi network that will be created
 const char *password = "expresslrs";       // The password required to connect to it, leave blank for an open network
 const char *myHostname = "elrs_tx";
@@ -159,7 +165,7 @@ void BeginWebUpdate()
     server.on(
         "/update", HTTP_POST, []() {
       server.sendHeader("Connection", "close");
-      server.send(200, "text/plain", (Update.hasError()) ? "FAIL" : "OK");
+      server.send(200, "text/plain", target_seen ? ((Update.hasError()) ? "FAIL" : "OK") : "WRONG FIRMWARE");
       ESP.restart(); }, []() {
       HTTPUpload& upload = server.upload();
       if (upload.status == UPLOAD_FILE_START) {
@@ -168,17 +174,37 @@ void BeginWebUpdate()
         if (!Update.begin()) { //start with max available size
           Update.printError(Serial);
         }
+        target_seen = 0;
+        target_pos = 0;
       } else if (upload.status == UPLOAD_FILE_WRITE) {
         if (Update.write(upload.buf, upload.currentSize) != upload.currentSize) {
           Update.printError(Serial);
         }
-      } else if (upload.status == UPLOAD_FILE_END) {
-        if (Update.end(true)) { //true to set the size to the current progress
-          Serial.printf("Upload Success: %ubytes\nPlease wait for LED to resume blinking before disconnecting power\n", upload.totalSize);
-        } else {
-          Update.printError(Serial);
+        if (!target_seen) {
+          for (int i=0 ; i<upload.currentSize ;i++) {
+            if (upload.buf[i] == target_name[target_pos]) {
+              ++target_pos;
+              if (target_pos >= sizeof(target_name)) {
+                target_seen = 1;
+              }
+            }
+            else {
+              target_pos = 0; // Startover
+            }
+          }
         }
-        Serial.setDebugOutput(false);
+      } else if (upload.status == UPLOAD_FILE_END) {
+        if (target_seen) {
+          if (Update.end(true)) { //true to set the size to the current progress
+            Serial.printf("Upload Success: %ubytes\nPlease wait for LED to resume blinking before disconnecting power\n", upload.totalSize);
+          } else {
+            Update.printError(Serial);
+          }
+          Serial.setDebugOutput(false);
+        } else {
+          Update.abort();
+          Serial.printf("Wrong firmware uploaded, not %s, update aborted\n", &target_name[4]);
+        }
       } else {
         Serial.printf("Update Failed Unexpectedly (likely broken connection): status=%d\n", upload.status);
       } });

--- a/src/src/ESP32_WebUpdate.cpp
+++ b/src/src/ESP32_WebUpdate.cpp
@@ -26,10 +26,8 @@ extern CRSF crsf;
 #include <Update.h>
 
 #include "ESP32_WebUpdate.h"
+#include "config.h"
 
-#define QUOTE(arg) #arg
-#define STR(macro) QUOTE(macro)
-const unsigned char target_name[] = "\xBE\xEF\xCA\xFE" STR(TARGET_NAME);
 uint8_t target_seen = 0;
 uint8_t target_pos = 0;
 
@@ -188,7 +186,7 @@ void BeginWebUpdate()
           for (int i=0 ; i<upload.currentSize ;i++) {
             if (upload.buf[i] == target_name[target_pos]) {
               ++target_pos;
-              if (target_pos >= sizeof(target_name)) {
+              if (target_pos >= target_name_size) {
                 target_seen = 1;
               }
             }
@@ -210,7 +208,7 @@ void BeginWebUpdate()
         }
         Serial.setDebugOutput(false);
       } else if(upload.status == UPLOAD_FILE_ABORTED){
-        Update.end();
+        Update.abort();
         Serial.println("Update was aborted");
       } });
 

--- a/src/src/ESP8266_WebUpdate.cpp
+++ b/src/src/ESP8266_WebUpdate.cpp
@@ -11,6 +11,10 @@ extern SX127xDriver Radio;
 extern SX1280Driver Radio;
 #endif
 
+#define QUOTE(arg) #arg
+#define STR(macro) QUOTE(macro)
+const char target_name[] = "\xBE\xEF\xCA\xFE" STR(TARGET_NAME);
+
 #define STASSID "ExpressLRS RX"
 #define STAPSK "expresslrs"
 const char *myHostname = "elrs_rx";

--- a/src/src/ESP8266_WebUpdate.cpp
+++ b/src/src/ESP8266_WebUpdate.cpp
@@ -1,5 +1,6 @@
 #ifdef PLATFORM_ESP8266
 #include "ESP8266_WebUpdate.h"
+#include "config.h"
 
 #if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
 #include "SX127xDriver.h"
@@ -11,9 +12,6 @@ extern SX127xDriver Radio;
 extern SX1280Driver Radio;
 #endif
 
-#define QUOTE(arg) #arg
-#define STR(macro) QUOTE(macro)
-const char target_name[] = "\xBE\xEF\xCA\xFE" STR(TARGET_NAME);
 uint8_t target_seen = 0;
 uint8_t target_pos = 0;
 
@@ -184,7 +182,7 @@ void BeginWebUpdate(void)
           for (size_t i=0 ; i<upload.currentSize ;i++) {
             if (upload.buf[i] == target_name[target_pos]) {
               ++target_pos;
-              if (target_pos >= sizeof(target_name)) {
+              if (target_pos >= target_name_size) {
                 target_seen = 1;
               }
             }
@@ -201,12 +199,10 @@ void BeginWebUpdate(void)
             Update.printError(Serial);
           }
         } else {
-          Update.end();
           Serial.printf("Wrong firmware uploaded, not %s, update aborted\n", &target_name[4]);
         }
         Serial.setDebugOutput(false);
       } else if(upload.status == UPLOAD_FILE_ABORTED){
-        Update.end();
         Serial.println("Update was aborted");
       }
       delay(0);

--- a/src/src/config.cpp
+++ b/src/src/config.cpp
@@ -2,6 +2,11 @@
 #include "common.h"
 #include "POWERMGNT.h"
 
+#define QUOTE(arg) #arg
+#define STR(macro) QUOTE(macro)
+const unsigned char target_name[] = "\xBE\xEF\xCA\xFE" STR(TARGET_NAME);
+const uint8_t target_name_size = sizeof(target_name);
+
 void
 TxConfig::Load()
 {

--- a/src/src/config.h
+++ b/src/src/config.h
@@ -3,6 +3,9 @@
 #include "targets.h"
 #include "elrs_eeprom.h"
 
+extern const unsigned char target_name[];
+extern const uint8_t target_name_size;
+
 #define TX_CONFIG_VERSION   1
 #define RX_CONFIG_VERSION   1
 #define UID_LEN             6

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1343,6 +1343,8 @@ struct bootloader {
 
 void reset_into_bootloader(void)
 {
+    CRSF_TX_SERIAL.println((const char *)&target_name[4]);
+    CRSF_TX_SERIAL.flush();
 #if defined(PLATFORM_STM32)
     delay(100);
     Serial.println("Jumping to Bootloader...");
@@ -1361,6 +1363,7 @@ void reset_into_bootloader(void)
 
     HAL_NVIC_SystemReset();
 #elif defined(PLATFORM_ESP8266)
+    delay(100);
     ESP.rebootIntoUartDownloadMode();
 #endif
 }

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -46,7 +46,7 @@ upload_speed = 460800
 monitor_speed = 420000
 upload_resetmethod = nodemcu
 bf_upload_command =
-	python "$PROJECT_DIR/python/BFinitPassthrough.py" -b $UPLOAD_SPEED ${UPLOAD_PORT and "-p "+UPLOAD_PORT}
+	python "$PROJECT_DIR/python/BFinitPassthrough.py" -b $UPLOAD_SPEED ${UPLOAD_PORT and "-p "+UPLOAD_PORT} -r $PIOENV
 	python "$PROJECT_DIR/python/esptool-3.0/esptool.py" -b $UPLOAD_SPEED ${UPLOAD_PORT and "-p "+UPLOAD_PORT} -c esp8266 --before no_reset --after soft_reset write_flash 0x0000 "$SOURCE"
 
 # ------------------------- COMMON STM32 DEFINITIONS -----------------


### PR DESCRIPTION
So I have a proof of concept for the problem of uploading the wrong firmware via wifi to an ESP based TX. It can be done for the RX as well, but I need to rewrite the uploader code to not use the builtin update server.

What it does is create a string with the target name (with the VIA... removed) with a magic prefix. As the file is being uploaded it looks for the magic string and if it sees it it will remember that the firmware is for this target. When the upload completes it will either continue as normal or abort the update and return "WRONG FIRMWARE" to the user.

My only problem is the backpack ones or are they always the FrSky module and we can hardcode the target_name into the backpack currently?
