### PR TITLE
makes 500hz default

### DIFF
--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -23,7 +23,6 @@ expresslrs_rf_pref_params_s ExpressLRS_AirRateRFperf[RATE_MAX] = {
 #include "SX1280Driver.h"
 extern SX1280Driver Radio;
 
-#ifdef USE_500HZ
 expresslrs_mod_settings_s ExpressLRS_AirRateConfig[RATE_MAX] = {
     {0, RATE_500HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF5, SX1280_LORA_CR_LI_4_6, 2000, TLM_RATIO_1_128, 4, 12},
     {1, RATE_250HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF6, SX1280_LORA_CR_LI_4_7, 4000, TLM_RATIO_1_64, 4, 14},
@@ -35,20 +34,6 @@ expresslrs_rf_pref_params_s ExpressLRS_AirRateRFperf[RATE_MAX] = {
     {1, RATE_250HZ, -108, 3300, 3000, 2500, 2000, 4000},
     {2, RATE_150HZ, -112, 5871, 3500, 2500, 2000, 4000},
     {3, RATE_50HZ, -117, 18443, 4000, 2500, 2000, 4000}};
-#else
-expresslrs_mod_settings_s ExpressLRS_AirRateConfig[RATE_MAX] = {
-    {0, RATE_250HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF6, SX1280_LORA_CR_LI_4_7, 4000, TLM_RATIO_1_64, 4, 14},
-    {1, RATE_150HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF7, SX1280_LORA_CR_LI_4_7, 6666, TLM_RATIO_1_32, 4, 12},
-    {2, RATE_50HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF9, SX1280_LORA_CR_LI_4_6, 20000, TLM_RATIO_NO_TLM, 4, 12},
-    {3, RATE_25HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF10, SX1280_LORA_CR_LI_4_6, 40000, TLM_RATIO_NO_TLM, 4, 12}};
-
-expresslrs_rf_pref_params_s ExpressLRS_AirRateRFperf[RATE_MAX] = {
-    {0, RATE_250HZ, -108, 3300, 3000, 2500, 2000, 4000},
-    {1, RATE_150HZ, -112, 5871, 3500, 2500, 2000, 4000},
-    {2, RATE_50HZ, -117, 18443, 4000, 2500, 2000, 4000},
-    {3, RATE_25HZ, -120, 35625, 6000, 4000, 2000, 4000}};
-#endif
-
 #endif
 
 expresslrs_mod_settings_s *get_elrs_airRateConfig(int8_t index);

--- a/src/user_defines.txt
+++ b/src/user_defines.txt
@@ -57,8 +57,6 @@
 #-DDISABLE_STARTUP_BEEP
 #-DMY_STARTUP_MELODY="B5 16 P16 B5 16 P16 B5 16 P16 B5 2 G5 2 A5 2 B5 8 P4 A5 8 B5 1|140|-3"
 
-#-DUSE_500HZ
-
 # Comment this to disable advanced telemetry.
 #-DENABLE_TELEMETRY
 


### PR DESCRIPTION
Opening this PR so we can get a discussion going in one place.

This was always going to happen but ideally we would wait for BF and OpenTX releases.  BF4.3 will probably come before ELRS V1.1, so lets get this out ready.  And OpenTx 2.4... well may never come.  Everyone is already using nightlies or EdgeTX.

500Hz does require a 400k enabled handset, but we have a catch for this in the code and do not allow 500 with 115200.  The other users who may get caught out are Tango2 users with freedomtx which only supports up to 250Hz ATM.  But currently there is nothing to stop them flashing 500 right now, so nothing changes.  I dare say freedomtx will be updated soon to support higher rates with crsf v3.

The HM AIO does require 500hz enables on the tx for binding.  Making 500 default will minimise binding confusion, and we expect to see more FCs with SPI rx in the future.

What are everyones houghts?