### PR TITLE
Add Happymodel ES915TX WIFI target

### DIFF
--- a/src/targets/happymodel_900.ini
+++ b/src/targets/happymodel_900.ini
@@ -23,6 +23,8 @@ upload_flags =
 [env:HappyModel_TX_ES915TX_via_stock_BL]
 extends = env:HappyModel_TX_ES915TX_via_STLINK
 
+[env:HappyModel_TX_ES915TX_via_WIFI]
+extends = env:HappyModel_TX_ES915TX_via_STLINK
 
 # ********************************
 # Receiver targets


### PR DESCRIPTION
It is possible to attach an esp backpack to Happymodel ES915TX, wiring illustration has been added to ESP Backpack WIKI.