### PR TITLE
Return VBatt to the LinkStatistics telemetry

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -254,6 +254,23 @@ void ICACHE_RAM_ATTR CRSF::sendLinkStatisticsToTX()
 #endif
 }
 
+void CRSF::sendVBattToTX(uint16_t vbatt)
+{
+// Only send if advanced telemetry is disabled, otherwise this will wipe out Current / mAh / Fuel
+#if !defined(ENABLE_TELEMETRY)
+  uint8_t packet[CRSF_FRAME_BATTERY_SENSOR_PAYLOAD_SIZE+4] = {0};
+
+  packet[0] = CRSF_ADDRESS_FLIGHT_CONTROLLER;
+  packet[1] = CRSF_FRAME_BATTERY_SENSOR_PAYLOAD_SIZE + 2;
+  packet[2] = CRSF_FRAMETYPE_BATTERY_SENSOR;
+  packet[3] = vbatt >> 8;
+  packet[4] = vbatt & 0xff;
+  packet[sizeof(packet)-1] = crsf_crc.calc(&packet[2], CRSF_FRAME_BATTERY_SENSOR_PAYLOAD_SIZE + 1);;
+
+  sendTelemetryToTX(packet);
+#endif
+}
+
 void CRSF::sendELRSparam(uint8_t val[], uint8_t len, uint8_t frameType, const char *elrsInfo, uint8_t len2)
 {
     if (!CRSF::CRSFstate)

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -73,6 +73,7 @@ public:
     void sendLinkStatisticsToFC();
     void ICACHE_RAM_ATTR sendLinkStatisticsToTX();
     void ICACHE_RAM_ATTR sendTelemetryToTX(uint8_t *data);
+    void sendVBattToTX(uint16_t vbatt);
 
     void sendELRSparam(uint8_t val[], uint8_t len, uint8_t frameType, const char *elrsInfo, uint8_t len2);
     uint8_t sendCRSFparam(crsf_frame_type_e frame,uint8_t fieldchunk, crsf_value_type_e dataType, void * luaData, uint8_t wholePacketSize);

--- a/src/lib/Telemetry/telemetry.cpp
+++ b/src/lib/Telemetry/telemetry.cpp
@@ -221,7 +221,7 @@ void Telemetry::AppendTelemetryPackage()
         #if defined(UNIT_TEST)
         else
         {
-            cout << "buffer not large enough for type " << (int)payloadTypes[i].type  << " with size " << (int)payloadTypes[i].size << " would need " << CRSF_FRAME_SIZE(CRSFinBuffer[CRSF_TELEMETRY_LENGTH_INDEX]) << '\n';
+            cout << "buffer not large enough for type " << (int)payloadTypes[idx].type  << " with size " << (int)payloadTypes[idx].size << " would need " << CRSF_FRAME_SIZE(CRSFinBuffer[CRSF_TELEMETRY_LENGTH_INDEX]) << '\n';
         }
         #endif
     }

--- a/src/lib/Telemetry/telemetry.h
+++ b/src/lib/Telemetry/telemetry.h
@@ -45,6 +45,8 @@ public:
     bool GetNextPayload(uint8_t* nextPayloadSize, uint8_t **payloadData);
     uint8_t UpdatedPayloadCount();
     uint8_t ReceivedPackagesCount();
+    int findPayloadType(uint8_t type);
+    uint8_t getVBattSensorLow();
 private:
     void AppendToPackage(volatile crsf_telemetry_package_t *current);
     void AppendTelemetryPackage();

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -299,11 +299,11 @@ bool ICACHE_RAM_ATTR HandleSendTelemetryResponse()
         // The value in linkstatistics is "positivized" (inverted polarity)
         // and must be inverted on the TX side. Positive values are used
         // so save a bit to encode which antenna is in use
-        Radio.TXdataBuffer[2] = crsf.LinkStatistics.uplink_RSSI_1 | (antenna << 7);
-        Radio.TXdataBuffer[3] = crsf.LinkStatistics.uplink_RSSI_2;
+        Radio.TXdataBuffer[2] = crsf.LinkStatistics.uplink_RSSI_1 | ((MspReceiver.GetCurrentConfirm() ? 1 : 0) << 7);
+        Radio.TXdataBuffer[3] = crsf.LinkStatistics.uplink_RSSI_2 | (antenna << 7);
         Radio.TXdataBuffer[4] = crsf.LinkStatistics.uplink_SNR;
         Radio.TXdataBuffer[5] = crsf.LinkStatistics.uplink_Link_quality;
-        Radio.TXdataBuffer[6] = MspReceiver.GetCurrentConfirm() ? 1 : 0;
+        Radio.TXdataBuffer[6] = telemetry.getVBattSensorLow();
     }
     else
     {


### PR DESCRIPTION
This PR enables reporting of VBatt on systems compiled **without** `ENABLE_TELEMETRY`. It does this by using an unused byte of the LinkStatistics telemetry (the packet has been reorganized to fit this). The value will only be sent to the handset if the advanced telemetry is not enabled, to prevent it from being mixed with the actual battery telemetry packet, which would wipe out the Current, mAh, and Fuel sensors.

Only one byte is used, but the sensor is Volts / 10 so this gives us up to 25.6V or 6S batteries. So odd that CRSF supports voltage up to 6553.5V instead of 655.35V and having much better resolution.

Fixes #532?