### PR TITLE
Default Dynamic Power config was not set

### DIFF
--- a/src/src/config.cpp
+++ b/src/src/config.cpp
@@ -159,6 +159,8 @@ TxConfig::SetDefaults()
         SetRate(modParams->index);
         SetTlm(modParams->TLMinterval);
         SetPower(DefaultPowerEnum);
+        SetDynamicPower(0);
+        SetBoostChannel(0);
         SetSwitchMode(1);
         SetModelMatch(false);
     }


### PR DESCRIPTION
The default values for dynamic power is not set when upgrading and so random values are in the config which causes LUA errors because of illegal values.
 
fixes issue #842 
