### PR TITLE
Move sync channel to middle of the band

### DIFF
--- a/src/lib/FHSS/FHSS.cpp
+++ b/src/lib/FHSS/FHSS.cpp
@@ -1,22 +1,258 @@
 #include "FHSS.h"
+#include <string.h>
 
-uint8_t volatile FHSSptr = 0;
-uint8_t FHSSsequence[256] = {0};
+uint8_t volatile FHSSptr;
+uint8_t FHSSsequence[NR_SEQUENCE_ENTRIES];
+int32_t FreqCorrection;
+uint_fast8_t sync_channel;
 
-//uint8_t NumOfFHSSfrequencies = 20;
-int32_t FreqCorrection = 0;
+
+// Our table of FHSS frequencies. Define a regulatory domain to select the correct set for your location and radio
+#ifdef Regulatory_Domain_AU_433
+const uint32_t FHSSfreqs[] = {
+    FREQ_HZ_TO_REG_VAL(433420000),
+    FREQ_HZ_TO_REG_VAL(433920000),
+    FREQ_HZ_TO_REG_VAL(434420000)};
+#elif defined Regulatory_Domain_AU_915
+const uint32_t FHSSfreqs[] = {
+    FREQ_HZ_TO_REG_VAL(915500000),
+    FREQ_HZ_TO_REG_VAL(916100000),
+    FREQ_HZ_TO_REG_VAL(916700000),
+    FREQ_HZ_TO_REG_VAL(917300000),
+
+    FREQ_HZ_TO_REG_VAL(917900000),
+    FREQ_HZ_TO_REG_VAL(918500000),
+    FREQ_HZ_TO_REG_VAL(919100000),
+    FREQ_HZ_TO_REG_VAL(919700000),
+
+    FREQ_HZ_TO_REG_VAL(920300000),
+    FREQ_HZ_TO_REG_VAL(920900000),
+    FREQ_HZ_TO_REG_VAL(921500000),
+    FREQ_HZ_TO_REG_VAL(922100000),
+
+    FREQ_HZ_TO_REG_VAL(922700000),
+    FREQ_HZ_TO_REG_VAL(923300000),
+    FREQ_HZ_TO_REG_VAL(923900000),
+    FREQ_HZ_TO_REG_VAL(924500000),
+
+    FREQ_HZ_TO_REG_VAL(925100000),
+    FREQ_HZ_TO_REG_VAL(925700000),
+    FREQ_HZ_TO_REG_VAL(926300000),
+    FREQ_HZ_TO_REG_VAL(926900000)};
+#elif defined Regulatory_Domain_EU_868
+/* Frequency bands taken from https://wetten.overheid.nl/BWBR0036378/2016-12-28#Bijlagen
+ * Note: these frequencies fall in the license free H-band, but in combination with 500kHz
+ * LoRa modem bandwidth used by ExpressLRS (EU allows up to 125kHz modulation BW only) they
+ * will never pass RED certification and they are ILLEGAL to use.
+ *
+ * Therefore we simply maximize the usage of available spectrum so laboratory testing of the software won't disturb existing
+ * 868MHz ISM band traffic too much.
+ */
+const uint32_t FHSSfreqs[] = {
+    FREQ_HZ_TO_REG_VAL(863275000), // band H1, 863 - 865MHz, 0.1% duty cycle or CSMA techniques, 25mW EIRP
+    FREQ_HZ_TO_REG_VAL(863800000),
+    FREQ_HZ_TO_REG_VAL(864325000),
+    FREQ_HZ_TO_REG_VAL(864850000),
+    FREQ_HZ_TO_REG_VAL(865375000), // Band H2, 865 - 868.6MHz, 1.0% dutycycle or CSMA, 25mW EIRP
+    FREQ_HZ_TO_REG_VAL(865900000),
+    FREQ_HZ_TO_REG_VAL(866425000),
+    FREQ_HZ_TO_REG_VAL(866950000),
+    FREQ_HZ_TO_REG_VAL(867475000),
+    FREQ_HZ_TO_REG_VAL(868000000),
+    FREQ_HZ_TO_REG_VAL(868525000), // Band H3, 868.7-869.2MHz, 0.1% dutycycle or CSMA, 25mW EIRP
+    FREQ_HZ_TO_REG_VAL(869050000),
+    FREQ_HZ_TO_REG_VAL(869575000)};
+#elif defined Regulatory_Domain_IN_866
+/**
+ * India currently delicensed the 865-867 MHz band with a maximum of 1W Transmitter power,
+ * 4Watts Effective Radiated Power and 200Khz carrier bandwidth as per
+ * https://dot.gov.in/sites/default/files/Delicensing%20in%20865-867%20MHz%20band%20%5BGSR%20564%20%28E%29%5D_0.pdf .
+ * There is currently no mention of Direct-sequence spread spectrum,
+ * So these frequencies are a subset of Regulatory_Domain_EU_868 frequencies.
+ */
+const uint32_t FHSSfreqs[] = {
+    FREQ_HZ_TO_REG_VAL(865375000),
+    FREQ_HZ_TO_REG_VAL(865900000),
+    FREQ_HZ_TO_REG_VAL(866425000),
+    FREQ_HZ_TO_REG_VAL(866950000)};
+#elif defined Regulatory_Domain_EU_433
+/* Frequency band G, taken from https://wetten.overheid.nl/BWBR0036378/2016-12-28#Bijlagen
+ * Note: As is the case with the 868Mhz band, these frequencies only comply to the license free portion
+ * of the spectrum, nothing else. As such, these are likely illegal to use.
+ */
+const uint32_t FHSSfreqs[] = {
+    FREQ_HZ_TO_REG_VAL(433100000),
+    FREQ_HZ_TO_REG_VAL(433925000),
+    FREQ_HZ_TO_REG_VAL(434450000)};
+#elif defined Regulatory_Domain_FCC_915
+/* Very definitely not fully checked. An initial pass at increasing the hops
+*/
+const uint32_t FHSSfreqs[] = {
+    FREQ_HZ_TO_REG_VAL(903500000),
+    FREQ_HZ_TO_REG_VAL(904100000),
+    FREQ_HZ_TO_REG_VAL(904700000),
+    FREQ_HZ_TO_REG_VAL(905300000),
+
+    FREQ_HZ_TO_REG_VAL(905900000),
+    FREQ_HZ_TO_REG_VAL(906500000),
+    FREQ_HZ_TO_REG_VAL(907100000),
+    FREQ_HZ_TO_REG_VAL(907700000),
+
+    FREQ_HZ_TO_REG_VAL(908300000),
+    FREQ_HZ_TO_REG_VAL(908900000),
+    FREQ_HZ_TO_REG_VAL(909500000),
+    FREQ_HZ_TO_REG_VAL(910100000),
+
+    FREQ_HZ_TO_REG_VAL(910700000),
+    FREQ_HZ_TO_REG_VAL(911300000),
+    FREQ_HZ_TO_REG_VAL(911900000),
+    FREQ_HZ_TO_REG_VAL(912500000),
+
+    FREQ_HZ_TO_REG_VAL(913100000),
+    FREQ_HZ_TO_REG_VAL(913700000),
+    FREQ_HZ_TO_REG_VAL(914300000),
+    FREQ_HZ_TO_REG_VAL(914900000),
+
+    FREQ_HZ_TO_REG_VAL(915500000), // as per AU..
+    FREQ_HZ_TO_REG_VAL(916100000),
+    FREQ_HZ_TO_REG_VAL(916700000),
+    FREQ_HZ_TO_REG_VAL(917300000),
+
+    FREQ_HZ_TO_REG_VAL(917900000),
+    FREQ_HZ_TO_REG_VAL(918500000),
+    FREQ_HZ_TO_REG_VAL(919100000),
+    FREQ_HZ_TO_REG_VAL(919700000),
+
+    FREQ_HZ_TO_REG_VAL(920300000),
+    FREQ_HZ_TO_REG_VAL(920900000),
+    FREQ_HZ_TO_REG_VAL(921500000),
+    FREQ_HZ_TO_REG_VAL(922100000),
+
+    FREQ_HZ_TO_REG_VAL(922700000),
+    FREQ_HZ_TO_REG_VAL(923300000),
+    FREQ_HZ_TO_REG_VAL(923900000),
+    FREQ_HZ_TO_REG_VAL(924500000),
+
+    FREQ_HZ_TO_REG_VAL(925100000),
+    FREQ_HZ_TO_REG_VAL(925700000),
+    FREQ_HZ_TO_REG_VAL(926300000),
+    FREQ_HZ_TO_REG_VAL(926900000)};
+#elif Regulatory_Domain_ISM_2400
+const uint32_t FHSSfreqs[] = {
+    FREQ_HZ_TO_REG_VAL(2400400000),
+    FREQ_HZ_TO_REG_VAL(2401400000),
+    FREQ_HZ_TO_REG_VAL(2402400000),
+    FREQ_HZ_TO_REG_VAL(2403400000),
+    FREQ_HZ_TO_REG_VAL(2404400000),
+
+    FREQ_HZ_TO_REG_VAL(2405400000),
+    FREQ_HZ_TO_REG_VAL(2406400000),
+    FREQ_HZ_TO_REG_VAL(2407400000),
+    FREQ_HZ_TO_REG_VAL(2408400000),
+    FREQ_HZ_TO_REG_VAL(2409400000),
+
+    FREQ_HZ_TO_REG_VAL(2410400000),
+    FREQ_HZ_TO_REG_VAL(2411400000),
+    FREQ_HZ_TO_REG_VAL(2412400000),
+    FREQ_HZ_TO_REG_VAL(2413400000),
+    FREQ_HZ_TO_REG_VAL(2414400000),
+
+    FREQ_HZ_TO_REG_VAL(2415400000),
+    FREQ_HZ_TO_REG_VAL(2416400000),
+    FREQ_HZ_TO_REG_VAL(2417400000),
+    FREQ_HZ_TO_REG_VAL(2418400000),
+    FREQ_HZ_TO_REG_VAL(2419400000),
+
+    FREQ_HZ_TO_REG_VAL(2420400000),
+    FREQ_HZ_TO_REG_VAL(2421400000),
+    FREQ_HZ_TO_REG_VAL(2422400000),
+    FREQ_HZ_TO_REG_VAL(2423400000),
+    FREQ_HZ_TO_REG_VAL(2424400000),
+
+    FREQ_HZ_TO_REG_VAL(2425400000),
+    FREQ_HZ_TO_REG_VAL(2426400000),
+    FREQ_HZ_TO_REG_VAL(2427400000),
+    FREQ_HZ_TO_REG_VAL(2428400000),
+    FREQ_HZ_TO_REG_VAL(2429400000),
+
+    FREQ_HZ_TO_REG_VAL(2430400000),
+    FREQ_HZ_TO_REG_VAL(2431400000),
+    FREQ_HZ_TO_REG_VAL(2432400000),
+    FREQ_HZ_TO_REG_VAL(2433400000),
+    FREQ_HZ_TO_REG_VAL(2434400000),
+
+    FREQ_HZ_TO_REG_VAL(2435400000),
+    FREQ_HZ_TO_REG_VAL(2436400000),
+    FREQ_HZ_TO_REG_VAL(2437400000),
+    FREQ_HZ_TO_REG_VAL(2438400000),
+    FREQ_HZ_TO_REG_VAL(2439400000),
+
+    FREQ_HZ_TO_REG_VAL(2440400000),
+    FREQ_HZ_TO_REG_VAL(2441400000),
+    FREQ_HZ_TO_REG_VAL(2442400000),
+    FREQ_HZ_TO_REG_VAL(2443400000),
+    FREQ_HZ_TO_REG_VAL(2444400000),
+
+    FREQ_HZ_TO_REG_VAL(2445400000),
+    FREQ_HZ_TO_REG_VAL(2446400000),
+    FREQ_HZ_TO_REG_VAL(2447400000),
+    FREQ_HZ_TO_REG_VAL(2448400000),
+    FREQ_HZ_TO_REG_VAL(2449400000),
+
+    FREQ_HZ_TO_REG_VAL(2450400000),
+    FREQ_HZ_TO_REG_VAL(2451400000),
+    FREQ_HZ_TO_REG_VAL(2452400000),
+    FREQ_HZ_TO_REG_VAL(2453400000),
+    FREQ_HZ_TO_REG_VAL(2454400000),
+
+    FREQ_HZ_TO_REG_VAL(2455400000),
+    FREQ_HZ_TO_REG_VAL(2456400000),
+    FREQ_HZ_TO_REG_VAL(2457400000),
+    FREQ_HZ_TO_REG_VAL(2458400000),
+    FREQ_HZ_TO_REG_VAL(2459400000),
+
+    FREQ_HZ_TO_REG_VAL(2460400000),
+    FREQ_HZ_TO_REG_VAL(2461400000),
+    FREQ_HZ_TO_REG_VAL(2462400000),
+    FREQ_HZ_TO_REG_VAL(2463400000),
+    FREQ_HZ_TO_REG_VAL(2464400000),
+
+    FREQ_HZ_TO_REG_VAL(2465400000),
+    FREQ_HZ_TO_REG_VAL(2466400000),
+    FREQ_HZ_TO_REG_VAL(2467400000),
+    FREQ_HZ_TO_REG_VAL(2468400000),
+    FREQ_HZ_TO_REG_VAL(2469400000),
+
+    FREQ_HZ_TO_REG_VAL(2470400000),
+    FREQ_HZ_TO_REG_VAL(2471400000),
+    FREQ_HZ_TO_REG_VAL(2472400000),
+    FREQ_HZ_TO_REG_VAL(2473400000),
+    FREQ_HZ_TO_REG_VAL(2474400000),
+
+    FREQ_HZ_TO_REG_VAL(2475400000),
+    FREQ_HZ_TO_REG_VAL(2476400000),
+    FREQ_HZ_TO_REG_VAL(2477400000),
+    FREQ_HZ_TO_REG_VAL(2478400000),
+    FREQ_HZ_TO_REG_VAL(2479400000)};
+#else
+#error No regulatory domain defined, please define one in user_defines.txt
+#endif
+
+
+// The number of FHSS frequencies in the table
+constexpr uint32_t NR_FHSS_ENTRIES = (sizeof(FHSSfreqs) / sizeof(uint32_t));
+constexpr uint32_t SYNC_INTERVAL = NR_FHSS_ENTRIES;
+
 
 // Set all of the flags in the array to true, except for the first one
 // which corresponds to the sync channel and is never available for normal
 // allocation.
