### PR TITLE
Fix power output on FR Mini TX, missing 100mw

### DIFF
--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -344,7 +344,7 @@ PowerLevels_e POWERMGNT::setPower(PowerLevels_e Power)
         Radio.SetOutputPower(3);
         break;
     }
-#elif defined(TARGET_TX_FM30) || defined(TARGET_RX_FM30_MINI)
+#elif defined(TARGET_TX_FM30) || defined(TARGET_RX_FM30_MINI) || defined(TARGET_TX_FM30_MINI)
     switch (Power)
     {
     case PWR_10mW:

--- a/src/lib/POWERMGNT/POWERMGNT.h
+++ b/src/lib/POWERMGNT/POWERMGNT.h
@@ -47,7 +47,9 @@
 #define MaxPower PWR_10mW // Output is actually 14mW
 #define DefaultPowerEnum PWR_10mW
 
-#elif defined(TARGET_TX_FM30) || defined(TARGET_RX_FM30_MINI)
+#elif defined(TARGET_TX_FM30) || \
+      defined(TARGET_RX_FM30_MINI) || \
+      defined(TARGET_TX_FM30_MINI)
 #define MaxPower PWR_100mW
 #define DefaultPowerEnum PWR_50mW
 


### PR DESCRIPTION
The FR Mini RX as TX branch can output 100mW but the code currently limits it to displaying "50mW" but actually putting out 150mW at almost all power levels. This fixes me forgetting to add the power management bits back into the RX as TX branch.

This should be merged ASAP because the default code jacks the power output to +8dB at even the 10mW level, which is higher than the max specification for the PA chip used (+6dB) and people might start smoking their TXes at the current max which is +12dB.