### PR TITLE
Add GPIO_PIN_BUTTON to TTGO V1 target

### DIFF
--- a/src/include/targets.h
+++ b/src/include/targets.h
@@ -31,6 +31,7 @@
 #define GPIO_PIN_RCSIGNAL_RX 13
 #define GPIO_PIN_RCSIGNAL_TX 13
 #define GPIO_PIN_LED 2
+#define GPIO_PIN_BUTTON 0
 
 #elif defined(TARGET_TTGO_LORA_V1_AS_RX)
 
@@ -327,7 +328,7 @@ High = Ant2
 #define GPIO_PIN_LED_WS2812         PB6
 #define GPIO_PIN_LED_WS2812_FAST    PB_6
 #define GPIO_PIN_PA_SE2622L_ENABLE  PB11  // https://www.skyworksinc.com/-/media/SkyWorks/Documents/Products/2101-2200/SE2622L_202733C.pdf
-#define GPIO_PIN_RF_AMP_DET         PA3  // Voltage detector pin 
+#define GPIO_PIN_RF_AMP_DET         PA3  // Voltage detector pin
 #define GPIO_PIN_BUZZER             PC13
 #define timerOffset                 1
 


### PR DESCRIPTION
The TTGO V1 is a truly terrible ELRS TX, with mine putting out just 1.5mW at max power and getting up to 100C to do so, but at least the button should be usable, right? I use the button to cycle power levels or enable/disable the TX for testing and it would be nice to not have to keep stashing this one line change all the time.