### PR TITLE
Use the release version of Arduino ESP8266

### DIFF
--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -33,16 +33,12 @@ lib_deps = NeoPixelBus
 
 # ------------------------- COMMON ESP82xx DEFINITIONS -----------------
 [env_common_esp82xx]
-platform = espressif8266@2.6.3
-platform_packages =
-    mcspr/toolchain-xtensa@~5.100200.201223
-    framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git#0049090
+platform = espressif8266@3.0.0
 board = esp8285
 build_flags =
 	-D PLATFORM_ESP8266=1
 	-D VTABLES_IN_FLASH=1
-	-D MMU_IRAM_SIZE=0xC000
-	-D MMU_ICACHE_SIZE=0x4000
+	-D PIO_FRAMEWORK_ARDUINO_MMU_CACHE16_IRAM48
 	-O2
 board_build.f_cpu = 160000000L
 src_filter = ${common_env_data.src_filter} -<ESP32*.*> -<STM32*.*> -<WS281B*.*>


### PR DESCRIPTION
Upgrade to the new release of the Arduino ESP8266 framework that includes the changes which allow us to change the MMU size for CACHE vs IRAM.
No longer relies on a git hash version.