### PR TITLE
Fix scoreboard adding extra missing packet following Telemetry

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -523,9 +523,11 @@ void ICACHE_RAM_ATTR HWtimerCallbackTock()
     #endif /* Regulatory_Domain_ISM_2400 */
 
     #if defined(PRINT_RX_SCOREBOARD)
-    if (!LQCalc.currentIsSet())
+    static bool lastPacketWasTelemetry = false;
+    if (!LQCalc.currentIsSet() && !lastPacketWasTelemetry)
         Serial.write(lastPacketCrcError ? '.' : '_');
     lastPacketCrcError = false;
+    lastPacketWasTelemetry = tlmSent;
     #endif
 }
 


### PR DESCRIPTION
If the packet preceding a telemetry send was missed, the RX_SCOREBOARD would show T_ instead of just T. This is because the previous packet was missed, AND the TX process writes a T, so the code just needs to make sure the last packet wasn't telemetry.

Silly little nothing fix nobody would notice wasn't working.