### PR TITLE
Reorganization and bugfixes for SX127x RX sudden failsafe

### DIFF
--- a/src/lib/HWTIMER/ESP8266_hwTimer.cpp
+++ b/src/lib/HWTIMER/ESP8266_hwTimer.cpp
@@ -71,8 +71,8 @@ void ICACHE_RAM_ATTR hwTimer::decFreqOffset()
 
 void ICACHE_RAM_ATTR hwTimer::phaseShift(int32_t newPhaseShift)
 {
-    int32_t minVal = -(hwTimer::HWtimerInterval >> 4);
-    int32_t maxVal = (hwTimer::HWtimerInterval >> 4);
+    int32_t minVal = -(hwTimer::HWtimerInterval >> 2);
+    int32_t maxVal = (hwTimer::HWtimerInterval >> 2);
 
     hwTimer::PhaseShift = constrain(newPhaseShift, minVal, maxVal) * HWTIMER_TICKS_PER_US;
 }

--- a/src/lib/HWTIMER/STM32_hwTimer.cpp
+++ b/src/lib/HWTIMER/STM32_hwTimer.cpp
@@ -68,8 +68,10 @@ void hwTimer::resume()
     isTick = true;
     running = true;
     SkipCallback = true; //skip first callback
+    #if defined(TARGET_TX)
     MyTim->setOverflow((hwTimer::HWtimerInterval >> 1), MICROSEC_FORMAT);
     MyTim->setCount(0);
+    #endif
     MyTim->resume();
     MyTim->refresh();
 }
@@ -103,11 +105,13 @@ void hwTimer::phaseShift(int32_t newPhaseShift)
 
 void hwTimer::callback(void)
 {
+    #if !defined(TARGET_TX)
     if (SkipCallback)
     {
         SkipCallback = false;
         return;
     }
+    #endif
 
     if (hwTimer::isTick)
     {

--- a/src/lib/HWTIMER/STM32_hwTimer.cpp
+++ b/src/lib/HWTIMER/STM32_hwTimer.cpp
@@ -69,9 +69,12 @@ void hwTimer::resume()
     running = true;
     SkipCallback = true; //skip first callback
     #if defined(TARGET_TX)
+    MyTim->setPrescaleFactor(MyTim->getTimerClkFreq() / 1000000); // 1us per tick
+    MyTim->setOverflow(hwTimer::HWtimerInterval >> 1, TICK_FORMAT);
+    #else
     MyTim->setOverflow((hwTimer::HWtimerInterval >> 1), MICROSEC_FORMAT);
-    MyTim->setCount(0);
     #endif
+    MyTim->setCount(0);
     MyTim->resume();
     MyTim->refresh();
 }

--- a/src/lib/HWTIMER/STM32_hwTimer.h
+++ b/src/lib/HWTIMER/STM32_hwTimer.h
@@ -13,7 +13,6 @@ public:
 
     static volatile uint32_t HWtimerInterval;
     static volatile bool isTick;
-    static volatile bool SkipCallback;
     static volatile int32_t PhaseShift;
     static volatile int32_t FreqOffset;
     static volatile uint32_t PauseDuration;

--- a/src/lib/HWTIMER/STM32_hwTimer.h
+++ b/src/lib/HWTIMER/STM32_hwTimer.h
@@ -13,6 +13,7 @@ public:
 
     static volatile uint32_t HWtimerInterval;
     static volatile bool isTick;
+    static volatile bool SkipCallback;
     static volatile int32_t PhaseShift;
     static volatile int32_t FreqOffset;
     static volatile uint32_t PauseDuration;

--- a/src/lib/PFD/PFD.h
+++ b/src/lib/PFD/PFD.h
@@ -41,6 +41,6 @@ public:
         return result;
     }
 
-    uint32_t getIntEventTime() const { return intEventTime; }
-    uint32_t getExtEventTime() const { return extEventTime; }
+    volatile uint32_t getIntEventTime() const { return intEventTime; }
+    volatile uint32_t getExtEventTime() const { return extEventTime; }
 };

--- a/src/lib/PFD/PFD.h
+++ b/src/lib/PFD/PFD.h
@@ -6,8 +6,8 @@
 class PFD
 {
 private:
-    uint32_t intEventTime = 0; 
-    uint32_t extEventTime = 0;  
+    uint32_t intEventTime = 0;
+    uint32_t extEventTime = 0;
     int32_t result;
     bool gotExtEvent;
     bool gotIntEvent;
@@ -20,7 +20,7 @@ public:
     }
 
     inline void intEvent(uint32_t time) // internal osc event
-    { 
+    {
         intEventTime = time;
         gotIntEvent = true;
     }
@@ -40,4 +40,7 @@ public:
     {
         return result;
     }
+
+    uint32_t getIntEventTime() const { return intEventTime; }
+    uint32_t getExtEventTime() const { return extEventTime; }
 };

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -69,6 +69,9 @@ void SX127xDriver::ConfigLoraDefaults()
   hal.writeRegister(SX127X_REG_OP_MODE, ModFSKorLoRa); //must be written in sleep mode
   SetMode(SX127x_OPMODE_STANDBY);
 