-void resetIsAvailable(uint8_t *array)
+void resetIsAvailable(uint8_t * const array, const uint8_t size)
 {
-    // channel 0 is the sync channel and is never considered available
-    array[0] = 0;
-
-    // all other entires to 1
-    for (unsigned int i = 1; i < NR_FHSS_ENTRIES; i++)
-        array[i] = 1;
+    // Mark all other entires to free (1)
+    memset(array, 1, size);
+    // the sync channel is never considered available
+    array[sync_channel] = 0;
 }
 
 /**
@@ -36,9 +272,8 @@ Approach:
     if the index is not a repeat, assing it to the FHSSsequence array, clear the availability flag and decrement the available count
     if there are no available channels left, reset the flags array and the count
 */
-void FHSSrandomiseFHSSsequence(long seed)
+void FHSSrandomiseFHSSsequence(const uint32_t seed)
 {
-
 #ifdef Regulatory_Domain_AU_915
     Serial.println("Setting 915MHz Mode");
 #elif defined Regulatory_Domain_FCC_915
@@ -57,44 +292,44 @@ void FHSSrandomiseFHSSsequence(long seed)
 #error No regulatory domain defined, please define one in common.h
 #endif
 
-    Serial.print("Number of FHSS frequencies =");
+    Serial.print("Number of FHSS frequencies = ");
     Serial.println(NR_FHSS_ENTRIES);
+
+    sync_channel = NR_FHSS_ENTRIES / 2;
+    Serial.print("Sync channel = ");
+    Serial.println(sync_channel);
 
     rngSeed(seed);
 
     uint8_t isAvailable[NR_FHSS_ENTRIES];
 
-    resetIsAvailable(isAvailable);
+    resetIsAvailable(isAvailable, NR_FHSS_ENTRIES);
+
+    int32_t nLeft = NR_FHSS_ENTRIES - 1; // how many channels are left to be allocated. Does not include the sync channel
+    uint32_t prev = sync_channel;        // needed to prevent repeats of the same index
+    uint32_t index;
+    int32_t c, found;
 
     // Fill the FHSSsequence with channel indices
     // The 0 index is special - the 'sync' channel. The sync channel appears every
     // syncInterval hops. The other channels are randomly distributed between the
     // sync channels
-    const int SYNC_INTERVAL = NR_FHSS_ENTRIES;
-
-    int nLeft = NR_FHSS_ENTRIES - 1; // how many channels are left to be allocated. Does not include the sync channel
-    unsigned int prev = 0;           // needed to prevent repeats of the same index
-
-    // for each slot in the sequence table
-    for (int i = 0; i < NR_SEQUENCE_ENTRIES; i++)
+    for (uint32_t i = 0; i < NR_SEQUENCE_ENTRIES; i++)
     {
-        if (i % SYNC_INTERVAL == 0)
+        if ((i % SYNC_INTERVAL) == 0)
         {
-            // assign sync channel 0
-            FHSSsequence[i] = 0;
-            prev = 0;
+            // assign sync channel
+            prev = sync_channel;
         }
         else
         {
             // pick one of the available channels. May need to loop to avoid repeats
-            unsigned int index;
             do
             {
-                int c = rngN(nLeft); // returnc 0<c<nLeft
+                c = rngN(nLeft); // returnc 0<c<nLeft
                 // find the c'th entry in the isAvailable array
-                // can skip 0 as that's the sync channel and is never available for normal allocation
-                index = 1;
-                int found = 0;
+                index = 0;
+                found = 0;
                 while (index < NR_FHSS_ENTRIES)
                 {
                     if (isAvailable[index])
@@ -111,24 +346,25 @@ void FHSSrandomiseFHSSsequence(long seed)
                     Serial.print("FAILED to find the available entry!\n");
                     // What to do? We don't want to hang as that will stop us getting to the wifi hotspot
                     // Use the sync channel
-                    index = 0;
+                    index = sync_channel;
                     break;
                 }
             } while (index == prev); // can't use index if it repeats the previous value
 
-            FHSSsequence[i] = index; // assign the value to the sequence array
             isAvailable[index] = 0;  // clear the flag
             prev = index;            // remember for next iteration
             nLeft--;                 // reduce the count of available channels
             if (nLeft == 0)
             {
                 // we've assigned all of the channels, so reset for next cycle
-                resetIsAvailable(isAvailable);
+                resetIsAvailable(isAvailable, NR_FHSS_ENTRIES);
                 nLeft = NR_FHSS_ENTRIES - 1;
             }
         }
 
-        Serial.print(FHSSsequence[i]);
+        FHSSsequence[i] = prev; // assign the value to the sequence array
+
+        Serial.print(prev);
         if ((i + 1) % 10 == 0)
         {
             Serial.println();
@@ -142,3 +378,7 @@ void FHSSrandomiseFHSSsequence(long seed)
     Serial.println();
 }
 
+uint32_t FHSSNumEntriess(void)
+{
+    return NR_FHSS_ENTRIES;
+}

--- a/src/lib/FHSS/FHSS.h
+++ b/src/lib/FHSS/FHSS.h
@@ -26,254 +26,23 @@
 #define Regulatory_Domain_Index 8
 #endif
 
-extern volatile uint8_t FHSSptr;
-extern uint8_t NumOfFHSSfrequencies;
-extern int32_t FreqCorrection;
-
 #define FreqCorrectionMax ((int32_t)(100000/FREQ_STEP))
 #define FreqCorrectionMin ((int32_t)(-100000/FREQ_STEP))
 
 #define FREQ_HZ_TO_REG_VAL(freq) ((uint32_t)((double)freq/(double)FREQ_STEP))
 
-// Our table of FHSS frequencies. Define a regulatory domain to select the correct set for your location and radio
-#ifdef Regulatory_Domain_AU_433
-const uint32_t FHSSfreqs[] = {
-    FREQ_HZ_TO_REG_VAL(433420000),
-    FREQ_HZ_TO_REG_VAL(433920000),
-    FREQ_HZ_TO_REG_VAL(434420000)};
-#elif defined Regulatory_Domain_AU_915
-const uint32_t FHSSfreqs[] = {
-    FREQ_HZ_TO_REG_VAL(915500000),
-    FREQ_HZ_TO_REG_VAL(916100000),
-    FREQ_HZ_TO_REG_VAL(916700000),
-    FREQ_HZ_TO_REG_VAL(917300000),
-
-    FREQ_HZ_TO_REG_VAL(917900000),
-    FREQ_HZ_TO_REG_VAL(918500000),
-    FREQ_HZ_TO_REG_VAL(919100000),
-    FREQ_HZ_TO_REG_VAL(919700000),
-
-    FREQ_HZ_TO_REG_VAL(920300000),
-    FREQ_HZ_TO_REG_VAL(920900000),
-    FREQ_HZ_TO_REG_VAL(921500000),
-    FREQ_HZ_TO_REG_VAL(922100000),
-
-    FREQ_HZ_TO_REG_VAL(922700000),
-    FREQ_HZ_TO_REG_VAL(923300000),
-    FREQ_HZ_TO_REG_VAL(923900000),
-    FREQ_HZ_TO_REG_VAL(924500000),
-
-    FREQ_HZ_TO_REG_VAL(925100000),
-    FREQ_HZ_TO_REG_VAL(925700000),
-    FREQ_HZ_TO_REG_VAL(926300000),
-    FREQ_HZ_TO_REG_VAL(926900000)};
-#elif defined Regulatory_Domain_EU_868
-/* Frequency bands taken from https://wetten.overheid.nl/BWBR0036378/2016-12-28#Bijlagen
- * Note: these frequencies fall in the license free H-band, but in combination with 500kHz
- * LoRa modem bandwidth used by ExpressLRS (EU allows up to 125kHz modulation BW only) they
- * will never pass RED certification and they are ILLEGAL to use.
- *
- * Therefore we simply maximize the usage of available spectrum so laboratory testing of the software won't disturb existing
- * 868MHz ISM band traffic too much.
- */
-const uint32_t FHSSfreqs[] = {
-    FREQ_HZ_TO_REG_VAL(863275000), // band H1, 863 - 865MHz, 0.1% duty cycle or CSMA techniques, 25mW EIRP
-    FREQ_HZ_TO_REG_VAL(863800000),
-    FREQ_HZ_TO_REG_VAL(864325000),
-    FREQ_HZ_TO_REG_VAL(864850000),
-    FREQ_HZ_TO_REG_VAL(865375000), // Band H2, 865 - 868.6MHz, 1.0% dutycycle or CSMA, 25mW EIRP
-    FREQ_HZ_TO_REG_VAL(865900000),
-    FREQ_HZ_TO_REG_VAL(866425000),
-    FREQ_HZ_TO_REG_VAL(866950000),
-    FREQ_HZ_TO_REG_VAL(867475000),
-    FREQ_HZ_TO_REG_VAL(868000000),
-    FREQ_HZ_TO_REG_VAL(868525000), // Band H3, 868.7-869.2MHz, 0.1% dutycycle or CSMA, 25mW EIRP
-    FREQ_HZ_TO_REG_VAL(869050000),
-    FREQ_HZ_TO_REG_VAL(869575000)};
-#elif defined Regulatory_Domain_IN_866
-/**
- * India currently delicensed the 865-867 MHz band with a maximum of 1W Transmitter power,
- * 4Watts Effective Radiated Power and 200Khz carrier bandwidth as per
- * https://dot.gov.in/sites/default/files/Delicensing%20in%20865-867%20MHz%20band%20%5BGSR%20564%20%28E%29%5D_0.pdf .
- * There is currently no mention of Direct-sequence spread spectrum,
- * So these frequencies are a subset of Regulatory_Domain_EU_868 frequencies.
- */
-const uint32_t FHSSfreqs[] = {
-    FREQ_HZ_TO_REG_VAL(865375000),
-    FREQ_HZ_TO_REG_VAL(865900000),
-    FREQ_HZ_TO_REG_VAL(866425000),
-    FREQ_HZ_TO_REG_VAL(866950000)};
-#elif defined Regulatory_Domain_EU_433
-/* Frequency band G, taken from https://wetten.overheid.nl/BWBR0036378/2016-12-28#Bijlagen
- * Note: As is the case with the 868Mhz band, these frequencies only comply to the license free portion
- * of the spectrum, nothing else. As such, these are likely illegal to use.
- */
-const uint32_t FHSSfreqs[] = {
-    FREQ_HZ_TO_REG_VAL(433100000),
-    FREQ_HZ_TO_REG_VAL(433925000),
-    FREQ_HZ_TO_REG_VAL(434450000)};
-#elif defined Regulatory_Domain_FCC_915
-/* Very definitely not fully checked. An initial pass at increasing the hops
-*/
-const uint32_t FHSSfreqs[] = {
-    FREQ_HZ_TO_REG_VAL(903500000),
-    FREQ_HZ_TO_REG_VAL(904100000),
-    FREQ_HZ_TO_REG_VAL(904700000),
-    FREQ_HZ_TO_REG_VAL(905300000),
-
-    FREQ_HZ_TO_REG_VAL(905900000),
-    FREQ_HZ_TO_REG_VAL(906500000),
-    FREQ_HZ_TO_REG_VAL(907100000),
-    FREQ_HZ_TO_REG_VAL(907700000),
-
-    FREQ_HZ_TO_REG_VAL(908300000),
-    FREQ_HZ_TO_REG_VAL(908900000),
-    FREQ_HZ_TO_REG_VAL(909500000),
-    FREQ_HZ_TO_REG_VAL(910100000),
-
-    FREQ_HZ_TO_REG_VAL(910700000),
-    FREQ_HZ_TO_REG_VAL(911300000),
-    FREQ_HZ_TO_REG_VAL(911900000),
-    FREQ_HZ_TO_REG_VAL(912500000),
-
-    FREQ_HZ_TO_REG_VAL(913100000),
-    FREQ_HZ_TO_REG_VAL(913700000),
-    FREQ_HZ_TO_REG_VAL(914300000),
-    FREQ_HZ_TO_REG_VAL(914900000),
-
-    FREQ_HZ_TO_REG_VAL(915500000), // as per AU..
-    FREQ_HZ_TO_REG_VAL(916100000),
-    FREQ_HZ_TO_REG_VAL(916700000),
-    FREQ_HZ_TO_REG_VAL(917300000),
-
-    FREQ_HZ_TO_REG_VAL(917900000),
-    FREQ_HZ_TO_REG_VAL(918500000),
-    FREQ_HZ_TO_REG_VAL(919100000),
-    FREQ_HZ_TO_REG_VAL(919700000),
-
-    FREQ_HZ_TO_REG_VAL(920300000),
-    FREQ_HZ_TO_REG_VAL(920900000),
-    FREQ_HZ_TO_REG_VAL(921500000),
-    FREQ_HZ_TO_REG_VAL(922100000),
-
-    FREQ_HZ_TO_REG_VAL(922700000),
-    FREQ_HZ_TO_REG_VAL(923300000),
-    FREQ_HZ_TO_REG_VAL(923900000),
-    FREQ_HZ_TO_REG_VAL(924500000),
-
-    FREQ_HZ_TO_REG_VAL(925100000),
-    FREQ_HZ_TO_REG_VAL(925700000),
-    FREQ_HZ_TO_REG_VAL(926300000),
-    FREQ_HZ_TO_REG_VAL(926900000)};
-#elif Regulatory_Domain_ISM_2400
-const uint32_t FHSSfreqs[] = {
-    FREQ_HZ_TO_REG_VAL(2400400000),
-    FREQ_HZ_TO_REG_VAL(2401400000),
-    FREQ_HZ_TO_REG_VAL(2402400000),
-    FREQ_HZ_TO_REG_VAL(2403400000),
-    FREQ_HZ_TO_REG_VAL(2404400000),
-
-    FREQ_HZ_TO_REG_VAL(2405400000),
-    FREQ_HZ_TO_REG_VAL(2406400000),
-    FREQ_HZ_TO_REG_VAL(2407400000),
-    FREQ_HZ_TO_REG_VAL(2408400000),
-    FREQ_HZ_TO_REG_VAL(2409400000),
-
-    FREQ_HZ_TO_REG_VAL(2410400000),
-    FREQ_HZ_TO_REG_VAL(2411400000),
-    FREQ_HZ_TO_REG_VAL(2412400000),
-    FREQ_HZ_TO_REG_VAL(2413400000),
-    FREQ_HZ_TO_REG_VAL(2414400000),
-
-    FREQ_HZ_TO_REG_VAL(2415400000),
-    FREQ_HZ_TO_REG_VAL(2416400000),
-    FREQ_HZ_TO_REG_VAL(2417400000),
-    FREQ_HZ_TO_REG_VAL(2418400000),
-    FREQ_HZ_TO_REG_VAL(2419400000),
-
-    FREQ_HZ_TO_REG_VAL(2420400000),
-    FREQ_HZ_TO_REG_VAL(2421400000),
-    FREQ_HZ_TO_REG_VAL(2422400000),
-    FREQ_HZ_TO_REG_VAL(2423400000),
-    FREQ_HZ_TO_REG_VAL(2424400000),
-
-    FREQ_HZ_TO_REG_VAL(2425400000),
-    FREQ_HZ_TO_REG_VAL(2426400000),
-    FREQ_HZ_TO_REG_VAL(2427400000),
-    FREQ_HZ_TO_REG_VAL(2428400000),
-    FREQ_HZ_TO_REG_VAL(2429400000),
-
-    FREQ_HZ_TO_REG_VAL(2430400000),
-    FREQ_HZ_TO_REG_VAL(2431400000),
-    FREQ_HZ_TO_REG_VAL(2432400000),
-    FREQ_HZ_TO_REG_VAL(2433400000),
-    FREQ_HZ_TO_REG_VAL(2434400000),
-
-    FREQ_HZ_TO_REG_VAL(2435400000),
-    FREQ_HZ_TO_REG_VAL(2436400000),
-    FREQ_HZ_TO_REG_VAL(2437400000),
-    FREQ_HZ_TO_REG_VAL(2438400000),
-    FREQ_HZ_TO_REG_VAL(2439400000),
-
-    FREQ_HZ_TO_REG_VAL(2440400000),
-    FREQ_HZ_TO_REG_VAL(2441400000),
-    FREQ_HZ_TO_REG_VAL(2442400000),
-    FREQ_HZ_TO_REG_VAL(2443400000),
-    FREQ_HZ_TO_REG_VAL(2444400000),
-
-    FREQ_HZ_TO_REG_VAL(2445400000),
-    FREQ_HZ_TO_REG_VAL(2446400000),
-    FREQ_HZ_TO_REG_VAL(2447400000),
-    FREQ_HZ_TO_REG_VAL(2448400000),
-    FREQ_HZ_TO_REG_VAL(2449400000),
-
-    FREQ_HZ_TO_REG_VAL(2450400000),
-    FREQ_HZ_TO_REG_VAL(2451400000),
-    FREQ_HZ_TO_REG_VAL(2452400000),
-    FREQ_HZ_TO_REG_VAL(2453400000),
-    FREQ_HZ_TO_REG_VAL(2454400000),
-
-    FREQ_HZ_TO_REG_VAL(2455400000),
-    FREQ_HZ_TO_REG_VAL(2456400000),
-    FREQ_HZ_TO_REG_VAL(2457400000),
-    FREQ_HZ_TO_REG_VAL(2458400000),
-    FREQ_HZ_TO_REG_VAL(2459400000),
-
-    FREQ_HZ_TO_REG_VAL(2460400000),
-    FREQ_HZ_TO_REG_VAL(2461400000),
-    FREQ_HZ_TO_REG_VAL(2462400000),
-    FREQ_HZ_TO_REG_VAL(2463400000),
-    FREQ_HZ_TO_REG_VAL(2464400000),
-
-    FREQ_HZ_TO_REG_VAL(2465400000),
-    FREQ_HZ_TO_REG_VAL(2466400000),
-    FREQ_HZ_TO_REG_VAL(2467400000),
-    FREQ_HZ_TO_REG_VAL(2468400000),
-    FREQ_HZ_TO_REG_VAL(2469400000),
-
-    FREQ_HZ_TO_REG_VAL(2470400000),
-    FREQ_HZ_TO_REG_VAL(2471400000),
-    FREQ_HZ_TO_REG_VAL(2472400000),
-    FREQ_HZ_TO_REG_VAL(2473400000),
-    FREQ_HZ_TO_REG_VAL(2474400000),
-
-    FREQ_HZ_TO_REG_VAL(2475400000),
-    FREQ_HZ_TO_REG_VAL(2476400000),
-    FREQ_HZ_TO_REG_VAL(2477400000),
-    FREQ_HZ_TO_REG_VAL(2478400000),
-    FREQ_HZ_TO_REG_VAL(2479400000)};
-#else
-#error No regulatory domain defined, please define one in user_defines.txt
-#endif
-
-// The number of FHSS frequencies in the table
-#define NR_FHSS_ENTRIES (sizeof(FHSSfreqs) / sizeof(uint32_t))
-
 #define NR_SEQUENCE_ENTRIES 256
-extern uint8_t FHSSsequence[NR_SEQUENCE_ENTRIES];
-void FHSSrandomiseFHSSsequence(long seed);
 
-static inline void FHSSsetCurrIndex(uint8_t value)
+extern volatile uint8_t FHSSptr;
+extern int32_t FreqCorrection;
+extern uint8_t FHSSsequence[NR_SEQUENCE_ENTRIES];
+extern const uint32_t FHSSfreqs[];
+extern uint_fast8_t sync_channel;
+
+void FHSSrandomiseFHSSsequence(uint32_t seed);
+uint32_t FHSSNumEntriess(void);
+
+static inline void FHSSsetCurrIndex(const uint8_t value)
 { // set the current index of the FHSS pointer
     FHSSptr = value;
 }
@@ -285,11 +54,10 @@ static inline uint8_t FHSSgetCurrIndex()
 
 static inline uint32_t GetInitialFreq()
 {
-    return FHSSfreqs[0] - FreqCorrection;
+    return FHSSfreqs[sync_channel] - FreqCorrection;
 }
 
 static inline uint32_t FHSSgetNextFreq()
 {
     return FHSSfreqs[FHSSsequence[FHSSptr++]] - FreqCorrection;
 }
-

--- a/src/lib/FHSS/random.cpp
+++ b/src/lib/FHSS/random.cpp
@@ -1,20 +1,20 @@
 #include "random.h"
 
-static unsigned long seed = 0;
+static uint32_t seed = 0;
 
 // returns values between 0 and 0x7FFF
 // NB rngN depends on this output range, so if we change the
 // behaviour rngN will need updating
-long rng(void)
+uint32_t rng(void)
 {
-    unsigned long m = 2147483648;
-    long a = 214013;
-    long c = 2531011;
+    const uint32_t m = 2147483648;
+    const uint32_t a = 214013;
+    const uint32_t c = 2531011;
     seed = (a * seed + c) % m;
     return seed >> 16;
 }
 
-void rngSeed(long newSeed)
+void rngSeed(const uint32_t newSeed)
 {
     seed = newSeed;
 }
@@ -22,32 +22,31 @@ void rngSeed(long newSeed)
 // returns 0 <= x < max where max <= 256
 // (actual upper limit is higher, but there is one and I haven't
 //  thought carefully about what it is)
-unsigned int rngN(unsigned int max)
+uint32_t rngN(const uint32_t max)
 {
-    unsigned long x = rng();
-    unsigned int result = (x * max) / RNG_MAX;
+    const uint32_t x = rng();
+    const uint32_t result = (x * max) / RNG_MAX;
     return result;
 }
 
 // 0..255 returned
-long rng8Bit(void)
+uint8_t rng8Bit(void)
 {
-    return rng() & 0b11111111;
+    return rng() & 0xff;
 }
 
 // 0..31 returned
-long rng5Bit(void)
+uint8_t rng5Bit(void)
 {
-    return rng() & 0b11111;
+    return rng() & 0x1F;
 }
 
-// 0..255 returned
-long rng0to2(void)
+uint8_t rng0to2(void)
 {
-    int randomNumber = rng() & 0b11;
+    uint8_t randomNumber = rng() & 0b11;
 
-    while(randomNumber == 3) {
+    while (randomNumber == 3) {
         randomNumber = rng() & 0b11;
     }
     return randomNumber;
-} 
+}

--- a/src/lib/FHSS/random.h
+++ b/src/lib/FHSS/random.h
@@ -1,15 +1,17 @@
 #pragma once
 
+#include <stdint.h>
+
 // the max value returned by rng
 #define RNG_MAX 0x7FFF
 
-long rng(void);
+uint32_t rng(void);
 
-void rngSeed(long newSeed);
+void rngSeed(uint32_t newSeed);
 // 0..255 returned
-long rng8Bit(void);
+uint8_t rng8Bit(void);
 // 0..31 returned
-long rng5Bit(void);
+uint8_t rng5Bit(void);
 
 // returns 0 <= x < n where n <= 256
-unsigned int rngN(unsigned int upper);
+uint32_t rngN(uint32_t upper);

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -469,10 +469,10 @@ void ICACHE_RAM_ATTR SX127xDriver::ClearIRQFlags()
 
 // int16_t MeasureNoiseFloor() TODO disabled for now
 // {
-//     int NUM_READS = RSSI_FLOOR_NUM_READS * NR_FHSS_ENTRIES;
+//     int NUM_READS = RSSI_FLOOR_NUM_READS * FHSSNumEntriess();
 //     float returnval = 0;
 
-//     for (uint32_t freq = 0; freq < NR_FHSS_ENTRIES; freq++)
+//     for (uint32_t freq = 0; freq < FHSSNumEntriess(); freq++)
 //     {
 //         FHSSsetCurrIndex(freq);
 //         Radio.SetMode(SX127X_CAD);

--- a/src/platformio.ini
+++ b/src/platformio.ini
@@ -31,6 +31,8 @@ src_filter = ${common_env_data.src_filter} -<ESP32*.*> -<STM32*.*> -<ESP8*.*> -<
 build_flags =
 	-std=c++11
 	-Iinclude
+	-D PROGMEM=""
+	-D UNIT_TEST=1
 	-D TARGET_NATIVE
 	-D CRSF_RX_MODULE
 	-D CRSF_TX_MODULE

--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -164,3 +164,10 @@ uint16_t RateEnumToHz(expresslrs_RFrates_e eRate)
     default: return 1;
     }
 }
