### PR TITLE
Add support for RTTTL melodies

### DIFF
--- a/src/python/build_flags.py
+++ b/src/python/build_flags.py
@@ -39,9 +39,7 @@ def parse_flags(path):
                         sys.stdout.write("\u001b[32mUID bytes: " + UIDbytes + "\n")
                         sys.stdout.flush()
                     if "MY_STARTUP_MELODY=" in define:
-                        defineValue = define.split('"')[1::2][0].split("|") # notes|bpm|transpose
-                        transposeBySemitones = int(defineValue[2]) if len(defineValue) > 2 else 0
-                        parsedMelody = melodyparser.parseMelody(defineValue[0].strip(), int(defineValue[1]), transposeBySemitones)
+                        parsedMelody = melodyparser.parse(define.split('"')[1::2][0])
                         define = "-DMY_STARTUP_MELODY_ARR=\"" + parsedMelody + "\""
                     if not define in build_flags:
                         build_flags.append(define)

--- a/src/python/melodyparser.py
+++ b/src/python/melodyparser.py
@@ -51,3 +51,24 @@ def generateArrayString(melodyArray):
 	for element in melodyArray:
 		elements.append("{" + str(element[0]) + "," + str(element[1]) + "}")
 	return "{" + ','.join(elements) + "}"
+
+def parse(melodyOrRTTTL):
+	# If | in melody it is original notes|bpm|transpose format
+	if ('|' in melodyOrRTTTL):
+		defineValue = melodyOrRTTTL.split("|")
+		transposeBySemitones = int(defineValue[2]) if len(defineValue) > 2 else 0
+		return parseMelody(defineValue[0].strip(), int(defineValue[1]), transposeBySemitones)
+	# Else assume RTTL
+	else:
+		from rtttl import RTTTL
+		retVal = ""
+		tune = RTTTL(melodyOrRTTTL)
+		for freq, msec in tune.notes():
+			retVal += f"{{{freq:.0f},{msec:.0f}}},"
+
+		if retVal != "":
+			retVal = "{" + retVal[:-1] + "}"
+		else:
+			raise ValueError('Blank RTTTL melody detected')
+		return retVal
+

--- a/src/python/rtttl.py
+++ b/src/python/rtttl.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# From: https://github.com/dhylands/upy-rtttl
+# Downloaded 2021-05-22
+# License: MIT
+# You can find a description of RTTTL here: https://en.wikipedia.org/wiki/Ring_Tone_Transfer_Language
+
+NOTE = [
+	440.0,	# A
+	493.9,	# B or H
+	261.6,	# C
+	293.7,	# D
+	329.6,	# E
+	349.2,  # F
+	392.0,	# G
+	0.0,    # pad
+
+	466.2,	# A#
+	0.0,
+	277.2,	# C#
+	311.1,	# D#
+	0.0,
+	370.0,	# F#
+	415.3,	# G#
+	0.0,
+]
+
+class RTTTL:
+
+	def __init__(self, tune):
+		tune_pieces = tune.split(':')
+		if len(tune_pieces) != 3:
+			raise ValueError('tune should contain exactly 2 colons')
+		self.tune = tune_pieces[2]
+		self.tune_idx = 0
+		self.parse_defaults(tune_pieces[1])
+
+	def parse_defaults(self, defaults):
+		# Example: d=4,o=5,b=140
+		val = 0
+		id = ' '
+		for char in defaults:
+			char = char.lower()
+			if char.isdigit():
+				val *= 10
+				val += ord(char) - ord('0')
+				if id == 'o':
+					self.default_octave = val
+				elif id == 'd':
+					self.default_duration = val
+				elif id == 'b':
+					self.bpm = val
+			elif char.isalpha():
+				id = char
+				val = 0
+		# 240000 = 60 sec/min * 4 beats/whole-note * 1000 msec/sec
+		self.msec_per_whole_note = 240000.0 / self.bpm
+
+	def next_char(self):
+		if self.tune_idx < len(self.tune):
+			char = self.tune[self.tune_idx]
+			self.tune_idx += 1
+			if char == ',':
+				char = ' '
+			return char
+		return '|'
+
+	def notes(self):
+		"""Generator which generates notes. Each note is a tuple where the
+		   first element is the frequency (in Hz) and the second element is
+		   the duration (in milliseconds).
+		"""
+		while True:
+			# Skip blank characters and commas
+			char = self.next_char()
+			while char == ' ':
+				char = self.next_char()
+
+			# Parse duration, if present. A duration of 1 means a whole note.
+			# A duration of 8 means 1/8 note.
+			duration = 0
+			while char.isdigit():
+				duration *= 10
+				duration += ord(char) - ord('0')
+				char = self.next_char()
+			if duration == 0:
+				duration = self.default_duration
+
+			if char == '|': # marker for end of tune
+				return
+
+			note = char.lower()
+			if note >= 'a' and note <= 'g':
+				note_idx = ord(note) - ord('a')
+			elif note == 'h':
+				note_idx = 1    # H is equivalent to B
+			else:
+				note_idx = 7    # pause
+			char = self.next_char()
+
+			# Check for sharp note
+			if char == '#':
+				note_idx += 8
+				char = self.next_char()
+
+			# Check for duration modifier before octave
+			# The spec has the dot after the octave, but some places do it
+			# the other way around.
+			duration_multiplier = 1.0
+			if char == '.':
+				duration_multiplier = 1.5
+				char = self.next_char()
+
+			# Check for octave
+			if char >= '4' and char <= '7':
+				octave = ord(char) - ord('0')
+				char = self.next_char()
+			else:
+				octave = self.default_octave
+
+			# Check for duration modifier after octave
+			if char == '.':
+				duration_multiplier = 1.5
+				char = self.next_char()
+
+			freq = NOTE[note_idx] * (1 << (octave - 4))
+			msec = (self.msec_per_whole_note / duration) * duration_multiplier
+
+			#print('note ', note, 'duration', duration, 'octave', octave, 'freq', freq, 'msec', msec)
+
+			yield freq, msec


