### PR TITLE
Only unlock telemetry data that was locked before

### DIFF
--- a/src/lib/Telemetry/telemetry.cpp
+++ b/src/lib/Telemetry/telemetry.cpp
@@ -30,9 +30,6 @@ bool Telemetry::GetNextPayload(uint8_t* nextPayloadSize, uint8_t **payloadData)
     uint8_t oldPayloadIndex = currentPayloadIndex;
     uint8_t realLength = 0;
 
-    payloadTypes[currentPayloadIndex].locked = false;
-    payloadTypes[currentPayloadIndex].updated = false;
-
     do
     {
         currentPayloadIndex = (currentPayloadIndex + 1) % payloadTypesCount;
@@ -66,9 +63,18 @@ bool Telemetry::GetNextPayload(uint8_t* nextPayloadSize, uint8_t **payloadData)
     return false;
 }
 
+void Telemetry::UnlockCurrentPayload()
+{
+    if (payloadTypes[currentPayloadIndex].locked)
+    {
+        payloadTypes[currentPayloadIndex].locked = false;
+        payloadTypes[currentPayloadIndex].updated = false;
+    }
+}
+
 uint8_t* Telemetry::GetCurrentPayload()
 {
-    if (payloadTypes[currentPayloadIndex].updated)
+    if (payloadTypes[currentPayloadIndex].locked)
     {
         return payloadTypes[currentPayloadIndex].data;
     }

--- a/src/lib/Telemetry/telemetry.cpp
+++ b/src/lib/Telemetry/telemetry.cpp
@@ -30,6 +30,12 @@ bool Telemetry::GetNextPayload(uint8_t* nextPayloadSize, uint8_t **payloadData)
     uint8_t oldPayloadIndex = currentPayloadIndex;
     uint8_t realLength = 0;
 
+    if (payloadTypes[currentPayloadIndex].locked)
+    {
+        payloadTypes[currentPayloadIndex].locked = false;
+        payloadTypes[currentPayloadIndex].updated = false;
+    }
+
     do
     {
         currentPayloadIndex = (currentPayloadIndex + 1) % payloadTypesCount;
@@ -61,25 +67,6 @@ bool Telemetry::GetNextPayload(uint8_t* nextPayloadSize, uint8_t **payloadData)
     *nextPayloadSize = 0;
     *payloadData = 0;
     return false;
-}
-
-void Telemetry::UnlockCurrentPayload()
-{
-    if (payloadTypes[currentPayloadIndex].locked)
-    {
-        payloadTypes[currentPayloadIndex].locked = false;
-        payloadTypes[currentPayloadIndex].updated = false;
-    }
-}
-
-uint8_t* Telemetry::GetCurrentPayload()
-{
-    if (payloadTypes[currentPayloadIndex].locked)
-    {
-        return payloadTypes[currentPayloadIndex].data;
-    }
-
-    return 0;
 }
 
 uint8_t Telemetry::UpdatedPayloadCount()

--- a/src/lib/Telemetry/telemetry.h
+++ b/src/lib/Telemetry/telemetry.h
@@ -46,6 +46,7 @@ public:
     uint8_t* GetCurrentPayload();
     uint8_t UpdatedPayloadCount();
     uint8_t ReceivedPackagesCount();
+    void UnlockCurrentPayload();
     #endif
 private:
     void AppendToPackage(volatile crsf_telemetry_package_t *current);

--- a/src/lib/Telemetry/telemetry.h
+++ b/src/lib/Telemetry/telemetry.h
@@ -43,10 +43,8 @@ public:
     bool ShouldCallBootloader();
     #ifdef ENABLE_TELEMETRY
     bool GetNextPayload(uint8_t* nextPayloadSize, uint8_t **payloadData);
-    uint8_t* GetCurrentPayload();
     uint8_t UpdatedPayloadCount();
     uint8_t ReceivedPackagesCount();
-    void UnlockCurrentPayload();
     #endif
 private:
     void AppendToPackage(volatile crsf_telemetry_package_t *current);

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1327,19 +1327,9 @@ void loop()
     #ifdef ENABLE_TELEMETRY
     uint8_t *nextPayload = 0;
     uint8_t nextPlayloadSize = 0;
-    if (!TelemetrySender.IsActive())
+    if (!TelemetrySender.IsActive() && telemetry.GetNextPayload(&nextPlayloadSize, &nextPayload))
     {
-        // unlock payload after sender is done
-        if (telemetry.GetCurrentPayload())
-        {
-            telemetry.UnlockCurrentPayload();
-        }
-
-        // check for next telemetry payload to be sent
-        if (telemetry.GetNextPayload(&nextPlayloadSize, &nextPayload))
-        {
-            TelemetrySender.SetDataToTransmit(nextPlayloadSize, nextPayload, ELRS_TELEMETRY_BYTES_PER_CALL);
-        }
+        TelemetrySender.SetDataToTransmit(nextPlayloadSize, nextPayload, ELRS_TELEMETRY_BYTES_PER_CALL);
     }
     #endif
     updateTelemetryBurst();

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1327,9 +1327,19 @@ void loop()
     #ifdef ENABLE_TELEMETRY
     uint8_t *nextPayload = 0;
     uint8_t nextPlayloadSize = 0;
-    if (!TelemetrySender.IsActive() && telemetry.GetNextPayload(&nextPlayloadSize, &nextPayload))
+    if (!TelemetrySender.IsActive())
     {
-        TelemetrySender.SetDataToTransmit(nextPlayloadSize, nextPayload, ELRS_TELEMETRY_BYTES_PER_CALL);
+        // unlock payload after sender is done
+        if (telemetry.GetCurrentPayload())
+        {
+            telemetry.UnlockCurrentPayload();
+        }
+
+        // check for next telemetry payload to be sent
+        if (telemetry.GetNextPayload(&nextPlayloadSize, &nextPayload))
+        {
+            TelemetrySender.SetDataToTransmit(nextPlayloadSize, nextPayload, ELRS_TELEMETRY_BYTES_PER_CALL);
+        }
     }
     #endif
     updateTelemetryBurst();

--- a/src/test/telemetry_native/test_telemetry.cpp
+++ b/src/test/telemetry_native/test_telemetry.cpp
@@ -31,6 +31,7 @@ void test_function_battery(void)
 {
     telemetry.ResetState();
     uint8_t batterySequence[] = {0xEC,10,CRSF_FRAMETYPE_BATTERY_SENSOR,0,0,0,0,0,0,0,0,109};
+    uint8_t batterySequence2[] = {0xEC,10,CRSF_FRAMETYPE_BATTERY_SENSOR,1,0,0,0,0,0,0,0,46};
     int length = sizeof(batterySequence);
     int sentLength = sendData(batterySequence, length);
     TEST_ASSERT_EQUAL(length, sentLength);
@@ -42,6 +43,19 @@ void test_function_battery(void)
     for (int i = 0; i < length; i++)
     {
         TEST_ASSERT_EQUAL(batterySequence[i], data[i]);
+    }
+
+    // simulate sending done + send another message of the same type to make sure that the repeated sending of only one type works
+    telemetry.UnlockCurrentPayload();
+    sentLength = sendData(batterySequence2, length);
+    TEST_ASSERT_EQUAL(length, sentLength);
+
+    telemetry.GetNextPayload(&receivedLength, &data);
+    TEST_ASSERT_NOT_EQUAL(0, data);
+
+    for (int i = 0; i < length; i++)
+    {
+        TEST_ASSERT_EQUAL(batterySequence2[i], data[i]);
     }
 }
 

--- a/src/test/telemetry_native/test_telemetry.cpp
+++ b/src/test/telemetry_native/test_telemetry.cpp
@@ -46,10 +46,15 @@ void test_function_battery(void)
     }
 
     // simulate sending done + send another message of the same type to make sure that the repeated sending of only one type works
-    telemetry.UnlockCurrentPayload();
+
+    // this unlocks the data but does not send it again since it's not updated
+    TEST_ASSERT_EQUAL(false, telemetry.GetNextPayload(&receivedLength, &data));
+
+    // update data
     sentLength = sendData(batterySequence2, length);
     TEST_ASSERT_EQUAL(length, sentLength);
 
+    // now it's ready to be sent
     telemetry.GetNextPayload(&receivedLength, &data);
     TEST_ASSERT_NOT_EQUAL(0, data);
 


### PR DESCRIPTION
This PR fixes a bug that prevents sending of telemetry data if only one type of message is received from the FC.

Unlocking the old tlm message did happen in the same method that did fetch the next tlm message to be sent.
If no other type of tlm message is received the unlock step did always clear the update flag and prevented any further communication.

To fix this bug the unlock is only done if the value was locked before.

After that a new message can be stored. The next call to GetNextPayload returns this message.

This issue would happen if betaflight is configured to send only the battery sensor.