### PR TITLE
NamimnoRC - Enable higher power by default and set 2.4G Tx min power to 25 mW

### DIFF
--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -135,10 +135,10 @@ PowerLevels_e POWERMGNT::setPower(PowerLevels_e Power)
     switch (Power)
     {
     case PWR_10mW:
-        rfpower = -18;
-        break;
+        // Tx can not do less than 25 mW
     case PWR_25mW:
         rfpower = -18;
+        Power = PWR_25mW;
         break;
     case PWR_100mW:
         rfpower = -12;

--- a/src/lib/POWERMGNT/POWERMGNT.h
+++ b/src/lib/POWERMGNT/POWERMGNT.h
@@ -14,7 +14,7 @@
     defined(TARGET_R9M_TX)        || \
     defined(TARGET_TX_ES915TX)    || \
     defined(TARGET_ES900TX)
-#ifdef UNLOCK_HIGHER_POWER
+#if defined(UNLOCK_HIGHER_POWER) || defined(TARGET_NAMIMNORC_TX)
 #define MaxPower PWR_1000mW
 #else
 #define MaxPower PWR_250mW


### PR DESCRIPTION
These modules come with a fan and higher power should be enabled by default.  They also can not do less than 25 mW.

These changes should also be cherry picked to V1.0.x