### PR TITLE
Turns on wifi when TX UART has never connected for a while

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -41,6 +41,8 @@ void (*CRSF::RecvParameterUpdate)() = &nullCallback; // called when recv paramet
 uint32_t CRSF::GoodPktsCountResult = 0;
 uint32_t CRSF::BadPktsCountResult = 0;
 
+bool CRSF::hasEverConnected = false;
+
 volatile uint8_t CRSF::SerialInPacketLen = 0; // length of the CRSF packet as measured
 volatile uint8_t CRSF::SerialInPacketPtr = 0; // index where we are reading/writing
 
@@ -684,6 +686,7 @@ bool ICACHE_RAM_ATTR CRSF::ProcessPacket()
         LPF_OPENTX_SYNC_MARGIN.init(0);
         LPF_OPENTX_SYNC_OFFSET.init(0);
 #endif // FEATURE_OPENTX_SYNC_AUTOTUNE
+        hasEverConnected = true;
         connected();
     }
     

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -66,6 +66,8 @@ public:
     static uint32_t GoodPktsCountResult; // need to latch the results
     static uint32_t BadPktsCountResult; // need to latch the results
 
+    static bool hasEverConnected;
+
     static void Begin(); //setup timers etc
     static void End(); //stop timers etc
 

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -76,7 +76,6 @@ volatile uint8_t NonceTX;
 
 bool webUpdateMode = false;
 #ifdef PLATFORM_ESP32
-#define START_UP_CHECK_MS 15000LU
 bool startUpCheck = false;
 #endif
 
@@ -891,12 +890,10 @@ void loop()
   //if webupdate was requested before or START_UP_CHECK_MS has been elapsed but uart is not detected
   //start webupdate, there might be wrong configuration flashed.
 
-    if(startUpCheck == false && now > START_UP_CHECK_MS && webUpdateMode == false){
-      Serial.println("NO SPORTTTTTTTTTTTTTTTTTTTTT");
-      Serial.println(now);
-      Serial.println("NO SPORTTTTTTTTTTTTTTTTTTTTT");
-      Serial.println(startUpCheck);
-      Serial.println("NO SPORTTTTTTTTTTTTTTTTTTTTT");
+    if(startUpCheck == false && now > (AUTO_WIFI_ON_INTERVAL*1000) && webUpdateMode == false){
+    #ifNdef DEBUG_SUPPRESS
+      Serial.println("startup Check Failled")
+    #endif
       webUpdateMode = true;
         BeginWebUpdate();
     }

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -619,10 +619,12 @@ void UARTconnected()
   pinMode(GPIO_PIN_BUZZER, INPUT);
   #endif
     delay(200);
-    
+
+#if defined(PLATFORM_ESP32)
   if(!startUpCheck){
     startUpCheck = true;
   }
+#endif
   hwTimer.resume();
 }
 

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -887,7 +887,7 @@ void loop()
   updateLEDs(now, connectionState, ExpressLRS_currAirRate_Modparams->index, POWERMGNT.currPower());
 
   #if defined(PLATFORM_ESP32)
-  //if webupdate was requested before or START_UP_CHECK_MS has been elapsed but uart is not detected
+  //if webupdate was requested before or AUTO_WIFI_ON_INTERVAL has been elapsed but uart is not detected
   //start webupdate, there might be wrong configuration flashed.
 
     if(startUpCheck == false && now > (AUTO_WIFI_ON_INTERVAL*1000) && webUpdateMode == false){

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -891,7 +891,7 @@ void loop()
   //start webupdate, there might be wrong configuration flashed.
 
     if(startUpCheck == false && now > (AUTO_WIFI_ON_INTERVAL*1000) && webUpdateMode == false){
-    #ifNdef DEBUG_SUPPRESS
+    #ifndef DEBUG_SUPPRESS
       Serial.println("startup Check Failled")
     #endif
       webUpdateMode = true;

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -75,9 +75,6 @@ char commitStr[7] = {LATEST_COMMIT , 0};
 volatile uint8_t NonceTX;
 
 bool webUpdateMode = false;
-#ifdef PLATFORM_ESP32
-bool startUpCheck = false;
-#endif
 
 //// MSP Data Handling ///////
 bool NextPacketIsMspData = false;  // if true the next packet will contain the msp data
@@ -619,11 +616,6 @@ void UARTconnected()
   #endif
     delay(200);
 
-#if defined(PLATFORM_ESP32)
-  if(!startUpCheck){
-    startUpCheck = true;
-  }
-#endif
   hwTimer.resume();
 }
 
@@ -886,23 +878,23 @@ void loop()
   UpdateConnectDisconnectStatus(now);
   updateLEDs(now, connectionState, ExpressLRS_currAirRate_Modparams->index, POWERMGNT.currPower());
 
-  #if defined(PLATFORM_ESP32)
+#ifdef PLATFORM_ESP32
   //if webupdate was requested before or AUTO_WIFI_ON_INTERVAL has been elapsed but uart is not detected
   //start webupdate, there might be wrong configuration flashed.
 
-    if(startUpCheck == false && now > (AUTO_WIFI_ON_INTERVAL*1000) && webUpdateMode == false){
-    #ifndef DEBUG_SUPPRESS
-      Serial.println("startup Check Failled")
-    #endif
-      webUpdateMode = true;
-        BeginWebUpdate();
-    }
-    if (webUpdateMode)
-    {
-      HandleWebUpdate();
-      return;
-    }
-  #endif
+  if(crsf.hasEverConnected == false && now > (AUTO_WIFI_ON_INTERVAL*1000)){
+#ifndef DEBUG_SUPPRESS
+  Serial.println("startup Check Failled")
+#endif
+    webUpdateMode = true;
+    BeginWebUpdate();
+  }
+  if (webUpdateMode)
+  {
+    HandleWebUpdate();
+    return;
+  }
+#endif
   HandleUpdateParameter();
   CheckConfigChangePending();
 


### PR DESCRIPTION
this PR will switch wifi mode on when after module is powered on and crsf uart is not detected for a while. 
this PR was also suggested by @zu_adha from discord channel, when he gave me a TX from his t8sg, and I had to use UART because i cannot access update button through my opentx (inverted uart vs non inverted)
it might help easier for flashing without handset by just connecting the power pad and helps user when changing module from one handset which has inverted UART to another handset that does not have inverter UART. (or wrong user_config flashed that causes no CRSF connection).