### PR TITLE
Stop transmitting before switching rate to do a bind

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1010,10 +1010,10 @@ void ExitBindingMode()
 void SendUIDOverMSP()
 {
   BindingPackage[0] = MSP_ELRS_BIND;
-  BindingPackage[1] = UID[2];
-  BindingPackage[2] = UID[3];
-  BindingPackage[3] = UID[4];
-  BindingPackage[4] = UID[5];
+  BindingPackage[1] = MasterUID[2];
+  BindingPackage[2] = MasterUID[3];
+  BindingPackage[3] = MasterUID[4];
+  BindingPackage[4] = MasterUID[5];
   MspSender.ResetState();
   BindingSendCount = 0;
   MspSender.SetDataToTransmit(5, BindingPackage, ELRS_MSP_BYTES_PER_CALL);

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -960,7 +960,11 @@ void EnterBindingMode()
       return;
   }
 
-  // Start periodically sending the current UID as MSP packets
+  // Disable the TX timer and wait for any TX to complete
+  hwTimer.stop();
+  while (busyTransmitting);
+
+  // Queue up sending the Master UID as MSP packets
   SendUIDOverMSP();
 
   // Set UID to special binding values
@@ -978,6 +982,8 @@ void EnterBindingMode()
   // Lock the RF rate and freq while binding
   SetRFLinkRate(RATE_DEFAULT);
   Radio.SetFrequencyReg(GetInitialFreq());
+  // Start transmitting again
+  hwTimer.resume();
 
   Serial.print("Entered binding mode at freq = ");
   Serial.println(Radio.currFreq);

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -225,15 +225,16 @@ void ICACHE_RAM_ATTR GenerateSyncPacketData()
 void ICACHE_RAM_ATTR SetRFLinkRate(uint8_t index) // Set speed of RF link (hz)
 {
   expresslrs_mod_settings_s *const ModParams = get_elrs_airRateConfig(index);
-  if (ModParams == ExpressLRS_currAirRate_Modparams)
-    return;
   expresslrs_rf_pref_params_s *const RFperf = get_elrs_RFperfParams(index);
-  if (RFperf == ExpressLRS_currAirRate_RFperfParams)
+  bool invertIQ = UID[5] & 0x01;
+  if ((ModParams == ExpressLRS_currAirRate_Modparams)
+    && (RFperf == ExpressLRS_currAirRate_RFperfParams)
+    && (invertIQ == Radio.IQinverted))
     return;
 
   Serial.println("set rate");
   hwTimer.updateInterval(ModParams->interval);
-  Radio.Config(ModParams->bw, ModParams->sf, ModParams->cr, GetInitialFreq(), ModParams->PreambleLen, bool(UID[5] & 0x01));
+  Radio.Config(ModParams->bw, ModParams->sf, ModParams->cr, GetInitialFreq(), ModParams->PreambleLen, invertIQ);
 
   ExpressLRS_currAirRate_Modparams = ModParams;
   ExpressLRS_currAirRate_RFperfParams = RFperf;
@@ -971,7 +972,6 @@ void EnterBindingMode()
   UID[5] = BindingUID[5];
 
   CRCInitializer = 0;
-
   InBindingMode = true;
 
   // Start attempting to bind


### PR DESCRIPTION
It appears on ESP32 platform, we can WDT reboot when trying to do a bind. When the TX starts to set the radio params to change rates, the TXdoneISR can fire and really mess things up as evidenced by the stack trace provided by @schugabe. This small update disables the hwTimer and waits for any pending TX to complete before starting changing things to send the bind, then resumes the timer. Johannes says he tried it 4 times and there was no reboot, whereas previously it was a 50/50 chance of crashing. I also tested it on STM32 5x and had no trouble binding (although I didn't before either).

If there's a better way to pause the TX just let me know and I can adjust or just close the PR if you'd like to pick this up. Sorry about using the same branch again, but it should apply cleanly, it is just 3 lines and comments.

Stack trace on DIY_900_TX_TTGO_V1_SX127x_via_UART target:
```
0x4008f2f8: vListInsert at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/list.c:188 (discriminator 1)
0x4008e50c: vTaskPlaceOnEventList at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/tasks.c:3507
0x4008c827: xQueueGenericReceive at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/queue.c:2038
0x4014d876: spiSimpleTransaction at ~/.platformio/packages/framework-arduinoespressif32/cores/esp32/esp32-hal-spi.c:283
0x4014cba1: SPIClass::writeBytes(unsigned char const*, unsigned int) at ~/.platformio/packages/framework-arduinoespressif32/libraries/SPI/src/SPI.cpp:269
0x400828be: SX127xHal::writeRegister(unsigned char, unsigned char) at ./src/lib/SX127xDriver/SX127xHal.cpp:197
0x40082650: SX127xDriver::ClearIRQFlags() at ./src/lib/SX127xDriver/SX127x.cpp:463
0x40082679: SX127xDriver::ClearIRQFlags() at ./src/lib/SX127xDriver/SX127x.cpp:463
  \-> inlined by: SX127xDriver::TXnbISR() at ./src/lib/SX127xDriver/SX127x.cpp:272
0x400827f9: SX127xHal::dioISR() at ./src/lib/SX127xDriver/SX127xHal.cpp:107
0x40082b55: __onPinInterrupt at ~/.platformio/packages/framework-arduinoespressif32/cores/esp32/esp32-hal-gpio.c:274
0x4008922d: _xt_lowint1 at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/xtensa_vectors.S:1154
0x4008db61: vTaskExitCritical at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/tasks.c:3507
0x4008c7d3: xQueueGenericReceive at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/queue.c:2038
0x4014d80d: spiTransferBytes at ~/.platformio/packages/framework-arduinoespressif32/cores/esp32/esp32-hal-spi.c:283
0x4014cbcc: SPIClass::transferBytes(unsigned char const*, unsigned char*, unsigned int) at ~/.platformio/packages/framework-arduinoespressif32/libraries/SPI/src/SPI.cpp:269
0x4014cbe2: SPIClass::transfer(unsigned char*, unsigned int) at ~/.platformio/packages/framework-arduinoespressif32/libraries/SPI/src/SPI.cpp:269
0x4008283a: SX127xHal::readRegister(unsigned char) at ./src/lib/SX127xDriver/SX127xHal.cpp:107
0x400828fb: SX127xHal::setRegValue(unsigned char, unsigned char, unsigned char, unsigned char) at ./src/lib/SX127xDriver/SX127xHal.cpp:130
0x400d32d5: SX127xDriver::ConfigLoraDefaults() at ./src/lib/SX127xDriver/SX127x.cpp:76
0x400d3377: SX127xDriver::Config(SX127x_Bandwidth, SX127x_SpreadingFactor, SX127x_CodingRate, unsigned int, unsigned char, unsigned char, bool) at ./src/lib/SX127xDriver/SX127x.cpp:344
0x400d33c5: SX127xDriver::Config(SX127x_Bandwidth, SX127x_SpreadingFactor, SX127x_CodingRate, unsigned int, unsigned char, bool) at ./src/lib/SX127xDriver/SX127x.cpp:338
0x4008197c: SetRFLinkRate(unsigned char) at ./src/src/tx_main.cpp:909
0x400d23be: EnterBindingMode() at ./src/src/tx_main.cpp:979
0x400d2571: HandleUpdateParameter() at ./src/src/tx_main.cpp:520
0x400d2883: loop() at ./src/src/tx_main.cpp:789
```