### PR TITLE
Don't count telemetry packets as LQ on the RX

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -419,10 +419,15 @@ void ICACHE_RAM_ATTR HWtimerCallbackTick() // this is 180 out of phase with the 
 {
     updatePhaseLock();
     NonceRX++;
-    alreadyFHSS = false;
-    alreadyTLMresp = false;
+
+    // Save the LQ value before the inc() reduces it by 1
     uplinkLQ = LQCalc.getLQ();
-    LQCalc.inc();
+    // Only advance the LQI period counter if we didn't send Telemetry this period
+    if (!alreadyTLMresp)
+        LQCalc.inc();
+
+    alreadyTLMresp = false;
+    alreadyFHSS = false;
     crsf.RXhandleUARTout();
 }
 
@@ -829,7 +834,6 @@ void inline RXdoneISR()
 void ICACHE_RAM_ATTR TXdoneISR()
 {
     Radio.RXnb();
-    LQCalc.add(); // Adds packet to LQ calculation otherwise an artificial drop in LQ is seen due to sending TLM.
 #if defined(PRINT_RX_SCOREBOARD)
     Serial.write('T');
 #endif


### PR DESCRIPTION
The LQI we report at the RX is incremented both for incoming packets (RX) and outgoing packet (Telemetry). This artificially inflates the LQI reported by the Telemetry Ratio percentage (e.g. 50% for 1:2, 25% for 1:4, etc) and can lead to failsafes at relatively high LQ. 

This PR addresses this by only incrementing the LQ period counter on periods we did not send telemetry, and also removes the matching add() call when the Telemetry packet has been sent. This still means the user will see 100% LQ when 100% of the RX packets are received, but now can go below the ratio floor.

Note that the TX code already does this properly, but reversed, only inc()s at the telemetry interval and add()ing if it receives a packet-- not inc()ing every period and add()ing for both TX and RX packets.