### PR TITLE
adds crc16 to 10B OTA packet

### DIFF
--- a/src/lib/CRC/crc.cpp
+++ b/src/lib/CRC/crc.cpp
@@ -66,3 +66,35 @@ uint16_t ICACHE_RAM_ATTR GENERIC_CRC14::calc(volatile uint8_t *data, uint8_t len
     }
     return crc & 0x3FFF;
 }
+
+GENERIC_CRC16::GENERIC_CRC16(uint16_t poly)
+{
+    uint16_t crc;
+    for (uint16_t i = 0; i < crclen; i++)
+    {
+        crc = i << (16 - 8);
+        for (uint8_t j = 0; j < 8; j++)
+        {
+            crc = (crc << 1) ^ ((crc & 0x2000) ? poly : 0);
+        }
+        crc16tab[i] = crc;
+    }
+}
+
+uint16_t ICACHE_RAM_ATTR GENERIC_CRC16::calc(uint8_t *data, uint8_t len, uint16_t crc)
+{
+    while (len--)
+    {
+        crc = (crc << 8) ^ crc16tab[((crc >> 8) ^ (uint16_t) *data++) & 0x00FF];
+    }    
+    return crc;
+}
+
+uint16_t ICACHE_RAM_ATTR GENERIC_CRC16::calc(volatile uint8_t *data, uint8_t len, uint16_t crc)
+{
+    while (len--)
+    {
+        crc = (crc << 8) ^ crc16tab[((crc >> 8) ^ (uint16_t) *data++) & 0x00FF];
+    }
+    return crc;
+}

--- a/src/lib/CRC/crc.h
+++ b/src/lib/CRC/crc.h
@@ -27,3 +27,15 @@ public:
     uint16_t calc(uint8_t *data, uint8_t len, uint16_t crc);
     uint16_t calc(volatile uint8_t *data, uint8_t len, uint16_t crc);
 };
+
+class GENERIC_CRC16
+{
+private:
+    uint16_t crc16tab[crclen];
+    uint16_t crcpoly;
+
+public:
+    GENERIC_CRC16(uint16_t poly);
+    uint16_t calc(uint8_t *data, uint8_t len, uint16_t crc);
+    uint16_t calc(volatile uint8_t *data, uint8_t len, uint16_t crc);
+};

--- a/src/src/common.h
+++ b/src/src/common.h
@@ -152,3 +152,4 @@ uint8_t ICACHE_RAM_ATTR enumRatetoIndex(expresslrs_RFrates_e rate);
 //Koopman formatting https://users.ece.cmu.edu/~koopman/crc/
 #define ELRS_CRC_POLY 0x07 // 0x83
 #define ELRS_CRC14_POLY 0x2E57 // 0x372B
+#define ELRS_CRC16_POLY 0x3D65 // 0x9EB2


### PR DESCRIPTION
This is a draft PR (no rush) for comment and will need updating after https://github.com/ExpressLRS/ExpressLRS/pull/716

For now only the RC packet is using crc16.  crcXXtab can be made generic and save us some space after tlm has been updated for 10B packets.