### PR TITLE
Use advertised MDNS name

### DIFF
--- a/src/python/build_env_setup.py
+++ b/src/python/build_env_setup.py
@@ -69,11 +69,10 @@ elif platform in ['espressif32']:
     env.AddPreAction("${BUILD_DIR}/src/ESP32_WebUpdate.cpp.o", build_html.build_tx_html)
     if "_WIFI" in target_name:
         env.Replace(UPLOAD_PROTOCOL="custom")
-        env.Replace(UPLOAD_PORT="elrx_tx.local")
         env.Replace(UPLOADCMD=upload_via_esp8266_backpack.on_upload)
 
 if "_WIFI" in target_name:
     if "_TX_" in target_name:
-        env.Replace(UPLOAD_PORT="elrx_tx.local")
+        env.SetDefault(UPLOAD_PORT="elrs_tx.local")
     else:
-        env.Replace(UPLOAD_PORT="elrx_rx.local")
+        env.SetDefault(UPLOAD_PORT="elrs_rx.local")

--- a/src/python/build_env_setup.py
+++ b/src/python/build_env_setup.py
@@ -64,8 +64,16 @@ elif platform in ['espressif8266']:
     if "_WIFI" in target_name:
         env.Replace(UPLOAD_PROTOCOL="custom")
         env.Replace(UPLOADCMD=upload_via_esp8266_backpack.on_upload)
+
 elif platform in ['espressif32']:
     env.AddPreAction("${BUILD_DIR}/src/ESP32_WebUpdate.cpp.o", build_html.build_tx_html)
     if "_WIFI" in target_name:
         env.Replace(UPLOAD_PROTOCOL="custom")
+        env.Replace(UPLOAD_PORT="elrx_tx.local")
         env.Replace(UPLOADCMD=upload_via_esp8266_backpack.on_upload)
+
+if "_WIFI" in target_name:
+    if "_TX_" in target_name:
+        env.Replace(UPLOAD_PORT="elrx_tx.local")
+    else:
+        env.Replace(UPLOAD_PORT="elrx_rx.local")

--- a/src/python/build_flags.py
+++ b/src/python/build_flags.py
@@ -33,6 +33,7 @@ def parse_flags(path):
                 define = define.strip()
                 if define.startswith("-D") or define.startswith("!-D"):
                     if "MY_BINDING_PHRASE" in define:
+                        build_flags.append(define)
                         bindingPhraseHash = hashlib.md5(define.encode()).digest()
                         UIDbytes = ",".join(list(map(str, bindingPhraseHash))[0:6])
                         define = "-DMY_UID=" + UIDbytes

--- a/src/python/build_html.py
+++ b/src/python/build_html.py
@@ -45,7 +45,7 @@ def get_git_version(env):
     return '%s (%s)' % (ver, hash)
 
 def build_version(out, env):
-    out.write('static const char PROGMEM VERSION[] = "%s";\n\n' % get_git_version(env))
+    out.write('static const char VERSION[] = "%s";\n\n' % get_git_version(env))
 
 def build_html(mainfile, var, out, env):
     with open('html/%s' % mainfile, 'r') as file:

--- a/src/src/ESP32_WebUpdate.cpp
+++ b/src/src/ESP32_WebUpdate.cpp
@@ -26,6 +26,7 @@ extern hwTimer hwTimer;
 #include "CRSF.h"
 extern CRSF crsf;
 
+#include "options.h"
 #include "config.h"
 extern TxConfig config;
 
@@ -368,6 +369,7 @@ void BeginWebUpdate()
     MDNS.addServiceTxt("http", "tcp", "type", "tx");
     MDNS.addServiceTxt("http", "tcp", "target", (const char *)&target_name[4]);
     MDNS.addServiceTxt("http", "tcp", "version", VERSION);
+    MDNS.addServiceTxt("http", "tcp", "options", compile_options);
 
     server.begin();
 }

--- a/src/src/ESP32_WebUpdate.cpp
+++ b/src/src/ESP32_WebUpdate.cpp
@@ -358,6 +358,11 @@ void BeginWebUpdate()
       Serial.println("Error starting mDNS");
       return;
     }
+
+    String instance = String(myHostname) + "_" + WiFi.macAddress();
+    instance.replace(":", "");
+    MDNS.setInstanceName(instance);
+
     MDNS.addService("http", "tcp", 80);
     MDNS.addServiceTxt("http", "tcp", "vendor", "elrs");
     MDNS.addServiceTxt("http", "tcp", "type", "tx");

