### PR TITLE
Don't use sprintf, it's a flash hog!

### DIFF
--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -245,12 +245,8 @@ bool SX127xDriver::DetectChip()
     {
       Serial.print(" not found! (");
       Serial.print(i + 1);
-      Serial.print(" of 3 tries) REG_VERSION == ");
-
-      char buffHex[5];
-      sprintf(buffHex, "0x%02X", version);
-      Serial.print(buffHex);
-      Serial.println();
+      Serial.print(" of 3 tries) REG_VERSION == 0x");
+      Serial.println(version, HEX);
       delay(200);
       i++;
     }


### PR DESCRIPTION
Change the `sprintf` code in SX127x.cpp to use `itoa` instead because sprintf is a big .data segment hog! 