### PR TITLE
Fixes to couple of things (WIFI crash, UART upload/mon speed)

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -155,7 +155,7 @@ void CRSF::End()
             break;
         }
     }
-    CRSF::Port.end();
+    //CRSF::Port.end(); // don't call seria.end(), it causes some sort of issue with the 900mhz hardware using gpio2 for serial 
     Serial.println("CRSF UART END");
 #endif // CRSF_TX_MODULE
 }

--- a/src/src/ESP8266_WebUpdate.cpp
+++ b/src/src/ESP8266_WebUpdate.cpp
@@ -130,7 +130,7 @@ void BeginWebUpdate(void)
   WiFi.disconnect();   //added to start with the wifi off, avoid crashing
   WiFi.mode(WIFI_OFF); //added to start with the wifi off, avoid crashing
   WiFi.setOutputPower(13);
-  WiFi.setPhyMode(WIFI_PHY_MODE_11B);
+  WiFi.setPhyMode(WIFI_PHY_MODE_11N);
   wifi_station_set_hostname(myHostname);
   delay(500);
   WiFi.softAPConfig(apIP, apIP, netMsk);

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -7,7 +7,6 @@ framework = arduino
 extra_scripts =
 	pre:python/build_flags.py
 	python/build_env_setup.py
-monitor_speed = 420000
 monitor_dtr = 0
 monitor_rts = 0
 
@@ -22,7 +21,8 @@ build_flags_rx = -DTARGET_RX=1 ${common_env_data.build_flags}
 [env_common_esp32]
 platform = espressif32@3.2.0
 board = esp32dev
-upload_speed = 921600
+upload_speed = 460800
+monitor_speed = 460800
 upload_resetmethod = nodemcu
 build_flags =
 	-D PLATFORM_ESP32=1
@@ -43,6 +43,7 @@ build_flags =
 board_build.f_cpu = 160000000L
 src_filter = ${common_env_data.src_filter} -<ESP32*.*> -<STM32*.*> -<WS281B*.*>
 upload_speed = 460800
+monitor_speed = 420000
 upload_resetmethod = nodemcu
 bf_upload_command =
 	python "$PROJECT_DIR/python/BFinitPassthrough.py" -b $UPLOAD_SPEED ${UPLOAD_PORT and "-p "+UPLOAD_PORT}


### PR DESCRIPTION
1. The 900mhz ESP32 WIFI crash bug has something to do with serial.end() being called while the serial pin configured as gpio2, it doesn't happen on 2.4 hardware which is configured to use gpio13. Easy workaround just don't call serial.end() in crsf.end(), since the task is not running anyway we don't actually need to de-init the serial port to stop processing packets. 

2. Found a bug where the monitor_speed was wrong for the DIY targets, decided to move upload_speed and monitor_speed into the [env_common_esp32] environment. Also explicitly defined monitor_speed = 420000 for ESP RX targets. Reduced default speed on esp32 targets to 460800, linux users previously have report some issues with 921600 baud. 

3. Previously the esp8285 targets were using wifi B mode, due to the fact that the ESP datasheets says this mode has the best RF sensitivity, I have feeling it may be causing compatibility issues on some modem since most things run at least N mode nowadays. So, therefore enabled wireless N for ESP RX targets. 

