### PR TITLE
Fix iNav bricking ESP8285 RX on passthrough upload

### DIFF
--- a/src/python/esptool-3.0/esptool.py
+++ b/src/python/esptool-3.0/esptool.py
@@ -224,7 +224,7 @@ class ESPLoader(object):
     ROM_INVALID_RECV_MSG = 0x05   # response if an invalid message is received
 
     # Maximum block sized for RAM and Flash writes, respectively.
-    ESP_RAM_BLOCK   = 0x1800
+    ESP_RAM_BLOCK   = 0x0800
 
     FLASH_WRITE_SIZE = 0x400
 
@@ -1201,7 +1201,7 @@ class ESP8266ROM(ESPLoader):
 class ESP8266StubLoader(ESP8266ROM):
     """ Access class for ESP8266 stub loader, runs on top of ROM.
     """
-    FLASH_WRITE_SIZE = 0x4000  # matches MAX_WRITE_BLOCK in stub_loader.c
+    FLASH_WRITE_SIZE = 0x0800  # matches MAX_WRITE_BLOCK in stub_loader.c
     IS_STUB = True
 
     def __init__(self, rom_loader):
@@ -3577,11 +3577,11 @@ def main(custom_commandline=None):
         if args.override_vddsdio:
             esp.override_vddsdio(args.override_vddsdio)
 
-        if args.baud > initial_baud:
-            try:
-                esp.change_baud(args.baud)
-            except NotImplementedInROMError:
-                print("WARNING: ROM doesn't support changing baud rate. Keeping initial baud rate %d" % initial_baud)
+        # if args.baud > initial_baud:
+        #     try:
+        #         esp.change_baud(args.baud)
+        #     except NotImplementedInROMError:
+        #         print("WARNING: ROM doesn't support changing baud rate. Keeping initial baud rate %d" % initial_baud)
 
         # override common SPI flash parameter stuff if configured to do so
         if hasattr(args, "spi_connection") and args.spi_connection is not None:

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -50,7 +50,7 @@ upload_speed = 460800
 upload_resetmethod = nodemcu
 bf_upload_command =
 	python "$PROJECT_DIR/python/BFinitPassthrough.py" -b $UPLOAD_SPEED ${UPLOAD_PORT and "-p "+UPLOAD_PORT}
-	python "$PROJECT_DIR/python/esptool-3.0/esptool.py" --no-stub -b $UPLOAD_SPEED ${UPLOAD_PORT and "-p "+UPLOAD_PORT} -c esp8266 --before no_reset --after soft_reset write_flash 0x0000 "$SOURCE"
+	python "$PROJECT_DIR/python/esptool-3.0/esptool.py" -b $UPLOAD_SPEED ${UPLOAD_PORT and "-p "+UPLOAD_PORT} -c esp8266 --before no_reset --after soft_reset write_flash 0x0000 "$SOURCE"
 
 # ------------------------- COMMON STM32 DEFINITIONS -----------------
 [env_common_stm32]


### PR DESCRIPTION
These changes allow the uploader to use the esptool stub bootloader in place of the ROM bootloader.

This means that if we have an iNav target that fails uploading, at least it fails during the upload of the stub loader into RAM, rather than after the flash has been erased and is uploading the new image. So it will not update on iNav, but at least the RX is not erased and has to pulled out of a build and UART flashed to recover.

Changes to esptool to allow use of stub uploader
- reduce the size of the uploaded packets so they don't overflow buffers
- remove baud-rate change as that can't work via passthrough