+
+uint32_t uidMacSeedGet(void)
+{
+    const uint32_t macSeed = ((uint32_t)UID[2] << 24) + ((uint32_t)UID[3] << 16) +
+                             ((uint32_t)UID[4] << 8) + UID[5];
+    return macSeed;
+}

--- a/src/src/common.h
+++ b/src/src/common.h
@@ -139,6 +139,8 @@ uint8_t ICACHE_RAM_ATTR enumRatetoIndex(expresslrs_RFrates_e rate);
 
 #endif // UNIT_TEST
 
+uint32_t uidMacSeedGet(void);
+
 #define AUX1 4
 #define AUX2 5
 #define AUX3 6

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -214,7 +214,7 @@ void ICACHE_RAM_ATTR ProcessTLMpacket()
 
   uint8_t type = Radio.RXdataBuffer[0] & TLM_PACKET;
   uint8_t TLMheader = Radio.RXdataBuffer[1];
-  
+
   if ((inCRC != calculatedCRC))
   {
 #ifndef DEBUG_SUPPRESS
@@ -501,7 +501,7 @@ void registerLuaParameters() {
         config.SetRate(crsf.getModelID(), arg);
       #if defined(HAS_OLED)
         OLED.updateScreen(OLED.getPowerString((PowerLevels_e)POWERMGNT.currPower()),
-                          OLED.getRateString((expresslrs_RFrates_e)arg), 
+                          OLED.getRateString((expresslrs_RFrates_e)arg),
                           OLED.getTLMRatioString((expresslrs_tlm_ratio_e)(ExpressLRS_currAirRate_Modparams->TLMinterval)), commitStr);
       #endif
     }
@@ -516,7 +516,7 @@ void registerLuaParameters() {
         config.SetTlm(crsf.getModelID(), (expresslrs_tlm_ratio_e)arg);
       #if defined(HAS_OLED)
         OLED.updateScreen(OLED.getPowerString((PowerLevels_e)POWERMGNT.currPower()),
-                          OLED.getRateString((expresslrs_RFrates_e)ExpressLRS_currAirRate_Modparams->enum_rate), 
+                          OLED.getRateString((expresslrs_RFrates_e)ExpressLRS_currAirRate_Modparams->enum_rate),
                           OLED.getTLMRatioString((expresslrs_tlm_ratio_e)arg), commitStr);
       #endif
     }
@@ -530,7 +530,7 @@ void registerLuaParameters() {
       config.SetPower(crsf.getModelID(), newPower < MaxPower ? newPower : MaxPower);
     #if defined(HAS_OLED)
       OLED.updateScreen(OLED.getPowerString((PowerLevels_e)arg),
-                        OLED.getRateString((expresslrs_RFrates_e)ExpressLRS_currAirRate_Modparams->enum_rate), 
+                        OLED.getRateString((expresslrs_RFrates_e)ExpressLRS_currAirRate_Modparams->enum_rate),
                         OLED.getTLMRatioString((expresslrs_tlm_ratio_e)ExpressLRS_currAirRate_Modparams->TLMinterval), commitStr);
     #endif
   });
