### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1-Bug_report.md
@@ -4,12 +4,6 @@ about: You found a bug in expresslrs. 🐞
 labels: 'bug'
 ---
 
-<!-- Please use the following issue template or your issue will be closed -->
-
-## Expected Behavior
-
-<!--- What should have happened? -->
-
 ## Current Behavior
 
 <!--- What went wrong? -->
@@ -45,3 +39,9 @@ labels: 'bug'
 
 - TX hardware:
 - RX hardware:
+- Handset model:
+- OpenTX version (including nightly number)
+- ELRS version (TX & RX MUST MATCH):
+- Packet Rate:
+- Telemetry Ratio:
+- user_defines:

--- a/.github/ISSUE_TEMPLATE/1-Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1-Bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: You found a bug in expresslrs. 🐞
+about: You found a bug in ExpressLRS. 🐞
 labels: 'bug'
 ---
 
@@ -41,7 +41,7 @@ labels: 'bug'
 - RX hardware:
 - Handset model:
 - OpenTX version (including nightly number)
-- ELRS version (TX & RX MUST MATCH):
+- ExpressLRS version (TX & RX MUST MATCH):
 - Packet Rate:
 - Telemetry Ratio:
 - user_defines:

--- a/.github/ISSUE_TEMPLATE/1-Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1-Bug_report.md
@@ -1,0 +1,45 @@
+---
+name: Bug report
+about: You found a bug in expresslrs. 🐞
+labels: 'bug'
+---
+
+<!-- Please use the following issue template or your issue will be closed -->
+
+## Expected Behavior
+
+<!--- What should have happened? -->
+
+## Current Behavior
+
+<!--- What went wrong? -->
+
+## Steps to Reproduce
+
+<!-- Add relevant code and/or a live example -->
+<!-- Add stack traces -->
+
+1.
+
+2.
+
+3.
+
+4.
+
+## Possible Solution (Not obligatory)
+
+<!--- Suggest a reason for the bug or how to fix it. -->
+
+## Context
+
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Did you make any changes to the boilerplate after cloning it? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Your Environment
+
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+
+- TX hardware:
+- RX hardware:

--- a/.github/ISSUE_TEMPLATE/1-Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1-Bug_report.md
@@ -31,7 +31,9 @@ labels: 'bug'
 
 <!--- Suggest a reason for the bug or how to fix it. -->
 
-## Context
+## Details
+
+<!--- Additional details you think might be relevant -->
 
 <!--- How has this issue affected you? What are you trying to accomplish? -->
 <!--- Did you make any changes to the boilerplate after cloning it? -->

--- a/.github/ISSUE_TEMPLATE/2-Enhancement.md
+++ b/.github/ISSUE_TEMPLATE/2-Enhancement.md
@@ -1,0 +1,5 @@
+---
+name: Enhancement
+about: You want to propose an enhancement to expresslrs. 🎉
+labels: 'enhancement'
+---

--- a/.github/ISSUE_TEMPLATE/2-Enhancement.md
+++ b/.github/ISSUE_TEMPLATE/2-Enhancement.md
@@ -1,5 +1,0 @@
----
-name: Enhancement
-about: You want to propose an enhancement to expresslrs. 🎉
-labels: 'enhancement'
----

--- a/.github/ISSUE_TEMPLATE/2-Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/2-Feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: You want to propose a new feature or enhancement to expresslrs. 🎉
+about: You want to propose a new feature or enhancement to ExpressLRS. 🎉
 labels: 'enhancement'
 ---
 

--- a/.github/ISSUE_TEMPLATE/2-Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/2-Feature_request.md
@@ -1,0 +1,10 @@
+---
+name: Feature request
+about: You want to propose a new feature or enhancement to expresslrs. 🎉
+labels: 'enhancement'
+---
+
+<!--- Insert your suggestions here -->
+
+
+*Instead of commenting "I want this too", consider leaving a :+1: instead, to reduce spam and clutter*

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Community Discord
+    url: https://discord.gg/dS6ReFY
+    about: Please ask and answer questions here
+  - name: Facebook Group
+    url: https://www.facebook.com/groups/636441730280366
+    about: Please ask and answer questions here
+  - name: Wiki
+    url: https://github.com/ExpressLRS/ExpressLRS/wiki
+    about: If you look for information regarding ELRS, you will find them here


### PR DESCRIPTION
Fixes #510.
Inspired by the ExpressLRS-Configurator's issue templates, I added similar ones (basically a copy). They will help to keep issues structured. 
The difference from ExpressLRS-Configurator's issues templates is, that I changed them to encourage users to ask questions on Discord rather than posting an issue on GitHub.

Please let me know what you think.