### PR TITLE
Set STM32 interrupts to equal priority. Reverts #658

### DIFF
--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -300,12 +300,10 @@ void ICACHE_RAM_ATTR SX127xDriver::TXnb(uint8_t volatile *data, uint8_t length)
 
 void ICACHE_RAM_ATTR SX127xDriver::RXnbISR()
 {
-  noInterrupts();
   instance->ClearIRQFlags();
   hal.readRegisterFIFO(instance->RXdataBuffer, instance->RXbuffLen);
   instance->LastPacketRSSI = instance->GetLastPacketRSSI();
   instance->LastPacketSNR = instance->GetLastPacketSNR();
-  interrupts();
   RXdoneCallback();
 }
 

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -319,13 +319,11 @@ void ICACHE_RAM_ATTR SX1280Driver::TXnb(volatile uint8_t *data, uint8_t length)
 
 void ICACHE_RAM_ATTR SX1280Driver::RXnbISR()
 {
-    noInterrupts();
     instance->currOpmode = SX1280_MODE_FS;
     instance->ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
     uint8_t FIFOaddr = instance->GetRxBufferAddr();
     hal.ReadBuffer(FIFOaddr, instance->RXdataBuffer, TXRXBuffSize);
     instance->GetLastPacketStats();
-    interrupts();
     instance->RXdoneCallback();
 }
 

--- a/src/variants/FM30/variant.h
+++ b/src/variants/FM30/variant.h
@@ -119,7 +119,7 @@ extern "C" {
 #define PIN_SERIAL_TX           PA9
 
 // Adjust IRQ priority
-#define TIM_IRQ_PRIO            3
+#define TIM_IRQ_PRIO            4
 #define EXTI_IRQ_PRIO           4
 
 #ifdef __cplusplus

--- a/src/variants/FM30_mini/variant.h
+++ b/src/variants/FM30_mini/variant.h
@@ -93,7 +93,7 @@ extern "C" {
 #define ALT4 (1 << (STM_PIN_AFNUM_SHIFT+3))
 
 // Adjust IRQ priority
-#define TIM_IRQ_PRIO            3
+#define TIM_IRQ_PRIO            4
 #define EXTI_IRQ_PRIO           4
 
 #ifdef __cplusplus

--- a/src/variants/GHOST_ATTO/variant.h
+++ b/src/variants/GHOST_ATTO/variant.h
@@ -79,7 +79,7 @@ extern "C" {
 //#define HAL_I2C_MODULE_DISABLED
 
 // Adjust IRQ priority
-#define TIM_IRQ_PRIO            3
+#define TIM_IRQ_PRIO            4
 #define EXTI_IRQ_PRIO           4
 
 #ifdef __cplusplus

--- a/src/variants/GHOST_TX/variant.h
+++ b/src/variants/GHOST_TX/variant.h
@@ -111,7 +111,7 @@ extern "C" {
 #define PIN_SERIAL_TX           PB10
 
 // Adjust IRQ priority
-#define TIM_IRQ_PRIO            3
+#define TIM_IRQ_PRIO            4
 #define EXTI_IRQ_PRIO           4
 
 /* Extra HAL modules */

--- a/src/variants/L432K/variant.h
+++ b/src/variants/L432K/variant.h
@@ -84,7 +84,7 @@ extern "C" {
 //#define HAL_DAC_MODULE_ENABLED
 
 // Adjust IRQ priority
-#define TIM_IRQ_PRIO            3
+#define TIM_IRQ_PRIO            4
 #define EXTI_IRQ_PRIO           4
 
 #ifdef __cplusplus

--- a/src/variants/R9MM/variant.h
+++ b/src/variants/R9MM/variant.h
@@ -113,7 +113,7 @@ extern "C" {
 //#define PIN_SERIAL_TX           PA9
 
 // Adjust IRQ priority
-#define TIM_IRQ_PRIO            3
+#define TIM_IRQ_PRIO            4
 #define EXTI_IRQ_PRIO           4
 
 #ifdef __cplusplus

--- a/src/variants/r9mx/variant.h
+++ b/src/variants/r9mx/variant.h
@@ -112,7 +112,7 @@ extern "C" {
 #define HAL_DAC_MODULE_ENABLED
 
 // Adjust IRQ priority
-#define TIM_IRQ_PRIO            3
+#define TIM_IRQ_PRIO            4
 #define EXTI_IRQ_PRIO           4
 
 #ifdef __cplusplus


### PR DESCRIPTION
I messed up big time with #658 (Disable interrupts while RXing). While it does resolve the issue with the RF receive getting preempted by the timer and locking up in the SPI transfer, the duration the interrupts were off is just too long (~80us on the FM30) which caused issues with UART transfers. This was seen as BadPackets in the Lua reporting, as well as I am sure lots of other weirdness with the PR applied.

This PR reverts the global interrupt disabling in favor of setting the Timer priority and the EXT priority (the RF interrupt) to be the same to prevent them from preempting each other. This has the effect of creating more jitter in the Tock's capture of the current time (the `intEvent`), but we can perhaps look at adjusting that by subtracting the Timer count when we capture it, however the 
I'm not exactly sure how to properly adjust for when it happens in the RF interrupt (the `extEvent`). I believe we can look at that in 1.1, or if someone has a better idea how to prevent the lockup bug without mucking with the interrupts. I believe ESP/ESP32 platform have their Timer/EXT interrupts with the same priority, so this change also normalizes the behavior across platforms, but that's not necessarily a good thing when the other platforms are slightly more off sync.

I'm currently running another full test of the R9MM with second transmitter active to see if I can get a lockup, but theoretically this should still be fixed. I've set this as draft for the next day for testing purposes, but please review and comment on how terrible an idea this is or isn't.

EDIT: A day with no lockups on R9M/R9MM and zero reported failsafes from Betaflight. Team2.4 FM30 was also tested briefly at 50-500Hz.