--- a/src/src/ESP32_WebUpdate.cpp
+++ b/src/src/ESP32_WebUpdate.cpp
@@ -362,6 +362,7 @@ void BeginWebUpdate()
     MDNS.addServiceTxt("http", "tcp", "vendor", "elrs");
     MDNS.addServiceTxt("http", "tcp", "type", "tx");
     MDNS.addServiceTxt("http", "tcp", "target", (const char *)&target_name[4]);
+    MDNS.addServiceTxt("http", "tcp", "version", VERSION);
 
     server.begin();
 }

--- a/src/src/ESP32_WebUpdate.cpp
+++ b/src/src/ESP32_WebUpdate.cpp
@@ -359,6 +359,9 @@ void BeginWebUpdate()
       return;
     }
     MDNS.addService("http", "tcp", 80);
+    MDNS.addServiceTxt("http", "tcp", "vendor", "elrs");
+    MDNS.addServiceTxt("http", "tcp", "type", "tx");
+    MDNS.addServiceTxt("http", "tcp", "target", (const char *)&target_name[4]);
 
     server.begin();
 }

--- a/src/src/ESP8266_WebUpdate.cpp
+++ b/src/src/ESP8266_WebUpdate.cpp
@@ -9,6 +9,7 @@
 #include <set>
 #include <StreamString.h>
 
+#include "options.h"
 #include "ESP8266_WebContent.h"
 
 #if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
@@ -374,6 +375,7 @@ void BeginWebUpdate(void)
   MDNS.addServiceTxt(service, "type", "rx");
   MDNS.addServiceTxt(service, "target", (const char *)&target_name[4]);
   MDNS.addServiceTxt(service, "version", VERSION);
+  MDNS.addServiceTxt(service, "options", compile_options);
 
   server.begin();
   Serial.printf("HTTPUpdateServer ready! Open http://%s.local in your browser\n", myHostname);
@@ -400,6 +402,7 @@ void HandleWebUpdate(void)
       default:
         break;
     }
+    MDNS.notifyAPChange();
     changeMode = WIFI_OFF;
   }
   dnsServer.processNextRequest();

--- a/src/src/ESP8266_WebUpdate.cpp
+++ b/src/src/ESP8266_WebUpdate.cpp
@@ -364,10 +364,11 @@ void BeginWebUpdate(void)
     Serial.println("Error starting mDNS");
     return;
   }
-    MDNS.addService("http", "tcp", 80);
-    MDNS.addServiceTxt("http", "tcp", "vendor", "elrs");
-    MDNS.addServiceTxt("http", "tcp", "type", "rx");
-    MDNS.addServiceTxt("http", "tcp", "target", (const char *)&target_name[4]);
+  MDNS.addService("http", "tcp", 80);
+  MDNS.addServiceTxt("http", "tcp", "vendor", "elrs");
+  MDNS.addServiceTxt("http", "tcp", "type", "rx");
+  MDNS.addServiceTxt("http", "tcp", "target", (const char *)&target_name[4]);
+  MDNS.addServiceTxt("http", "tcp", "version", VERSION);
 
   server.begin();
   Serial.printf("HTTPUpdateServer ready! Open http://%s.local in your browser\n", myHostname);

--- a/src/src/ESP8266_WebUpdate.cpp
+++ b/src/src/ESP8266_WebUpdate.cpp
@@ -45,6 +45,8 @@ static IPAddress netMsk(255, 255, 255, 0);
 static DNSServer dnsServer;
 static ESP8266WebServer server(80);
 
+static MDNSResponder::hMDNSService service;
+
 /** Is this an IP? */
 static boolean isIp(String str)
 {
@@ -364,11 +366,14 @@ void BeginWebUpdate(void)
     Serial.println("Error starting mDNS");
     return;
   }
