### PR TITLE
Enable interrupt priorities on FM30/FM30_MINI

### DIFF
--- a/src/variants/FM30/variant.h
+++ b/src/variants/FM30/variant.h
@@ -118,6 +118,10 @@ extern "C" {
 #define PIN_SERIAL_RX           PA10
 #define PIN_SERIAL_TX           PA9
 
+// Adjust IRQ priority
+#define TIM_IRQ_PRIO            3
+#define EXTI_IRQ_PRIO           4
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/variants/FM30_mini/variant.h
+++ b/src/variants/FM30_mini/variant.h
@@ -92,6 +92,10 @@ extern "C" {
 #define ALT3 (1 << (STM_PIN_AFNUM_SHIFT+2))
 #define ALT4 (1 << (STM_PIN_AFNUM_SHIFT+3))
 
+// Adjust IRQ priority
+#define TIM_IRQ_PRIO            3
+#define EXTI_IRQ_PRIO           4
+
 #ifdef __cplusplus
 } // extern "C"
 #endif


### PR DESCRIPTION
While working on the patch1 changes, we've discovered I never enabled interrupt priorities on the variants used for FM30 and FM30_MINI boards. This enables them to match other STM32 targets.

Tested on my sample size of 1 RX and 1 TX, but now the behavior difference between Ghost ATTO and FM30 Mini has been removed. On the FM30 Mini the hwtimer ISR was being deferred until after the ProcessRFPacket versus firing immediately on ATTO, which is exactly what you'd expect.