### PR TITLE
Increase SYNC frequency when disconnected, decrease when connected

### DIFF
--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -12,10 +12,10 @@ expresslrs_mod_settings_s ExpressLRS_AirRateConfig[RATE_MAX] = {
     {3, RATE_25HZ, SX127x_BW_500_00_KHZ, SX127x_SF_9, SX127x_CR_4_7, 40000, TLM_RATIO_NO_TLM, 4, 10, 8}};
 
 expresslrs_rf_pref_params_s ExpressLRS_AirRateRFperf[RATE_MAX] = {
-    {0, RATE_200HZ, -112, 4380, 3000, 2500, 2000, 4000},
-    {1, RATE_100HZ, -117, 8770, 3500, 2500, 2000, 4000},
-    {2, RATE_50HZ, -120, 17540, 4000, 2500, 2000, 4000},
-    {3, RATE_25HZ, -123, 17540, 6000, 4000, 2000, 4000}};
+    {0, RATE_200HZ, -112, 4380, 3000, 2500, 600, 5000},
+    {1, RATE_100HZ, -117, 8770, 3500, 2500, 600, 5000},
+    {2, RATE_50HZ, -120, 17540, 4000, 2500, 600, 5000},
+    {3, RATE_25HZ, -123, 17540, 6000, 4000, 0, 5000}};
 #endif
 
 #if defined(Regulatory_Domain_ISM_2400)
@@ -30,10 +30,10 @@ expresslrs_mod_settings_s ExpressLRS_AirRateConfig[RATE_MAX] = {
     {3, RATE_50HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF9, SX1280_LORA_CR_LI_4_6, 20000, TLM_RATIO_NO_TLM, 4, 12, 8}};
 
 expresslrs_rf_pref_params_s ExpressLRS_AirRateRFperf[RATE_MAX] = {
-    {0, RATE_500HZ, -105, 1665, 2500, 2500, 2000, 4000},
-    {1, RATE_250HZ, -108, 3300, 3000, 2500, 2000, 4000},
-    {2, RATE_150HZ, -112, 5871, 3500, 2500, 2000, 4000},
-    {3, RATE_50HZ, -117, 18443, 4000, 2500, 2000, 4000}};
+    {0, RATE_500HZ, -105, 1665, 2500, 2500, 0, 5000},
+    {1, RATE_250HZ, -108, 3300, 3000, 2500, 0, 5000},
+    {2, RATE_150HZ, -112, 5871, 3500, 2500, 0, 5000},
+    {3, RATE_50HZ, -117, 18443, 4000, 2500, 0, 5000}};
 #endif
 
 expresslrs_mod_settings_s *get_elrs_airRateConfig(int8_t index);


### PR DESCRIPTION
This PR increases the frequency that SYNC packets are sent when the TX is in the "disconnected" state, and reduces the frequency they are sent while connected. The reason for this change is that it can be difficult to re-establish a connection after a failsafe due to the combination of very infrequent sync opportunities mixed with low LQ causing the sync packets to not be received. When the RX is waiting for a connection, it can only begin reestablishment on a sync packet, so sending only **one** opportunity every 2-6 seconds really slows down the reconnect process.

