### PR TITLE
fix on r9slim (1 antenna)

### DIFF
--- a/src/include/targets.h
+++ b/src/include/targets.h
@@ -128,6 +128,8 @@ https://github.com/jaxxzer
     #define GPIO_PIN_LED_RED        PA11 // Red
     #define GPIO_PIN_LED_GREEN      PA12 // Green
     #define GPIO_PIN_BUTTON         PC13  // pullup e.g. LOW when pressed
+    /* PB3: RX = HIGH, TX = LOW */
+    #define GPIO_PIN_RX_ENABLE      PB3
 #elif defined(TARGET_R9SLIMPLUS_RX)
     #define GPIO_PIN_LED_RED        PA11 // Red
     #define GPIO_PIN_LED_GREEN      PA12 // Green


### PR DESCRIPTION
vantasstic from discord reported short range of r9slim, and he discovered using the slim+ firmware fixed the rssi value from -70 to -20db (bench testing), but since r9slim+ and r9slim have different RC signal pins, it might not be a good idea to use the slim+ firmware, and the other thing that is different is only antenna select and rx_enable pin. this PR activate the rx enable pin and solved the problem, confirmed by vantasstic.