### PR TITLE
Match IQInverted between TX and RX in BindingMode

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1010,10 +1010,10 @@ void ExitBindingMode()
 void SendUIDOverMSP()
 {
   BindingPackage[0] = MSP_ELRS_BIND;
-  BindingPackage[1] = UID[2];
-  BindingPackage[2] = UID[3];
-  BindingPackage[3] = UID[4];
-  BindingPackage[4] = UID[5];
+  BindingPackage[1] = MasterUID[2];
+  BindingPackage[2] = MasterUID[3];
+  BindingPackage[3] = MasterUID[4];
+  BindingPackage[4] = MasterUID[5];
   MspSender.ResetState();
   BindingSendCount = 0;
   MspSender.SetDataToTransmit(5, BindingPackage, ELRS_MSP_BYTES_PER_CALL);

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -225,15 +225,16 @@ void ICACHE_RAM_ATTR GenerateSyncPacketData()
 void ICACHE_RAM_ATTR SetRFLinkRate(uint8_t index) // Set speed of RF link (hz)
 {
   expresslrs_mod_settings_s *const ModParams = get_elrs_airRateConfig(index);
-  if (ModParams == ExpressLRS_currAirRate_Modparams)
-    return;
   expresslrs_rf_pref_params_s *const RFperf = get_elrs_RFperfParams(index);
-  if (RFperf == ExpressLRS_currAirRate_RFperfParams)
+  bool invertIQ = UID[5] & 0x01;
+  if ((ModParams == ExpressLRS_currAirRate_Modparams)
+    && (RFperf == ExpressLRS_currAirRate_RFperfParams)
+    && (invertIQ == Radio.IQinverted))
     return;
 
   Serial.println("set rate");
   hwTimer.updateInterval(ModParams->interval);
-  Radio.Config(ModParams->bw, ModParams->sf, ModParams->cr, GetInitialFreq(), ModParams->PreambleLen, bool(UID[5] & 0x01));
+  Radio.Config(ModParams->bw, ModParams->sf, ModParams->cr, GetInitialFreq(), ModParams->PreambleLen, invertIQ);
 
   ExpressLRS_currAirRate_Modparams = ModParams;
   ExpressLRS_currAirRate_RFperfParams = RFperf;
@@ -971,7 +972,6 @@ void EnterBindingMode()
   UID[5] = BindingUID[5];
 
   CRCInitializer = 0;
-
   InBindingMode = true;
 
   // Start attempting to bind


### PR DESCRIPTION
Addresses #560

When entering binding mode, the UID is set to a fixed value 1,2,3,4,5. This can change the InvertIQ parameter of the Radio. There were two bugs here that were interracting

* On the TX side, the `SetRFLinkRate()` function didn't check to see if InvertIQ was changed and would exit without changing config. The updated code now checks three parameters to make sure something has changed. Note the old code also had a bug that could bail if only the `expresslrs_mod_settings_s` parameter was the same, without checking `expresslrs_rf_pref_params_s` too. This can't be a problem because both are referenced by the same index, so that's not a breaking problem.
* On the RX side, `SetRFLinkRate()` would change the Radio config, but it appears to not take effect if we're already in RX mode, the code was changed to restart Radio RX after doing the SetRFLinkRate.

The bulk of the changes here are to allow SetRFLinkRate to work while InBindingMode just to make the functions in the RX and TX match, but it also simplifies the code of `cycleRfMode()` which was still trying to cycle modes in binding mode, but being blocked by SetRFLinkRate(). It is better to have this check just one place.
* Finally, pedantically a separate commit 72dd6e4: when the TX sends a bind packet, it needs to tell the RX the **MasterUID** not the current UID, which changes depending on what's going on. This isn't an issue with the current code organization (UID == MasterUID when the code is hit) but let's prevent that from being a possible bug later.