### PR TITLE
Boost dynamic power if disconnected and armed

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -144,6 +144,11 @@ static int32_t dynamic_power_rssi_n;
 static int32_t dynamic_power_avg_lq;
 static bool dynamic_power_updated;
 
+static bool ICACHE_RAM_ATTR IsArmed()
+{
+   return CRSF_to_BIT(crsf.ChannelDataIn[AUX1]);
+}
+
 //////////// DYNAMIC TX OUTPUT POWER ////////////
 
 // Assume this function is called inside loop(). Heavy functions goes here.
@@ -154,14 +159,14 @@ void DynamicPower_Update()
   }
 
   // =============  DYNAMIC_POWER_BOOST: Switch-triggered power boost up ==============
+  // Or if telemetry is lost while armed (done up here because dynamic_power_updated is only updated on telemetry)
   uint8_t boostChannel = config.GetBoostChannel();
-  if (boostChannel > 0) {
-    // if a user selected to disable dynamic power (ch16)
-    if(CRSF_to_BIT(crsf.ChannelDataIn[AUX9 + boostChannel - 1]) == 0) {
-      POWERMGNT.setPower((PowerLevels_e)config.GetPower());
-      // POWERMGNT.setPower((PowerLevels_e)MaxPower);    // if you want to make the power to the aboslute maximum of a module, use this line.
-      return;
-    }
+  if ((connectionState == disconnected && IsArmed()) ||
+    (boostChannel && (CRSF_to_BIT(crsf.ChannelDataIn[AUX9 + boostChannel - 1]) == 0)))
+  {
+    POWERMGNT.setPower((PowerLevels_e)config.GetPower());
+    // POWERMGNT.setPower((PowerLevels_e)MaxPower);    // if you want to make the power to the aboslute maximum of a module, use this line.
+    return;
   }
 
   // if telemetry is not arrived, quick return.
@@ -217,13 +222,6 @@ void DynamicPower_Update()
   dynamic_power_rssi_sum = 0;
   dynamic_power_rssi_n = 0;
 }
-
-#if defined(NO_SYNC_ON_ARM)
-static bool ICACHE_RAM_ATTR IsArmed()
-{
-   return CRSF_to_BIT(crsf.ChannelDataIn[AUX1]);
-}
-#endif
 
 void ICACHE_RAM_ATTR ProcessTLMpacket()
 {
@@ -1186,8 +1184,8 @@ void ProcessMSPPacket(mspPacket_t *packet)
 void VtxConfigToMSPOut()
 {
   // 0 = off in the lua Band field
-  // Do not send while armed.  Replace CRSF_to_BIT with IsArmed() after PR #786 is merged
-  if (!config.GetVtxBand() || CRSF_to_BIT(crsf.ChannelDataIn[AUX1]))
+  // Do not send while armed
+  if (!config.GetVtxBand() || IsArmed())
     return;
 
   uint8_t vtxIdx = (config.GetVtxBand()-1) * 8 + config.GetVtxChannel();


### PR DESCRIPTION
This PR sets output power to configured power if we've missed a number of telemetry packets in a row and the arm channel is high.

### Details
Now that dynamic power is out and is getting some testing with the simple "telemetry is required to make any changes" system, it's time to start considering how to boost the power when there suddenly isn't telemetry. There is an obvious concern that it is easy to outfly the range of the telemetry coming back and that will lock your TX at that output power, even if it is less than configured. I think it is important that we do have some sort of facility for dealing with telemetry asymmetry in dynamic power before 1.1 release.

### The concern
What I really want to avoid is everyone setting their power to 1W + Dynamic, and leaving their TX on all the time, blasting out 1W while standing around in the pit while shooting the breeze and creating interference while they're not even plugged in. Dynamic power will lower the power when landing nearby, so that's good. If we simply key off missing telemetry packets to boost the power to max, then unplugging will boost the power fully and it will stay there until the next pack is plugged in (possibly a long time). That's why I don't strictly want to use missing telemetry as a key to know when to go to max: there's just too many times there simply isn't a receiver available at all.

### Maybe a good idea?
What I'm proposing after some Discord discussion is that we use the arm switch (AUX1) to indicate that we _should_ be receiving telemetry. That's what this small change does, if we've gone to disconnected (5x missed telemetry packets), and we're armed, go to full configured power.

Another option would be to base it off the last received RSSI, but I think that picking a threshold like 60dBm might be difficult. Some users would expect that the power would have increased but it didn't or maybe it activates even when it isn't supposed to. The arm switch method has the advantage that the user knows exactly what the expected behavior is and doesn't have to remember the magic number.

I'd definitely like to pick just one condition though to make it less complicated and understandable instead of having it become a flowchart that nobody can quite tell if it is working according to spec.

I'd like to hear other ideas for how to handle this if someone has a better idea for how we can boost power when there's no telemetry, but also does not idle at full power when someone leaves their TX running for long stretches between batteries.

### Testing
It is hard to tell if this is working or not, given that the only indicator we have for Transmit Power is telemetry to OpenTX. I tested it on my system by temporarily editing the code to keep sending telemetry to OpenTX even in the disconnected state.
```
diff --git a/src/src/tx_main.cpp b/src/src/tx_main.cpp
index f3b01fc..c65b86e 100644
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1054,7 +1054,7 @@ void loop()

   /* Send TLM updates to handset if connected + reporting period
    * is elapsed. This keeps handset happy dispite of the telemetry ratio */
-  if ((connectionState == connected) && (LastTLMpacketRecvMillis != 0) &&
+  if ((LastTLMpacketRecvMillis != 0) &&
       (now >= (uint32_t)(TLM_REPORT_INTERVAL_MS + TLMpacketReported))) {
     crsf.sendLinkStatisticsToTX();
     TLMpacketReported = now;

```