### PR TITLE
R9 lite pro fixes to power on boot. Added additional low power modes.

### DIFF
--- a/src/include/targets.h
+++ b/src/include/targets.h
@@ -230,7 +230,7 @@ https://github.com/jaxxzer
 
 #elif defined(TARGET_R9M_LITE_PRO_TX)
 #define GPIO_PIN_RFamp_APC1           PA4  //2.7V
-#define GPIO_PIN_RFamp_APC2           PA5  //100mW@590mV, 200mW@870mV, 500mW@1.093V, 1W@1.493V
+#define GPIO_PIN_RFamp_APC2           PA5
 #define GPIO_PIN_RFswitch_CONTROL     PA6  // confirmed  //HIGH = RX, LOW = TX
 
 #define GPIO_PIN_NSS            PB12 // confirmed

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -193,27 +193,28 @@ PowerLevels_e POWERMGNT::setPower(PowerLevels_e Power)
     switch (Power)
     {
     case PWR_10mW:
-        analogWrite(GPIO_PIN_RFamp_APC2, 600);  
+        analogWrite(GPIO_PIN_RFamp_APC2, 600);
         break;
     case PWR_25mW:
-        analogWrite(GPIO_PIN_RFamp_APC2, 770);  
-        break;
-    case PWR_50mW:
-        analogWrite(GPIO_PIN_RFamp_APC2, 950);  
-        break;
-    case PWR_250mW:
-        analogWrite(GPIO_PIN_RFamp_APC2, 1480); 
-        break;
-    case PWR_500mW:
-        analogWrite(GPIO_PIN_RFamp_APC2, 2000); 
-        break;
-    case PWR_1000mW:
-        analogWrite(GPIO_PIN_RFamp_APC2, 3500); 
+        analogWrite(GPIO_PIN_RFamp_APC2, 770);
         break;
     case PWR_100mW:
-    default:
-        analogWrite(GPIO_PIN_RFamp_APC2, 1150);  
+        analogWrite(GPIO_PIN_RFamp_APC2, 1150);
         CurrentPower = PWR_100mW;
+        break;
+    case PWR_250mW:
+        analogWrite(GPIO_PIN_RFamp_APC2, 1480);
+        break;
+    case PWR_500mW:
+        analogWrite(GPIO_PIN_RFamp_APC2, 2000);
+        break;
+    case PWR_1000mW:
+        analogWrite(GPIO_PIN_RFamp_APC2, 3500);
+        break;
+    case PWR_50mW:
+    default:
+        analogWrite(GPIO_PIN_RFamp_APC2, 950);
+        CurrentPower = PWR_50mW;
         break;
     }
 #elif defined(TARGET_100mW_MODULE) || defined(TARGET_R9M_LITE_TX)

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -200,7 +200,6 @@ PowerLevels_e POWERMGNT::setPower(PowerLevels_e Power)
         break;
     case PWR_100mW:
         analogWrite(GPIO_PIN_RFamp_APC2, 1150);
-        CurrentPower = PWR_100mW;
         break;
     case PWR_250mW:
         analogWrite(GPIO_PIN_RFamp_APC2, 1480);
@@ -214,7 +213,7 @@ PowerLevels_e POWERMGNT::setPower(PowerLevels_e Power)
     case PWR_50mW:
     default:
         analogWrite(GPIO_PIN_RFamp_APC2, 950);
-        CurrentPower = PWR_50mW;
+        Power = PWR_50mW;
         break;
     }
 #elif defined(TARGET_100mW_MODULE) || defined(TARGET_R9M_LITE_TX)

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -9,7 +9,7 @@ extern SX127xDriver Radio;
 extern SX1280Driver Radio;
 #endif
 
-PowerLevels_e POWERMGNT::CurrentPower = (PowerLevels_e)DefaultPowerEnum;
+PowerLevels_e POWERMGNT::CurrentPower = PWR_COUNT; // default "undefined" initial value
 
 PowerLevels_e POWERMGNT::incPower()
 {
@@ -63,11 +63,19 @@ void POWERMGNT::init()
     pinMode(GPIO_PIN_RFamp_APC1, OUTPUT);
     pinMode(GPIO_PIN_RFamp_APC2, OUTPUT);
     analogWriteResolution(12);
+
+    // WARNING: The two calls to analogWrite below are needed for the
+    // lite pro, as it seems that the very first calls to analogWrite
+    // fail for an unknown reason (suspect Arduino lib bug). These
+    // set power to 50mW, which should get overwitten shortly after
+    // boot by whatever is set in the EEPROM. @wvarty
+    analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095 2.7V
+    analogWrite(GPIO_PIN_RFamp_APC2, 950);
 #endif
 #if defined(GPIO_PIN_FAN_EN) && (GPIO_PIN_FAN_EN != UNDEF_PIN)
     pinMode(GPIO_PIN_FAN_EN, OUTPUT);
 #endif
-    CurrentPower = PWR_COUNT;
+    setDefaultPower();
 }
 
 void POWERMGNT::setDefaultPower()
