### PR TITLE
Include active_antenna in telemetry

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -293,10 +293,11 @@ bool ICACHE_RAM_ATTR HandleSendTelemetryResponse()
             #endif
             Radio.TXdataBuffer[1] = ELRS_TELEMETRY_TYPE_LINK;
 
-            // OpenTX RSSI as -dBm is fine and supports +dBm values as well
-            // but the value in linkstatistics is "positivized" (inverted polarity)
-            Radio.TXdataBuffer[2] = -crsf.LinkStatistics.uplink_RSSI_1;
-            Radio.TXdataBuffer[3] = -crsf.LinkStatistics.uplink_RSSI_2;
+            // The value in linkstatistics is "positivized" (inverted polarity)
+            // and must be inverted on the TX side. Positive values are used
+            // so save a bit to encode which antenna is in use
+            Radio.TXdataBuffer[2] = crsf.LinkStatistics.uplink_RSSI_1 | (antenna << 7);
+            Radio.TXdataBuffer[3] = crsf.LinkStatistics.uplink_RSSI_2;
             Radio.TXdataBuffer[4] = crsf.LinkStatistics.uplink_SNR;
             Radio.TXdataBuffer[5] = crsf.LinkStatistics.uplink_Link_quality;
             Radio.TXdataBuffer[6] = MspReceiver.GetCurrentConfirm() ? 1 : 0;

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -166,9 +166,12 @@ void ICACHE_RAM_ATTR ProcessTLMpacket()
     switch(TLMheader & ELRS_TELEMETRY_TYPE_MASK)
     {
         case ELRS_TELEMETRY_TYPE_LINK:
-            // RSSI received is signed, proper polarity (negative value = -dBm)
-            crsf.LinkStatistics.uplink_RSSI_1 = Radio.RXdataBuffer[2];
-            crsf.LinkStatistics.uplink_RSSI_2 = Radio.RXdataBuffer[3];
+            // Antenna is the high bit in the RSSI_1 value
+            crsf.LinkStatistics.active_antenna = Radio.RXdataBuffer[2] >> 7;
+            // RSSI received is signed, inverted polarity (positive value = -dBm)
+            // OpenTX's value is signed and will display +dBm and -dBm properly
+            crsf.LinkStatistics.uplink_RSSI_1 = -(Radio.RXdataBuffer[2] & 0x7f);
+            crsf.LinkStatistics.uplink_RSSI_2 = -(Radio.RXdataBuffer[3]);
             crsf.LinkStatistics.uplink_SNR = Radio.RXdataBuffer[4];
             crsf.LinkStatistics.uplink_Link_quality = Radio.RXdataBuffer[5];
             crsf.LinkStatistics.uplink_TX_Power = POWERMGNT.powerToCrsfPower(POWERMGNT.currPower());


### PR DESCRIPTION
I'd like to have the TX know which antenna is active on diversity RX both for reporting to OpenTX and we'll need it for dynamic power. We only use 7 of the 8 bits of RSSI in the LinkStatistics telemetry packet, so this encodes the active antenna in the high bit of RSSI_1. 

Note that this inverts the polarity of the RSSI over the air, it is now positive when sent by the RX and is therefore inverted on the TX after removing the antenna bit. 

Tested with FM30 TX on SIYI FR Mini diversity RX and HM EP2 non-diversity (university?) RX.
