### PR TITLE
Allow tx to return to original rate, mod params, iq inversion after bind

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1007,6 +1007,7 @@ void ExitBindingMode()
 
   InBindingMode = false;
   MspSender.ResetState();
+  SetRFLinkRate(config.GetRate()); //return to original rate
 
   Serial.println("Exiting binding mode");
 }


### PR DESCRIPTION
This fixes a possible bug in TX binding routine. When entering bind mode the rate is switched to rate with default index (0). After sending msp bind packets the logic never returns to the original rate, iq inversion, etc.