### PR TITLE
Added support for Regulatory_Domain_IN_866

### DIFF
--- a/src/lib/FHSS/FHSS.cpp
+++ b/src/lib/FHSS/FHSS.cpp
@@ -45,6 +45,8 @@ void FHSSrandomiseFHSSsequence(long seed)
     Serial.println("Setting 915MHz Mode");
 #elif defined Regulatory_Domain_EU_868
     Serial.println("Setting 868MHz Mode");
+#elif defined Regulatory_Domain_IN_866
+    Serial.println("Setting 866MHz Mode");
 #elif defined Regulatory_Domain_AU_433
     Serial.println("Setting 433MHz EU Mode");
 #elif defined Regulatory_Domain_EU_433

--- a/src/lib/FHSS/FHSS.h
+++ b/src/lib/FHSS/FHSS.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
 #include "SX127xDriver.h"
 #elif Regulatory_Domain_ISM_2400
 #include "SX1280Driver.h"
@@ -20,8 +20,10 @@
 #define Regulatory_Domain_Index 5
 #elif defined Regulatory_Domain_ISM_2400
 #define Regulatory_Domain_Index 6
-#else
+#elif defined Regulatory_Domain_IN_866
 #define Regulatory_Domain_Index 7
+#else
+#define Regulatory_Domain_Index 8
 #endif
 
 extern volatile uint8_t FHSSptr;
@@ -88,6 +90,19 @@ const uint32_t FHSSfreqs[] = {
     FREQ_HZ_TO_REG_VAL(868525000), // Band H3, 868.7-869.2MHz, 0.1% dutycycle or CSMA, 25mW EIRP
     FREQ_HZ_TO_REG_VAL(869050000),
     FREQ_HZ_TO_REG_VAL(869575000)};
