### PR TITLE
Start LQ at 100% instead of 0%

### DIFF
--- a/src/lib/LQCALC/LQCALC.h
+++ b/src/lib/LQCALC/LQCALC.h
@@ -23,7 +23,6 @@ public:
     /* Start a new period */
     void inc()
     {
-        LQprevious = currentIsSet();
         // Increment the counter by shifting one bit higher
         // If we've shifted out all the bits, move to next idx
         LQmask = LQmask << 1;
@@ -45,25 +44,41 @@ public:
             LQArray[LQbyte] &= ~LQmask;
             LQ -= 1;
         }
+
+        if (count < N)
+          ++count;
     }
 
     /* Return the current running total of bits set, in percent */
     uint8_t getLQ() const
     {
-        // Allow the compiler to optimize out some or all of the
-        // math if evenly divisible
-        if (100 % N == 0)
-            return (uint32_t)LQ * (100 / N);
-        else
-            return (uint32_t)LQ * 100 / N;
+        return (uint32_t)LQ * 100U / count;
+    }
+
+    /* Return the current running total of bits set, up to N */
+    uint8_t getLQRaw() const
+    {
+        return LQ;
+    }
+
+    /* Return the number of periods recorded so far, up to N */
+    uint8_t getCount() const
+    {
+        return count;
+    }
+
+    /* Return N, the size of the LQ history */
+    uint8_t getSize() const
+    {
+        return N;
     }
 
     /* Initialize and zero the history */
     void reset()
     {
+        count = 0;
         LQ = 0;
         LQbyte = 0;
-        LQprevious = false;
         LQmask = (1 << 0);
         for (uint8_t i = 0; i < (sizeof(LQArray)/sizeof(LQArray[0])); i++)
             LQArray[i] = 0;
@@ -75,16 +90,10 @@ public:
         return LQArray[LQbyte] & LQmask;
     }
 
-    /*  Return true if the previous period was add()ed */
-    bool previousIsSet() const
-    {
-        return LQprevious;
-    }
-
 private:
     uint8_t LQ;
     uint8_t LQbyte;
-    bool LQprevious;
+    uint8_t count;
     uint32_t LQmask;
     uint32_t LQArray[(N + 31)/32];
 };

--- a/src/lib/LQCALC/LQCALC.h
+++ b/src/lib/LQCALC/LQCALC.h
@@ -76,9 +76,12 @@ public:
     /* Initialize and zero the history */
     void reset()
     {
-        count = 0;
         LQ = 0;
         index = 0;
+        // count is reset to 1 to prevent divide by zero and
+        // typical usage pattern is to call add() on the first packet
+        // after a reset, which would increase `LQ` over `count`
+        count = 1;
         LQmask = (1 << 0);
         for (uint8_t i = 0; i < (sizeof(LQArray)/sizeof(LQArray[0])); i++)
             LQArray[i] = 0;

--- a/src/lib/LQCALC/LQCALC.h
+++ b/src/lib/LQCALC/LQCALC.h
@@ -9,6 +9,9 @@ public:
     LQCALC(void)
     {
         reset();
+        // count is reset here only once on construction to start LQ counting
+        // at 100% on first connect, but 0 out of N after a failsafe
+        count = 1;
     }
 
     /* Set the bit for the current period to true and update the running LQ */
@@ -76,12 +79,10 @@ public:
     /* Initialize and zero the history */
     void reset()
     {
+        // count is intentonally not zeroed here to start LQ counting up from 0
+        // after a failsafe, instead of down from 100
         LQ = 0;
         index = 0;
-        // count is reset to 1 to prevent divide by zero and
-        // typical usage pattern is to call add() on the first packet
-        // after a reset, which would increase `LQ` over `count`
-        count = 1;
         LQmask = (1 << 0);
         for (uint8_t i = 0; i < (sizeof(LQArray)/sizeof(LQArray[0])); i++)
             LQArray[i] = 0;

--- a/src/lib/LQCALC/LQCALC.h
+++ b/src/lib/LQCALC/LQCALC.h
@@ -16,7 +16,7 @@ public:
     {
         if (currentIsSet())
             return;
-        LQArray[LQbyte] |= LQmask;
+        LQArray[index] |= LQmask;
         LQ += 1;
     }
 
@@ -29,19 +29,19 @@ public:
         if (LQmask == 0)
         {
             LQmask = (1 << 0);
-            LQbyte += 1;
+            index += 1;
         }
 
         // At idx N / 32 and bit N % 32, wrap back to idx=0, bit=0
-        if ((LQbyte == (N / 32)) && (LQmask & (1 << (N % 32))))
+        if ((index == (N / 32)) && (LQmask & (1 << (N % 32))))
         {
-            LQbyte = 0;
+            index = 0;
             LQmask = (1 << 0);
         }
 
-        if ((LQArray[LQbyte] & LQmask) != 0)
+        if ((LQArray[index] & LQmask) != 0)
         {
-            LQArray[LQbyte] &= ~LQmask;
+            LQArray[index] &= ~LQmask;
             LQ -= 1;
         }
 
@@ -78,7 +78,7 @@ public:
     {
         count = 0;
         LQ = 0;
-        LQbyte = 0;
+        index = 0;
         LQmask = (1 << 0);
         for (uint8_t i = 0; i < (sizeof(LQArray)/sizeof(LQArray[0])); i++)
             LQArray[i] = 0;
@@ -87,12 +87,12 @@ public:
     /*  Return true if the current period was add()ed */
     bool currentIsSet() const
     {
-        return LQArray[LQbyte] & LQmask;
+        return LQArray[index] & LQmask;
     }
 
 private:
     uint8_t LQ;
-    uint8_t LQbyte;
+    uint8_t index; // current position in LQArray
     uint8_t count;
     uint32_t LQmask;
     uint32_t LQArray[(N + 31)/32];

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1225,7 +1225,7 @@ void loop()
         LostConnection();
     }
 
-    if ((connectionState == tentative) && (abs(OffsetDx) <= 10) && (Offset < 100) && (uplinkLQ > minLqForChaos())) //detects when we are connected
+    if ((connectionState == tentative) && (abs(OffsetDx) <= 10) && (Offset < 100) && (LQCalc.getLQRaw() > minLqForChaos())) //detects when we are connected
     {
         GotConnection();
     }


### PR DESCRIPTION
There have been complaints and questions about the OpenTX "Signal strength critical" warning on link establishment due to the LQ not being very high on initial connect. This changes the LQ calculator class to account for the number of packets that have been received when calculating LQ. Effectively that means it starts at 100% instead of 1% (for N=100) and will not generate the warning, except where applicable.

This is the proper way to do it anyway, since if there has been 1 packet so far and we got all 1 of them, that should be 100 LQ and not 1 LQ.

Fixes #632.

### Further Opportunity
The RX used the old style LQ to determine when it has received enough valid packets (a packet count and not a percentage). I've left that requiring the same number of packets, which is the upper-bound for periods=100. If we made the code more complicated it could use the period counter **and** packet count to establish the link more quickly. We're talking 5 packets instead of 9 though, worst case for EU/AU Team900, so I didn't think it was worth the code bytes and complexity.

### Refactoring
* Removed unused `previousIsSet`
* Renamed `LQbyte` to `index` of course it is still a byte, that's its size not its purpose!
