### PR TITLE
Remove stack allocated array initialisation

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -248,7 +248,7 @@ void ICACHE_RAM_ATTR CRSF::sendLinkStatisticsToTX()
         return;
     }
 
-    uint8_t outBuffer[LinkStatisticsFrameLength + 4] = {0};
+    uint8_t outBuffer[LinkStatisticsFrameLength + 4];
 
     outBuffer[0] = CRSF_ADDRESS_RADIO_TRANSMITTER;
     outBuffer[1] = LinkStatisticsFrameLength + 2;
@@ -280,7 +280,7 @@ void CRSF::sendELRSparam(uint8_t val[], uint8_t len, uint8_t frameType, const ch
     memcpy(val2,elrsInfo,(len2 + 1));
 
     uint8_t LUArespLength = len + 2 + (len2+1);
-    uint8_t outBuffer[LUArespLength + 5] = {0};
+    uint8_t outBuffer[LUArespLength + 5];
 
     outBuffer[0] = CRSF_ADDRESS_RADIO_TRANSMITTER;
     outBuffer[1] = LUArespLength + 2;
@@ -320,7 +320,7 @@ void CRSF::sendCRSFdevice(const void * luaData, uint8_t wholePacketSize)
     uint8_t LUArespLength;      
     LUArespLength = 2+ wholePacketSize; //2 bytes of header, name , 12 bytes of 'nonsense', 1 byte of lua field amount
     //create outbuffer size
-    uint8_t outBuffer[wholePacketSize + 5 + 2 + 2] = {0}; 
+    uint8_t outBuffer[wholePacketSize + 5 + 2 + 2]; 
     //it is byte op, we can use memcpy with index to
     // destination memory.
     struct tagLuaDevice *p1 = (struct tagLuaDevice*)luaData;
@@ -463,8 +463,8 @@ uint8_t CRSF::sendCRSFparam(crsf_frame_type_e frame,uint8_t fieldchunk, crsf_val
                                         //fieldsetup1(fieldparent,fieldtype),field name, 
                                         //fieldsetup2(value,min,max,default),field unit
     //create outbuffer size
-    uint8_t chunkBuffer[wholePacketSize] = {0};
-    uint8_t outBuffer[currentPacketSize + 5 + 2 + 2] = {0}; 
+    uint8_t chunkBuffer[wholePacketSize];
+    uint8_t outBuffer[currentPacketSize + 5 + 2 + 2]; 
         //it is byte op, we can use memcpy with index to
         // destination memory.
     switch(dataType){
@@ -640,7 +640,7 @@ void ICACHE_RAM_ATTR CRSF::sendSyncPacketToTX() // in values in us.
 
         int32_t offset = CRSF::OpenTXsyncOffset * 10 - CRSF::OpenTXsyncOffsetSafeMargin; // + 400us offset that that opentx always has some headroom
 
-        uint8_t outBuffer[OpenTXsyncFrameLength + 4] = {0};
+        uint8_t outBuffer[OpenTXsyncFrameLength + 4];
 
         outBuffer[0] = CRSF_ADDRESS_RADIO_TRANSMITTER; //0xEA
         outBuffer[1] = OpenTXsyncFrameLength + 2;      // equals 13?
@@ -778,7 +778,7 @@ void ICACHE_RAM_ATTR CRSF::AddMspMessage(mspPacket_t* packet)
     }
 
     const uint8_t totalBufferLen = ENCAPSULATED_MSP_FRAME_LEN + CRSF_FRAME_LENGTH_EXT_TYPE_CRC + CRSF_FRAME_NOT_COUNTED_BYTES;
-    uint8_t outBuffer[totalBufferLen] = {0};
+    uint8_t outBuffer[totalBufferLen];
 
     // CRSF extended frame header
     outBuffer[0] = CRSF_ADDRESS_BROADCAST;                                      // address
@@ -1120,7 +1120,7 @@ bool CRSF::RXhandleUARTout()
 
 void ICACHE_RAM_ATTR CRSF::sendLinkStatisticsToFC()
 {
-    uint8_t outBuffer[LinkStatisticsFrameLength + 4] = {0};
+    uint8_t outBuffer[LinkStatisticsFrameLength + 4];
 
     outBuffer[0] = CRSF_ADDRESS_FLIGHT_CONTROLLER;
     outBuffer[1] = LinkStatisticsFrameLength + 2;
@@ -1140,7 +1140,7 @@ void ICACHE_RAM_ATTR CRSF::sendLinkStatisticsToFC()
 
 void ICACHE_RAM_ATTR CRSF::sendRCFrameToFC()
 {
-    uint8_t outBuffer[RCframeLength + 4] = {0};
+    uint8_t outBuffer[RCframeLength + 4];
 
     outBuffer[0] = CRSF_ADDRESS_FLIGHT_CONTROLLER;
     outBuffer[1] = RCframeLength + 2;

--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -270,16 +270,13 @@ void ICACHE_RAM_ATTR CRSF::sendLinkStatisticsToTX()
 #endif
 }
 
-void CRSF::sendELRSparam(uint8_t val[], uint8_t len, uint8_t frameType, const char *elrsInfo, uint8_t len2)
+void CRSF::sendELRSparam(uint8_t val[], uint8_t len, uint8_t frameType, const char *elrsInfo)
 {
     if (!CRSF::CRSFstate)
     {
         return;
     }
-    char val2[len2+1];
-    memcpy(val2,elrsInfo,(len2 + 1));
-
-    uint8_t LUArespLength = len + 2 + (len2+1);
+    uint8_t LUArespLength = len + 2 + strlen(elrsInfo) + 1;
     uint8_t outBuffer[LUArespLength + 5];
 
     outBuffer[0] = CRSF_ADDRESS_RADIO_TRANSMITTER;
@@ -289,14 +286,8 @@ void CRSF::sendELRSparam(uint8_t val[], uint8_t len, uint8_t frameType, const ch
     outBuffer[3] = CRSF_ADDRESS_RADIO_TRANSMITTER;
     outBuffer[4] = CRSF_ADDRESS_CRSF_TRANSMITTER;
 
-    for (uint8_t i = 0; i < len; ++i)
-    {
-        outBuffer[5 + i] = val[i];
-    }
-    for (uint8_t i = 0; i < (len2+1); ++i)
-    {
-        outBuffer[5 + i + len] = val2[i];
-    }
+    memcpy(outBuffer+5, val, len);
+    strcpy((char *)outBuffer+5+len, elrsInfo);
 
     uint8_t crc = crsf_crc.calc(&outBuffer[2], LUArespLength + 1);
 

--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -257,7 +257,6 @@ void ICACHE_RAM_ATTR CRSF::sendLinkStatisticsToTX()
     memcpy(outBuffer + 3, (byte *)&LinkStatistics, LinkStatisticsFrameLength);
 
     uint8_t crc = crsf_crc.calc(&outBuffer[2], LinkStatisticsFrameLength + 1);
-
     outBuffer[LinkStatisticsFrameLength + 3] = crc;
 
 #ifdef PLATFORM_ESP32
@@ -277,7 +276,7 @@ void CRSF::sendELRSparam(uint8_t val[], uint8_t len, uint8_t frameType, const ch
         return;
     }
     uint8_t LUArespLength = len + 2 + strlen(elrsInfo) + 1;
-    uint8_t outBuffer[LUArespLength + 5];
+    uint8_t outBuffer[LUArespLength + 4];
 
     outBuffer[0] = CRSF_ADDRESS_RADIO_TRANSMITTER;
     outBuffer[1] = LUArespLength + 2;
@@ -290,7 +289,6 @@ void CRSF::sendELRSparam(uint8_t val[], uint8_t len, uint8_t frameType, const ch
     strcpy((char *)outBuffer+5+len, elrsInfo);
 
     uint8_t crc = crsf_crc.calc(&outBuffer[2], LUArespLength + 1);
-
     outBuffer[LUArespLength + 3] = crc;
 
 #ifdef PLATFORM_ESP32
@@ -309,20 +307,22 @@ void CRSF::sendCRSFdevice(const void * luaData, uint8_t wholePacketSize)
         return;
     }
     uint8_t LUArespLength;      
-    LUArespLength = 2+ wholePacketSize; //2 bytes of header, name , 12 bytes of 'nonsense', 1 byte of lua field amount
+    LUArespLength = 2 + wholePacketSize; //2 bytes of header, name , 12 bytes of 'nonsense', 1 byte of lua field amount
     //create outbuffer size
-    uint8_t outBuffer[wholePacketSize + 5 + 2 + 2]; 
+    uint8_t outBuffer[LUArespLength + 4]; 
     //it is byte op, we can use memcpy with index to
     // destination memory.
-    struct tagLuaDevice *p1 = (struct tagLuaDevice*)luaData;
-    memcpy(outBuffer+5,p1->label1,strlen(p1->label1)+1);
-    memcpy(outBuffer+5+(strlen(p1->label1)+1),&p1->luaDeviceProperties,sizeof(p1->luaDeviceProperties));
     outBuffer[0] = CRSF_ADDRESS_RADIO_TRANSMITTER;
     outBuffer[1] = LUArespLength + 2;   //received as #data in lua
     outBuffer[2] = CRSF_FRAMETYPE_DEVICE_INFO; //received as command in lua
+ 
     // all below received as data in lua
     outBuffer[3] = CRSF_ADDRESS_RADIO_TRANSMITTER;
     outBuffer[4] = CRSF_ADDRESS_CRSF_TRANSMITTER;
+    struct tagLuaDevice *p1 = (struct tagLuaDevice*)luaData;
+    char *next = stpcpy((char *)outBuffer+5,p1->label1) + 1;
+    memcpy(next,&p1->luaDeviceProperties,sizeof(p1->luaDeviceProperties));
+
     uint8_t crc = crsf_crc.calc(&outBuffer[2], LUArespLength + 1);
     outBuffer[LUArespLength + 3] = crc;
     
@@ -343,10 +343,12 @@ uint8_t CRSF::setLuaHiddenFlag(uint8_t id, bool value){
 
 void CRSF::getLuaTextSelectionStructToArray(const void * luaStruct, uint8_t *outarray){
     struct tagLuaItem_textSelection *p1 = (struct tagLuaItem_textSelection*)luaStruct;
-    memcpy(outarray+4,p1->label1,strlen(p1->label1)+1);
-    memcpy(outarray+4+(strlen(p1->label1)+1),p1->textOption,strlen(p1->textOption)+1);
-    memcpy(outarray+4+(strlen(p1->label1)+1)+(strlen(p1->textOption)+1),&p1->luaProperties2,sizeof(p1->luaProperties2));
-    memcpy(outarray+4+(strlen(p1->label1)+1)+(strlen(p1->textOption)+1)+sizeof(p1->luaProperties2)+1,p1->label2,strlen(p1->label2)+1);
+    char *next = stpcpy((char *)outarray+4,p1->label1) + 1;
+    next = stpcpy(next,p1->textOption) + 1;
+    memcpy(next,&p1->luaProperties2,sizeof(p1->luaProperties2));
+    next+=sizeof(p1->luaProperties2);
+    *next++=0; // default value
+    stpcpy(next,p1->label2);
     
     outarray[0] = p1->luaProperties1.id;
     outarray[1] = 0; //chunk
@@ -358,9 +360,11 @@ void CRSF::getLuaTextSelectionStructToArray(const void * luaStruct, uint8_t *out
 
 void CRSF::getLuaCommandStructToArray(const void * luaStruct, uint8_t *outarray){
     struct tagLuaItem_command *p1 = (struct tagLuaItem_command*)luaStruct;
-    memcpy(outarray+4,p1->label1,strlen(p1->label1)+1);
-    memcpy(outarray+4+(strlen(p1->label1)+1),&p1->luaProperties2,sizeof(p1->luaProperties2));
-    memcpy(outarray+4+(strlen(p1->label1)+1)+sizeof(p1->luaProperties2),p1->label2,strlen(p1->label2)+1);
+    char *next = stpcpy((char *)outarray+4,p1->label1) + 1;
+    memcpy(next,&p1->luaProperties2,sizeof(p1->luaProperties2));
+    next+=sizeof(p1->luaProperties2);
+    *next++=0; // default value
+    stpcpy(next,p1->label2);
     
     outarray[0] = p1->luaProperties1.id;
     outarray[1] = 0; //chunk
@@ -372,9 +376,11 @@ void CRSF::getLuaCommandStructToArray(const void * luaStruct, uint8_t *outarray)
 
 void CRSF::getLuaUint8StructToArray(const void * luaStruct, uint8_t *outarray){
     struct tagLuaItem_uint8 *p1 = (struct tagLuaItem_uint8*)luaStruct;
-    memcpy(outarray+4,p1->label1,strlen(p1->label1)+1);
-    memcpy(outarray+4+(strlen(p1->label1)+1),&p1->luaProperties2,sizeof(p1->luaProperties2));
-    memcpy(outarray+4+(strlen(p1->label1)+1)+sizeof(p1->luaProperties2)+1,p1->label2,strlen(p1->label2)+1);
+    char *next = stpcpy((char *)outarray+4,p1->label1) + 1;
+    memcpy(next,&p1->luaProperties2,sizeof(p1->luaProperties2));
+    next+=sizeof(p1->luaProperties2);
+    *next++=0; // default value
+    stpcpy(next,p1->label2);
     
     outarray[0] = p1->luaProperties1.id;
     outarray[1] = 0; //chunk
@@ -386,9 +392,11 @@ void CRSF::getLuaUint8StructToArray(const void * luaStruct, uint8_t *outarray){
 
 void CRSF::getLuaUint16StructToArray(const void * luaStruct, uint8_t *outarray){
     struct tagLuaItem_uint16 *p1 = (struct tagLuaItem_uint16*)luaStruct;
-    memcpy(outarray+4,p1->label1,strlen(p1->label1)+1);
-    memcpy(outarray+4+(strlen(p1->label1)+1),&p1->luaProperties2,sizeof(p1->luaProperties2));
-    memcpy(outarray+4+(strlen(p1->label1)+1)+sizeof(p1->luaProperties2)+2,p1->label2,strlen(p1->label2)+1);
+    char *next = stpcpy((char *)outarray+4,p1->label1) + 1;
+    memcpy(next,&p1->luaProperties2,sizeof(p1->luaProperties2));
+    next+=sizeof(p1->luaProperties2);
+    *next++=0; // default value
+    stpcpy(next,p1->label2);
     
     outarray[0] = p1->luaProperties1.id;
     outarray[1] = 0; //chunk
@@ -399,11 +407,10 @@ void CRSF::getLuaUint16StructToArray(const void * luaStruct, uint8_t *outarray){
     //outarray[4+(strlen(p1->label1)+2)] = (uint8_t)luaValues[p1->luaProperties1.id];
 }
 
-
 void CRSF::getLuaStringStructToArray(const void * luaStruct, uint8_t *outarray){
     struct tagLuaItem_string *p1 = (struct tagLuaItem_string*)luaStruct;
-    memcpy(outarray+4,p1->label1,strlen(p1->label1)+1);
-    memcpy(outarray+4+(strlen(p1->label1)+1),p1->label2,strlen(p1->label2)+1);
+    char *next = stpcpy((char *)outarray+4,p1->label1) + 1;
+    stpcpy(next,p1->label2);
     outarray[0] = p1->luaProperties1.id;
     outarray[1] = 0; //chunk
     outarray[2] = p1->luaProperties1.parent; //parent
@@ -412,7 +419,7 @@ void CRSF::getLuaStringStructToArray(const void * luaStruct, uint8_t *outarray){
 }
 void CRSF::getLuaFolderStructToArray(const void * luaStruct, uint8_t *outarray){
     struct tagLuaItem_string *p1 = (struct tagLuaItem_string*)luaStruct;
-    memcpy(outarray+4,p1->label1,strlen(p1->label1)+1);
+    stpcpy((char *)outarray+4,p1->label1);
     outarray[0] = p1->luaProperties1.id;
     outarray[1] = 0; //chunk
     outarray[2] = p1->luaProperties1.parent; //parent
@@ -512,19 +519,20 @@ uint8_t CRSF::sendCRSFparam(crsf_frame_type_e frame,uint8_t fieldchunk, crsf_val
         break;
 
     }
-        memcpy(outBuffer+7,chunkBuffer+2+((fieldchunk*CHUNK_MAX_NUMBER_OF_BYTES)),currentPacketSize);
-        outBuffer[0] = CRSF_ADDRESS_RADIO_TRANSMITTER;
-        outBuffer[1] = LUArespLength + 2;   //received as #data in lua
-        outBuffer[2] = frame; //received as command in lua
-        // all below received as data in lua
-        outBuffer[3] = CRSF_ADDRESS_RADIO_TRANSMITTER;
-        outBuffer[4] = CRSF_ADDRESS_CRSF_TRANSMITTER;
+    outBuffer[0] = CRSF_ADDRESS_RADIO_TRANSMITTER;
+    outBuffer[1] = LUArespLength + 2;   //received as #data in lua
+    outBuffer[2] = frame; //received as command in lua
+    // all below received as data in lua
+    outBuffer[3] = CRSF_ADDRESS_RADIO_TRANSMITTER;
+    outBuffer[4] = CRSF_ADDRESS_CRSF_TRANSMITTER;
 
-        outBuffer[5] = chunkBuffer[0];
-        outBuffer[6] = ((chunks - (fieldchunk+1))); //remaining chunk to send;
+    outBuffer[5] = chunkBuffer[0];
+    outBuffer[6] = ((chunks - (fieldchunk+1))); //remaining chunk to send;
 
-        uint8_t crc = crsf_crc.calc(&outBuffer[2], LUArespLength + 1);
-        outBuffer[LUArespLength + 3] = crc;
+    memcpy(outBuffer+7,chunkBuffer+2+((fieldchunk*CHUNK_MAX_NUMBER_OF_BYTES)),currentPacketSize);
+
+    uint8_t crc = crsf_crc.calc(&outBuffer[2], LUArespLength + 1);
+    outBuffer[LUArespLength + 3] = crc;
     
 #ifdef PLATFORM_ESP32
     portENTER_CRITICAL(&FIFOmux);

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -83,7 +83,7 @@ public:
     void ICACHE_RAM_ATTR sendLinkStatisticsToTX();
     void ICACHE_RAM_ATTR sendTelemetryToTX(uint8_t *data);
 
-    void sendELRSparam(uint8_t val[], uint8_t len, uint8_t frameType, const char *elrsInfo, uint8_t len2);
+    void sendELRSparam(uint8_t val[], uint8_t len, uint8_t frameType, const char *elrsInfo);
     uint8_t sendCRSFparam(crsf_frame_type_e frame,uint8_t fieldchunk, crsf_value_type_e dataType, const void * luaData, uint8_t wholePacketSize);
     void sendCRSFdevice(const void * luaData, uint8_t wholePacketSize);
 

--- a/src/lib/LUA/lua.cpp
+++ b/src/lib/LUA/lua.cpp
@@ -85,7 +85,7 @@ void sendELRSstatus()
                          (uint8_t)(crsf.GoodPktsCountResult & 0xFF),
                          (uint8_t)(getLuaWarning())};
 
-  crsf.sendELRSparam(luaParams,4, 0x2E, getLuaWarning() ? "beta" : " ", 4); //*elrsinfo is the info that we want to pass when there is getluawarning()
+  crsf.sendELRSparam(luaParams,4, 0x2E, getLuaWarning() ? "beta" : " "); //*elrsinfo is the info that we want to pass when there is getluawarning()
 }
 
 void ICACHE_RAM_ATTR luaParamUpdateReq()

--- a/src/src/ESP32_BLE_HID.h
+++ b/src/src/ESP32_BLE_HID.h
@@ -38,9 +38,9 @@ void BluetoothJoystickUpdateValues()
 {
     if (bleGamepad.isConnected())
     {
-        int16_t data[sizeof(crsf.ChannelDataIn)] = {0};
+        int16_t data[8];
 
-        for (uint8_t i = 0; i < 9; i++)
+        for (uint8_t i = 0; i < 8; i++)
         {
             data[i] = map(crsf.ChannelDataIn[i], CRSF_CHANNEL_VALUE_MIN - 1, CRSF_CHANNEL_VALUE_MAX + 1, -32768, 32768);
         }

--- a/src/src/ESP32_BLE_HID.h
+++ b/src/src/ESP32_BLE_HID.h
@@ -4,6 +4,7 @@
 
 #include "targets.h"
 #include <BleGamepad.h>
+#include "logging.h"
 
 #include "CRSF.h"
 extern CRSF crsf;
@@ -28,8 +29,8 @@ BleGamepad bleGamepad("ExpressLRS Joystick", "ELRS", 100);
 
 void BluetoothJoystickBegin()
 {
+    DBGLN("Starting BLE Joystick!");
     bleGamepad.setAutoReport(false);
-    Serial.println("Starting BLE Joystick!");
     bleGamepad.setControllerType(CONTROLLER_TYPE_GAMEPAD);
     bleGamepad.begin(numOfButtons, numOfHatSwitches, enableX, enableY, enableZ, enableRZ, enableRX, enableRY, enableSlider1, enableSlider2, enableRudder, enableThrottle, enableAccelerator, enableBrake, enableSteering);
 }


### PR DESCRIPTION
So I found some more flash bytes just laying around!

In CRSF.cpp we were needlessly filling the stack allocated buffers with zero (by assigning them `= {0}`) and then putting the data into them for sending out the UART. By removing the `= {0}` we save some flash and time too.

Also, using memcpy/strcpy `sendELRSparam` function is smaller than a for loop. Also the only place it was used passed a wrong (hard-coded) length, so I changed function to do a strcpy on the string passed in and removed the length parameter.

## Before, on R9M TX
RAM:   [==        ]  23.9% (used 4892 bytes from 20480 bytes)
Flash: [=======   ]  72.6% (used 47584 bytes from 65536 bytes)

## After
RAM:   [==        ]  23.9% (used 4892 bytes from 20480 bytes)
Flash: [=======   ]  72.3% (used 47328 bytes from 65536 bytes)

A whopping 256 bytes saved!