+#elif defined Regulatory_Domain_IN_866
+/**
+ * India currently delicensed the 865-867 MHz band with a maximum of 1W Transmitter power,
+ * 4Watts Effective Radiated Power and 200Khz carrier bandwidth as per
+ * https://dot.gov.in/sites/default/files/Delicensing%20in%20865-867%20MHz%20band%20%5BGSR%20564%20%28E%29%5D_0.pdf .
+ * There is currently no mention of Direct-sequence spread spectrum,
+ * So these frequencies are a subset of Regulatory_Domain_EU_868 frequencies.
+ */
+const uint32_t FHSSfreqs[] = {
+    FREQ_HZ_TO_REG_VAL(865375000),
+    FREQ_HZ_TO_REG_VAL(865900000),
+    FREQ_HZ_TO_REG_VAL(866425000),
+    FREQ_HZ_TO_REG_VAL(866950000)};
 #elif defined Regulatory_Domain_EU_433
 /* Frequency band G, taken from https://wetten.overheid.nl/BWBR0036378/2016-12-28#Bijlagen
  * Note: As is the case with the 868Mhz band, these frequencies only comply to the license free portion

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -3,7 +3,7 @@
 #include "targets.h"
 
 
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
 extern SX127xDriver Radio;
 #elif Regulatory_Domain_ISM_2400
 extern SX1280Driver Radio;

--- a/src/lib/POWERMGNT/POWERMGNT.h
+++ b/src/lib/POWERMGNT/POWERMGNT.h
@@ -4,7 +4,7 @@
 #include "targets.h"
 #include "DAC.h"
 
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
 #include "SX127xDriver.h"
 #elif Regulatory_Domain_ISM_2400
 #include "SX1280Driver.h"

--- a/src/lua/ELRS.lua
+++ b/src/lua/ELRS.lua
@@ -74,9 +74,9 @@ local RFfreq = {
     editable = false,
     name = 'RF Freq',
     selected = 99,
-    list = {'915 AU', '915 FCC', '868 EU', '433 AU', '433 EU', '2.4G ISM'},
-    values = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
-    max_allowed = 6,
+    list = {'915 AU', '915 FCC', '868 EU', '433 AU', '433 EU', '2.4G ISM', '866 IN'},
+    values = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07},
+    max_allowed = 7,
 }
 
 local function binding(item, event)

--- a/src/python/build_flags.py
+++ b/src/python/build_flags.py
@@ -133,6 +133,9 @@ if fnmatch.filter(env['BUILD_FLAGS'], '*Regulatory_Domain_AU_915*'):
 elif fnmatch.filter(env['BUILD_FLAGS'], '*Regulatory_Domain_EU_868*'):
     sys.stdout.write("\u001b[32mBuilding for SX1276 868EU\n")
 
+elif fnmatch.filter(env['BUILD_FLAGS'], '*Regulatory_Domain_IN_866*'):
+    sys.stdout.write("\u001b[32mBuilding for SX1276 866IN\n")
+
 elif fnmatch.filter(env['BUILD_FLAGS'], '*Regulatory_Domain_AU_433*'):
     sys.stdout.write("\u001b[32mBuilding for SX1278 433AU\n")
 

--- a/src/src/ESP32_WebUpdate.cpp
+++ b/src/src/ESP32_WebUpdate.cpp
@@ -2,7 +2,7 @@
 
 #include "targets.h"
 
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
 #include "SX127xDriver.h"
 extern SX127xDriver Radio;
 #endif

--- a/src/src/ESP8266_WebUpdate.cpp
+++ b/src/src/ESP8266_WebUpdate.cpp
@@ -1,7 +1,7 @@
 #ifdef PLATFORM_ESP8266
 #include "ESP8266_WebUpdate.h"
 
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
 #include "SX127xDriver.h"
 extern SX127xDriver Radio;
 #endif

--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -1,6 +1,6 @@
 #include "common.h"
 
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
 
 #include "SX127xDriver.h"
 extern SX127xDriver Radio;

--- a/src/src/common.h
+++ b/src/src/common.h
@@ -4,7 +4,7 @@
 
 #include "FHSS.h"
 
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868)  || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
 #include "SX127xDriver.h"
 #endif
 
@@ -85,8 +85,7 @@ typedef struct expresslrs_rf_pref_params_s
 } expresslrs_rf_pref_params_s;
 
 #ifndef UNIT_TEST
-
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
 #define RATE_MAX 4
 #define RATE_DEFAULT 0
 typedef struct expresslrs_mod_settings_s

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -2,7 +2,7 @@
 #include "common.h"
 #include "LowPassFilter.h"
 
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
 #include "SX127xDriver.h"
 SX127xDriver Radio;
 #elif defined(Regulatory_Domain_ISM_2400)
@@ -1139,6 +1139,8 @@ void setup()
     Serial.println("Setting 915MHz Mode");
 #elif defined Regulatory_Domain_EU_868
     Serial.println("Setting 868MHz Mode");
+#elif defined Regulatory_Domain_IN_866
+    Serial.println("Setting 866MHz Mode");
 #elif defined Regulatory_Domain_AU_433 || defined Regulatory_Domain_EU_433
     Serial.println("Setting 433MHz Mode");
 #elif defined Regulatory_Domain_ISM_2400

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1,7 +1,7 @@
 #include "targets.h"
 #include "common.h"
 
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
 #include "SX127xDriver.h"
 SX127xDriver Radio;
 #elif defined(Regulatory_Domain_ISM_2400)

--- a/src/user_defines.txt
+++ b/src/user_defines.txt
@@ -18,6 +18,7 @@
 
 #-DRegulatory_Domain_AU_915
 #-DRegulatory_Domain_EU_868
+#-DRegulatory_Domain_IN_866
 #-DRegulatory_Domain_AU_433
 #-DRegulatory_Domain_EU_433
 #-DRegulatory_Domain_FCC_915


### PR DESCRIPTION
India currently delicensed the 865-867 MHz band for use with:
* a maximum of 1W Transmitter power
* 4Watts Effective Radiated Power
* 200Khz carrier bandwidth

as per:
https://dot.gov.in/sites/default/files/Delicensing%20in%20865-867%20MHz%20band%20%5BGSR%20564%20%28E%29%5D_0.pdf

This commit partially adds support towards the Indian regulation.

Fixes https://github.com/ExpressLRS/ExpressLRS/issues/426