### PR TITLE
Force disable diversity on HappyModel EPx receivers

### DIFF
--- a/src/python/build_flags.py
+++ b/src/python/build_flags.py
@@ -53,6 +53,9 @@ def process_flags(path):
     if not os.path.isfile(path):
         return
     parse_flags(path)
+
+def condense_flags():
+    global build_flags
     for line in build_flags:
         # Some lines have multiple flags so this will split them and remove them all
         for flag in re.findall("!-D\s*[^\s]+", line):
@@ -103,8 +106,8 @@ def get_git_sha():
 
 process_flags("user_defines.txt")
 process_flags("super_defines.txt") # allow secret super_defines to override user_defines
-
 build_flags.append("-DLATEST_COMMIT=" + get_git_sha())
+condense_flags()
 
 env['BUILD_FLAGS'] = build_flags
 print("build flags: %s" % env['BUILD_FLAGS'])

--- a/src/targets/happymodel_2400.ini
+++ b/src/targets/happymodel_2400.ini
@@ -22,9 +22,11 @@ build_flags =
 
 [env:HappyModel_EP_2400_RX_via_UART]
 extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART
+build_flags = ${env:DIY_2400_RX_ESP8285_SX1280_via_UART.build_flags} !-DUSE_DIVERSITY
 
 [env:HappyModel_EP_2400_RX_via_BetaflightPassthrough]
 extends = env:DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough
+build_flags = ${env:DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough.build_flags} !-DUSE_DIVERSITY
 
 [env:HappyModel_EP_2400_RX_via_WIFI]
 extends = env:HappyModel_EP_2400_RX_via_UART


### PR DESCRIPTION
This is insanely minor so I can understand if this will get set to milestone 1.1, just classify it as such.

### Bug (cosmetic)
HappyModel EP1 and EP2 receivers when compiled with USE_DIVERSITY show that they are switching antennas even though they have no such capability. This is because they are based on the DIY_2400_RX_ESP8285_SX1280 target, which can be built with diversity switching. it is purely cosmetic because there's no hardware switch, but RSSI1 and RSSI2 are both populated as the diversity thinks it is switching, and the antenna icon changes in iNav.

### Resolution
This PR force disables USE_DIVERSITY for the `HappyModel_EP_2400_RX_via_*` targets.

* There's a problem with the build_flags.py, in that parent build_flags can't disable flags that are further down the chain (user_defines and super_defines). Because this PR needs the platformio.ini to change [user|super]_defines, Updates build_flags.py to support this by having it gather all the flags first with `parse_flags` then remove all the `!-D` bits with a new function `condense_flags`
* Adds `!-DUSE_DIVERSITY` to the EP1 and EP2 environments