### PR TITLE
changed semtech fw test high value to 66535

### DIFF
--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -57,7 +57,7 @@ bool SX1280Driver::Begin()
     Serial.print("Read Vers: ");
     uint16_t firmwareRev = (((hal.ReadRegister(REG_LR_FIRMWARE_VERSION_MSB)) << 8) | (hal.ReadRegister(REG_LR_FIRMWARE_VERSION_MSB + 1)));
     Serial.println(firmwareRev);
-    if ((firmwareRev == 0) || (firmwareRev == 65536))
+    if ((firmwareRev == 0) || (firmwareRev == 65535))
     {
         // SPI communication failed, just return without configuration
         return false;


### PR DESCRIPTION
Changed invalid semtech fw value.
While testing my tx with the semtech e28 module not soldered I realised that the tx behaves as if it were present.
The reason is that it reads 65535 from the SPI not 65536. This makes sense because the highest value readable on two bytes is 65535 not 65536 

So the semtech init check passes when it should not.

This change should address the issue