+  instance->IRQneedsClear = true;
+  instance->ClearIRQFlags();
+
   hal.writeRegister(SX127X_REG_PAYLOAD_LENGTH, TXbuffLen);
   SetSyncWord(currSyncWord);
   hal.writeRegister(SX127X_REG_FIFO_TX_BASE_ADDR, SX127X_FIFO_TX_BASE_ADDR_MAX);

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -521,6 +521,7 @@ void LostConnection()
     connectionState = disconnected; //set lost connection
     RXtimerState = tim_disconnected;
     hwTimer.resetFreqOffset();
+    hwTimer.phaseShift(0);
     FreqCorrection = 0;
     Offset = 0;
     OffsetDx = 0;

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -121,7 +121,6 @@ uint8_t uplinkLQ;
 
 uint8_t scanIndex = RATE_DEFAULT;
 
-uint32_t TockTime;
 int32_t RawOffset;
 int32_t prevRawOffset;
 int32_t Offset;
@@ -528,7 +527,6 @@ void ICACHE_RAM_ATTR HWtimerCallbackTock()
         Serial.write(lastPacketCrcError ? '.' : '_');
     lastPacketCrcError = false;
     #endif
-    TockTime = micros();
 }
 
 void LostConnection()
@@ -560,7 +558,7 @@ void LostConnection()
 
     if (!InBindingMode)
     {
-        while(micros() - TockTime > 250); // time it just after the tock()
+        while(micros() - PFDloop.getIntEventTime() > 250); // time it just after the tock()
         hwTimer.stop();
         SetRFLinkRate(ExpressLRS_nextAirRateIndex); // also sets to initialFreq
         Radio.RXnb();
@@ -602,7 +600,7 @@ void ICACHE_RAM_ATTR TentativeConnection()
     WS281BsetLED(LEDcolor);
     LEDWS2812LastUpdate = millis();
 #endif
-    
+
 }
 
 void GotConnection()

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -430,11 +430,6 @@ void ICACHE_RAM_ATTR HWtimerCallbackTick() // this is 180 out of phase with the 
     updatePhaseLock();
     NonceRX++;
 
-    if (!alreadyTLMresp && !alreadyFHSS && !LQCalc.currentIsSet()) // packet timeout AND didn't DIDN'T just hop or send TLM
-    {
-        Radio.RXnb(); // put the radio cleanly back into RX in case of garbage data
-    }
-
     // Save the LQ value before the inc() reduces it by 1
     uplinkLQ = LQCalc.getLQ();
     // Only advance the LQI period counter if we didn't send Telemetry this period
@@ -518,16 +513,18 @@ void ICACHE_RAM_ATTR HWtimerCallbackTock()
     bool didFHSS = HandleFHSS();
     bool tlmSent = HandleSendTelemetryResponse();
 
-    #if !defined(Regulatory_Domain_ISM_2400)
-    if (!didFHSS && !tlmSent && LQCalc.currentIsSet())
+    if (!didFHSS && !tlmSent)
     {
-        HandleFreqCorr(Radio.GetFrequencyErrorbool()); //corrects for RX freq offset
-        Radio.SetPPMoffsetReg(FreqCorrection*FREQ_STEP);         //as above but corrects a different PPM offset based on freq error
+        if (LQCalc.currentIsSet())
+        {
+        #if !defined(Regulatory_Domain_ISM_2400)
+            HandleFreqCorr(Radio.GetFrequencyErrorbool());      // Adjusts FreqCorrection for RX freq offset
+            Radio.SetPPMoffsetReg(FreqCorrection*FREQ_STEP);    // as above but corrects a different PPM offset based on freq error
+        #endif /* Regulatory_Domain_ISM_2400 */
+        }
+        else
+            Radio.RXnb(); // put the radio cleanly back into RX in case of garbage data
     }
-    #else
-        (void)didFHSS;
-        (void)tlmSent;
-    #endif /* Regulatory_Domain_ISM_2400 */
 
     #if defined(PRINT_RX_SCOREBOARD)
     if (!LQCalc.currentIsSet())

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -360,7 +360,7 @@ void ICACHE_RAM_ATTR updatePhaseLock()
         PFDloop.reset();
         RawOffset = constrain(PFDloop.getResult(), -(int32_t)(ExpressLRS_currAirRate_Modparams->interval/4), (int32_t)(ExpressLRS_currAirRate_Modparams->interval/4));
         Offset = LPF_Offset.update(RawOffset);
