### PR TITLE
Simplify RX configuration

### DIFF
--- a/src/lib/OTA/OTA.cpp
+++ b/src/lib/OTA/OTA.cpp
@@ -8,9 +8,9 @@
 
 #include "OTA.h"
 
-#if defined HYBRID_SWITCHES_8 or defined UNIT_TEST
-
 #if TARGET_TX or defined UNIT_TEST
+
+#if defined HYBRID_SWITCHES_8 or defined UNIT_TEST
 /**
  * Hybrid switches packet encoding for sending over the air
  *
@@ -65,9 +65,35 @@ void ICACHE_RAM_ATTR GenerateChannelDataHybridSwitch8(volatile uint8_t* Buffer, 
   // update the sent value
   crsf->setSentSwitch(nextSwitchIndex, value);
 }
+#endif // HYBRID_SWITCHES_8
+
+#if !defined HYBRID_SWITCHES_8 or defined UNIT_TEST
+void ICACHE_RAM_ATTR GenerateChannelData10bit(volatile uint8_t* Buffer, CRSF *crsf)
+{
+  Buffer[0] = RC_DATA_PACKET & 0b11;
+  Buffer[1] = ((crsf->ChannelDataIn[0]) >> 3);
+  Buffer[2] = ((crsf->ChannelDataIn[1]) >> 3);
+  Buffer[3] = ((crsf->ChannelDataIn[2]) >> 3);
+  Buffer[4] = ((crsf->ChannelDataIn[3]) >> 3);
+  Buffer[5] = ((crsf->ChannelDataIn[0] & 0b110) << 5) |
+                           ((crsf->ChannelDataIn[1] & 0b110) << 3) |
+                           ((crsf->ChannelDataIn[2] & 0b110) << 1) |
+                           ((crsf->ChannelDataIn[3] & 0b110) >> 1);
+  Buffer[6] = CRSF_to_BIT(crsf->ChannelDataIn[4]) << 7;
+  Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[5]) << 6;
+  Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[6]) << 5;
+  Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[7]) << 4;
+  Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[8]) << 3;
+  Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[9]) << 2;
+  Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[10]) << 1;
+  Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[11]) << 0;
+}
+#endif // !HYBRID_SWITCHES_8
+
 #endif
 
 #if TARGET_RX or defined UNIT_TEST
+
 /**
  * Hybrid switches decoding of over the air data
  *
@@ -121,37 +147,6 @@ void ICACHE_RAM_ATTR UnpackChannelDataHybridSwitch8(volatile uint8_t* Buffer, CR
     }
 }
 
-#endif
-#endif // HYBRID_SWITCHES_8
-
-#if !defined HYBRID_SWITCHES_8 or defined UNIT_TEST
-
-#if TARGET_TX or defined UNIT_TEST
-
-void ICACHE_RAM_ATTR GenerateChannelData10bit(volatile uint8_t* Buffer, CRSF *crsf)
-{
-  Buffer[0] = RC_DATA_PACKET & 0b11;
-  Buffer[1] = ((crsf->ChannelDataIn[0]) >> 3);
-  Buffer[2] = ((crsf->ChannelDataIn[1]) >> 3);
-  Buffer[3] = ((crsf->ChannelDataIn[2]) >> 3);
-  Buffer[4] = ((crsf->ChannelDataIn[3]) >> 3);
-  Buffer[5] = ((crsf->ChannelDataIn[0] & 0b110) << 5) |
-                           ((crsf->ChannelDataIn[1] & 0b110) << 3) |
-                           ((crsf->ChannelDataIn[2] & 0b110) << 1) |
-                           ((crsf->ChannelDataIn[3] & 0b110) >> 1);
-  Buffer[6] = CRSF_to_BIT(crsf->ChannelDataIn[4]) << 7;
-  Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[5]) << 6;
-  Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[6]) << 5;
-  Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[7]) << 4;
-  Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[8]) << 3;
-  Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[9]) << 2;
-  Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[10]) << 1;
-  Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[11]) << 0;
-}
-#endif
-
-#if TARGET_RX or defined UNIT_TEST
-
 void ICACHE_RAM_ATTR UnpackChannelData10bit(volatile uint8_t* Buffer, CRSF *crsf)
 {
     crsf->PackedRCdataOut.ch0 = (Buffer[1] << 3) | ((Buffer[5] & 0b11000000) >> 5);
@@ -169,5 +164,3 @@ void ICACHE_RAM_ATTR UnpackChannelData10bit(volatile uint8_t* Buffer, CRSF *crsf
 }
 
 #endif
-
-#endif // !HYBRID_SWITCHES_8

--- a/src/lib/OTA/OTA.h
+++ b/src/lib/OTA/OTA.h
@@ -13,34 +13,29 @@
 #define TLM_PACKET 0b11
 #define SYNC_PACKET 0b10
 
-#if defined HYBRID_SWITCHES_8 or defined UNIT_TEST
 #if TARGET_TX or defined UNIT_TEST
+#if defined HYBRID_SWITCHES_8 or defined UNIT_TEST
 #ifdef ENABLE_TELEMETRY
 void ICACHE_RAM_ATTR GenerateChannelDataHybridSwitch8(volatile uint8_t* Buffer, CRSF *crsf, bool TelemetryStatus);
 #else
 void ICACHE_RAM_ATTR GenerateChannelDataHybridSwitch8(volatile uint8_t* Buffer, CRSF *crsf);
 #endif
 #endif
-#if TARGET_RX or defined UNIT_TEST
-void ICACHE_RAM_ATTR UnpackChannelDataHybridSwitch8(volatile uint8_t* Buffer, CRSF *crsf);
-#endif
-#endif
 
 #if !defined HYBRID_SWITCHES_8 or defined UNIT_TEST
-#if TARGET_TX or defined UNIT_TEST
 void ICACHE_RAM_ATTR GenerateChannelData10bit(volatile uint8_t* Buffer, CRSF *crsf);
-#endif
-#if TARGET_RX or defined UNIT_TEST
-void ICACHE_RAM_ATTR UnpackChannelData10bit(volatile uint8_t* Buffer, CRSF *crsf);
-#endif
 #endif
 
 #if defined HYBRID_SWITCHES_8
 #define GenerateChannelData GenerateChannelDataHybridSwitch8
-#define UnpackChannelData UnpackChannelDataHybridSwitch8
 #else
 #define GenerateChannelData GenerateChannelData10bit
-#define UnpackChannelData UnpackChannelData10bit
+#endif
+#endif
+
+#if TARGET_RX or defined UNIT_TEST
+void ICACHE_RAM_ATTR UnpackChannelDataHybridSwitch8(volatile uint8_t* Buffer, CRSF *crsf);
+void ICACHE_RAM_ATTR UnpackChannelData10bit(volatile uint8_t* Buffer, CRSF *crsf);
 #endif
 
 #endif // H_OTA

--- a/src/lib/Telemetry/telemetry.cpp
+++ b/src/lib/Telemetry/telemetry.cpp
@@ -28,7 +28,6 @@ bool Telemetry::ShouldCallEnterBind()
     return enterBind;
 }
 
-#ifdef ENABLE_TELEMETRY
 PAYLOAD_DATA(GPS, BATTERY_SENSOR, ATTITUDE, DEVICE_INFO, FLIGHT_MODE, MSP_RESP);
 
 bool Telemetry::GetNextPayload(uint8_t* nextPayloadSize, uint8_t **payloadData)
@@ -94,7 +93,6 @@ uint8_t Telemetry::ReceivedPackagesCount()
 {
     return receivedPackages;
 }
-#endif
 
 void Telemetry::ResetState()
 {
@@ -103,7 +101,6 @@ void Telemetry::ResetState()
     currentPayloadIndex = 0;
     receivedPackages = 0;
 
-    #ifdef ENABLE_TELEMETRY
     uint8_t offset = 0;
 
     for (int8_t i = 0; i < payloadTypesCount; i++)
@@ -119,7 +116,6 @@ void Telemetry::ResetState()
         }
         #endif
     }
-    #endif
 }
 
 bool Telemetry::RXhandleUARTin(uint8_t data)
@@ -193,7 +189,6 @@ void Telemetry::AppendTelemetryPackage()
         callEnterBind = true;
         return;
     }
-    #ifdef ENABLE_TELEMETRY
     for (int8_t i = 0; i < payloadTypesCount; i++)
     {
         if (CRSFinBuffer[CRSF_TELEMETRY_TYPE_INDEX] == payloadTypes[i].type && !payloadTypes[i].locked)
@@ -212,6 +207,5 @@ void Telemetry::AppendTelemetryPackage()
             return;
         }
     }
-    #endif
 }
 #endif

--- a/src/lib/Telemetry/telemetry.h
+++ b/src/lib/Telemetry/telemetry.h
@@ -42,11 +42,9 @@ public:
     void ResetState();
     bool ShouldCallBootloader();
     bool ShouldCallEnterBind();
-    #ifdef ENABLE_TELEMETRY
     bool GetNextPayload(uint8_t* nextPayloadSize, uint8_t **payloadData);
     uint8_t UpdatedPayloadCount();
     uint8_t ReceivedPackagesCount();
-    #endif
 private:
     void AppendToPackage(volatile crsf_telemetry_package_t *current);
     void AppendTelemetryPackage();


### PR DESCRIPTION
Remove defines for TELEMETRY & SWITCHES from RX code.

This allows a TX and RX to connect and the RX will use the switch settings as sent from the TX in the sync packet.
Telemetry is supported in "Hybrid" switch mode and not supported in "One-bit" mode. To disable telemetry in hybrid mode, use the LUA script.

This only leaves LOCK_ON_FIRST_CONNECTION and AUTO_WIFI_ON_INTERVAL as software config defines, all the others are hardware specific defines.