-  MDNS.addService("http", "tcp", 80);
-  MDNS.addServiceTxt("http", "tcp", "vendor", "elrs");
-  MDNS.addServiceTxt("http", "tcp", "type", "rx");
-  MDNS.addServiceTxt("http", "tcp", "target", (const char *)&target_name[4]);
-  MDNS.addServiceTxt("http", "tcp", "version", VERSION);
+  
+  String instance = String(myHostname) + "_" + WiFi.macAddress();
+  instance.replace(":", "");
+  service = MDNS.addService(instance.c_str(), "http", "tcp", 80);
+  MDNS.addServiceTxt(service, "vendor", "elrs");
+  MDNS.addServiceTxt(service, "type", "rx");
+  MDNS.addServiceTxt(service, "target", (const char *)&target_name[4]);
+  MDNS.addServiceTxt(service, "version", VERSION);
 
   server.begin();
   Serial.printf("HTTPUpdateServer ready! Open http://%s.local in your browser\n", myHostname);

--- a/src/src/ESP8266_WebUpdate.cpp
+++ b/src/src/ESP8266_WebUpdate.cpp
@@ -364,7 +364,10 @@ void BeginWebUpdate(void)
     Serial.println("Error starting mDNS");
     return;
   }
-  MDNS.addService("http", "tcp", 80);
+    MDNS.addService("http", "tcp", 80);
+    MDNS.addServiceTxt("http", "tcp", "vendor", "elrs");
+    MDNS.addServiceTxt("http", "tcp", "type", "rx");
+    MDNS.addServiceTxt("http", "tcp", "target", (const char *)&target_name[4]);
 
   server.begin();
   Serial.printf("HTTPUpdateServer ready! Open http://%s.local in your browser\n", myHostname);

--- a/src/src/config.cpp
+++ b/src/src/config.cpp
@@ -2,11 +2,6 @@
 #include "common.h"
 #include "POWERMGNT.h"
 