-        OffsetDx = LPF_OffsetDx.update(RawOffset - OffsetDx);
+        OffsetDx = LPF_OffsetDx.update(RawOffset - prevRawOffset);
 
         if (RXtimerState == tim_locked && LQCalc.currentIsSet())
         {

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -579,10 +579,7 @@ void LostConnection()
 
 void ICACHE_RAM_ATTR TentativeConnection()
 {
-    // Subtract out the amount of time it took to get here from the ISR firing
-    // plus the desired slack space between the packet coming and our timer
     hwTimer.resume();
-    hwTimer.phaseShift(PFDloop.getExtEventTime() - micros());
     PFDloop.reset();
     connectionStatePrev = connectionState;
     connectionState = tentative;
@@ -754,7 +751,9 @@ void ICACHE_RAM_ATTR ProcessRFPacket()
                 ExpressLRS_nextAirRateIndex = indexIN;
              }
 
-             if (NonceRX != Radio.RXdataBuffer[2] || FHSSgetCurrIndex() != Radio.RXdataBuffer[1])
+             if (connectionState == disconnected
+                || NonceRX != Radio.RXdataBuffer[2]
+                || FHSSgetCurrIndex() != Radio.RXdataBuffer[1])
              {
                  //Serial.print(NonceRX, DEC); Serial.write('x'); Serial.println(Radio.RXdataBuffer[2], DEC);
                  FHSSsetCurrIndex(Radio.RXdataBuffer[1]);

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -363,8 +363,7 @@ void ICACHE_RAM_ATTR updatePhaseLock()
     {
         PFDloop.calcResult();
         PFDloop.reset();
-
-        RawOffset = PFDloop.getResult();
+        RawOffset = constrain(PFDloop.getResult(), -(int32_t)(ExpressLRS_currAirRate_Modparams->interval/4), (int32_t)(ExpressLRS_currAirRate_Modparams->interval/4));
         Offset = LPF_Offset.update(RawOffset);
         OffsetSlow = LPF_OffsetSlow.update(RawOffset);
         OffsetDx = abs(LPF_OffsetDx.update(RawOffset - prevOffset));
@@ -378,7 +377,7 @@ void ICACHE_RAM_ATTR updatePhaseLock()
             hwTimer.phaseShift(Offset >> 2);
         }
 
-        if (RXtimerState == tim_locked && (micros() - beginProcessing) < ExpressLRS_currAirRate_Modparams->interval)
+        if (RXtimerState == tim_locked && (micros() - LastValidPacket) < ExpressLRS_currAirRate_Modparams->interval)
         {
             if (NonceRX % 8 == 0) //limit rate of freq offset adjustment slightly
             {
@@ -548,6 +547,7 @@ void LostConnection()
 
     RFmodeCycleMultiplier = 1;
     Serial.println("lost conn");
+    Serial.println(FreqCorrection);
 
 #ifdef GPIO_PIN_LED_GREEN
     digitalWrite(GPIO_PIN_LED_GREEN, LOW ^ GPIO_LED_GREEN_INVERTED);

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -539,7 +539,7 @@ void ICACHE_RAM_ATTR HWtimerCallbackTock()
 void LostConnection()
 {
     Serial.print(F("lost conn fc=")); Serial.print(FreqCorrection, DEC);
-    Serial.print(F(" off=")); Serial.println(Offset, DEC);
+    Serial.print(F(" fo=")); Serial.println(hwTimer.FreqOffset, DEC);
 
     RFmodeCycleMultiplier = 1;
     connectionStatePrev = connectionState;


### PR DESCRIPTION
This is the collected changes Alessandro and I have been working on to attempt to resolve the RX lockup issues causing sudden failsafes for SX127x RX, 868/915MHz. #553

* Removes FHSS/Telemetry/RF frequency offset adjustment from packet handler to do all this work entirely in the Tock handler. This prevents the timer interrupt from taking priority and perhaps preempting the packet handler halfway through its work
* Fix first timer being the wrong interval when enabling hwtimer on STM32 (both because it wasn't set or due to using the previous prescaler)
* Reset many state variables on disconnect to prevent compares against previous connect's values
* Reduce the minimum LQ required for connection to be established from a fixed 75LQ to be based on number of FHSS channels per domain
  * 2.4GHz - 5
  * FCC915 - 5
  * AU915 - 9
  * EU868 - 9
  * EU/AU433 - 37
* Prevent double rate change when switching packet rates while connected
* Reduce window for expected packet lateness from 250us to 200us to allow enough time for frequency to settle when making a large change in hertzes.
* Reset RF frequency correction on disconnect on SX127x hardware
* Prevent not being able to connect to RX in the rare case the RXnonce already matched the sync packet Nonce
* Synchronize stopping the hwtimer to just after it fires instead of disabling it and waiting a long duration
* Skew hwtimer phase offset half more slowly when connected (from half to quarter the LPFed offset)
* Increases the maximum phase shift per cycle to allow the hwtimer to sync more quickly when the timer is far off sync when not connected
