### PR TITLE
 Update SetPPMoffsetReg correctly calculate PPM

### DIFF
--- a/src/lib/FHSS/FHSS.h
+++ b/src/lib/FHSS/FHSS.h
@@ -28,8 +28,8 @@ extern volatile uint8_t FHSSptr;
 extern uint8_t NumOfFHSSfrequencies;
 extern int32_t FreqCorrection;
 
-#define FreqCorrectionMax 200000
-#define FreqCorrectionMin -20000
+#define FreqCorrectionMax ((int32_t)(100000/FREQ_STEP))
+#define FreqCorrectionMin ((int32_t)(-100000/FREQ_STEP))
 
 #define FREQ_HZ_TO_REG_VAL(freq) ((uint32_t)((double)freq/(double)FREQ_STEP))
 
@@ -67,10 +67,10 @@ const uint32_t FHSSfreqs[] = {
     FREQ_HZ_TO_REG_VAL(926900000)};
 #elif defined Regulatory_Domain_EU_868
 /* Frequency bands taken from https://wetten.overheid.nl/BWBR0036378/2016-12-28#Bijlagen
- * Note: these frequencies fall in the license free H-band, but in combination with 500kHz 
+ * Note: these frequencies fall in the license free H-band, but in combination with 500kHz
  * LoRa modem bandwidth used by ExpressLRS (EU allows up to 125kHz modulation BW only) they
- * will never pass RED certification and they are ILLEGAL to use. 
- * 
+ * will never pass RED certification and they are ILLEGAL to use.
+ *
  * Therefore we simply maximize the usage of available spectrum so laboratory testing of the software won't disturb existing
  * 868MHz ISM band traffic too much.
  */
@@ -91,7 +91,7 @@ const uint32_t FHSSfreqs[] = {
 #elif defined Regulatory_Domain_EU_433
 /* Frequency band G, taken from https://wetten.overheid.nl/BWBR0036378/2016-12-28#Bijlagen
  * Note: As is the case with the 868Mhz band, these frequencies only comply to the license free portion
- * of the spectrum, nothing else. As such, these are likely illegal to use. 
+ * of the spectrum, nothing else. As such, these are likely illegal to use.
  */
 const uint32_t FHSSfreqs[] = {
     FREQ_HZ_TO_REG_VAL(433100000),
@@ -241,7 +241,7 @@ const uint32_t FHSSfreqs[] = {
     FREQ_HZ_TO_REG_VAL(2472400000),
     FREQ_HZ_TO_REG_VAL(2473400000),
     FREQ_HZ_TO_REG_VAL(2474400000),
-    
+
     FREQ_HZ_TO_REG_VAL(2475400000),
     FREQ_HZ_TO_REG_VAL(2476400000),
     FREQ_HZ_TO_REG_VAL(2477400000),

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -28,7 +28,7 @@ const uint8_t SX127x_AllowedSyncwords[105] =
      193, 196, 199, 201, 204, 205, 208, 209,
      212, 213, 219, 220, 221, 223, 227, 229,
      235, 239, 240, 242, 243, 246, 247, 255};
-     
+
 //////////////////////////////////////////////
 
 SX127xDriver::SX127xDriver()
@@ -200,7 +200,7 @@ void ICACHE_RAM_ATTR SX127xDriver::SetFrequencyHz(uint32_t freq)
 {
   currFreq = freq;
   SetMode(SX127x_OPMODE_STANDBY);
-  
+
   int32_t FRQ = ((uint32_t)((double)freq / (double)FREQ_STEP));
 
   uint8_t FRQ_MSB = (uint8_t)((FRQ >> 16) & 0xFF);
@@ -409,19 +409,15 @@ uint32_t ICACHE_RAM_ATTR SX127xDriver::GetCurrBandwidthNormalisedShifted() // th
   return -1;
 }
 
+/**
+ * Set the PPMcorrection register to adjust data rate to frequency error
+ * @param offset is in Hz or FREQ_STEP (FREQ_HZ_TO_REG_VAL) units, whichever
+ *    was used to SetFrequencyHz/SetFrequencyReg
+ */
 void ICACHE_RAM_ATTR SX127xDriver::SetPPMoffsetReg(int32_t offset)
 {
-  int32_t offsetValue = ((int32_t)243) * (offset << 8) / ((((int32_t)SX127xDriver::currFreq / 1000000)) << 8);
-  offsetValue >>= 8;
-
-  uint8_t regValue = offsetValue & 0b01111111;
-
-  if (offsetValue < 0)
-  {
-    regValue = regValue | 0b10000000; //set neg bit for 2s complement
-  }
-
-  hal.writeRegister(SX127x_PPMOFFSET, regValue);
+  int8_t offsetPPM = constrain((offset * 1e6 / currFreq) * 95 / 100, -128, 127);
+  hal.writeRegister(SX127x_PPMOFFSET, (uint8_t)offsetPPM);
 }
 
 bool ICACHE_RAM_ATTR SX127xDriver::GetFrequencyErrorbool()

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -416,7 +416,7 @@ uint32_t ICACHE_RAM_ATTR SX127xDriver::GetCurrBandwidthNormalisedShifted() // th
  */
 void ICACHE_RAM_ATTR SX127xDriver::SetPPMoffsetReg(int32_t offset)
 {
-  int8_t offsetPPM = constrain((offset * 1e6 / currFreq) * 95 / 100, -128, 127);
+  int8_t offsetPPM = (offset * 1e6 / currFreq) * 95 / 100;
   hal.writeRegister(SX127x_PPMOFFSET, (uint8_t)offsetPPM);
 }
 

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -515,7 +515,7 @@ void ICACHE_RAM_ATTR HWtimerCallbackTock()
     if (!didFHSS && !tlmSent && LQCalc.currentIsSet())
     {
         HandleFreqCorr(Radio.GetFrequencyErrorbool());      // Adjusts FreqCorrection for RX freq offset
-        Radio.SetPPMoffsetReg(FreqCorrection*FREQ_STEP);    // as above but corrects a different PPM offset based on freq error
+        Radio.SetPPMoffsetReg(FreqCorrection);
     }
     #else
         (void)didFHSS;


### PR DESCRIPTION
The frequency correction algorithm for Team900 was correctly shifting the FrequencyCorrection but the datarate PPM correction was producing bonkers numbers. This simplifies the calculation of offset to PPM so the value comes out correctly. For a FrequencyCorrection of ~90, I was getting an offsetValue of ~350, that the code was turning into 94, when the correct PPM should be ~6 (which is close to neither 350 nor 94).

The `FreqCorrectionMax` and `FreqCorrectionMin` values were also using Hz and the code expect reg values (Hz/FREQ_STEP). To prevent overflow, the limits are now +/-100KHz changed from -20KHz +200KHz.