### PR TITLE
Enables buttonless passthrough bootloader for ESP8266 targets based on ROM bootloader

### DIFF
--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -239,7 +239,7 @@ bool SX127xDriver::DetectChip()
     {
       Serial.print(" not found! (");
       Serial.print(i + 1);
-      Serial.print(" of 10 tries) REG_VERSION == ");
+      Serial.print(" of 3 tries) REG_VERSION == ");
 
       char buffHex[5];
       sprintf(buffHex, "0x%02X", version);

--- a/src/lib/Telemetry/telemetry.cpp
+++ b/src/lib/Telemetry/telemetry.cpp
@@ -11,11 +11,7 @@ using namespace std;
 
 Telemetry::Telemetry()
 {
-    telemetry_state = TELEMETRY_IDLE;
-    currentTelemetryByte = 0;
-    currentPayloadIndex = 0;
-    callBootloader = false;
-    receivedPackages = 0;
+    ResetState();
 }
 
 bool Telemetry::ShouldCallBootloader()

--- a/src/src/ESP32_WebUpdate.cpp
+++ b/src/src/ESP32_WebUpdate.cpp
@@ -185,7 +185,7 @@ void BeginWebUpdate()
 
     dnsServer.start(DNS_PORT, "*", apIP);
     dnsServer.setErrorReplyCode(DNSReplyCode::NoError);
-    
+
     if (!MDNS.begin(myHostname))
     {
       Serial.println("Error starting mDNS");
@@ -200,7 +200,7 @@ void HandleWebUpdate()
 {
     dnsServer.processNextRequest();
     server.handleClient();
-    delay(1);
+    yield();
 }
 
 #endif

--- a/src/src/ESP8266_WebUpdate.cpp
+++ b/src/src/ESP8266_WebUpdate.cpp
@@ -168,6 +168,5 @@ void HandleWebUpdate(void)
   dnsServer.processNextRequest();
   //mdns.update();
   yield();
-  delay(1);
 }
 #endif

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -957,6 +957,7 @@ static void setupBindingFromConfig()
 #endif
 }
 
+#if defined(PLATFORM_ESP8266)
 static void WebUpdateLoop()
 {
     HandleWebUpdate();
@@ -969,6 +970,7 @@ static void WebUpdateLoop()
         LEDLastUpdate = millis();
     }
 }
+#endif
 
 static void HandleUARTin()
 {

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -738,7 +738,6 @@ void setup()
     delay(1000);
   }
   #ifdef ENABLE_TELEMETRY
-  TelemetryReceiver.ResetState();
   TelemetryReceiver.SetDataToReceive(sizeof(CRSFinBuffer), CRSFinBuffer, ELRS_TELEMETRY_BYTES_PER_CALL);
   #endif
   POWERMGNT.setDefaultPower();
@@ -755,7 +754,6 @@ void setup()
   hwTimer.init();
   //hwTimer.resume();  //uncomment to automatically start the RX timer and leave it running
   crsf.Begin();
-  MspSender.ResetState();
 }
 
 void loop()

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -48,7 +48,9 @@ board_build.f_cpu = 160000000L
 src_filter = ${common_env_data.src_filter} -<ESP32*.*> -<STM32*.*> -<WS281B*.*>
 upload_speed = 460800
 upload_resetmethod = nodemcu
-
+bf_upload_command =
+	python "$PROJECT_DIR/python/BFinitPassthrough.py" -b $UPLOAD_SPEED ${UPLOAD_PORT and "-p "+UPLOAD_PORT}
+	python "$PROJECT_DIR/python/esptool-3.0/esptool.py" --no-stub -b $UPLOAD_SPEED ${UPLOAD_PORT and "-p "+UPLOAD_PORT} -c esp8266 --before no_reset --after soft_reset write_flash 0x0000 "$SOURCE"
 
 # ------------------------- COMMON STM32 DEFINITIONS -----------------
 [env_common_stm32]

--- a/src/targets/diy_2400.ini
+++ b/src/targets/diy_2400.ini
@@ -58,9 +58,7 @@ src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART
 upload_protocol = custom
 upload_speed = 420000
-upload_command =
-	python "$PROJECT_DIR/python/BFinitPassthrough.py" $UPLOAD_SPEED "reset_to_bootloader"
-	python "$PROJECT_DIR/python/esptool-3.0/esptool.py" --no-stub -b $UPLOAD_SPEED -c esp8266 --before no_reset --after soft_reset write_flash 0x0000 "$SOURCE"
+upload_command = ${env_common_esp82xx.bf_upload_command}
 
 [env:DIY_2400_RX_ESP8285_SX1280_via_WIFI]
 extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART

--- a/src/targets/diy_2400.ini
+++ b/src/targets/diy_2400.ini
@@ -57,9 +57,9 @@ src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 [env:DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough]
 extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART
 upload_protocol = custom
-upload_speed = 115200
+upload_speed = 420000
 upload_command =
-	python "$PROJECT_DIR/python/BFinitPassthrough.py" $UPLOAD_SPEED
+	python "$PROJECT_DIR/python/BFinitPassthrough.py" $UPLOAD_SPEED "reset_to_bootloader"
 	python "$PROJECT_DIR/python/esptool-3.0/esptool.py" --no-stub -b $UPLOAD_SPEED -c esp8266 --before no_reset --after soft_reset write_flash 0x0000 "$SOURCE"
 
 [env:DIY_2400_RX_ESP8285_SX1280_via_WIFI]

--- a/src/targets/diy_900.ini
+++ b/src/targets/diy_900.ini
@@ -58,9 +58,9 @@ src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 [env:DIY_900_RX_ESP8285_SX127x_via_BetaflightPassthrough]
 extends = env:DIY_900_RX_ESP8285_SX127x_via_UART
 upload_protocol = custom
