### PR TITLE
Add 250mW option to FM30 TX

### DIFF
--- a/src/lib/POWERMGNT/POWERMGNT.h
+++ b/src/lib/POWERMGNT/POWERMGNT.h
@@ -50,7 +50,11 @@
 #elif defined(TARGET_TX_FM30) || \
       defined(TARGET_RX_FM30_MINI) || \
       defined(TARGET_TX_FM30_MINI)
+#if defined(UNLOCK_HIGHER_POWER)
+#define MaxPower PWR_250mW
+#else
 #define MaxPower PWR_100mW
+#endif
 #define DefaultPowerEnum PWR_50mW
 
 #else


### PR DESCRIPTION
This PR uses the existing `UNLOCK_HIGHER_POWER` user_define to add a 250mW mode to FM30 TX and FR Mini RX as TX targets. 

The actual power output looks to be about 200mW but quickly drops to around 175mW as the amp heats up. The specifications for the SE2431L chip used +24dBm (250mW) so this should be fine. I put it behind the define because I think with our high duty cycle it might need cooling. I've run it for several hours on the bench with no problem, but inside an enclosure in the sun I feel safer about requiring the user to unlock it. I'm fine with removing the requirement if other devs think it is ok to just let everyone have 250mW though (since this would require the Configurator to be updated to allow the unlock). The SX1280 is set to +6dBm out which is the max input specified by the SE2431L.

This should be safe because the FR Mini RX as TX code was actually setting the output higher than this and there were several people using it at the power before it was fixed.