### PR TITLE
Use modelId for configuration and model matching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,9 +98,9 @@ jobs:
             ;;
         esac
         # All the features
-        PLATFORMIO_BUILD_FLAGS="$REG -DHYBRID_SWITCHES_8 -DENABLE_TELEMETRY -DUSE_DIVERSITY" pio run -e ${{ matrix.target }}
+        PLATFORMIO_BUILD_FLAGS="$REG -DUSE_DIVERSITY" pio run -e ${{ matrix.target }}
         # Minimal/default features
-        PLATFORMIO_BUILD_FLAGS="$REG !-DHYBRID_SWITCHES_8 !-DENABLE_TELEMETRY !-DUSE_DIVERSITY" pio run -e ${{ matrix.target }}
+        PLATFORMIO_BUILD_FLAGS="$REG !-DUSE_DIVERSITY" pio run -e ${{ matrix.target }}
         mv .pio/build ~/artifacts/AU_915
 
     - name: Store Artifacts

--- a/src/html/rx_index.html
+++ b/src/html/rx_index.html
@@ -55,6 +55,24 @@
 				</fieldset>
 			</div>
 
+			<div align="left">
+				<fieldset>
+					If you set the 'Model Match' below to a number other than zero, you can specify the 'Receiver' number in OpenTX/EdgeTX
+					model setup page and turn on the 'Model Match' in the ELRS LUA script for that model. 'Model Match' is between 0 and 63 inclusive.
+					<br><br>
+					<legend>
+						<h2>Model Match:</h2>
+					</legend>
+					<form action='/modelmatch' id='modelmatch' method='POST'>
+						<div class="group">
+							<input id='modelid' type='text' name='modelid'>
+							<input type='submit' value='Set Model Match'>
+						</div>
+					</form>
+					<br><br>
+				</fieldset>
+			</div>
+
 			<div align="left" id="apmode" style="display:none;">
 				<fieldset>
 					Here you can join a network and it will be saved as your &quot;home&quot; network.

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -1,6 +1,10 @@
 document.addEventListener("DOMContentLoaded", get_mode, false);
 var scanTimer = undefined;
 
