### PR TITLE
Remove seperate task for UART handling on ESP32

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -103,6 +103,7 @@ void CRSF::Begin()
                      GPIO_PIN_RCSIGNAL_RX, GPIO_PIN_RCSIGNAL_TX,
                      false, 500);
     CRSF::duplex_set_RX();
+    CRSF::Port.setRxBufferSize(1024);
     flush_port_input();
 #elif defined(PLATFORM_STM32)
     Serial.println("Start STM32 R9M TX CRSF UART");

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -805,9 +805,7 @@ void loop()
     #endif // GPIO_PIN_LED_RED
   }
 
-  #ifdef PLATFORM_STM32
-    crsf.handleUARTin();
-  #endif // PLATFORM_STM32
+  crsf.handleUARTin();
 
   #if defined(GPIO_PIN_BUTTON) && (GPIO_PIN_BUTTON != UNDEF_PIN)
     button.handle();


### PR DESCRIPTION
This PR makes the ESP32 and STM32 handling of the UART consistent across both platforms.
As discussed with @schugabe on discord.