### PR TITLE
Adds extra safety check of non-stale UART data before TX packet transmit

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -326,6 +326,11 @@ void ICACHE_RAM_ATTR CRSF::setSyncParams(uint32_t PacketInterval)
 #endif
 }
 
+uint32_t ICACHE_RAM_ATTR CRSF::GetRCdataLastRecv()
+{
+    return CRSF::RCdataLastRecv;
+}
+
 void ICACHE_RAM_ATTR CRSF::JustSentRFpacket()
 {
     CRSF::OpenTXsyncOffset = micros() - CRSF::RCdataLastRecv;

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -91,6 +91,7 @@ public:
     /////////////////////////////////////////////////////////////
 
     static void ICACHE_RAM_ATTR GetChannelDataIn();
+    static uint32_t ICACHE_RAM_ATTR GetRCdataLastRecv();
     static void ICACHE_RAM_ATTR updateSwitchValues();
 
     static void inline nullCallback(void);

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -366,7 +366,7 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
  */
 void ICACHE_RAM_ATTR timerCallbackNormal()
 {
-  if ((int32_t)(micros() - crsf.RCdataLastRecv) < 1000000) // safety check 
+  if ((int32_t)(micros() - crsf.GetRCdataLastRecv()) < 1000000) // safety check 
   {
     busyTransmitting = true;
     PacketLastSentMicros = micros();

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -366,9 +366,12 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
  */
 void ICACHE_RAM_ATTR timerCallbackNormal()
 {
-  busyTransmitting = true;
-  PacketLastSentMicros = micros();
-  SendRCdataToRF();
+  if ((int32_t)(micros() - crsf.RCdataLastRecv) < 1000000) // safety check 
+  {
+    busyTransmitting = true;
+    PacketLastSentMicros = micros();
+    SendRCdataToRF();
+  }
 }
 
 /*


### PR DESCRIPTION
Possibly prevent cases like #660 if uartWDT() fails to execute for some reason  