### PR TITLE
Fix x9d Lua

### DIFF
--- a/src/lua/x9d_212x64/TELEMETRY/elrsV2.lua
+++ b/src/lua/x9d_212x64/TELEMETRY/elrsV2.lua
@@ -534,6 +534,7 @@ local function runDevicePage(event)
         elseif functions[field.type+1] then
           lcd.drawText(0, 1+8*y, field.name)
           functions[field.type+1].display(field, 1+8*y, attr)
+        end
       end
     end
   end


### PR DESCRIPTION
Added missing "end" statement
Without this the lua was not working (syntax error), the runDevicePage function for the other radios looks exactly like the one for x9d after this change.