### PR TITLE
Add a telemetry bind command

### DIFF
--- a/src/lib/Telemetry/telemetry.cpp
+++ b/src/lib/Telemetry/telemetry.cpp
@@ -21,6 +21,13 @@ bool Telemetry::ShouldCallBootloader()
     return bootloader;
 }
 
+bool Telemetry::ShouldCallEnterBind()
+{
+    bool enterBind = callEnterBind;
+    callEnterBind = false;
+    return enterBind;
+}
+
 #ifdef ENABLE_TELEMETRY
 PAYLOAD_DATA(GPS, BATTERY_SENSOR, ATTITUDE, DEVICE_INFO, FLIGHT_MODE, MSP_RESP);
 
@@ -176,9 +183,14 @@ bool Telemetry::RXhandleUARTin(uint8_t data)
 
 void Telemetry::AppendTelemetryPackage()
 {
-    if (CRSFinBuffer[CRSF_TELEMETRY_TYPE_INDEX] == CRSF_FRAMETYPE_COMMAND && CRSFinBuffer[3] == 0x62 && CRSFinBuffer[4] == 0x6c)
+    if (CRSFinBuffer[CRSF_TELEMETRY_TYPE_INDEX] == CRSF_FRAMETYPE_COMMAND && CRSFinBuffer[3] == 'b' && CRSFinBuffer[4] == 'l')
     {
         callBootloader = true;
+        return;
+    }
+    if (CRSFinBuffer[CRSF_TELEMETRY_TYPE_INDEX] == CRSF_FRAMETYPE_COMMAND && CRSFinBuffer[3] == 'b' && CRSFinBuffer[4] == 'd')
+    {
+        callEnterBind = true;
         return;
     }
     #ifdef ENABLE_TELEMETRY

--- a/src/lib/Telemetry/telemetry.h
+++ b/src/lib/Telemetry/telemetry.h
@@ -41,6 +41,7 @@ public:
     bool RXhandleUARTin(uint8_t data);
     void ResetState();
     bool ShouldCallBootloader();
+    bool ShouldCallEnterBind();
     #ifdef ENABLE_TELEMETRY
     bool GetNextPayload(uint8_t* nextPayloadSize, uint8_t **payloadData);
     uint8_t UpdatedPayloadCount();
@@ -56,4 +57,5 @@ private:
     volatile crsf_telemetry_package_t *telemetryPackageHead;
     uint8_t receivedPackages;
     bool callBootloader;
+    bool callEnterBind;
 };

--- a/src/python/bind.py
+++ b/src/python/bind.py
@@ -1,0 +1,48 @@
+import serial, time, sys, re
+import argparse
+import serials_find
+import SerialHelper
+import bootloader
+from BFinitPassthrough import *
+
+SCRIPT_DEBUG = 0
+
+def send_bind_command(args):
+    dbg_print("======== SEND BIND COMMAND ========")
+    s = serial.Serial(port=args.port, baudrate=args.baud,
+        bytesize=8, parity='N', stopbits=1,
+        timeout=1, xonxoff=0, rtscts=0)
+    if args.half_duplex:
+        BindInitSeq = bootloader.get_bind_seq('GHST', args.type)
+        dbg_print("  * Using half duplex (GHST)")
+    else:
+        BindInitSeq = bootloader.get_bind_seq('CRSF', args.type)
+        dbg_print("  * Using full duplex (CFSF)")
+    s.write(BindInitSeq)
+    s.flush()
+    time.sleep(.5)
+    s.close()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Initialize BetaFlight passthrough and send the 'enter bind mode' command")
+    parser.add_argument("-b", "--baud", type=int, default=420000,
+        help="Baud rate for passthrough communication")
+    parser.add_argument("-p", "--port", type=str,
+        help="Override serial port autodetection and use PORT")
+    parser.add_argument("-hd", "--half-duplex", action="store_true",
+        dest="half_duplex", help="Use half duplex mode")
+    parser.add_argument("-t", "--type", type=str, default="ESP82",
+        help="Defines flash target type which is sent to target in reboot command")
+    args = parser.parse_args()
+
+    if (args.port == None):
+        args.port = serials_find.get_serial_port()
+
+    try:
+        bf_passthrough_init(args.port, args.baud)
+    except PassthroughEnabled as err:
+        dbg_print(str(err))
+
+    send_bind_command(args)

