### PR TITLE
Disable interrupts when reading RX fifo (RX lockup)

### DIFF
--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -460,7 +460,7 @@ int8_t ICACHE_RAM_ATTR SX127xDriver::GetCurrRSSI()
 int8_t ICACHE_RAM_ATTR SX127xDriver::GetLastPacketSNR()
 {
   int8_t rawSNR = (int8_t)hal.getRegValue(SX127X_REG_PKT_SNR_VALUE);
-  return (rawSNR / 4.0);
+  return (rawSNR / 4);
 }
 
 void ICACHE_RAM_ATTR SX127xDriver::ClearIRQFlags()

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -69,7 +69,6 @@ void SX127xDriver::ConfigLoraDefaults()
   hal.writeRegister(SX127X_REG_OP_MODE, ModFSKorLoRa); //must be written in sleep mode
   SetMode(SX127x_OPMODE_STANDBY);
 
-  instance->IRQneedsClear = true;
   instance->ClearIRQFlags();
 
   hal.writeRegister(SX127X_REG_PAYLOAD_LENGTH, TXbuffLen);
@@ -271,7 +270,6 @@ bool SX127xDriver::DetectChip()
 void ICACHE_RAM_ATTR SX127xDriver::TXnbISR()
 {
   //hal.TXRXdisable();
-  instance->IRQneedsClear = true;
   instance->ClearIRQFlags();
   instance->currOpmode = SX127x_OPMODE_STANDBY; //goes into standby after transmission
   //instance->TXdoneMicros = micros();
@@ -285,7 +283,6 @@ void ICACHE_RAM_ATTR SX127xDriver::TXnb(uint8_t volatile *data, uint8_t length)
   //   Serial.println("abort TX");
   //   return; // we were already TXing so abort. this should never happen!!!
   // }
-  instance->IRQneedsClear = true;
   instance->ClearIRQFlags();
   instance->SetMode(SX127x_OPMODE_STANDBY);
   hal.TXenable();
@@ -303,8 +300,6 @@ void ICACHE_RAM_ATTR SX127xDriver::TXnb(uint8_t volatile *data, uint8_t length)
 
 void ICACHE_RAM_ATTR SX127xDriver::RXnbISR()
 {
-  //hal.TXRXdisable();
-  instance->IRQneedsClear = true;
   instance->ClearIRQFlags();
   hal.readRegisterFIFO(instance->RXdataBuffer, instance->RXbuffLen);
   instance->LastPacketRSSI = instance->GetLastPacketRSSI();
@@ -319,7 +314,6 @@ void ICACHE_RAM_ATTR SX127xDriver::RXnb()
   //   Serial.println("abort RX");
   //   return; // we were already TXing so abort
   // }
-  instance->IRQneedsClear = true;
   instance->ClearIRQFlags();
   instance->SetMode(SX127x_OPMODE_STANDBY);
   hal.RXenable();
@@ -469,11 +463,7 @@ int8_t ICACHE_RAM_ATTR SX127xDriver::GetLastPacketSNR()
 
 void ICACHE_RAM_ATTR SX127xDriver::ClearIRQFlags()
 {
-  if (IRQneedsClear)
-  {
-    hal.writeRegister(SX127X_REG_IRQ_FLAGS, 0b11111111);
-    IRQneedsClear = false;
-  }
+  hal.writeRegister(SX127X_REG_IRQ_FLAGS, 0b11111111);
 }
 
 // int16_t MeasureNoiseFloor() TODO disabled for now

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -300,10 +300,12 @@ void ICACHE_RAM_ATTR SX127xDriver::TXnb(uint8_t volatile *data, uint8_t length)
 
 void ICACHE_RAM_ATTR SX127xDriver::RXnbISR()
 {
+  noInterrupts();
   instance->ClearIRQFlags();
   hal.readRegisterFIFO(instance->RXdataBuffer, instance->RXbuffLen);
   instance->LastPacketRSSI = instance->GetLastPacketRSSI();
   instance->LastPacketSNR = instance->GetLastPacketSNR();
+  interrupts();
   RXdoneCallback();
 }
 

--- a/src/lib/SX127xDriver/SX127x.h
+++ b/src/lib/SX127xDriver/SX127x.h
@@ -15,7 +15,7 @@ public:
     SX127xDriver();
     ///////Callback Function Pointers/////
     static void inline nullCallback(void);
-    
+
     static void (*RXdoneCallback)(); //function pointer for callback
     static void (*TXdoneCallback)(); //function pointer for callback
 
@@ -55,7 +55,6 @@ public:
     uint32_t HeadRoom;
     uint32_t LastTXdoneMicros;
     uint32_t TXdoneMicros;
-    bool IRQneedsClear = true;
     /////////////////////////////////
 
     ////////////////Configuration Functions/////////////

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -7,7 +7,7 @@ SX1280Driver *SX1280Driver::instance = NULL;
 
 //DEBUG_SX1280_OTA_TIMING
 
-/* Steps for startup 
+/* Steps for startup
 
 1. If not in STDBY_RC mode, then go to this mode by sending the command:
 SetStandby(STDBY_RC)
@@ -287,7 +287,7 @@ void ICACHE_RAM_ATTR SX1280Driver::TXnbISR()
     endTX = micros();
 #endif
     instance->ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
-    
+
 #ifdef DEBUG_SX1280_OTA_TIMING
     Serial.print("TOA: ");
     Serial.println(endTX - beginTX);
@@ -319,11 +319,13 @@ void ICACHE_RAM_ATTR SX1280Driver::TXnb(volatile uint8_t *data, uint8_t length)
 
 void ICACHE_RAM_ATTR SX1280Driver::RXnbISR()
 {
+    noInterrupts();
     instance->currOpmode = SX1280_MODE_FS;
     instance->ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
     uint8_t FIFOaddr = instance->GetRxBufferAddr();
     hal.ReadBuffer(FIFOaddr, instance->RXdataBuffer, TXRXBuffSize);
     instance->GetLastPacketStats();
+    interrupts();
     instance->RXdoneCallback();
 }
 

--- a/src/variants/R9MM/variant.h
+++ b/src/variants/R9MM/variant.h
@@ -122,9 +122,6 @@ extern "C" {
 /*----------------------------------------------------------------------------
  *        Arduino objects - C++ only
  *----------------------------------------------------------------------------*/
- 
- #define TIM_IRQ_PRIO       3
- #define EXTI_IRQ_PRIO      4
 
 #ifdef __cplusplus
 // These serial port names are intended to allow libraries and architecture-neutral


### PR DESCRIPTION
This pull is more work to eliminate #553. It forces interrupts off while the Radio driver is reading the RF data during a receive interrupt on all MCU and RF platforms.

### Root cause analysis
Running an R9M TX + R9Mini RX, I was able to reproduce the lockup at a rate of about once every other day. 100% of the time the code was locked in the RXnbISR reading the FIFO. The number of bytes into the receive varied, but always it was hanging busywaiting for the SPI peripheral to set the `SPI_SR_RXNE` flag (RX not empty). There's no getting out of this loop due to the timeout existing _outside_ this busywait; not that anything checks the SPI transfer result anyway.
![stack trace](https://cdn.discordapp.com/attachments/744445841779064863/847499004119613442/unknown.png)

What is happening is that the hwTimer Tock is firing **while we are in the middle of a packet read**. I have verified this by setting a flag when in this critical code and checking it in the Tock handler and incrementing a counter. This happens every minute or two, sometimes in bursts of 2-3, but _usually_ does not lock up because there's more code there than just the SPI transfer and we only run into a problem 1) on FHSS hop 2) on telemetry send 3) if changing PPM offset. All of these both write data to SPI (which will likely be ineffective due to being mid-transfer) and then de-assert `nCS` to the RF chip which will prevent it from sending more data from the FIFO. Here is the simple "danger" counter code:
![dangercode](https://cdn.discordapp.com/attachments/744445841779064863/847909546545381376/unknown.png)

Note that this isn't necessarily a packet of data from ExpressLRS as the interrupt sometimes can fire from other people's packets. You down with OPP? This interrupt is. The CRC will fail later, but if we can't get the 8 bytes from the SX12xx without locking up, we'll never know.

### Fix
I think disabling interrupts during this critical code is the only way to guarantee that the timer won't preempt the read. I considered only wrapping the FIFO read, but really that could mean any of the other SPI transfers would fail. Those would be ephemeral and just give us some bad RSSI/SNR or maybe not clear the RX interrupt but I think we should guard against that as well.

The other option would be to set the STM32 ext interrupt priority to be the same as the timer's, but I do not think that is necessary. The other code in the packet callback doesn't do any radio stuff or muck about with any global variables that would cause an issue.  If we are interested in the lowest possible latency for our channels data, then it would make sense to make their priority equal, because the way I have it now the Tock timer ISR will fire immediately between the FIFO read and the packet actually being sent in `ProcessRFPacket()`. I didn't make the design decision to make them different priorities so that decision is above my pay grade and I am not entirely sure it is necessary.

There could be other solutions? Let me know in the comments and like and subscribe and hit that bell.

### External Factors

Having an RF-noisy environment was key to reproducing this lockup. I was getting one lockup every two days, but then I added a second Team900 TX to the mix, on a different bind phrase. After adding the second TX I got 3 lockups in 4 hours, of of which were hung in the RX ISR. The extra TX generates more RX ISR when the receivers are on the same channel I believe, and that increases the chances of being in the critical code when the timer fires.

### Extras
* IRQneedsClear has been removed due to every case of calling `ClearIRQFlags()` being immediately preceded by setting it to true. Less code means less time with interrupts disabled.
* `GetLastPacketSNR()` did a float divide instead of integer divide and then converted it to an int. Again, less code means less time with interrupts disabled.
* The R9MM variant had two places it set interrupt priority (that were identical) so I've removed one of them. All other variants were checked and they only have one instance of these lines.

### Thanks
Thanks to discord pro JamesK for their feedback and suggestions about the ISR collisions and leading me to quantify just how frequently they occur. I was fairly sure Tock would preempt the RX ISR very rarely but JamesK was all like "It is probably happening a lot more frequently than you think" and that turns out to be right. Great to have you with us, JamesK!