### PR TITLE
Use AirRate / TlmRatio to determine TX disconnect time

### DIFF
--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -37,9 +37,6 @@ expresslrs_rf_pref_params_s ExpressLRS_AirRateRFperf[RATE_MAX] = {
 #endif
 
 expresslrs_mod_settings_s *get_elrs_airRateConfig(int8_t index);
-//const expresslrs_mod_settings_s * ExpressLRS_nextAirRate;
-expresslrs_mod_settings_s *ExpressLRS_currAirRate;
-expresslrs_mod_settings_s *ExpressLRS_prevAirRate;
 
 expresslrs_mod_settings_s *get_elrs_airRateConfig(int8_t index)
 {

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -830,7 +830,7 @@ void ICACHE_RAM_ATTR TXdoneISR()
 static void UpdateConnectDisconnectStatus(const uint32_t now)
 {
   // Number of telemetry packets which can be lost in a row before going to disconnected state
-  constexpr unsigned RX_LOSS_CNT = 4;
+  constexpr unsigned RX_LOSS_CNT = 5;
   const uint32_t tlmInterval = TLMratioEnumToValue(ExpressLRS_currAirRate_Modparams->TLMinterval);
   const uint32_t msConnectionLostTimeout = tlmInterval * ExpressLRS_currAirRate_Modparams->interval / (1000U / RX_LOSS_CNT);
   if (LastTLMpacketRecvMillis && ((now - LastTLMpacketRecvMillis) < msConnectionLostTimeout))

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -52,7 +52,6 @@ button button;
 #define DEBUG_SUPPRESS
 
 //// CONSTANTS ////
-#define RX_CONNECTION_LOST_TIMEOUT 3000LU // After 3000ms of no TLM response consider that slave has lost connection
 #define MSP_PACKET_SEND_INTERVAL 10LU
 
 #ifndef TLM_REPORT_INTERVAL_MS
@@ -828,6 +827,27 @@ void ICACHE_RAM_ATTR TXdoneISR()
   HandleTLM();
 }
 
+static void UpdateConnectDisconnectStatus(const uint32_t now)
+{
+  // Number of telemetry packets which can be lost in a row before going to disconnected state
+  constexpr unsigned RX_LOSS_CNT = 4;
+  const uint32_t tlmInterval = TLMratioEnumToValue(ExpressLRS_currAirRate_Modparams->TLMinterval);
+  const uint32_t msConnectionLostTimeout = tlmInterval * ExpressLRS_currAirRate_Modparams->interval / (1000U / RX_LOSS_CNT);
+  if (LastTLMpacketRecvMillis && ((now - LastTLMpacketRecvMillis) < msConnectionLostTimeout))
+  {
+    connectionState = connected;
+    #if defined(GPIO_PIN_LED_RED) && (GPIO_PIN_LED_RED != UNDEF_PIN)
+    digitalWrite(GPIO_PIN_LED_RED, HIGH ^ GPIO_LED_RED_INVERTED);
+    #endif // GPIO_PIN_LED_RED
+  }
+  else
+  {
+    connectionState = disconnected;
+    #if defined(GPIO_PIN_LED_RED) && (GPIO_PIN_LED_RED != UNDEF_PIN)
+    digitalWrite(GPIO_PIN_LED_RED, LOW ^ GPIO_LED_RED_INVERTED);
+    #endif // GPIO_PIN_LED_RED
+  }
+}
 
 void setup()
 {
@@ -990,6 +1010,7 @@ void loop()
   uint32_t now = millis();
   static bool mspTransferActive = false;
 
+  UpdateConnectDisconnectStatus(now);
   updateLEDs(now, connectionState, ExpressLRS_currAirRate_Modparams->index, POWERMGNT.currPower());
 
   #if defined(PLATFORM_ESP32)
@@ -1006,21 +1027,6 @@ void loop()
 #ifdef FEATURE_OPENTX_SYNC
   // Serial.println(crsf.OpenTXsyncOffset);
   #endif
-
-  if (now > (RX_CONNECTION_LOST_TIMEOUT + LastTLMpacketRecvMillis))
-  {
-    connectionState = disconnected;
-    #if defined(GPIO_PIN_LED_RED) && (GPIO_PIN_LED_RED != UNDEF_PIN)
-    digitalWrite(GPIO_PIN_LED_RED, LOW ^ GPIO_LED_RED_INVERTED);
-    #endif // GPIO_PIN_LED_RED
-  }
-  else
-  {
-    connectionState = connected;
-    #if defined(GPIO_PIN_LED_RED) && (GPIO_PIN_LED_RED != UNDEF_PIN)
-    digitalWrite(GPIO_PIN_LED_RED, HIGH ^ GPIO_LED_RED_INVERTED);
-    #endif // GPIO_PIN_LED_RED
-  }
 
   #ifdef PLATFORM_STM32
     crsf.handleUARTin();


### PR DESCRIPTION
The current TX code expects 1 telemetry packet every 3 seconds in order to stay in the "connected" state. This PR changes that to be dynamic based on the current packet air rate and telemetry ratio. The threshold chosen is 5x missed telemetry packets in a row.

Example "disconnect" times
| Air Rate | TLM Ratio | Old Timeout | New Timeout |
|---|---|---|---|
| 500Hz | 1:128 | 3s | 1.280s |
| 250Hz | 1:64 | 3s | 1.280s |
| 250Hz | 1:16 | 3s | 0.320s |
| 150Hz | 1:16 | 3s | 0.533s |
| 100Hz | 1:64 | 3s | 3.200s |

### Benefits
* OpenTX will not think we're still connected for 3 seconds after unplugging. For users coming from FrSky RX where the connection drops almost immediately, the warning that the RX is still connected may be confusing-- especially because it is wrong.
* A faster switch to disconnected state increases the number of sync packets being sent, reducing delay in reconnecting after failsafe.
* Slow air rates with infrequent ratios need longer times than the fixed 3s value

### Drawbacks
* Because we're going to stop re-sending old faked LinkStatistics packets to the handset sooner in almost all cases, there's a larger opportunity for "Telemetry Lost" messages when telemetry is lost. I feel like this is mitigated by the fact that this is literally what is happening. OpenTX also has its own delay before reporting the loss so there's a chance we'll pick it back up before the OpenTX timeout and there will be no warning.

### Why 5x packets?
I felt that 3 seconds was too long for the common rates of 500Hz 1:128 and 250Hz 1:64. This cuts that in more than half for those rates but allows the user to go lower with a higher telemetry ratio. 5x seemed to give plenty of room for lower durations and high telemetry ratios like 1:2 are already resistant to disconnect events in OpenTX by its own long timeout. 5x missed packets in a row seemed like a lot to miss in a row. I could be convinced 6 is the right number, but not much higher. :-P

### Other Improvements
* The "connected" LED on the TX no longer turns on when you first turn on the TX and has bugged me since the very first ExpressLRS build I compiled. The RED LED now correctly indicates the connection status at all times.
* Removed two unused variables that confused me if they were the one that held the current module parameters. They weren't used at all so 🚂 off you go.

