### PR TITLE
Discussion - remove NO_SYNC_ON_ARM and base sync packets on LQ and tlm connection status

### DIFF
--- a/src/src/options.cpp
+++ b/src/src/options.cpp
@@ -15,9 +15,6 @@ const char PROGMEM compile_options[] = {
     #ifdef UNLOCK_HIGHER_POWER
         "-DUNLOCK_HIGHER_POWER "
     #endif
-    #ifdef NO_SYNC_ON_ARM
-        "-DNO_SYNC_ON_ARM "
-    #endif
     #ifdef FEATURE_OPENTX_SYNC
         "-DFEATURE_OPENTX_SYNC "
     #endif

--- a/src/user_defines.txt
+++ b/src/user_defines.txt
@@ -29,8 +29,6 @@
 #unlocks >250mw output power for R9M and Happy Model ES915TX (Fan mod suggested: https://github.com/AlessandroAU/ExpressLRS/wiki/R9M-Fan-Mod-Cover)
 #-DUNLOCK_HIGHER_POWER
 
-#-DNO_SYNC_ON_ARM
-
 -DFEATURE_OPENTX_SYNC
 #-DFEATURE_OPENTX_SYNC_AUTOTUNE
 


### PR DESCRIPTION
This PR proposes removal of NO_SYNC_ON_ARM and replace it with the below condition.  If the link is healthy then there is no need to send sync packets.

Thoughts on the below condition? 

```
  if ((connectionState == connected) && (LQCalc.getLQ() > 75) && (now < (LastTLMpacketRecvMillis + ExpressLRS_currAirRate_RFperfParams->SyncPktIntervalConnected)))
  {
    skipSync = true;
  }
```

