### PR TITLE
Simplify setting RX model match

### DIFF
--- a/src/src/luaParams.cpp
+++ b/src/src/luaParams.cpp
@@ -69,13 +69,6 @@ struct tagLuaItem_textSelection luaModelMatch = {
     emptySpace,
     LUA_TEXTSELECTION_SIZE(luaModelMatch)
 };
-struct tagLuaItem_uint8 luaSetRXModel = {
-    {6,0,(uint8_t)CRSF_UINT8},//id,type
-    "Set RX Model",
-    {0,0,63},//value,min,max
-    emptySpace,
-    LUA_UINT8_SIZE(luaSetRXModel)
-};
 struct tagLuaItem_command luaBind = {
     {0,0,(uint8_t)CRSF_COMMAND},//id,type
     "Bind",

--- a/src/src/luaParams.h
+++ b/src/src/luaParams.h
@@ -7,7 +7,6 @@ extern struct tagLuaItem_textSelection luaTlmRate;
 // Commented out for now until we add more switch options
 // extern struct tagLuaItem_textSelection luaSwitch;
 extern struct tagLuaItem_textSelection luaModelMatch;
-extern struct tagLuaItem_uint8 luaSetRXModel;
 extern struct tagLuaItem_command luaBind;
 extern struct tagLuaItem_string luaInfo;
 extern struct tagLuaItem_string luaELRSversion;

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -543,19 +543,19 @@ void registerLuaParameters() {
   // });
   registerLUAParameter(&luaModelMatch, [](uint8_t id, uint8_t arg){
     bool newModelMatch = crsf.ParameterUpdateData[2] & 0b1;
+#ifndef DEBUG_SUPPRESS
     DBGLN("Request Model Match: %d", newModelMatch);
+#endif
     config.SetModelMatch(newModelMatch);
-  });
-  registerLUAParameter(&luaSetRXModel, [](uint8_t id, uint8_t arg){
-    uint8_t rxModel = crsf.ParameterUpdateData[2];
-    DBGLN("Request Set RX Model: %d", rxModel);
-    mspPacket_t msp;
-    msp.reset();
-    msp.makeCommand();
-    msp.function = MSP_SET_RX_CONFIG;
-    msp.addByte(MSP_ELRS_MODEL_ID);
-    msp.addByte(rxModel);
-    crsf.AddMspMessage(&msp);
+    if (connectionState == connected) {
+      mspPacket_t msp;
+      msp.reset();
+      msp.makeCommand();
+      msp.function = MSP_SET_RX_CONFIG;
+      msp.addByte(MSP_ELRS_MODEL_ID);
+      msp.addByte(newModelMatch ? crsf.getModelID() : 0);
+      crsf.AddMspMessage(&msp);
+    }
   });
   registerLUAParameter(&luaPowerFolder);
   registerLUAParameter(&luaPower, [](uint8_t id, uint8_t arg){
@@ -671,13 +671,13 @@ void registerLuaParameters() {
   registerLUAParameter(&luaELRSversion);
 }
 
+static char modelNumStr[10];
 void resetLuaParams(){
   setLuaTextSelectionValue(&luaAirRate,(uint8_t)config.GetRate());
   setLuaTextSelectionValue(&luaTlmRate,(uint8_t)config.GetTlm());
   // Commented out for now until we add more switch options
   //setLuaTextSelectionValue(&luaSwitch,(uint8_t)(config.GetSwitchMode()));
   setLuaTextSelectionValue(&luaModelMatch,(uint8_t)config.GetModelMatch());
-  setLuaUint8Value(&luaSetRXModel,(uint8_t)0);
 
   setLuaTextSelectionValue(&luaPower,(uint8_t)(config.GetPower()));
 


### PR DESCRIPTION
When you enable model match and are connected to an RX the RX stores the model number and reboots, the TX starts sending RF with the model match enabled and the RX and TX should reconnect.

To remove model matching, connect to the model matched RX and disable model match in the LUA, the RX will disable model matching off and reboot, the TX starts sending RF with model match disabled and the RX and TX should connect again.