### PR TITLE
Fix MSP for 500hz update rate

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -662,18 +662,15 @@ void ICACHE_RAM_ATTR CRSF::handleUARTout()
         if (sendingOffset == 0) {
             packageLength = SerialOutFIFO.pop();
             SerialOutFIFO.popBytes(CRSFoutBuffer, packageLength);
-
-            // if the package is long we need to split it up so it fits in the sending interval
-            if (packageLength > MAX_BYTES_SENT_IN_UART_OUT) {
-                writeLength = MAX_BYTES_SENT_IN_UART_OUT;
-            } else {
-                writeLength = packageLength;
-            }
         }
-        else {
-            // large package in transit send remaining bytes
+
+        // if the package is long we need to split it up so it fits in the sending interval
+        if (packageLength > MAX_BYTES_SENT_IN_UART_OUT) {
+            writeLength = MAX_BYTES_SENT_IN_UART_OUT;
+        } else {
             writeLength = packageLength;
         }
+
 
 #ifdef PLATFORM_ESP32
         portEXIT_CRITICAL(&FIFOmux); // stops other tasks from writing to the FIFO when we want to read it

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -112,7 +112,6 @@ private:
     static volatile uint8_t SerialInPacketPtr;                   // index where we are reading/writing
 
     static volatile inBuffer_U inBuffer;
-    static volatile uint8_t CRSFoutBuffer[CRSF_MAX_PACKET_LEN + 1]; //index 0 hold the length of the datapacket
 
     static volatile bool CRSFframeActive;  //since we get a copy of the serial data use this flag to know when to ignore it
 
@@ -123,6 +122,7 @@ private:
     static volatile uint32_t RCdataLastRecv;
     static volatile int32_t OpenTXsyncOffset;
     static uint32_t OpenTXsyncOffsetSafeMargin;
+    static uint8_t CRSFoutBuffer[CRSF_MAX_PACKET_LEN];
 #ifdef FEATURE_OPENTX_SYNC_AUTOTUNE
     static uint32_t SyncWaitPeriodCounter;
 #endif
@@ -135,8 +135,6 @@ private:
     static bool CRSFstate;
     static uint8_t MspData[ELRS_MSP_BUFFER];
     static uint8_t MspDataLength;
-    static volatile uint8_t MspRequestsInTransit;
-    static uint32_t LastMspRequestSent;
 #ifdef PLATFORM_ESP32
     static void ESP32uartTask(void *pvParameters);
     static void ESP32syncPacketTask(void *pvParameters);


### PR DESCRIPTION
If large packages are sent back to the transmitter the time slot for the message is not long enough at high refresh rates and the data collides with the incoming data. Longer packages (>32 bytes for now) are now split up in two sending intervals to prevent this error (described in #690).

The bugfix in #618 fixes the underlying issue that required the special handling of CRSF_FRAMETYPE_MSP_RESP frames so this code is removed.

To speed up the MSP transmission further the time based method is replaced with a simple flag. Since this only happens if there is MSP data to transmit it does not influence normal flight timing.