### PR TITLE
Only store the options that are for each target type

### DIFF
--- a/src/src/ESP32_WebUpdate.cpp
+++ b/src/src/ESP32_WebUpdate.cpp
@@ -378,7 +378,7 @@ void BeginWebUpdate()
     MDNS.addServiceTxt("http", "tcp", "type", "tx");
     MDNS.addServiceTxt("http", "tcp", "target", (const char *)&target_name[4]);
     MDNS.addServiceTxt("http", "tcp", "version", VERSION);
-    MDNS.addServiceTxt("http", "tcp", "options", compile_options);
+    MDNS.addServiceTxt("http", "tcp", "options", String(FPSTR(compile_options)).c_str());
 
     server.begin();
 }

--- a/src/src/ESP8266_WebUpdate.cpp
+++ b/src/src/ESP8266_WebUpdate.cpp
@@ -383,7 +383,7 @@ void BeginWebUpdate(void)
   MDNS.addServiceTxt(service, "type", "rx");
   MDNS.addServiceTxt(service, "target", (const char *)&target_name[4]);
   MDNS.addServiceTxt(service, "version", VERSION);
-  MDNS.addServiceTxt(service, "options", compile_options);
+  MDNS.addServiceTxt(service, "options", String(FPSTR(compile_options)).c_str());
 
   server.begin();
   Serial.printf("HTTPUpdateServer ready! Open http://%s.local in your browser\n", myHostname);

--- a/src/src/options.cpp
+++ b/src/src/options.cpp
@@ -6,59 +6,65 @@
 const unsigned char target_name[] = "\xBE\xEF\xCA\xFE" STR(TARGET_NAME);
 const uint8_t target_name_size = sizeof(target_name);
 
-const char *compile_options = {
+const char PROGMEM compile_options[] = {
 #ifdef MY_BINDING_PHRASE
     "-DMY_BINDING_PHRASE=\"" STR(MY_BINDING_PHRASE) "\" "
 #endif
-#ifdef HYBRID_SWITCHES_8
-    "-DHYBRID_SWITCHES_8 "
+
+#ifdef TARGET_TX
+    #ifdef HYBRID_SWITCHES_8
+        "-DHYBRID_SWITCHES_8 "
+    #endif
+    #ifdef UNLOCK_HIGHER_POWER
+        "-DUNLOCK_HIGHER_POWER "
+    #endif
+    #ifdef NO_SYNC_ON_ARM
+        "-DNO_SYNC_ON_ARM "
+    #endif
+    #ifdef FEATURE_OPENTX_SYNC
+        "-DFEATURE_OPENTX_SYNC "
+    #endif
+    #ifdef FEATURE_OPENTX_SYNC_AUTOTUNE
+        "-DFEATURE_OPENTX_SYNC_AUTOTUNE "
+    #endif
+    #ifdef UART_INVERTED
+        "-DUART_INVERTED "
+    #endif
+    #ifdef JUST_BEEP_ONCE
+        "-DJUST_BEEP_ONCE "
+    #endif
+    #ifdef DISABLE_STARTUP_BEEP
+        "-DDISABLE_STARTUP_BEEP "
+    #endif
+    #ifdef MY_STARTUP_MELODY
+        "-DMY_STARTUP_MELODY=\"" STR(MY_STARTUP_MELODY) "\" "
+    #endif
+    #ifdef ENABLE_TELEMETRY
+        "-DENABLE_TELEMETRY "
+    #endif
+    #ifdef USE_DYNAMIC_POWER
+        "-DUSE_DYNAMIC_POWER "
+    #endif
+    #ifdef WS2812_IS_GRB
+        "-DWS2812_IS_GRB "
+    #endif
+    #ifdef TLM_REPORT_INTERVAL_MS
+        "-DTLM_REPORT_INTERVAL_MS=" STR(TLM_REPORT_INTERVAL_MS) " "
+    #endif
 #endif
-#ifdef UNLOCK_HIGHER_POWER
-    "-DUNLOCK_HIGHER_POWER "
-#endif
-#ifdef NO_SYNC_ON_ARM
-    "-DNO_SYNC_ON_ARM "
-#endif
-#ifdef FEATURE_OPENTX_SYNC
-    "-DFEATURE_OPENTX_SYNC "
-#endif
-#ifdef FEATURE_OPENTX_SYNC_AUTOTUNE
-    "-DFEATURE_OPENTX_SYNC_AUTOTUNE "
-#endif
-#ifdef LOCK_ON_FIRST_CONNECTION
-    "-DLOCK_ON_FIRST_CONNECTION "
-#endif
-#ifdef UART_INVERTED
-    "-DUART_INVERTED "
-#endif
-#ifdef USE_R9MM_R9MINI_SBUS
-    "-DUSE_R9MM_R9MINI_SBUS "
-#endif
-#ifdef TLM_REPORT_INTERVAL_MS
-    "-DTLM_REPORT_INTERVAL_MS=" STR(TLM_REPORT_INTERVAL_MS) " "
-#endif
-#ifdef AUTO_WIFI_ON_INTERVAL
-    "-DAUTO_WIFI_ON_INTERVAL=" STR(AUTO_WIFI_ON_INTERVAL) " "
-#endif
-#ifdef JUST_BEEP_ONCE
-    "-DJUST_BEEP_ONCE "
-#endif
-#ifdef DISABLE_STARTUP_BEEP
-    "-DDISABLE_STARTUP_BEEP "
-#endif
-#ifdef MY_STARTUP_MELODY
-    "-DMY_STARTUP_MELODY=\"" STR(MY_STARTUP_MELODY) "\" "
-#endif
-#ifdef ENABLE_TELEMETRY
-    "-DENABLE_TELEMETRY "
-#endif
-#ifdef USE_DIVERSITY
-    "-DUSE_DIVERSITY "
-#endif
-#ifdef USE_DYNAMIC_POWER
-    "-DUSE_DYNAMIC_POWER "
-#endif
-#ifdef WS2812_IS_GRB
-    "-DWS2812_IS_GRB "
+
+#ifdef TARGET_RX
+    #ifdef LOCK_ON_FIRST_CONNECTION
+        "-DLOCK_ON_FIRST_CONNECTION "
+    #endif
+    #ifdef USE_R9MM_R9MINI_SBUS
+        "-DUSE_R9MM_R9MINI_SBUS "
+    #endif
+    #ifdef AUTO_WIFI_ON_INTERVAL
+        "-DAUTO_WIFI_ON_INTERVAL=" STR(AUTO_WIFI_ON_INTERVAL) " "
+    #endif
+    #ifdef USE_DIVERSITY
+        "-DUSE_DIVERSITY "
+    #endif
 #endif
 };

--- a/src/src/options.h
+++ b/src/src/options.h
@@ -2,4 +2,4 @@
 
 extern const unsigned char target_name[];
 extern const uint8_t target_name_size;
-extern const char *compile_options;
+extern const char PROGMEM compile_options[];


### PR DESCRIPTION
Reduces the amount of space used by the options in flash memory.
Also use PROGMEM to store so as not waste too much RAM.