This is intended to help with #776, which I believe after a full day of testing to be caused by the needed sync packets being lost at low LQ. I had plenty of reconnect attempts where the receiver was getting a couple packets on the sync channel (`r` below), but none of them were sync packets, so it would take several cycles to reconnect.
![scoreboard](https://cdn.discordapp.com/attachments/733424557636976692/875402308320645150/unknown.png)

## Disconnected Rate
When disconnected, this raises the minimum amount of packets dedicated to sync from the existing 0.08% - 1.92%, to 0.63% - 3.85% (dependent on air rate and regulatory domain). The disconnected state is the state we're in:
* Before first connection occurs
* If telemetry signal is lost during flight
* If telemetry ratio is Off

This means that "long range" pilots will be using more uplink bandwidth for sync packets once they get out of telemetry range, but it is more likely that they will failsafe beyond that range so I do not think this is an issue because they'll enjoy faster reconnects. Pilots flying with telemetry off can enable `NO_SYNC_ON_ARM` to disable sync packets entirely, see below.

### Team2.4 Disconnected
Team2.4 has a lot of FHSS hops (80) which results in long cycle times to get back to the sync channel. This PR changes Team2.4 to send TWO sync packets out of every 320 packets in the FHSS rotation. All rates get 0.63% of their packets dedicated to SYNC now. For 500Hz that's 2x every 0.64s which seems like way too much, but it is only 0.63% still so I think that's not a big deal. This is only when disconnected too remember. This increases the number of chances to reconnect by as much as 8x or as little as 2x.
```
Time between Sync opportunities / worst case / sync packet percentage
Team2.4 (80 hops, 320 packets)
Reduce disconnected sync interval 2000ms to 0ms
500Hz = 0.64s / 2.56s -> 0.64s X2 / 0.08% -> 0.63%
250Hz = 1.28s / 2.56s -> 1.28s X2 / 0.16% -> 0.63%
150Hz = 2.13s / 2.13s -> X2 / 0.31% -> 0.63%
50Hz  = 6.40s / 6.40s -> X2 / 0.31% -> 0.63%
```

### Team900 Disconnected
Team900's FHSS cycles are a lot shorter for most domains, so the reconnect delays there weren't as bad. I've increased the sync frequency here as well, but not as much. There's now a 0.63% minimum rate across the board just like Team2.4, but only 25Hz gets 2X sync packets per cycle to prevent consuming too much bandwidth at lower air rates. 600ms was chosen as the interval as a threshold above the AU/200Hz, EU/200Hz, and EU/100Hz cycle intervals so they won't sync every cycle, but below all the other cycle intervals so they will sync every cycle. This increases the number of chances to reconnect by as much as 3x or as little as 2x, with the one exception being 915FCC 50Hz which still gets just 1x sync opportunity every 3.2s.
```
Team900AU (20 hops, 80 packets)
Reduce disconnected sync interval 2000ms to 600ms (0ms for 25Hz)
200Hz = 0.4s / 2.4s -> 0.8s / 0.21% -> 0.63%
100Hz = 0.8s / 2.4s -> 0.8s / 0.42% -> 1.25%
50Hz  = 1.6s / 3.2s -> 1.6s / 0.63% -> 1.25%
25Hz  = 3.2s / 3.2s -> X2 / 1.25% -> 2.5%

Team900EU (13 hops / 52 packets)
Reduce disconnected sync interval 2000ms to 600ms (0ms for 25Hz)
200Hz = 0.26s / 2.08s -> 0.78s / 0.24% -> 0.64%
100Hz = 0.52s / 2.08s -> 1.04s / 0.48% -> 0.96%
50Hz  = 1.04s / 2.08s -> 1.04s / 0.96% -> 1.92%
25Hz  = 2.08s / 2.08s -> X2 / 1.92% -> 3.85%

Team900US (40 hops / 160 packets)
Reduce disconnected sync interval 2000ms to 600ms (0ms for 25Hz)
200Hz = 0.8s / 2.4s -> 0.8s / 0.21% -> 0.63%
100Hz = 1.6s / 3.2s -> 1.6s / 0.31% -> 0.63%
50Hz  = 3.2s / 3.2s / 0.63%
25Hz  = 6.4s / 6.4s -> X2 / 0.63% -> 1.25%
```

## Connected Rate
This PR also reduces the number of SYNC packets sent in the connected state, from 4 second interval to 5 second. The sync packet is only needed as a "sanity check" when connected, and to change air rates so I feel like we can dedicate slightly fewer packets to it. 

## Alternative PR Title
"Make NO_SYNC_ON_ARM more useful". Sync packets take so few slots currently (0.08% without telemetry or 0.045% with?!) that this define is almost a joke. This can be made into a per-model option instead of a define once the updated Lua config and per-model config is merged.

## Tested
Tested on SIYI FM30 TX and FR Mini RX and verified with the RX scoreboard that the sync is being sent only once per cycle when "connected" and starts doubling up when telemetry is lost. Tested the new intervals on EX900TX / R9 Mini RX where there were no surprises and 200Hz link establishment is almost always faster given the 0.8s vs 2.4s sync interval.