@@ -601,7 +601,7 @@ void registerLuaParameters() {
 void resetLuaParams(){
   setLuaTextSelectionValue(&luaAirRate,(uint8_t)(ExpressLRS_currAirRate_Modparams->index));
   setLuaTextSelectionValue(&luaTlmRate,(uint8_t)(ExpressLRS_currAirRate_Modparams->TLMinterval));
-  
+
   #ifdef USE_DYNAMIC_POWER
   setLuaTextSelectionValue(&luaPower,(uint8_t)(config.GetPower(crsf.getModelID())));
   #else
@@ -846,8 +846,7 @@ void setup()
   // UID[0..2] are OUI (organisationally unique identifier) and are not ESP32 unique.  Do not use!
 #endif // PLATFORM_ESP32
 
-  long macSeed = ((long)UID[2] << 24) + ((long)UID[3] << 16) + ((long)UID[4] << 8) + UID[5];
-  FHSSrandomiseFHSSsequence(macSeed);
+  FHSSrandomiseFHSSsequence(uidMacSeedGet());
 
   Radio.RXdoneCallback = &RXdoneISR;
   Radio.TXdoneCallback = &TXdoneISR;

--- a/src/test/fhss_native/test_fhss.cpp
+++ b/src/test/fhss_native/test_fhss.cpp
@@ -7,11 +7,12 @@ void test_fhss_assignment(void)
 {
     FHSSrandomiseFHSSsequence(0x01020304L);
 
+    const uint32_t numFhss = FHSSNumEntriess();
     uint32_t initFreq = GetInitialFreq();
 
     for (unsigned int i = 0; i < 256; i++) {
         uint32_t freq = FHSSgetNextFreq();
-        if (i%NR_FHSS_ENTRIES == 0) {
+        if ((i % numFhss) == 0) {
             TEST_ASSERT_EQUAL(initFreq, freq);
         } else {
             TEST_ASSERT_NOT_EQUAL(initFreq, freq);
@@ -23,11 +24,12 @@ void test_fhss_unique(void)
 {
     FHSSrandomiseFHSSsequence(0x01020304L);
 
+    const uint32_t numFhss = FHSSNumEntriess();
     std::set<uint32_t> freqs;
 
     for (unsigned int i = 0; i < 256; i++) {
         uint32_t freq = FHSSgetNextFreq();
-        if (i%NR_FHSS_ENTRIES == 0) {
+        if ((i % numFhss) == 0) {
             freqs.clear();
             freqs.insert(freq);
         } else {


### PR DESCRIPTION
Sync channel is set currently to lowest edge of the bands (frequency index 0) which is not the most optimal location when compared to transmitter antenna tuning. Generally, antennas are tuned to middle of the band which means the best power output is on the middle.

Purpose of the PR is to move sync channel to middle of the band ( `num_of_frequencies / 2`) to maximize sync channel output power. This should help to recover link in case of link lost.
