### PR TITLE
UARTUpload silently fails if UPLOAD_PORT can't be opened

### DIFF
--- a/src/python/UARTupload.py
+++ b/src/python/UARTupload.py
@@ -216,7 +216,12 @@ def on_upload(source, target, env):
             if "GHST=" in flag:
                 ghst = eval(flag.split("=")[1])
 
-    uart_upload(upload_port, firmware_path, upload_speed, ghst)
+    try:
+        uart_upload(upload_port, firmware_path, upload_speed, ghst)
+    except Exception as e:
+        dbg_print("{0}\n".format(e))
+        return -1
+    return 0
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I'm not entirely sure why, but the SerialException we throw when trying to open an invalid serial port in UARTUpload.py is getting eaten up the chain and therefore platformio is reported SUCCESS even though nothing was uploaded, sometimes even eating the debug messages about trying "FIRMWARE UPLOAD". However, a generic Exception if `serials_find.get_serial_port()` fails does abort properly.
```
Building .pio\build\Jumper_RX_R900MINI_via_BetaflightPassthrough\firmware.bin
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [==        ]  18.2% (used 3736 bytes from 20480 bytes)
Flash: [=======   ]  69.1% (used 45284 bytes from 65536 bytes)
Configuring upload protocol...
AVAILABLE: blackmagic, custom, dfu, jlink, mbed, stlink
CURRENT: upload_protocol = custom
Uploading .pio\build\Jumper_RX_R900MINI_via_BetaflightPassthrough\firmware.bin
...===== [SUCCESS] Took 8.06 seconds =====...

Environment                                   Status    Duration
--------------------------------------------  --------  ------------
Jumper_RX_R900MINI_via_BetaflightPassthrough  SUCCESS   00:00:08.064
...===== 1 succeeded in 00:00:08.064 =====...
```

This patch catches any Exception in `uart_upload` and prints it to dbg and returns -1 instead of trying to let the Exception do the talking, which is not working.

```
Checking size .pio\build\Jumper_RX_R900MINI_via_BetaflightPassthrough\firmware.elf
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [==        ]  18.2% (used 3736 bytes from 20480 bytes)
Flash: [=======   ]  69.1% (used 45284 bytes from 65536 byt*** [upload] Error -1
es)
Configuring upload protocol...
AVAILABLE: blackmagic, custom, dfu, jlink, mbed, stlink
CURRENT: upload_protocol = custom
Uploading .pio\build\Jumper_RX_R900MINI_via_BetaflightPassthrough\firmware.bin
=================== FIRMWARE UPLOAD ===================
  Bin file '.pio\build\Jumper_RX_R900MINI_via_BetaflightPassthrough\firmware.bin'
  Port COM12 @ 420000
could not open port 'COM12': PermissionError(13, 'Access is denied.', None, 5)
...===== [FAILED] Took 4.50 seconds =====...
Environment                                   Status    Duration
--------------------------------------------  --------  ------------
Jumper_RX_R900MINI_via_BetaflightPassthrough  FAILED    00:00:04.497
...===== 1 failed, 0 succeeded in 00:00:04.497 =====...
```

To test this you need to set `upload_port` explicitly so the autodetect doesn't fire. This will be the case as more people start using the Configurator with the 💪 feature that you can set the port in it.