-#define QUOTE(arg) #arg
-#define STR(macro) QUOTE(macro)
-const unsigned char target_name[] = "\xBE\xEF\xCA\xFE" STR(TARGET_NAME);
-const uint8_t target_name_size = sizeof(target_name);
-
 void
 TxConfig::Load()
 {

--- a/src/src/config.h
+++ b/src/src/config.h
@@ -3,9 +3,6 @@
 #include "targets.h"
 #include "elrs_eeprom.h"
 
-extern const unsigned char target_name[];
-extern const uint8_t target_name_size;
-
 #define TX_CONFIG_VERSION   2
 #define RX_CONFIG_VERSION   2
 #define UID_LEN             6

--- a/src/src/options.cpp
+++ b/src/src/options.cpp
@@ -1,0 +1,64 @@
+#include "targets.h"
+#include "options.h"
+
+#define QUOTE(arg) #arg
+#define STR(macro) QUOTE(macro)
+const unsigned char target_name[] = "\xBE\xEF\xCA\xFE" STR(TARGET_NAME);
+const uint8_t target_name_size = sizeof(target_name);
+
+const char *compile_options = {
+#ifdef MY_BINDING_PHRASE
+    "-DMY_BINDING_PHRASE=\"" STR(MY_BINDING_PHRASE) "\" "
+#endif
+#ifdef HYBRID_SWITCHES_8
+    "-DHYBRID_SWITCHES_8 "
+#endif
+#ifdef UNLOCK_HIGHER_POWER
+    "-DUNLOCK_HIGHER_POWER "
+#endif
+#ifdef NO_SYNC_ON_ARM
+    "-DNO_SYNC_ON_ARM "
+#endif
+#ifdef FEATURE_OPENTX_SYNC
+    "-DFEATURE_OPENTX_SYNC "
+#endif
+#ifdef FEATURE_OPENTX_SYNC_AUTOTUNE
+    "-DFEATURE_OPENTX_SYNC_AUTOTUNE "
+#endif
+#ifdef LOCK_ON_FIRST_CONNECTION
+    "-DLOCK_ON_FIRST_CONNECTION "
+#endif
+#ifdef UART_INVERTED
+    "-DUART_INVERTED "
+#endif
+#ifdef USE_R9MM_R9MINI_SBUS
+    "-DUSE_R9MM_R9MINI_SBUS "
+#endif
+#ifdef TLM_REPORT_INTERVAL_MS
+    "-DTLM_REPORT_INTERVAL_MS=" STR(TLM_REPORT_INTERVAL_MS) " "
+#endif
+#ifdef AUTO_WIFI_ON_INTERVAL
+    "-DAUTO_WIFI_ON_INTERVAL=" STR(AUTO_WIFI_ON_INTERVAL) " "
+#endif
+#ifdef JUST_BEEP_ONCE
+    "-DJUST_BEEP_ONCE "
+#endif
+#ifdef DISABLE_STARTUP_BEEP
+    "-DDISABLE_STARTUP_BEEP "
+#endif
+#ifdef MY_STARTUP_MELODY
+    "-DMY_STARTUP_MELODY=\"" STR(MY_STARTUP_MELODY) "\" "
+#endif
+#ifdef ENABLE_TELEMETRY
+    "-DENABLE_TELEMETRY "
+#endif
+#ifdef USE_DIVERSITY
+    "-DUSE_DIVERSITY "
+#endif
+#ifdef USE_DYNAMIC_POWER
+    "-DUSE_DYNAMIC_POWER "
+#endif
+#ifdef WS2812_IS_GRB
+    "-DWS2812_IS_GRB "
+#endif
+};

--- a/src/src/options.h
+++ b/src/src/options.h
@@ -1,0 +1,5 @@
+#pragma once 
+
+extern const unsigned char target_name[];
+extern const uint8_t target_name_size;
+extern const char *compile_options;

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -35,6 +35,7 @@ SX1280Driver Radio;
 #include "LQCALC.h"
 #include "elrs_eeprom.h"
 #include "config.h"
+#include "options.h"
 #include "POWERMGNT.h"
 
 #ifdef TARGET_RX_GHOST_ATTO_V1

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -18,6 +18,7 @@ SX1280Driver Radio;
 #include "msptypes.h"
 #include <OTA.h>
 #include "elrs_eeprom.h"
+#include "options.h"
 #include "config.h"
 #include "hwTimer.h"
 #include "LQCALC.h"

--- a/src/targets/HGLRC_2400.ini
+++ b/src/targets/HGLRC_2400.ini
@@ -14,7 +14,6 @@ extends = env:HGLRC_Hermes_2400_TX_via_UART
 build_flags =
 	${env:DIY_2400_TX_ESP32_SX1280_E28_via_UART.build_flags}
 	-D TARGET_HGLRC_Hermes_2400_TX=1
-upload_port = 10.0.0.1
 
 # ********************************
 # Receiver targets
@@ -30,4 +29,3 @@ build_flags = ${env:DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough.build_f
 
 [env:HGLRC_Hermes_2400_RX_via_WIFI]
 extends = env:HGLRC_Hermes_2400_RX_via_UART
-upload_port = 10.0.0.1

--- a/src/targets/HGLRC_900.ini
+++ b/src/targets/HGLRC_900.ini
@@ -15,4 +15,3 @@ extends = env:DIY_900_RX_ESP8285_SX127x_via_BetaflightPassthrough
 
 [env:HGLRC_Hermes_900_RX_via_WIFI]
 extends = env:DIY_900_RX_ESP8285_SX127x_via_WIFI
-upload_port = 10.0.0.1

--- a/src/targets/betafpv_2400.ini
+++ b/src/targets/betafpv_2400.ini
@@ -17,7 +17,6 @@ src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 
 [env:BETAFPV_2400_TX_via_WIFI]
 extends = env:BETAFPV_2400_TX_via_UART
-upload_port = 10.0.0.1
 
 # ********************************
 # Receiver targets
@@ -40,4 +39,3 @@ upload_command = ${env_common_esp82xx.bf_upload_command}
 
 [env:BETAFPV_2400_RX_via_WIFI]
 extends = env:BETAFPV_2400_RX_via_UART
-upload_port = 10.0.0.1

--- a/src/targets/betafpv_900.ini
+++ b/src/targets/betafpv_900.ini
@@ -14,7 +14,6 @@ src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 
 [env:BETAFPV_900_TX_via_WIFI]
 extends = env:BETAFPV_900_TX_via_UART
-upload_port = 10.0.0.1
 
 # ********************************
 # Receiver targets
@@ -37,4 +36,3 @@ upload_command = ${env_common_esp82xx.bf_upload_command}
 
 [env:BETAFPV_900_RX_via_WIFI]
 extends = env:BETAFPV_900_RX_via_UART
-upload_port = 10.0.0.1

--- a/src/targets/diy_2400.ini
+++ b/src/targets/diy_2400.ini
@@ -29,7 +29,6 @@ src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 
 [env:DIY_2400_TX_ESP32_SX1280_E28_via_WIFI]
 extends = env:DIY_2400_TX_ESP32_SX1280_E28_via_UART
-upload_port = 10.0.0.1
 
 [env:DIY_2400_TX_ESP32_SX1280_LORA1280F27_via_UART]
 extends = env_common_esp32
@@ -66,7 +65,6 @@ upload_command = ${env_common_esp82xx.bf_upload_command}
 
 [env:DIY_2400_RX_ESP8285_SX1280_via_WIFI]
 extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART
-upload_port = 10.0.0.1
 
 [env:DIY_2400_RX_STM32_CCG_Nano_v0_5_via_STLINK]
 extends = env_common_stm32

--- a/src/targets/diy_900.ini
+++ b/src/targets/diy_900.ini
@@ -71,4 +71,3 @@ upload_command = ${env_common_esp82xx.bf_upload_command}
 
 [env:DIY_900_RX_ESP8285_SX127x_via_WIFI]
 extends = env:DIY_900_RX_ESP8285_SX127x_via_UART
-upload_port = 10.0.0.1

--- a/src/targets/happymodel_2400.ini
+++ b/src/targets/happymodel_2400.ini
@@ -29,7 +29,6 @@ build_flags = ${env:DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough.build_f
 
 [env:HappyModel_EP_2400_RX_via_WIFI]
 extends = env:HappyModel_EP_2400_RX_via_UART
-upload_port = 10.0.0.1
 
 [env:HappyModel_PP_2400_RX_via_STLINK]
 extends = env:DIY_2400_RX_STM32_CCG_Nano_v0_5_via_STLINK

--- a/src/targets/happymodel_2400.ini
+++ b/src/targets/happymodel_2400.ini
@@ -14,7 +14,6 @@ extends = env:HappyModel_ES24TX_2400_TX_via_UART
 build_flags =
 	${env:DIY_2400_TX_ESP32_SX1280_E28_via_UART.build_flags}
 	-D TARGET_HappyModel_ES24TX_2400_TX=1
-upload_port = 10.0.0.1
 
 # ********************************
 # Receiver targets

--- a/src/targets/happymodel_900.ini
+++ b/src/targets/happymodel_900.ini
@@ -36,7 +36,6 @@ src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 
 [env:HappyModel_TX_ES900TX_via_WIFI]
 extends = env:HappyModel_TX_ES900TX_via_UART
-upload_port = 10.0.0.1
 
 
 # ********************************
@@ -65,7 +64,6 @@ extends = env:HappyModel_RX_ES915RX_via_STLINK
 
 [env:HappyModel_RX_ES900RX_via_WIFI]
 extends = env:DIY_900_RX_ESP8285_SX127x_via_WIFI
-upload_port = 10.0.0.1
 
 [env:HappyModel_RX_ES900RX_via_BetaflightPassthrough]
 extends = env:DIY_900_RX_ESP8285_SX127x_via_BetaflightPassthrough

--- a/src/targets/namimnorc_2400.ini
+++ b/src/targets/namimnorc_2400.ini
@@ -58,5 +58,4 @@ extends = env:DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough
 
 [env:NamimnoRC_FLASH_2400_ESP_RX_via_WIFI]
 extends = env:NamimnoRC_FLASH_2400_ESP_RX_via_UART
-upload_port = 10.0.0.1
 

--- a/src/targets/namimnorc_900.ini
+++ b/src/targets/namimnorc_900.ini
@@ -64,4 +64,3 @@ upload_command = ${env_common_esp82xx.bf_upload_command}
 
 [env:NamimnoRC_VOYAGER_900_ESP_RX_via_WIFI]
 extends = env:NamimnoRC_VOYAGER_900_ESP_RX_via_UART
-upload_port = 10.0.0.1

--- a/src/targets/neutronrc_900.ini
+++ b/src/targets/neutronrc_900.ini
@@ -25,4 +25,3 @@ upload_command = ${env_common_esp82xx.bf_upload_command}
 
 [env:NeutronRC_900_RX_via_WIFI]
 extends = env:NeutronRC_900_RX_via_UART
-upload_port = 10.0.0.1


### PR DESCRIPTION
Rather than 10.0.0.1 we use the advertised DNS/MDNS name
Add properties to the MDNS entry so Configurator can automatically find flashable units.

Also, the MDNS advertised service has extra properties added
- `vendor` set to `elrs`
- `type` set to `tx` or `rx`
- `target` set to the basename of the target that was used to previously flash the device
- `version` the branch/tag and commit hash of the current firmware
- `options` the compile options/defines used when build the current firmware