-upload_speed = 115200
+upload_speed = 420000
 upload_command =
-	python "$PROJECT_DIR/python/BFinitPassthrough.py" $UPLOAD_SPEED
+	python "$PROJECT_DIR/python/BFinitPassthrough.py" $UPLOAD_SPEED "reset_to_bootloader"
 	python "$PROJECT_DIR/python/esptool-3.0/esptool.py" --no-stub -b $UPLOAD_SPEED -c esp8266 --before no_reset --after soft_reset write_flash 0x0000 "$SOURCE"
 
 [env:DIY_900_RX_ESP8285_SX127x_via_WIFI]

--- a/src/targets/diy_900.ini
+++ b/src/targets/diy_900.ini
@@ -59,9 +59,7 @@ src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 extends = env:DIY_900_RX_ESP8285_SX127x_via_UART
 upload_protocol = custom
 upload_speed = 420000
-upload_command =
-	python "$PROJECT_DIR/python/BFinitPassthrough.py" $UPLOAD_SPEED "reset_to_bootloader"
-	python "$PROJECT_DIR/python/esptool-3.0/esptool.py" --no-stub -b $UPLOAD_SPEED -c esp8266 --before no_reset --after soft_reset write_flash 0x0000 "$SOURCE"
+upload_command = ${env_common_esp82xx.bf_upload_command}
 
 [env:DIY_900_RX_ESP8285_SX127x_via_WIFI]
 extends = env:DIY_900_RX_ESP8285_SX127x_via_UART

--- a/src/targets/namimnorc_900.ini
+++ b/src/targets/namimnorc_900.ini
@@ -57,9 +57,9 @@ src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 [env:NamimnoRC_VOYAGER_900_ESP_RX_via_BetaflightPassthrough]
 extends = env:NamimnoRC_VOYAGER_900_ESP_RX_via_UART
 upload_protocol = custom
-upload_speed = 115200
+upload_speed = 420000
 upload_command =
-	python "$PROJECT_DIR/python/BFinitPassthrough.py" $UPLOAD_SPEED
+	python "$PROJECT_DIR/python/BFinitPassthrough.py" $UPLOAD_SPEED "reset_to_bootloader"
 	python "$PROJECT_DIR/python/esptool-3.0/esptool.py" --no-stub -b $UPLOAD_SPEED -c esp8266 --before no_reset --after soft_reset write_flash 0x0000 "$SOURCE"
 
 [env:NamimnoRC_VOYAGER_900_ESP_RX_via_WIFI]

--- a/src/targets/namimnorc_900.ini
+++ b/src/targets/namimnorc_900.ini
@@ -58,9 +58,7 @@ src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 extends = env:NamimnoRC_VOYAGER_900_ESP_RX_via_UART
 upload_protocol = custom
 upload_speed = 420000
-upload_command =
-	python "$PROJECT_DIR/python/BFinitPassthrough.py" $UPLOAD_SPEED "reset_to_bootloader"
-	python "$PROJECT_DIR/python/esptool-3.0/esptool.py" --no-stub -b $UPLOAD_SPEED -c esp8266 --before no_reset --after soft_reset write_flash 0x0000 "$SOURCE"
+upload_command = ${env_common_esp82xx.bf_upload_command}
 
 [env:NamimnoRC_VOYAGER_900_ESP_RX_via_WIFI]
 extends = env:NamimnoRC_VOYAGER_900_ESP_RX_via_UART

--- a/src/targets/neutronrc_900.ini
+++ b/src/targets/neutronrc_900.ini
@@ -21,9 +21,7 @@ src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 extends = env:NeutronRC_900_RX_via_UART
 upload_protocol = custom
 upload_speed = 420000
-upload_command =
-	python "$PROJECT_DIR/python/BFinitPassthrough.py" $UPLOAD_SPEED "reset_to_bootloader"
-	python "$PROJECT_DIR/python/esptool-3.0/esptool.py" --no-stub -b $UPLOAD_SPEED -c esp8266 --before no_reset --after soft_reset write_flash 0x0000 "$SOURCE"
+upload_command = ${env_common_esp82xx.bf_upload_command}
 
 [env:NeutronRC_900_RX_via_WIFI]
 extends = env:NeutronRC_900_RX_via_UART

--- a/src/targets/neutronrc_900.ini
+++ b/src/targets/neutronrc_900.ini
@@ -20,8 +20,9 @@ src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 [env:NeutronRC_900_RX_via_BetaflightPassthrough]
 extends = env:NeutronRC_900_RX_via_UART
 upload_protocol = custom
+upload_speed = 420000
 upload_command =
-	python "$PROJECT_DIR/python/BFinitPassthrough.py" $UPLOAD_SPEED
+	python "$PROJECT_DIR/python/BFinitPassthrough.py" $UPLOAD_SPEED "reset_to_bootloader"
 	python "$PROJECT_DIR/python/esptool-3.0/esptool.py" --no-stub -b $UPLOAD_SPEED -c esp8266 --before no_reset --after soft_reset write_flash 0x0000 "$SOURCE"
 
 [env:NeutronRC_900_RX_via_WIFI]


### PR DESCRIPTION
Thanks to @pkendall64 for pointing out the new ESP.rebootIntoUartDownloadMode(); function in the platform update. Along with the auto-baud detection of the ROM bootloader on ESP targets this allows a seamless buttonless reboot. 

The only caveat is that the flight controller must be "fresh" each for each new upload. IE, it cannot already been in passthrough mode. 

Suggestions for improvements welcome. 