### PR TITLE
Prevent switches_8 conversion from underflowing into other data

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -366,7 +366,7 @@ void ICACHE_RAM_ATTR CRSF::sendSyncPacketToTX() // in values in us.
         uint32_t packetRate;
         if (CRSF::UARTcurrentBaud == 115200 && CRSF::RequestedRCpacketInterval == 2000)
         {
-            packetRate = 40000; //constrain to 250hz max 
+            packetRate = 40000; //constrain to 250hz max
         }
         else
         {
@@ -907,13 +907,13 @@ void ICACHE_RAM_ATTR CRSF::updateSwitchValues()
         // If channel is within 1/4 a BIN of being in the middle use special value 7
         if (ch < (CRSF_CHANNEL_VALUE_MID-CHANNEL_BIN_SIZE/4)
             || ch > (CRSF_CHANNEL_VALUE_MID+CHANNEL_BIN_SIZE/4))
-            currentSwitches[i] = CRSF_to_N(ch, CHANNEL_BIN_COUNT);
+            currentSwitches[i] = CRSF_to_N(ch, CHANNEL_BIN_COUNT) & 0b111;
         else
             currentSwitches[i] = 7;
     } // for N_SWITCHES
 
     // AUXx is High Resolution 16-pos (4-bit)
-    currentSwitches[N_SWITCHES-1] = CRSF_to_N(ChannelDataIn[N_SWITCHES-1 + 4], 16);
+    currentSwitches[N_SWITCHES-1] = CRSF_to_N(ChannelDataIn[N_SWITCHES-1 + 4], 16) & 0b1111;
 }
 
 void ICACHE_RAM_ATTR CRSF::GetChannelDataIn() // data is packed as 11 bits per channel

--- a/src/lib/OTA/OTA.cpp
+++ b/src/lib/OTA/OTA.cpp
@@ -47,9 +47,9 @@ void ICACHE_RAM_ATTR GenerateChannelDataHybridSwitch8(volatile uint8_t* Buffer, 
   // If the two high bits are 0b11, the receiver knows it is the last switch and can use
   // that bit to store data
   uint8_t bitclearedSwitchIndex = nextSwitchIndex - 1;
-  // currentSwitches[] is 0-15 for index 1, 0-2 for index 2-7
+  // currentSwitches[] is 0-15 for index 6, 0-2 for index 0-5
   // Rely on currentSwitches to *only* have values in that rang
-  uint8_t value = crsf->currentSwitches[nextSwitchIndex] & 0b11;
+  uint8_t value = crsf->currentSwitches[nextSwitchIndex];
 
   Buffer[6] =
 #ifdef ENABLE_TELEMETRY

--- a/src/lib/OTA/OTA.cpp
+++ b/src/lib/OTA/OTA.cpp
@@ -49,7 +49,7 @@ void ICACHE_RAM_ATTR GenerateChannelDataHybridSwitch8(volatile uint8_t* Buffer, 
   uint8_t bitclearedSwitchIndex = nextSwitchIndex - 1;
   // currentSwitches[] is 0-15 for index 1, 0-2 for index 2-7
   // Rely on currentSwitches to *only* have values in that rang
-  uint8_t value = crsf->currentSwitches[nextSwitchIndex];
+  uint8_t value = crsf->currentSwitches[nextSwitchIndex] & 0b11;
 
   Buffer[6] =
 #ifdef ENABLE_TELEMETRY
@@ -89,14 +89,14 @@ void ICACHE_RAM_ATTR UnpackChannelDataHybridSwitch8(volatile uint8_t* Buffer, CR
     // The low latency switch
     crsf->PackedRCdataOut.ch4 = BIT_to_CRSF((Buffer[6] & 0b01000000) >> 6);
 
-    // The round-robin switch, switchIndex is actually index-1 
+    // The round-robin switch, switchIndex is actually index-1
     // to leave the low bit open for switch 7 (sent as 0b11x)
     // where x is the high bit of switch 7
     uint8_t switchIndex = (Buffer[6] & 0b111000) >> 3;
     uint16_t switchValue = SWITCH3b_to_CRSF(Buffer[6] & 0b111);
 
     switch (switchIndex) {
-        case 0:  
+        case 0:
             crsf->PackedRCdataOut.ch5 = switchValue;
             break;
         case 1:


### PR DESCRIPTION
An 11-bit CRSF channel value of "0" sent by opentx could underflow the conversion from the CRSF value to switch value and cause the result to leak into the switchidx and AUX1 channel of the data byte. This is observed as a flickering of the AUX1 channel between 1000 and 2000 at the output. 

Note that opentx won't send us 0. Even with Extended Limits turned on and the output set to -150%, we still get the right switch value out. However, if they ever _did_ send us 0 because they've gone loco, then this change will prevent the underflow. This fix is largely academic

A value over `CRSF_CHANNEL_VALUE_MAX` works fine, with us generating a switch mid value for any value > 2012us input.