+function _(el) {
+    return document.getElementById(el);
+}
+
 function get_mode() {
     var json_url = 'mode.json';
     xmlhttp = new XMLHttpRequest();
@@ -8,17 +12,18 @@ function get_mode() {
         if (this.readyState == 4 && this.status == 200) {
             var data = JSON.parse(this.responseText);
             if (data.mode==="STA") {
-                document.getElementById('stamode').style.display = 'block';
-                document.getElementById('ssid').textContent = data.ssid;
+                _('stamode').style.display = 'block';
+                _('ssid').textContent = data.ssid;
             } else {
-                document.getElementById('apmode').style.display = 'block';
+                _('apmode').style.display = 'block';
                 if (data.ssid) {
-                    document.getElementById('homenet').textContent = data.ssid;
+                    _('homenet').textContent = data.ssid;
                 } else {
-                    document.getElementById('connect').style.display = 'none';
+                    _('connect').style.display = 'none';
                 }
                 scanTimer = setInterval(get_networks, 2000);
             }
+            _('modelid').value = data.modelid;
         }
     };
     xmlhttp.open("POST", json_url, true);
@@ -32,8 +37,8 @@ function get_networks() {
     xmlhttp.onreadystatechange = function () {
         if (this.readyState == 4 && this.status == 200) {
             var data = JSON.parse(this.responseText);
-            document.getElementById('loader').style.display = 'none';
-            autocomplete(document.getElementById('network'), data);
+            _('loader').style.display = 'none';
+            autocomplete(_('network'), data);
             clearInterval(scanTimer);
         }
     };
@@ -109,7 +114,7 @@ function autocomplete(inp, arr) {
 
     /*execute a function presses a key on the keyboard:*/
     inp.addEventListener("keydown", function (e) {
-        var x = document.getElementById(this.id + "autocomplete-list");
+        var x = _(this.id + "autocomplete-list");
         if (x) x = x.getElementsByTagName("div");
         if (e.keyCode == 40) {
             /*If the arrow DOWN key is pressed,
@@ -165,10 +170,6 @@ function autocomplete(inp, arr) {
 }
 
 //=========================================================
-
-function _(el) {
-    return document.getElementById(el);
-}
 
 function uploadFile() {
     var file = _("firmware_file").files[0];
@@ -269,7 +270,10 @@ _('sethome').addEventListener('submit', callback("Set Home Network", "An error o
 }));
 _('connect').addEventListener('click', callback("Connect to Home Network", "An error occurred connecting to the Home network", "/connect", null));
 _('access').addEventListener('click', callback("Access Point", "An error occurred starting the Access Point", "/access", null));
-_('forget').addEventListener('click', callback("Forget Home Network",  "An error occurred forgetting the home network", "/forget", null));
+_('forget').addEventListener('click', callback("Forget Home Network", "An error occurred forgetting the home network", "/forget", null));
+if (_('modelmatch') != undefined) {
+    _('modelmatch').addEventListener('submit', callback("Set Model Match", "An error occurred updating the model match number", "/model", null));
+}
 
 //=========================================================
 

--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -52,6 +52,7 @@ volatile inBuffer_U CRSF::inBuffer;
 uint8_t CRSF::currentSwitches[N_SWITCHES] = {0};
 uint8_t CRSF::sentSwitches[N_SWITCHES] = {0};
 
+uint8_t CRSF::nextSwitchFirstIndex = 0;
 uint8_t CRSF::nextSwitchIndex = 0; // for round-robin sequential switches
 
 volatile uint8_t CRSF::ParameterUpdateData[3] = {0};
@@ -184,11 +185,7 @@ void CRSF::flush_port_input(void)
  */
 uint8_t ICACHE_RAM_ATTR CRSF::getNextSwitchIndex()
 {
-    int firstSwitch = 0; // sequential switches includes switch 0
-
-#if defined HYBRID_SWITCHES_8
-    firstSwitch = 1; // skip 0 since it is sent on every packet
-#endif
+    int firstSwitch = nextSwitchFirstIndex;
 
     // look for a changed switch
     int i;
@@ -206,16 +203,17 @@ uint8_t ICACHE_RAM_ATTR CRSF::getNextSwitchIndex()
     // keep track of which switch to send next if there are no changed switches
     // during the next call.
     nextSwitchIndex = (i + 1) % 8;
-
-#ifdef HYBRID_SWITCHES_8
-    // for hydrid switches 0 is sent on every packet, skip it in round-robin
     if (nextSwitchIndex == 0)
     {
-        nextSwitchIndex = 1;
+        nextSwitchIndex = nextSwitchFirstIndex;
     }
-#endif
 
     return i;
+}
+
+void ICACHE_RAM_ATTR CRSF::setNextSwitchFirstIndex(int firstSwitchIndex)
+{
+    nextSwitchFirstIndex = firstSwitchIndex;
 }
 
 /**

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -45,6 +45,8 @@ public:
 
     static uint8_t currentSwitches[N_SWITCHES];
     static uint8_t sentSwitches[N_SWITCHES];
+    // index of the first switch to send in round-robin
+    static uint8_t nextSwitchFirstIndex;
     // which switch should be sent in the next rc packet
     static uint8_t nextSwitchIndex;
 
@@ -82,6 +84,7 @@ public:
     static void ICACHE_RAM_ATTR sendSetVTXchannel(uint8_t band, uint8_t channel);
 
     uint8_t ICACHE_RAM_ATTR getNextSwitchIndex();
+    void ICACHE_RAM_ATTR setNextSwitchFirstIndex(int firstSwitchIndex);
     void ICACHE_RAM_ATTR setSentSwitch(uint8_t index, uint8_t value);
 
 ///// Variables for OpenTX Syncing //////////////////////////

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -49,10 +49,13 @@ public:
     static uint8_t nextSwitchFirstIndex;
     // which switch should be sent in the next rc packet
     static uint8_t nextSwitchIndex;
+    // The model ID as received from the Transmitter
+    static uint8_t modelId;
 
     static void (*disconnected)();
     static void (*connected)();
 
+    static void (*RecvModelUpdate)();
     static void (*RecvParameterUpdate)();
 
     static volatile uint8_t ParameterUpdateData[3];
@@ -87,7 +90,9 @@ public:
     void ICACHE_RAM_ATTR setNextSwitchFirstIndex(int firstSwitchIndex);
     void ICACHE_RAM_ATTR setSentSwitch(uint8_t index, uint8_t value);
 
-///// Variables for OpenTX Syncing //////////////////////////
+    uint8_t ICACHE_RAM_ATTR getModelID();
+
+    ///// Variables for OpenTX Syncing //////////////////////////
     #define OpenTXsyncPacketInterval 200 // in ms
     static void ICACHE_RAM_ATTR setSyncParams(uint32_t PacketInterval);
     static void ICACHE_RAM_ATTR JustSentRFpacket();

--- a/src/lib/CrsfProtocol/crsf_protocol.h
+++ b/src/lib/CrsfProtocol/crsf_protocol.h
@@ -120,6 +120,14 @@ typedef enum
     CRSF_FRAMETYPE_MSP_WRITE = 0x7C, // write with 8 byte chunked binary (OpenTX outbound telemetry buffer limit)
 } crsf_frame_type_e;
 
+typedef enum {
+    SUBCOMMAND_CRSF = 0x10
+} crsf_command_e;
+
+typedef enum {
+    COMMAND_MODEL_SELECT_ID = 0x05
+} crsf_subcommand_e;
+
 enum {
     CRSF_FRAME_TX_MSP_FRAME_SIZE = 58,
     CRSF_FRAME_RX_MSP_FRAME_SIZE = 8,

--- a/src/lib/MSP/msptypes.h
+++ b/src/lib/MSP/msptypes.h
@@ -2,6 +2,7 @@
 
 #define MSP_ELRS_FUNC       0x4578 // ['E','x']
 
+#define MSP_SET_RX_CONFIG   45
 #define MSP_VTX_CONFIG      88 //out message         Get vtx settings - betaflight
 #define MSP_SET_VTX_CONFIG  89 //in message          Set vtx settings - betaflight
 
@@ -10,6 +11,7 @@
 #define MSP_ELRS_TX_PWR     0x07
 #define MSP_ELRS_TLM_RATE   0x08
 #define MSP_ELRS_BIND       0x09
+#define MSP_ELRS_MODEL_ID   0x0A
 
 // CRSF encapsulated msp defines
 #define ENCAPSULATED_MSP_PAYLOAD_SIZE 4

--- a/src/lib/OTA/OTA.cpp
+++ b/src/lib/OTA/OTA.cpp
@@ -10,7 +10,6 @@
 
 #if TARGET_TX or defined UNIT_TEST
 
-#if defined HYBRID_SWITCHES_8 or defined UNIT_TEST
 /**
  * Hybrid switches packet encoding for sending over the air
  *
@@ -25,11 +24,7 @@
  * Inputs: crsf.ChannelDataIn, crsf.currentSwitches
  * Outputs: Radio.TXdataBuffer, side-effects the sentSwitch value
  */
-#ifdef ENABLE_TELEMETRY
 void ICACHE_RAM_ATTR GenerateChannelDataHybridSwitch8(volatile uint8_t* Buffer, CRSF *crsf, bool TelemetryStatus)
-#else
-void ICACHE_RAM_ATTR GenerateChannelDataHybridSwitch8(volatile uint8_t* Buffer, CRSF *crsf)
-#endif
 {
   Buffer[0] = RC_DATA_PACKET & 0b11;
   Buffer[1] = ((crsf->ChannelDataIn[0]) >> 3);
@@ -52,9 +47,7 @@ void ICACHE_RAM_ATTR GenerateChannelDataHybridSwitch8(volatile uint8_t* Buffer, 
   uint8_t value = crsf->currentSwitches[nextSwitchIndex];
 
   Buffer[6] =
-#ifdef ENABLE_TELEMETRY
       TelemetryStatus << 7 |
-#endif
       // switch 0 is one bit sent on every packet - intended for low latency arm/disarm
       crsf->currentSwitches[0] << 6 |
       // tell the receiver which switch index this is
@@ -65,10 +58,8 @@ void ICACHE_RAM_ATTR GenerateChannelDataHybridSwitch8(volatile uint8_t* Buffer, 
   // update the sent value
   crsf->setSentSwitch(nextSwitchIndex, value);
 }
-#endif // HYBRID_SWITCHES_8
 
-#if !defined HYBRID_SWITCHES_8 or defined UNIT_TEST
-void ICACHE_RAM_ATTR GenerateChannelData10bit(volatile uint8_t* Buffer, CRSF *crsf)
+void ICACHE_RAM_ATTR GenerateChannelData10bit(volatile uint8_t* Buffer, CRSF *crsf, bool TelemetryStatus)
 {
   Buffer[0] = RC_DATA_PACKET & 0b11;
   Buffer[1] = ((crsf->ChannelDataIn[0]) >> 3);
@@ -88,7 +79,6 @@ void ICACHE_RAM_ATTR GenerateChannelData10bit(volatile uint8_t* Buffer, CRSF *cr
   Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[10]) << 1;
   Buffer[6] |= CRSF_to_BIT(crsf->ChannelDataIn[11]) << 0;
 }
-#endif // !HYBRID_SWITCHES_8
 
 #endif
 

--- a/src/lib/OTA/OTA.h
+++ b/src/lib/OTA/OTA.h
@@ -14,23 +14,8 @@
 #define SYNC_PACKET 0b10
 
 #if TARGET_TX or defined UNIT_TEST
-#if defined HYBRID_SWITCHES_8 or defined UNIT_TEST
-#ifdef ENABLE_TELEMETRY
 void ICACHE_RAM_ATTR GenerateChannelDataHybridSwitch8(volatile uint8_t* Buffer, CRSF *crsf, bool TelemetryStatus);
-#else
-void ICACHE_RAM_ATTR GenerateChannelDataHybridSwitch8(volatile uint8_t* Buffer, CRSF *crsf);
-#endif
-#endif
-
-#if !defined HYBRID_SWITCHES_8 or defined UNIT_TEST
-void ICACHE_RAM_ATTR GenerateChannelData10bit(volatile uint8_t* Buffer, CRSF *crsf);
-#endif
-
-#if defined HYBRID_SWITCHES_8
-#define GenerateChannelData GenerateChannelDataHybridSwitch8
-#else
-#define GenerateChannelData GenerateChannelData10bit
-#endif
+void ICACHE_RAM_ATTR GenerateChannelData10bit(volatile uint8_t* Buffer, CRSF *crsf, bool TelemetryStatus);
 #endif
 
 #if TARGET_RX or defined UNIT_TEST

--- a/src/lib/Telemetry/telemetry.cpp
+++ b/src/lib/Telemetry/telemetry.cpp
@@ -28,6 +28,14 @@ bool Telemetry::ShouldCallEnterBind()
     return enterBind;
 }
 
+bool Telemetry::ShouldCallUpdateModelMatch()
+{
+    bool updateModelMatch = callUpdateModelMatch;
+    callUpdateModelMatch = false;
+    return updateModelMatch;
+}
+
+
 PAYLOAD_DATA(GPS, BATTERY_SENSOR, ATTITUDE, DEVICE_INFO, FLIGHT_MODE, MSP_RESP);
 
 bool Telemetry::GetNextPayload(uint8_t* nextPayloadSize, uint8_t **payloadData)
@@ -187,6 +195,12 @@ void Telemetry::AppendTelemetryPackage()
     if (CRSFinBuffer[CRSF_TELEMETRY_TYPE_INDEX] == CRSF_FRAMETYPE_COMMAND && CRSFinBuffer[3] == 'b' && CRSFinBuffer[4] == 'd')
     {
         callEnterBind = true;
+        return;
+    }
+    if (CRSFinBuffer[CRSF_TELEMETRY_TYPE_INDEX] == CRSF_FRAMETYPE_COMMAND && CRSFinBuffer[3] == 'm' && CRSFinBuffer[4] == 'm')
+    {
+        callUpdateModelMatch = true;
+        modelMatchId = CRSFinBuffer[5];
         return;
     }
     for (int8_t i = 0; i < payloadTypesCount; i++)

--- a/src/lib/Telemetry/telemetry.h
+++ b/src/lib/Telemetry/telemetry.h
@@ -42,6 +42,8 @@ public:
     void ResetState();
     bool ShouldCallBootloader();
     bool ShouldCallEnterBind();
+    bool ShouldCallUpdateModelMatch();
+    uint8_t GetUpdatedModelMatch() { return modelMatchId; }
     bool GetNextPayload(uint8_t* nextPayloadSize, uint8_t **payloadData);
     uint8_t UpdatedPayloadCount();
     uint8_t ReceivedPackagesCount();
@@ -56,4 +58,6 @@ private:
     uint8_t receivedPackages;
     bool callBootloader;
     bool callEnterBind;
+    bool callUpdateModelMatch;
+    uint8_t modelMatchId;
 };

--- a/src/platformio.ini
+++ b/src/platformio.ini
@@ -32,6 +32,5 @@ build_flags =
 	-std=c++11
 	-Iinclude
 	-D TARGET_NATIVE
-	-D ENABLE_TELEMETRY
 	-D CRSF_RX_MODULE
 	-D CRSF_TX_MODULE

--- a/src/python/bootloader.py
+++ b/src/python/bootloader.py
@@ -9,6 +9,8 @@ BIND_SEQ = {
     "GHST": [0x89,0x04,0x32,ord('b'),ord('d')],
 }
 
+MODEL_SEQ = [0xEC,0x04,0x32,ord('m'),ord('m')]
+
 def calc_crc8(payload, poly=0xD5):
     crc = 0
     for data in payload:
@@ -20,8 +22,8 @@ def calc_crc8(payload, poly=0xD5):
                 crc = crc << 1
     return crc & 0xFF
 
-def get_init_seq(module, key=None):
-    payload = list(INIT_SEQ.get(module, []))
+def get_telemetry_seq(seq, key=None):
+    payload = list(seq)
     if payload:
         if key:
             if type(key) == str:
@@ -31,16 +33,14 @@ def get_init_seq(module, key=None):
         payload += [calc_crc8(payload[2:])]
     return bytes(payload)
 
+def get_init_seq(module, key=None):
+    return get_telemetry_seq(INIT_SEQ.get(module, []), key)
+
 def get_bind_seq(module, key=None):
-    payload = list(BIND_SEQ.get(module, []))
-    if payload:
-        if key:
-            if type(key) == str:
-                key = [ord(x) for x in key]
-            payload += key
-            payload[1] += len(key)
-        payload += [calc_crc8(payload[2:])]
-    return bytes(payload)
+    return get_telemetry_seq(BIND_SEQ.get(module, []), key)
+
+def get_model_seq(model):
+    return get_telemetry_seq(MODEL_SEQ, model)
 
 if __name__ == '__main__':
     print("CRC: %s" % get_init_seq('CRSF', [ord(x) for x in 'R9MM']))

--- a/src/python/build_flags.py
+++ b/src/python/build_flags.py
@@ -155,9 +155,6 @@ print("build flags: %s" % env['BUILD_FLAGS'])
 if not fnmatch.filter(env['BUILD_FLAGS'], '*-DRegulatory_Domain*'):
     print_error('Please define a Regulatory_Domain in user_defines.txt')
 
-if fnmatch.filter(env['BUILD_FLAGS'], '*-DENABLE_TELEMETRY*') and not fnmatch.filter(env['BUILD_FLAGS'], '*-DHYBRID_SWITCHES_8*'):
-    print_error('Telemetry requires HYBRID_SWITCHES_8')
-
 if fnmatch.filter(env['BUILD_FLAGS'], '*PLATFORM_ESP32*'):
     sys.stdout.write("\u001b[32mBuilding for ESP32 Platform\n")
 elif fnmatch.filter(env['BUILD_FLAGS'], '*PLATFORM_STM32*'):

--- a/src/python/set_model.py
+++ b/src/python/set_model.py
@@ -1,0 +1,41 @@
+import serial, time, sys, re
+import argparse
+import serials_find
+import bootloader
+from BFinitPassthrough import *
+
+SCRIPT_DEBUG = 0
+
+def send_model_command(args):
+    dbg_print("======== SEND SET MODEL COMMAND ========")
+    s = serial.Serial(port=args.port, baudrate=args.baud,
+        bytesize=8, parity='N', stopbits=1,
+        timeout=1, xonxoff=0, rtscts=0)
+    TelemSeq = bootloader.get_model_seq(args.model)
+    s.write(TelemSeq)
+    s.flush()
+    time.sleep(.5)
+    s.close()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Initialize BetaFlight passthrough and send the 'enter bind mode' command")
+    parser.add_argument(
+        'model', metavar='int', nargs=1, type=int,
+        help='The model match number to set')
+    parser.add_argument("-b", "--baud", type=int, default=420000,
+        help="Baud rate for passthrough communication")
+    parser.add_argument("-p", "--port", type=str,
+        help="Override serial port autodetection and use PORT")
+    args = parser.parse_args()
+
+    if (args.port == None):
+        args.port = serials_find.get_serial_port()
+
+    try:
+        bf_passthrough_init(args.port, args.baud)
+    except PassthroughEnabled as err:
+        dbg_print(str(err))
+
+    send_model_command(args)

--- a/src/src/config.cpp
+++ b/src/src/config.cpp
@@ -67,6 +67,16 @@ TxConfig::SetPower(uint32_t power)
 }
 
 void
+TxConfig::SetSwitchMode(uint32_t switchMode)
+{
+    if (m_config.switchMode != switchMode)
+    {
+        m_config.switchMode = switchMode;
+        m_modified = true;
+    }
+}
+
+void
 TxConfig::SetDefaults()
 {
     expresslrs_mod_settings_s *const modParams = get_elrs_airRateConfig(RATE_DEFAULT);
@@ -74,6 +84,7 @@ TxConfig::SetDefaults()
     SetRate(modParams->index);
     SetTlm(modParams->TLMinterval);
     SetPower(DefaultPowerEnum);
+    SetSwitchMode(1);
     SetSSID("");
     SetPassword("");
     Commit();

--- a/src/src/config.cpp
+++ b/src/src/config.cpp
@@ -193,11 +193,22 @@ RxConfig::SetPowerOnCounter(uint8_t powerOnCounter)
 }
 
 void
+RxConfig::SetModelId(uint8_t modelId)
+{
+    if (m_config.modelId != modelId)
+    {
+        m_config.modelId = modelId;
+        m_modified = true;
+    }
+}
+
+void
 RxConfig::SetDefaults()
 {
     m_config.version = RX_CONFIG_VERSION;
     SetIsBound(false);
     SetPowerOnCounter(0);
+    SetModelId(0xFF);
     SetSSID("");
     SetPassword("");
     Commit();

--- a/src/src/config.cpp
+++ b/src/src/config.cpp
@@ -77,6 +77,16 @@ TxConfig::SetSwitchMode(uint8_t modelId, uint8_t switchMode)
 }
 
 void
+TxConfig::SetModelMatch(uint8_t modelId, bool modelMatch)
+{
+    if (m_config.model_config[modelId].modelMatch != modelMatch)
+    {
+        m_config.model_config[modelId].modelMatch = modelMatch;
+        m_modified = true;
+    }
+}
+
+void
 TxConfig::SetDefaults()
 {
     expresslrs_mod_settings_s *const modParams = get_elrs_airRateConfig(RATE_DEFAULT);
@@ -88,6 +98,7 @@ TxConfig::SetDefaults()
         SetTlm(i, modParams->TLMinterval);
         SetPower(i, DefaultPowerEnum);
         SetSwitchMode(i, 1);
+        SetModelMatch(i, false);
     }
     Commit();
 }

--- a/src/src/config.cpp
+++ b/src/src/config.cpp
@@ -37,41 +37,41 @@ TxConfig::Commit()
 
 // Setters
 void
-TxConfig::SetRate(uint32_t rate)
+TxConfig::SetRate(uint8_t modelId, uint8_t rate)
 {
-    if (m_config.rate != rate)
+    if (m_config.model_config[modelId].rate != rate)
     {
-        m_config.rate = rate;
+        m_config.model_config[modelId].rate = rate;
         m_modified = true;
     }
 }
 
 void
-TxConfig::SetTlm(uint32_t tlm)
+TxConfig::SetTlm(uint8_t modelId, uint8_t tlm)
 {
-    if (m_config.tlm != tlm)
+    if (m_config.model_config[modelId].tlm != tlm)
     {
-        m_config.tlm = tlm;
+        m_config.model_config[modelId].tlm = tlm;
         m_modified = true;
     }
 }
 
 void
-TxConfig::SetPower(uint32_t power)
+TxConfig::SetPower(uint8_t modelId, uint8_t power)
 {
-    if (m_config.power != power)
+    if (m_config.model_config[modelId].power != power)
     {
-        m_config.power = power;
+        m_config.model_config[modelId].power = power;
         m_modified = true;
     }
 }
 
 void
-TxConfig::SetSwitchMode(uint32_t switchMode)
+TxConfig::SetSwitchMode(uint8_t modelId, uint8_t switchMode)
 {
-    if (m_config.switchMode != switchMode)
+    if (m_config.model_config[modelId].switchMode != switchMode)
     {
-        m_config.switchMode = switchMode;
+        m_config.model_config[modelId].switchMode = switchMode;
         m_modified = true;
     }
 }
@@ -81,12 +81,14 @@ TxConfig::SetDefaults()
 {
     expresslrs_mod_settings_s *const modParams = get_elrs_airRateConfig(RATE_DEFAULT);
     m_config.version = TX_CONFIG_VERSION;
-    SetRate(modParams->index);
-    SetTlm(modParams->TLMinterval);
-    SetPower(DefaultPowerEnum);
-    SetSwitchMode(1);
     SetSSID("");
     SetPassword("");
+    for (int i=0 ; i<64 ; i++) {
+        SetRate(i, modParams->index);
+        SetTlm(i, modParams->TLMinterval);
+        SetPower(i, DefaultPowerEnum);
+        SetSwitchMode(i, 1);
+    }
     Commit();
 }
 

--- a/src/src/config.h
+++ b/src/src/config.h
@@ -8,10 +8,11 @@
 #define UID_LEN             6
 
 typedef struct {
-    uint8_t    rate:3;
-    uint8_t    tlm:3;
-    uint8_t    power:3;
-    uint8_t    switchMode:2;
+    uint8_t     rate:3;
+    uint8_t     tlm:3;
+    uint8_t     power:3;
+    uint8_t     switchMode:2;
+    uint8_t     modelMatch:1;
 } model_config_t;
 
 typedef struct {
@@ -32,6 +33,7 @@ public:
     uint8_t GetTlm(uint8_t modelId) const { return m_config.model_config[modelId].tlm; }
     uint8_t GetPower(uint8_t modelId) const { return m_config.model_config[modelId].power; }
     uint8_t GetSwitchMode(uint8_t modelId) const { return m_config.model_config[modelId].switchMode; }
+    bool GetModelMatch(uint8_t modelId) const { return m_config.model_config[modelId].modelMatch; }
     bool     IsModified() const { return m_modified; }
     const char* GetSSID() const { return m_config.ssid; }
     const char* GetPassword() const { return m_config.password; }
@@ -41,6 +43,7 @@ public:
     void SetTlm(uint8_t modelId, uint8_t tlm);
     void SetPower(uint8_t modelId, uint8_t power);
     void SetSwitchMode(uint8_t modelId, uint8_t switchMode);
+    void SetModelMatch(uint8_t modelId, bool modelMatch);
     void SetDefaults();
     void SetStorageProvider(ELRS_EEPROM *eeprom);
     void SetSSID(const char *ssid);

--- a/src/src/config.h
+++ b/src/src/config.h
@@ -4,7 +4,7 @@
 #include "elrs_eeprom.h"
 
 #define TX_CONFIG_VERSION   3
-#define RX_CONFIG_VERSION   2
+#define RX_CONFIG_VERSION   3
 #define UID_LEN             6
 
 typedef struct {
@@ -57,11 +57,16 @@ private:
 
 ///////////////////////////////////////////////////
 
+#ifndef MODEL_MATCH_ID
+#define MODEL_MATCH_ID 0
+#endif
+
 typedef struct {
     uint32_t    version;
     bool        isBound;
     uint8_t     uid[UID_LEN];
     uint8_t     powerOnCounter;
+    uint8_t     modelId;
     char        ssid[33];
     char        password[33];
 } rx_config_t;
@@ -82,6 +87,7 @@ public:
     }
     const uint8_t* GetUID() const { return m_config.uid; }
     uint8_t  GetPowerOnCounter() const { return m_config.powerOnCounter; }
+    uint8_t  GetModelId() const { return m_config.modelId == 0xFF ? MODEL_MATCH_ID : m_config.modelId; }
     bool     IsModified() const { return m_modified; }
     const char* GetSSID() const { return m_config.ssid; }
     const char* GetPassword() const { return m_config.password; }
@@ -90,6 +96,7 @@ public:
     void SetIsBound(bool isBound);
     void SetUID(uint8_t* uid);
     void SetPowerOnCounter(uint8_t powerOnCounter);
+    void SetModelId(uint8_t modelId);
     void SetDefaults();
     void SetStorageProvider(ELRS_EEPROM *eeprom);
     void SetSSID(const char *ssid);

--- a/src/src/config.h
+++ b/src/src/config.h
@@ -8,13 +8,17 @@
 #define UID_LEN             6
 
 typedef struct {
-    uint32_t    version;
-    uint32_t    rate;
-    uint32_t    tlm;
-    uint32_t    power;
-    uint32_t    switchMode;
-    char        ssid[33];
-    char        password[33];
+    uint8_t    rate:3;
+    uint8_t    tlm:3;
+    uint8_t    power:3;
+    uint8_t    switchMode:2;
+} model_config_t;
+
+typedef struct {
+    uint32_t        version;
+    char            ssid[33];
+    char            password[33];
+    model_config_t  model_config[64];
 } tx_config_t;
 
 class TxConfig
@@ -24,19 +28,19 @@ public:
     void Commit();
 
     // Getters
-    uint32_t GetRate() const { return m_config.rate; }
-    uint32_t GetTlm() const { return m_config.tlm; }
-    uint32_t GetPower() const { return m_config.power; }
-    uint32_t GetSwitchMode() const { return m_config.switchMode; }
+    uint8_t GetRate(uint8_t modelId) const { return m_config.model_config[modelId].rate; }
+    uint8_t GetTlm(uint8_t modelId) const { return m_config.model_config[modelId].tlm; }
+    uint8_t GetPower(uint8_t modelId) const { return m_config.model_config[modelId].power; }
+    uint8_t GetSwitchMode(uint8_t modelId) const { return m_config.model_config[modelId].switchMode; }
     bool     IsModified() const { return m_modified; }
     const char* GetSSID() const { return m_config.ssid; }
     const char* GetPassword() const { return m_config.password; }
 
     // Setters
-    void SetRate(uint32_t rate);
-    void SetTlm(uint32_t tlm);
-    void SetPower(uint32_t power);
-    void SetSwitchMode(uint32_t switchMode);
+    void SetRate(uint8_t modelId, uint8_t rate);
+    void SetTlm(uint8_t modelId, uint8_t tlm);
+    void SetPower(uint8_t modelId, uint8_t power);
+    void SetSwitchMode(uint8_t modelId, uint8_t switchMode);
     void SetDefaults();
     void SetStorageProvider(ELRS_EEPROM *eeprom);
     void SetSSID(const char *ssid);

--- a/src/src/config.h
+++ b/src/src/config.h
@@ -3,7 +3,7 @@
 #include "targets.h"
 #include "elrs_eeprom.h"
 
-#define TX_CONFIG_VERSION   2
+#define TX_CONFIG_VERSION   3
 #define RX_CONFIG_VERSION   2
 #define UID_LEN             6
 
@@ -12,6 +12,7 @@ typedef struct {
     uint32_t    rate;
     uint32_t    tlm;
     uint32_t    power;
+    uint32_t    switchMode;
     char        ssid[33];
     char        password[33];
 } tx_config_t;
@@ -26,6 +27,7 @@ public:
     uint32_t GetRate() const { return m_config.rate; }
     uint32_t GetTlm() const { return m_config.tlm; }
     uint32_t GetPower() const { return m_config.power; }
+    uint32_t GetSwitchMode() const { return m_config.switchMode; }
     bool     IsModified() const { return m_modified; }
     const char* GetSSID() const { return m_config.ssid; }
     const char* GetPassword() const { return m_config.password; }
@@ -34,6 +36,7 @@ public:
     void SetRate(uint32_t rate);
     void SetTlm(uint32_t tlm);
     void SetPower(uint32_t power);
+    void SetSwitchMode(uint32_t switchMode);
     void SetDefaults();
     void SetStorageProvider(ELRS_EEPROM *eeprom);
     void SetSSID(const char *ssid);

--- a/src/src/luaParams.cpp
+++ b/src/src/luaParams.cpp
@@ -36,7 +36,14 @@ struct tagLuaItem_textSelection luaPower = {
     "mW",
     LUA_TEXTSELECTION_SIZE(luaPower)
 };
-
+struct tagLuaItem_textSelection luaSwitch = {
+    {0,(uint8_t)CRSF_TEXT_SELECTION},//id,type
+    "Switch",
+    "1-Bit;Hybrid",
+    {0,0,1},//value,min,max,default
+    emptySpace,
+    LUA_TEXTSELECTION_SIZE(luaSwitch)
+};
 struct tagLuaItem_command luaBind = {
     {0,(uint8_t)CRSF_COMMAND},//id,type
     "Bind",
@@ -44,7 +51,6 @@ struct tagLuaItem_command luaBind = {
     emptySpace,
     LUA_COMMAND_SIZE(luaBind)
 };
-
 struct tagLuaItem_string luaInfo = {
     {0,(uint8_t)CRSF_INFO},//id,type
     thisCommit,

--- a/src/src/luaParams.cpp
+++ b/src/src/luaParams.cpp
@@ -52,6 +52,13 @@ struct tagLuaItem_textSelection luaModelMatch = {
     emptySpace,
     LUA_TEXTSELECTION_SIZE(luaModelMatch)
 };
+struct tagLuaItem_uint8 luaSetRXModel = {
+    {6,(uint8_t)CRSF_UINT8},//id,type
+    "Set RX Model",
+    {0,0,63},//value,min,max
+    emptySpace,
+    LUA_UINT8_SIZE(luaSetRXModel)
+};
 struct tagLuaItem_command luaBind = {
     {0,(uint8_t)CRSF_COMMAND},//id,type
     "Bind",

--- a/src/src/luaParams.cpp
+++ b/src/src/luaParams.cpp
@@ -44,6 +44,14 @@ struct tagLuaItem_textSelection luaSwitch = {
     emptySpace,
     LUA_TEXTSELECTION_SIZE(luaSwitch)
 };
+struct tagLuaItem_textSelection luaModelMatch = {
+    {5,(uint8_t)CRSF_TEXT_SELECTION},//id,type
+    "Model Match",
+    "Off;On",
+    {0,0,1},//value,min,max
+    emptySpace,
+    LUA_TEXTSELECTION_SIZE(luaModelMatch)
+};
 struct tagLuaItem_command luaBind = {
     {0,(uint8_t)CRSF_COMMAND},//id,type
     "Bind",

--- a/src/src/luaParams.h
+++ b/src/src/luaParams.h
@@ -7,6 +7,7 @@ extern struct tagLuaItem_textSelection luaTlmRate;
 extern struct tagLuaItem_textSelection luaPower;
 extern struct tagLuaItem_textSelection luaSwitch;
 extern struct tagLuaItem_textSelection luaModelMatch;
+extern struct tagLuaItem_uint8 luaSetRXModel;
 extern struct tagLuaItem_command luaBind;
 extern struct tagLuaItem_string luaInfo;
 extern struct tagLuaItem_string luaELRSversion;

--- a/src/src/luaParams.h
+++ b/src/src/luaParams.h
@@ -6,6 +6,7 @@ extern struct tagLuaItem_textSelection luaAirRate;
 extern struct tagLuaItem_textSelection luaTlmRate;
 extern struct tagLuaItem_textSelection luaPower;
 extern struct tagLuaItem_textSelection luaSwitch;
+extern struct tagLuaItem_textSelection luaModelMatch;
 extern struct tagLuaItem_command luaBind;
 extern struct tagLuaItem_string luaInfo;
 extern struct tagLuaItem_string luaELRSversion;

--- a/src/src/luaParams.h
+++ b/src/src/luaParams.h
@@ -5,6 +5,7 @@
 extern struct tagLuaItem_textSelection luaAirRate;
 extern struct tagLuaItem_textSelection luaTlmRate;
 extern struct tagLuaItem_textSelection luaPower;
+extern struct tagLuaItem_textSelection luaSwitch;
 extern struct tagLuaItem_command luaBind;
 extern struct tagLuaItem_string luaInfo;
 extern struct tagLuaItem_string luaELRSversion;

--- a/src/src/options.cpp
+++ b/src/src/options.cpp
@@ -12,9 +12,6 @@ const char PROGMEM compile_options[] = {
 #endif
 
 #ifdef TARGET_TX
-    #ifdef HYBRID_SWITCHES_8
-        "-DHYBRID_SWITCHES_8 "
-    #endif
     #ifdef UNLOCK_HIGHER_POWER
         "-DUNLOCK_HIGHER_POWER "
     #endif
@@ -38,9 +35,6 @@ const char PROGMEM compile_options[] = {
     #endif
     #ifdef MY_STARTUP_MELODY
         "-DMY_STARTUP_MELODY=\"" STR(MY_STARTUP_MELODY) "\" "
-    #endif
-    #ifdef ENABLE_TELEMETRY
-        "-DENABLE_TELEMETRY "
     #endif
     #ifdef USE_DYNAMIC_POWER
         "-DUSE_DYNAMIC_POWER "

--- a/src/src/options.cpp
+++ b/src/src/options.cpp
@@ -60,5 +60,8 @@ const char PROGMEM compile_options[] = {
     #ifdef USE_DIVERSITY
         "-DUSE_DIVERSITY "
     #endif
+    #ifdef MODEL_MATCH_ID
+        "-DMODEL_MATCH_ID=" STR(MODEL_MATCH_ID) " "
+    #endif
 #endif
 };

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -735,7 +735,7 @@ void ICACHE_RAM_ATTR ProcessRFPacket()
                 break;
          }
 
-         if (Radio.RXdataBuffer[4] == UID[3] && Radio.RXdataBuffer[5] == UID[4] && Radio.RXdataBuffer[6] == UID[5])
+         if (Radio.RXdataBuffer[4] == UID[3] && Radio.RXdataBuffer[5] == UID[4] && Radio.RXdataBuffer[6] == (UID[5] ^ config.GetModelId()))
          {
              LastSyncPacket = millis();
 #if defined(PRINT_RX_SCOREBOARD)

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -708,8 +708,15 @@ void ICACHE_RAM_ATTR ProcessRFPacket()
         }
         else if (MspReceiver.HasFinishedData())
         {
-            crsf.sendMSPFrameToFC(MspData);
-            MspReceiver.Unlock();
+            if (MspData[7] == MSP_SET_RX_CONFIG && MspData[8] == MSP_ELRS_MODEL_ID)
+            {
+                UpdateModelMatch(MspData[9]);
+            }
+            else
+            {
+                crsf.sendMSPFrameToFC(MspData);
+                MspReceiver.Unlock();
+            }
         }
         break;
 

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -181,6 +181,7 @@ bool InBindingMode = false;
 void reset_into_bootloader(void);
 void EnterBindingMode();
 void ExitBindingMode();
+void UpdateModelMatch(uint8_t model);
 void OnELRSBindMSP(uint8_t* packet);
 
 static uint8_t minLqForChaos()
@@ -992,6 +993,10 @@ static void HandleUARTin()
         {
             EnterBindingMode();
         }
+        if (telemetry.ShouldCallUpdateModelMatch())
+        {
+            UpdateModelMatch(telemetry.GetUpdatedModelMatch());
+        }
     }
 }
 
@@ -1471,4 +1476,16 @@ void OnELRSBindMSP(uint8_t* packet)
 
     disableWebServer = true;
     ExitBindingMode();
+}
+
+void UpdateModelMatch(uint8_t model)
+{
+    config.SetModelId(model);
+    config.Commit();
+    delay(100);
+#if defined(PLATFORM_STM32)
+    HAL_NVIC_SystemReset();
+#elif defined(PLATFORM_ESP8266)
+    ESP.restart();
+#endif
 }

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -553,6 +553,18 @@ void registerLuaParameters() {
     Serial.println(newModelMatch, DEC);
     config.SetModelMatch(crsf.getModelID(), newModelMatch);
   });
+  registerLUAParameter(&luaSetRXModel, [](uint8_t id, uint8_t arg){
+    Serial.print("Request Set RX Model: ");
+    uint8_t rxModel = crsf.ParameterUpdateData[2];
+    Serial.println(rxModel, DEC);
+    mspPacket_t msp;
+    msp.reset();
+    msp.makeCommand();
+    msp.function = MSP_SET_RX_CONFIG;
+    msp.addByte(MSP_ELRS_MODEL_ID);
+    msp.addByte(rxModel);
+    crsf.AddMspMessage(&msp);
+  });
   registerLUAParameter(&luaBind, [](uint8_t id, uint8_t arg){
     if (arg == 1)
     {
@@ -603,6 +615,7 @@ void resetLuaParams(){
   #endif
   setLuaTextSelectionValue(&luaSwitch,(uint8_t)(config.GetSwitchMode(crsf.getModelID())));
   setLuaTextSelectionValue(&luaModelMatch,(uint8_t)(config.GetModelMatch(crsf.getModelID())));
+  setLuaUint8Value(&luaSetRXModel,(uint8_t)0);
 }
 
 void updateLUApacketCount(){

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -302,6 +302,9 @@ void ICACHE_RAM_ATTR GenerateSyncPacketData()
   Radio.TXdataBuffer[4] = UID[3];
   Radio.TXdataBuffer[5] = UID[4];
   Radio.TXdataBuffer[6] = UID[5];
+  if (!InBindingMode && config.GetModelMatch(crsf.getModelID())) {
+    Radio.TXdataBuffer[6] ^= crsf.getModelID();
+  }
 
   SyncPacketLastSent = millis();
   if (syncSpamCounter)
@@ -544,6 +547,12 @@ void registerLuaParameters() {
     config.SetSwitchMode(crsf.getModelID(), newSwitchMode);
     SetSwitchMode(newSwitchMode);
   });
+  registerLUAParameter(&luaModelMatch, [](uint8_t id, uint8_t arg){
+    Serial.print("Request Model Match: ");
+    bool newModelMatch = crsf.ParameterUpdateData[2] & 0b1;
+    Serial.println(newModelMatch, DEC);
+    config.SetModelMatch(crsf.getModelID(), newModelMatch);
+  });
   registerLUAParameter(&luaBind, [](uint8_t id, uint8_t arg){
     if (arg == 1)
     {
@@ -593,6 +602,7 @@ void resetLuaParams(){
   setLuaTextSelectionValue(&luaPower,(uint8_t)(POWERMGNT.currPower()));//value
   #endif
   setLuaTextSelectionValue(&luaSwitch,(uint8_t)(config.GetSwitchMode(crsf.getModelID())));
+  setLuaTextSelectionValue(&luaModelMatch,(uint8_t)(config.GetModelMatch(crsf.getModelID())));
 }
 
 void updateLUApacketCount(){

--- a/src/test/ota_native/test_switches.cpp
+++ b/src/test/ota_native/test_switches.cpp
@@ -23,20 +23,32 @@ HardwareSerial CRSF::Port = HardwareSerial();
  * Successive calls should increment the next index until wrap
  * around from 7 to either 0 or 1 depending on mode.
  */
-void test_round_robin(void)
+void test_round_robin_index0(void)
 {
+    crsf.setNextSwitchFirstIndex(0);
     uint8_t expectedIndex = crsf.nextSwitchIndex;
-
+    
     for(uint8_t i = 0; i < 10; i++) {
         uint8_t nsi = crsf.getNextSwitchIndex();
         TEST_ASSERT_EQUAL(expectedIndex, nsi);
         expectedIndex++;
         if (expectedIndex == 8) {
-            #ifdef HYBRID_SWITCHES_8
-            expectedIndex = 1;
-            #else
             expectedIndex = 0;
-            #endif
+        }
+    }
+}
+
+void test_round_robin_index1(void)
+{
+    crsf.setNextSwitchFirstIndex(1);
+    uint8_t expectedIndex = crsf.nextSwitchIndex;
+    
+    for(uint8_t i = 0; i < 10; i++) {
+        uint8_t nsi = crsf.getNextSwitchIndex();
+        TEST_ASSERT_EQUAL(expectedIndex, nsi);
+        expectedIndex++;
+        if (expectedIndex == 8) {
+            expectedIndex = 1;
         }
     }
 }
@@ -261,7 +273,7 @@ void test_encoding10bit()
     }
 
     // encode it
-    GenerateChannelData10bit(TXdataBuffer, &crsf);
+    GenerateChannelData10bit(TXdataBuffer, &crsf, false);
 
     // check it looks right
     // 1st byte is CRC & packet type
@@ -310,7 +322,7 @@ void test_decoding10bit()
     }
 
     // use the encoding method to pack it into TXdataBuffer
-    GenerateChannelData10bit(TXdataBuffer, &crsf);
+    GenerateChannelData10bit(TXdataBuffer, &crsf, false);
 
     // run the decoder, results in crsf->PackedRCdataOut
     UnpackChannelData10bit(TXdataBuffer, &crsf);
@@ -334,7 +346,8 @@ void test_decoding10bit()
 int main(int argc, char **argv)
 {
     UNITY_BEGIN();
-    RUN_TEST(test_round_robin);
+    RUN_TEST(test_round_robin_index0);
+    RUN_TEST(test_round_robin_index1);
     RUN_TEST(test_priority);
 
     RUN_TEST(test_encodingHybrid8_3);

--- a/src/user_defines.txt
+++ b/src/user_defines.txt
@@ -24,12 +24,6 @@
 #-DRegulatory_Domain_FCC_915
 #-DRegulatory_Domain_ISM_2400
 
-
-### SWITCHES: ###
-
-#-DHYBRID_SWITCHES_8
-
-
 ### PERFORMANCE OPTIONS: ###
 
 #unlocks >250mw output power for R9M and Happy Model ES915TX (Fan mod suggested: https://github.com/AlessandroAU/ExpressLRS/wiki/R9M-Fan-Mod-Cover)
@@ -59,9 +53,6 @@
 #-DJUST_BEEP_ONCE
 #-DDISABLE_STARTUP_BEEP
 #-DMY_STARTUP_MELODY="B5 16 P16 B5 16 P16 B5 16 P16 B5 2 G5 2 A5 2 B5 8 P4 A5 8 B5 1|140|-3"
-
-# Comment this to disable advanced telemetry.
-#-DENABLE_TELEMETRY
 
 #Comment this to disable diversity function
 #-DUSE_DIVERSITY

--- a/src/user_defines.txt
+++ b/src/user_defines.txt
@@ -62,3 +62,6 @@
 
 #If commented out the LED is RGB otherwise GRB
 #-DWS2812_IS_GRB
+
+# The model number defined in OpenTX, if you want to use model matching.
+#-DMODEL_MATCH_ID=0


### PR DESCRIPTION
This PR moves some more TX parameters into configuration rather than user defines.
- Allows the user to set the switchmode (hybrid or 1-bit) in the LUA script
- Removes the TELEMETRY user define as it's based on the switch mode
- Introduces multiple configurations based on the `Receiver` set on the model setup page
  - All parameters stored per config are
  - Rate, TLM ratio, max power, switchmode, use model match
- Model Matching
  - If *use model match* is set in the model configuration then the model id in the RX must match before a connection can be made
  - If model matching is off then all RXes with model id 0 will connect no matter what the model id in the Radio is set to.
  - A compile-time define to set the default model Id for an RX (defaults to 0)
  - A python script to set RX model match id via passthrough
  - A section on the RX WiFi page to set the model match id
  - A telemetry & matching MSP command so LUA can tell the RX to set it's model match id