### PR DESCRIPTION
Our melody format is great and all but wouldn't it be better if you could just paste any RTTTL (Ring Tone Text Transfer Language) string in there instead of our somewhat different version? This adds support for RTTTL strings for MY_STARTUP_MELODY.

* If MY_STARTUP_MELODY contains a pipe `|` it is assumed to be the old style
* RTTTL melodies are delimited by colons `:` and start with a description which is a nice way to rickroll someone not that I did that below.

Here are some melodies
* Aqua - Barbie Girl:o=5,d=4,b=125:8g#5,8e5,8g#5,8c#6,a5,p5,8f#5,8d#5,8f#5,8b5,g#5,8f#5,8e5,p5,8e5,8c#5,f#5,c#5,p5,8f#5,8e5,g#5,f#5
* Indiana:d=4,o=5,b=250:e,8p,8f,8g,8p,1c6,8p.,d,8p,8e,1f,p.,g,8p,8a,8b,8p,1f6,p,a,8p,8b,2c6,2d6,2e6,e,8p,8f,8g,8p,1c6,p,d6,8p,8e6,1f.6,g,8p,8g,e.6,8p,d6,8p,8g,e.6,8p,d6,8p,8g,f.6,8p,e6,8p,8d6,2c6
* Zelda1:o=5,d=4,b=125:a#5,f5.,8a#5,16a#5,16c6,16d6,16d#6,2f6,8p5,8f6,16f6.,16f#6,16g#6.,2a#6.,16a#6.,16g#6,16f#6.,8g#6.,16f#6.,2f6,f6,8d#6,16d#6,16f6,2f#6,8f6,8d#6,8c#6,16c#6,16d#6,2f6,8d#6,8c#6,8c6,16c6,16d6,2e6,g6,8f6,16f5,16f5,8f5,16f5,16f5,8f5,16f5,16f5,8f5,8f5,a#5,f5.,8a#5,16a#5,16c6,16d6,16d#6,2f6,8p5,8f6,16f6.,16f#6,16g#6.,2a#6.,c#7,c7,2a6,f6,2f#6.,a#6,a6,2f6,f6,2f#6.,a#6,a6,2f6,d6,2d#6.,f#6,f6,2c#6,a#5,c6,16d6,2e6,g6,8f6,16f5,16f5,8f5,16f5,16f5,8f5,16f5,16f5,8f5,8f5

Prepare to be sued!