### PR TITLE
remove PaoloP74/extEEPROM and external eeprom use

### DIFF
--- a/src/targets/frsky.ini
+++ b/src/targets/frsky.ini
@@ -9,15 +9,12 @@ build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_tx}
 	-D TARGET_R9M_TX
-	-D TARGET_USE_EEPROM=1
 	-D TARGET_EEPROM_ADDR=0x51
 	-D HSE_VALUE=12000000U
 	-DVECT_TAB_OFFSET=0x2000U
 board_build.ldscript = variants/R9M_ldscript_old_bl.ld
 board_build.flash_offset = 0x2000
 src_filter = ${env_common_stm32.src_filter} -<rx_*.cpp>
-lib_deps =
-	https://github.com/PaoloP74/extEEPROM.git
 
 ## TODO: R9M STLINK/stock and R9M Lite targets can be merged
 [env:Frsky_TX_R9M_via_STLINK]
@@ -26,7 +23,6 @@ build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_tx}
 	-D TARGET_R9M_TX
-	-D TARGET_USE_EEPROM=1
 	-D TARGET_EEPROM_ADDR=0x51
 	-D HSE_VALUE=12000000U
 	-DVECT_TAB_OFFSET=0x4000U
@@ -36,8 +32,6 @@ src_filter = ${env_common_stm32.src_filter} -<rx_*.cpp>
 upload_flags =
 	BOOTLOADER=bootloader/r9m_bootloader.bin
 	VECT_OFFSET=0x4000
-lib_deps =
-	https://github.com/PaoloP74/extEEPROM.git
 
 [env:Frsky_TX_R9M_via_stock_BL]
 extends = env:Frsky_TX_R9M_via_STLINK
@@ -51,7 +45,6 @@ build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_tx}
 	-D TARGET_R9M_LITE_TX
-	-D TARGET_USE_EEPROM=1
 	-D TARGET_EEPROM_ADDR=0x51
 	-D HSE_VALUE=12000000U
 	-DVECT_TAB_OFFSET=0x4000U
@@ -67,7 +60,6 @@ build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_tx}
 	-D TARGET_R9M_LITE_PRO_TX
-	-D TARGET_USE_EEPROM=1
 	-D TARGET_EEPROM_ADDR=0x51
 	-D HSE_VALUE=12000000U
 	-O2
@@ -78,8 +70,6 @@ upload_flags =
 	BOOTLOADER=bootloader/r9m_lite_pro_bootloader.bin
 	VECT_OFFSET=0x8000
 src_filter = ${env_common_stm32.src_filter} -<rx_*.cpp>
-lib_deps =
-	https://github.com/PaoloP74/extEEPROM.git
 
 
 # ********************************
@@ -94,7 +84,6 @@ build_flags =
 	${common_env_data.build_flags_rx}
 	-D TARGET_R9M_RX
 	-D TARGET_100mW_MODULE
-	-D TARGET_USE_EEPROM=1
 	-D TARGET_EEPROM_ADDR=0x50
 	-D HSE_VALUE=24000000U
 	-DVECT_TAB_OFFSET=0x08008000U
@@ -125,7 +114,6 @@ build_flags =
 board_build.ldscript = variants/R9MM/R9MM_ldscript.ld
 src_filter = ${common_env_data.src_filter} -<ESP32*.*> -<ESP8266*.*> -<WS281B*.*> -<tx_*.cpp>
 lib_deps =
-	https://github.com/PaoloP74/extEEPROM.git
 	Wire
 
 [env:Frsky_RX_R9SLIMPLUS_via_STLINK]
@@ -143,7 +131,6 @@ build_flags =
 	-D TARGET_R9M_RX
 	-D TARGET_R9SLIMPLUS_RX
 	-D TARGET_100mW_MODULE
-	-D TARGET_USE_EEPROM=1
 	-D TARGET_EEPROM_ADDR=0x50
 	-D HSE_VALUE=12000000U
 	-DVECT_TAB_OFFSET=0x8000U
@@ -168,7 +155,6 @@ build_flags =
 	-D TARGET_R9M_RX
 	-D TARGET_R9MX_RX
 	-D TARGET_100mW_MODULE
-	-D TARGET_USE_EEPROM=1
 	-D TARGET_EEPROM_ADDR=0x50
 	-DVECT_TAB_OFFSET=0x08008000U
 	-D HSI_VALUE=16000000
@@ -195,7 +181,6 @@ build_flags =
 	-D TARGET_R9M_RX
 	-D TARGET_R900MINI_RX
 	-D TARGET_100mW_MODULE
-	-D TARGET_USE_EEPROM=1
 	-D TARGET_EEPROM_ADDR=0x50
 	-D HSE_VALUE=12000000U
 	-DVECT_TAB_OFFSET=0x8000U

--- a/src/targets/happymodel_900.ini
+++ b/src/targets/happymodel_900.ini
@@ -9,7 +9,6 @@ build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_tx}
 	-D TARGET_TX_ES915TX
-	-D TARGET_USE_EEPROM=1
 	-D TARGET_EEPROM_ADDR=0x51
 	-D HSE_VALUE=12000000U
 	-DVECT_TAB_OFFSET=0x4000U
@@ -51,7 +50,6 @@ build_flags =
 	${common_env_data.build_flags_rx}
 	-D TARGET_R9M_RX
 	-D TARGET_100mW_MODULE
-	-D TARGET_USE_EEPROM=1
 	-D TARGET_EEPROM_ADDR=0x50
 	-D HSE_VALUE=24000000U
 	-DVECT_TAB_OFFSET=0x08008000U


### PR DESCRIPTION
So it looks like the PaoloP74/extEEPROM lib is a big fat flash hog.  Should we remove it and only use internal eeprom?

Below are some target examples.  This needs to be tested against all affected targets.

```
Frsky_TX_R9M_via_STLINK	                47724 -> 46912 bytes

HappyModel_TX_ES915TX_via_STLINK 	47724 -> 46912 bytes

HappyModel_RX_ES915RX_via_STLINK	44504 -> 36836 bytes
```

Targets that need testing eeprom still works as expected and settings are preserved after reboot.  I believe everything is F1 except the LITE_PRO which is F3. 

- [x] Frsky_TX_R9M_via_STLINK 
- [ ] Frsky_TX_R9M_LITE_via_STLINK
- [ ] Frsky_TX_R9M_LITE_PRO_via_STLINK
- [ ] Frsky_RX_R9MM_R9MINI_via_STLINK
- [ ] Frsky_RX_R9SLIMPLUS_via_BetaflightPassthrough
- [ ] Frsky_RX_R9MX_via_STLINK
- [ ] Jumper_RX_R900MINI_via_BetaflightPassthrough
- [ ] HappyModel_TX_ES915TX_via_STLINK
- [ ] HappyModel_RX_ES915RX_via_STLINK