### PR TITLE
Fix compile error with DYNAMIC_POWER_BOOST defined

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -229,11 +229,6 @@ void ICACHE_RAM_ATTR CRSF::setSentSwitch(uint8_t index, uint8_t value)
     sentSwitches[index] = value;
 }
 
-uint8_t ICACHE_RAM_ATTR CRSF::getModelID()
-{
-    return modelId;
-}
-
 #if CRSF_TX_MODULE
 void ICACHE_RAM_ATTR CRSF::sendLinkStatisticsToTX()
 {

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -92,7 +92,7 @@ public:
     void ICACHE_RAM_ATTR setNextSwitchFirstIndex(int firstSwitchIndex);
     void ICACHE_RAM_ATTR setSentSwitch(uint8_t index, uint8_t value);
 
-    uint8_t ICACHE_RAM_ATTR getModelID();
+    uint8_t getModelID() const { return modelId; }
 
     ///// Variables for OpenTX Syncing //////////////////////////
     #define OpenTXsyncPacketInterval 200 // in ms

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -143,7 +143,7 @@ void DynamicPower_Update()
   #ifdef DYNAMIC_POWER_BOOST
     // if a user selected to disable dynamic power (ch16)
     if(CRSF_to_BIT(crsf.ChannelDataIn[DYNAMIC_POWER_BOOST])) {
-      POWERMGNT.setPower((PowerLevels_e)config.GetPower());
+      POWERMGNT.setPower((PowerLevels_e)config.GetPower(crsf.getModelID()));
       // POWERMGNT.setPower((PowerLevels_e)MaxPower);    // if you want to make the power to the aboslute maximum of a module, use this line.
       return;
     }


### PR DESCRIPTION
Fixes the compile error about not enough parameters to `config.GetPower()`

Also moves the modelId getter to the CRSF header file, which reduces the size of the TX code by over 100 bytes. The ICACHE_RAM_ATTR property will be applied to it if called from a function already declared as such.