### PR TITLE
Allow esp32 to run at 240mhz

### DIFF
--- a/src/targets/betafpv_2400.ini
+++ b/src/targets/betafpv_2400.ini
@@ -4,7 +4,6 @@
 
 [env:BETAFPV_2400_TX_via_UART]
 extends = env_common_esp32
-board_build.f_cpu = 160000000L
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}

--- a/src/targets/betafpv_900.ini
+++ b/src/targets/betafpv_900.ini
@@ -4,7 +4,6 @@
 
 [env:BETAFPV_900_TX_via_UART]
 extends = env_common_esp32
-board_build.f_cpu = 160000000L
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -24,6 +24,7 @@ board = esp32dev
 upload_speed = 460800
 monitor_speed = 460800
 upload_resetmethod = nodemcu
+board_build.f_cpu = 240000000L
 build_flags =
 	-D PLATFORM_ESP32=1
 	-D CONFIG_TCPIP_LWIP=1

--- a/src/targets/diy_2400.ini
+++ b/src/targets/diy_2400.ini
@@ -5,7 +5,6 @@
 
 [env:DIY_2400_TX_ESP32_SX1280_Mini_via_UART]
 extends = env_common_esp32
-board_build.f_cpu = 160000000L
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
@@ -17,7 +16,6 @@ src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 
 [env:DIY_2400_TX_ESP32_SX1280_E28_via_UART]
 extends = env_common_esp32
-board_build.f_cpu = 160000000L
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
@@ -32,7 +30,6 @@ extends = env:DIY_2400_TX_ESP32_SX1280_E28_via_UART
 
 [env:DIY_2400_TX_ESP32_SX1280_LORA1280F27_via_UART]
 extends = env_common_esp32
-board_build.f_cpu = 160000000L
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}


### PR DESCRIPTION
Unlocks all ESP32 targets to run at the full 240MHz