### PR TITLE
adds GPIO_PIN_FAN_EN to TARGET_TX_ESP32_E28_SX1280_V1

### DIFF
--- a/src/include/targets.h
+++ b/src/include/targets.h
@@ -356,6 +356,7 @@ High = Ant2
 #define GPIO_PIN_RCSIGNAL_RX 13
 #define GPIO_PIN_RCSIGNAL_TX 13
 #define GPIO_PIN_LED 15
+#define GPIO_PIN_FAN_EN 17
 
 #elif defined(TARGET_SX1280_RX_CCG_NANO_v05)
 #define GPIO_PIN_NSS         PA4


### PR DESCRIPTION
HappyModel added a fan to the new 2.4G nano module but target TARGET_TX_ESP32_E28_SX1280_V1 does not define GPIO_PIN_FAN_EN.  This PR shouldnt affect any other targets using TARGET_TX_ESP32_E28_SX1280_V1.

This commit should be cherry picked to maintenance for V1.0.2.