@@ -180,32 +188,32 @@ PowerLevels_e POWERMGNT::setPower(PowerLevels_e Power)
 #elif defined(TARGET_R9M_LITE_PRO_TX)
     Radio.SetOutputPower(0b0000);
     //Set DACs PA5 & PA4
+    analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095 2.7V
+
     switch (Power)
     {
-    case PWR_100mW:
-        analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095 2.7V
-        analogWrite(GPIO_PIN_RFamp_APC2, 732); //0-4095  590mV
-        CurrentPower = PWR_100mW;
+    case PWR_10mW:
+        analogWrite(GPIO_PIN_RFamp_APC2, 600);  
+        break;
+    case PWR_25mW:
+        analogWrite(GPIO_PIN_RFamp_APC2, 770);  
+        break;
+    case PWR_50mW:
+        analogWrite(GPIO_PIN_RFamp_APC2, 950);  
         break;
     case PWR_250mW:
-        analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095 2.7V
-        analogWrite(GPIO_PIN_RFamp_APC2, 1080); //0-4095 870mV this is actually 200mw
-        CurrentPower = PWR_250mW;
+        analogWrite(GPIO_PIN_RFamp_APC2, 1480); 
         break;
     case PWR_500mW:
-        analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095 2.7V
-        analogWrite(GPIO_PIN_RFamp_APC2, 1356); //0-4095 1.093V
-        CurrentPower = PWR_500mW;
+        analogWrite(GPIO_PIN_RFamp_APC2, 2000); 
         break;
     case PWR_1000mW:
-        analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095 2.7V
-        analogWrite(GPIO_PIN_RFamp_APC2, 1853); //0-4095 1.493V
-        CurrentPower = PWR_1000mW;
+        analogWrite(GPIO_PIN_RFamp_APC2, 3500); 
         break;
+    case PWR_100mW:
     default:
+        analogWrite(GPIO_PIN_RFamp_APC2, 1150);  
         CurrentPower = PWR_100mW;
-        analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095 2.7V
-        analogWrite(GPIO_PIN_RFamp_APC2, 732);  //0-4095 590mV
         break;
     }
 #elif defined(TARGET_100mW_MODULE) || defined(TARGET_R9M_LITE_TX)

--- a/src/lib/POWERMGNT/POWERMGNT.h
+++ b/src/lib/POWERMGNT/POWERMGNT.h
@@ -22,7 +22,7 @@
 
 #elif defined(TARGET_R9M_LITE_PRO_TX)
 #define MaxPower PWR_1000mW
-#define DefaultPowerEnum PWR_100mW
+#define DefaultPowerEnum PWR_50mW
 
 #elif defined(TARGET_TX_ESP32_E28_SX1280_V1) || \
       defined(TARGET_TX_ESP32_LORA1280F27)   || \

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -744,7 +744,6 @@ void setup()
   #ifdef ENABLE_TELEMETRY
   TelemetryReceiver.SetDataToReceive(sizeof(CRSFinBuffer), CRSFinBuffer, ELRS_TELEMETRY_BYTES_PER_CALL);
   #endif
-  POWERMGNT.setDefaultPower();
 
   eeprom.Begin(); // Init the eeprom
   config.SetStorageProvider(&eeprom); // Pass pointer to the Config class for access to storage

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -707,7 +707,6 @@ void setup()
 
   Serial.println("ExpressLRS TX Module Booted...");
 
-  POWERMGNT.init();
   Radio.currFreq = GetInitialFreq(); //set frequency first or an error will occur!!!
   #if !defined(Regulatory_Domain_ISM_2400)
   //Radio.currSyncWord = UID[3];
@@ -744,6 +743,8 @@ void setup()
   #ifdef ENABLE_TELEMETRY
   TelemetryReceiver.SetDataToReceive(sizeof(CRSFinBuffer), CRSFinBuffer, ELRS_TELEMETRY_BYTES_PER_CALL);
   #endif
+
+  POWERMGNT.init();
 
   eeprom.Begin(); // Init the eeprom
   config.SetStorageProvider(&eeprom); // Pass pointer to the Config class for access to storage


### PR DESCRIPTION
It seems like analogWrite fails on the first call after boot for the R9 lite pro.

This results in no RF output if the power value selected in the LUA is the same as the default power setting, since in this case, the analogWrite calls to set the DAC values only gets called once.

If the power level is set to something non-default on boot, the analogWrite will be called twice (once in setDefault, and once in setPower), and we get RF out.

To counter this, I've added an initial call for APC1 and APC2 analogWrite's in the init function for the lite pro.

I also added 10mW, 25mW, and 50mW for lite pro.

This fix should be regression tested for other targets to make sure I haven't borked something. A quick check that power can be set, and then returns to the correct value on reboot should suffice.