### PR TITLE
Added targets for Happy Model ES900RX and ES900TX

### DIFF
--- a/src/include/targets.h
+++ b/src/include/targets.h
@@ -504,6 +504,22 @@ Designed by NamimnoRC
 // Unused pins
 #define GPIO_PIN_UART1TX_INVERT PF6
 
+#elif defined(TARGET_ES900TX)
+#define GPIO_PIN_NSS            5
+#define GPIO_PIN_DIO0           26
+#define GPIO_PIN_DIO1           25
+#define GPIO_PIN_MOSI           23
+#define GPIO_PIN_MISO           19
+#define GPIO_PIN_SCK            18
+#define GPIO_PIN_RST            14
+#define GPIO_PIN_RX_ENABLE      13
+#define GPIO_PIN_TX_ENABLE      12
+#define GPIO_PIN_RCSIGNAL_RX    2
+#define GPIO_PIN_RCSIGNAL_TX    2 // so we don't have to solder the extra resistor, we switch rx/tx using gpio mux
+#define GPIO_PIN_LED            27
+#define GPIO_PIN_FAN_EN         17
+#define GPIO_PIN_RFamp_APC2     25
+
 #else
 #error "Unknown target!"
 #endif

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -339,6 +339,35 @@ PowerLevels_e POWERMGNT::setPower(PowerLevels_e Power)
         Radio.SetOutputPower(-7); // -7=~55mW, -8=46mW
         break;
     }
+#elif defined(TARGET_ES900TX)
+    Radio.SetOutputPower(0b0000);
+
+    switch (Power)
+    {
+    case PWR_10mW:
+        dacWrite(GPIO_PIN_RFamp_APC2, 41);
+        break;
+    case PWR_25mW:
+        dacWrite(GPIO_PIN_RFamp_APC2, 60);
+        break;
+    case PWR_100mW:
+        dacWrite(GPIO_PIN_RFamp_APC2, 90);
+        break;
+    case PWR_250mW:
+       dacWrite(GPIO_PIN_RFamp_APC2, 110);
+        break;
+    case PWR_500mW:
+        dacWrite(GPIO_PIN_RFamp_APC2, 132);
+        break;
+    case PWR_1000mW:
+        dacWrite(GPIO_PIN_RFamp_APC2, 190);
+        break;
+    case PWR_50mW:
+    default:
+        dacWrite(GPIO_PIN_RFamp_APC2, 73);
+        Power = PWR_50mW;
+        break;
+    }
 #elif defined(TARGET_RX)
 #ifdef TARGET_SX1280
     Radio.SetOutputPower(13); //default is max power (12.5dBm for SX1280 RX)

--- a/src/lib/POWERMGNT/POWERMGNT.h
+++ b/src/lib/POWERMGNT/POWERMGNT.h
@@ -12,7 +12,8 @@
 
 #if defined(TARGET_1000mW_MODULE) || \
     defined(TARGET_R9M_TX)        || \
-    defined(TARGET_TX_ES915TX)
+    defined(TARGET_TX_ES915TX)    || \
+    defined(TARGET_ES900TX)
 #ifdef UNLOCK_HIGHER_POWER
 #define MaxPower PWR_1000mW
 #else

--- a/src/targets/happymodel_900.ini
+++ b/src/targets/happymodel_900.ini
@@ -26,6 +26,19 @@ extends = env:HappyModel_TX_ES915TX_via_STLINK
 [env:HappyModel_TX_ES915TX_via_WIFI]
 extends = env:HappyModel_TX_ES915TX_via_STLINK
 
+[env:HappyModel_TX_ES900TX_via_UART]
+extends = env_common_esp32
+build_flags =
+	${env_common_esp32.build_flags}
+	${common_env_data.build_flags_tx}
+	-D TARGET_ES900TX
+src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+
+[env:HappyModel_TX_ES900TX_via_WIFI]
+extends = env:HappyModel_ES900TX_via_UART
+upload_port = 10.0.0.1
+
+
 # ********************************
 # Receiver targets
 # ********************************
@@ -50,3 +63,9 @@ upload_flags =
 [env:HappyModel_RX_ES915RX_via_BetaflightPassthrough]
 extends = env:HappyModel_RX_ES915RX_via_STLINK
 
+[env:HappyModel_RX_ES900RX_via_WIFI]
+extends = env:DIY_900_RX_ESP8285_SX127x_via_WIFI
+upload_port = 10.0.0.1
+
+[env:HappyModel_RX_ES900RX_via_BetaflightPassthrough]
+extends = env:DIY_900_RX_ESP8285_SX127x_via_BetaflightPassthrough


### PR DESCRIPTION
New targets added for:

- ES900TX (based on old E19 target)
- ES900TX (based on DIY ESP8285 hardware)

Power output tweaked and confirmed for all power level except 1W.