--- a/src/python/bind.py
+++ b/src/python/bind.py
@@ -17,7 +17,7 @@ def send_bind_command(args):
         dbg_print("  * Using half duplex (GHST)")
     else:
         BindInitSeq = bootloader.get_bind_seq('CRSF', args.type)
-        dbg_print("  * Using full duplex (CFSF)")
+        dbg_print("  * Using full duplex (CRSF)")
     s.write(BindInitSeq)
     s.flush()
     time.sleep(.5)

--- a/src/python/bootloader.py
+++ b/src/python/bootloader.py
@@ -1,10 +1,12 @@
 
-ELRS_BOOT_CMD_DEST = ord('b')
-ELRS_BOOT_CMD_ORIG = ord('l')
-
 INIT_SEQ = {
-    "CRSF": [0xEC,0x04,0x32,ELRS_BOOT_CMD_DEST,ELRS_BOOT_CMD_ORIG],
-    "GHST": [0x89,0x04,0x32,ELRS_BOOT_CMD_DEST,ELRS_BOOT_CMD_ORIG],
+    "CRSF": [0xEC,0x04,0x32,ord('b'),ord('l')],
+    "GHST": [0x89,0x04,0x32,ord('b'),ord('l')],
+}
+
+BIND_SEQ = {
+    "CRSF": [0xEC,0x04,0x32,ord('b'),ord('d')],
+    "GHST": [0x89,0x04,0x32,ord('b'),ord('d')],
 }
 
 def calc_crc8(payload, poly=0xD5):
@@ -20,6 +22,17 @@ def calc_crc8(payload, poly=0xD5):
 
 def get_init_seq(module, key=None):
     payload = list(INIT_SEQ.get(module, []))
+    if payload:
+        if key:
+            if type(key) == str:
+                key = [ord(x) for x in key]
+            payload += key
+            payload[1] += len(key)
+        payload += [calc_crc8(payload[2:])]
+    return bytes(payload)
+
+def get_bind_seq(module, key=None):
+    payload = list(BIND_SEQ.get(module, []))
     if payload:
         if key:
             if type(key) == str:

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -986,6 +986,10 @@ static void HandleUARTin()
         {
             reset_into_bootloader();
         }
+        if (telemetry.ShouldCallEnterBind())
+        {
+            EnterBindingMode();
+        }
     }
 }
 
@@ -1366,13 +1370,23 @@ void reset_into_bootloader(void)
 
 void EnterBindingMode()
 {
-    if ((connectionState == connected) || InBindingMode || webUpdateMode) {
+    if ((connectionState == connected) || InBindingMode) {
         // Don't enter binding if:
         // - we're already connected
         // - we're already binding
-        // - we're in web update mode
         Serial.println("Cannot enter binding mode!");
         return;
+    }
+    if (webUpdateMode) {
+#if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
+        wifiOff();
+        webUpdateMode = false;
+        Radio.RXdoneCallback = &RXdoneISR;
+        Radio.TXdoneCallback = &TXdoneISR;
+        Radio.Begin();
+        crsf.Begin();
+        hwTimer.resume();
+#endif
     }
 
     // Set UID to special binding values


### PR DESCRIPTION
Add a new CRSF telemetry command to enter into bind mode in the RX, also exits WiFi mode if that is enabled.
 
Add a python script, `bind.py` to setup passthrough and send the bind telemetry command (similar to the *reboot-to-bootloader* command used for passthrough updating).

I'm sure a button could easily be added to 'ExpressLRS Configurator' to call this `bind.py` script.
