### PR TITLE
Pin the version of the platform when building SIYI RX target

### DIFF
--- a/src/targets/siyi.ini
+++ b/src/targets/siyi.ini
@@ -23,7 +23,7 @@ extends = env:FM30_TX_via_STLINK
 
 [env:FM30_RX_MINI_via_STLINK]
 extends = env_common_stm32
-platform = ststm32
+platform = ststm32@13.0.0
 board = FM30_mini
 build_flags =
 	${env_common_stm32.build_flags}


### PR DESCRIPTION
Having the platform on a floating version caused a build failure for this target as the new version (14.0.0) of the platform has refactored the way variants are handled. When moving to version 14 the variant structure will need an overhaul. 