### PR TITLE
Fix RX locking up coming out of bind

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1405,16 +1405,15 @@ void ExitBindingMode()
         return;
     }
 
-    InBindingMode = false;
-
     LostConnection();
 
-    // Sets params to allow sync after binding and not instantly change RF mode
-    RFmodeCycleMultiplier = RFmodeCycleMultiplierSlow;
-    RFmodeLastCycled = millis();
+    // Force RF cycling to start at the beginning immediately
+    scanIndex = RATE_MAX;
+    RFmodeLastCycled = 0;
 
-    Serial.print("Exit binding mode at freq = ");
-    Serial.println(Radio.currFreq);
+    // Do this last as LostConnection() will wait for a tock that never comes
+    // if we're in binding mode
+    InBindingMode = false;
 }
 
 void OnELRSBindMSP(uint8_t* packet)


### PR DESCRIPTION
### Issue

When a bind completes, the RX hard locks and must be rebooted for it to work properly. This PR fixes that issue where caused by us waiting for a timer even that never comes.

### Root cause

`LostConnection()` waits for a tock event to occur before stopping the hwtimer and switching freqs / starting RX. Because the `InBindingMode` flag was cleared before calling LostConnection, this would hang the RX 100% of the time. The binding would be saved because the EEPROM commit happens before this, so a simple power cycle would fix this, but still the experience was unpleasant.

### Additional
* The code expected that after bind, connection would occur at the same rate and frequency as the bind happened. That's not always the case because binding happens at the highest rate and that's not always the selected rate. The RX would wait on this rate for 10x longer than normal just to be sure before starting cycling. I've changed this to immediately cycleRf on the next loop like the RX was just booted, so:
  * All our code for cycling Rf is in one place and doesn't half-initialize the state
  * The fastest rate is used at the beginning and gets its standard duration, so this is effectively the same. If the TX rate **is** the fastest rate, it will still connect just as fast with the standard process, but if it isn't then the connection happens much faster than it did before due to not waiting 10x longer than needed for packets that will not come at this rate.
* Removed the log message about what frequency binding ended on. Binding stays on the same frequency the whole time so this is redundant with the starting frequency log message.