### PR TITLE
Sync modelid switch while not transmitting, fix FHSS debug on startup

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -141,9 +141,9 @@ void CRSF::Begin()
 #endif
     DBGLN("STM32 CRSF UART LISTEN TASK STARTED");
     CRSF::Port.flush();
+    flush_port_input();
 #endif
 
-    flush_port_input();
 #endif // CRSF_TX_MODULE
 
     //The master module requires that the serial communication is bidirectional
@@ -1031,7 +1031,6 @@ void ICACHE_RAM_ATTR CRSF::ESP32uartTask(void *pvParameters)
                      GPIO_PIN_RCSIGNAL_RX, GPIO_PIN_RCSIGNAL_TX,
                      false, 500);
     CRSF::duplex_set_RX();
-    vTaskDelay(500);
     flush_port_input();
     (void)pvParameters;
     for (;;)

--- a/src/lib/FHSS/FHSS.cpp
+++ b/src/lib/FHSS/FHSS.cpp
@@ -279,10 +279,10 @@ void FHSSrandomiseFHSSsequence(const uint32_t seed)
 #error No regulatory domain defined, please define one in common.h
 #endif
 
-    DBGLN("Number of FHSS frequencies = %d", FHSS_SEQUENCE_CNT);
+    DBGLN("Number of FHSS frequencies = %u", FHSS_FREQ_CNT);
 
     sync_channel = FHSS_FREQ_CNT / 2;
-    DBGLN("Sync channel = %d", sync_channel);
+    DBGLN("Sync channel = %u", sync_channel);
 
     // reset the pointer (otherwise the tests fail)
     FHSSptr = 0;
@@ -300,10 +300,12 @@ void FHSSrandomiseFHSSsequence(const uint32_t seed)
         }
     }
 
-    for (uint8_t i=0; i < FHSS_SEQUENCE_CNT; i++) {
-
-        if (i % FHSS_FREQ_CNT != 0) { // if it's not the sync channel
-            uint8_t offset = (i / FHSS_FREQ_CNT)*FHSS_FREQ_CNT; // offset to start of current block
+    for (uint8_t i=0; i < FHSS_SEQUENCE_CNT; i++)
+    {
+        // if it's not the sync channel
+        if (i % FHSS_FREQ_CNT != 0)
+        {
+            uint8_t offset = (i / FHSS_FREQ_CNT) * FHSS_FREQ_CNT; // offset to start of current block
             uint8_t rand = rngN(FHSS_FREQ_CNT-1)+1; // random number between 1 and FHSS_FREQ_CNT
 
             // switch this entry and another random entry in the same block
@@ -311,19 +313,19 @@ void FHSSrandomiseFHSSsequence(const uint32_t seed)
             FHSSsequence[i] = FHSSsequence[offset+rand];
             FHSSsequence[offset+rand] = temp;
         }
-
-        // output FHSS sequence
-        DBG("%d ",FHSSsequence[i]);
-        if (i % 10 == 9)
-        {
-            DBGCR;
-        }
     }
 
+    // output FHSS sequence
+    for (uint8_t i=0; i < FHSS_SEQUENCE_CNT; i++)
+    {
+        DBG("%u ",FHSSsequence[i]);
+        if (i % 10 == 9)
+            DBGCR;
+    }
     DBGCR;
 }
 
-uint32_t FHSSNumEntries(void)
+uint32_t FHSSgetChannelCount(void)
 {
     return FHSS_FREQ_CNT;
 }

--- a/src/lib/FHSS/FHSS.h
+++ b/src/lib/FHSS/FHSS.h
@@ -41,17 +41,7 @@ extern const uint8_t FHSS_SEQUENCE_CNT;
 // create and randomise an FHSS sequence
 void FHSSrandomiseFHSSsequence(uint32_t seed);
 // The number of frequencies for this regulatory domain
-uint32_t FHSSNumEntries(void);
-
-static inline void FHSSsetCurrIndex(const uint8_t value)
-{   // set the current index of the FHSS pointer
-    FHSSptr = value % FHSS_SEQUENCE_CNT;
-}
-
-static inline uint8_t FHSSgetCurrIndex()
-{ // get the current index of the FHSS pointer
-    return FHSSptr;
-}
+uint32_t FHSSgetChannelCount(void);
 
 // get the initial frequency, which is also the sync channel
 static inline uint32_t GetInitialFreq()
@@ -59,16 +49,28 @@ static inline uint32_t GetInitialFreq()
     return FHSSfreqs[sync_channel] - FreqCorrection;
 }
 
-// get the next frequency in the sequence
+// Get the current sequence pointer
+static inline uint8_t FHSSgetCurrIndex()
+{
+    return FHSSptr;
+}
+
+// Set the sequence pointer, used by RX on SYNC
+static inline void FHSSsetCurrIndex(const uint8_t value)
+{
+    FHSSptr = value % FHSS_SEQUENCE_CNT;
+}
+
+// Advance the pointer to the next hop and return the frequency of that channel
 static inline uint32_t FHSSgetNextFreq()
 {
-    uint32_t freq = FHSSfreqs[FHSSsequence[FHSSptr]] - FreqCorrection;
     FHSSptr = (FHSSptr + 1) % FHSS_SEQUENCE_CNT;
+    uint32_t freq = FHSSfreqs[FHSSsequence[FHSSptr]] - FreqCorrection;
     return freq;
 }
 
 // get the number of entries in the FHSS sequence
-static inline uint8_t FHSSgetNumberOfEntries()
+static inline uint8_t FHSSgetSequenceCount()
 {
     return FHSS_SEQUENCE_CNT;
 }

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -464,10 +464,10 @@ void ICACHE_RAM_ATTR SX127xDriver::ClearIRQFlags()
 
 // int16_t MeasureNoiseFloor() TODO disabled for now
 // {
-//     int NUM_READS = RSSI_FLOOR_NUM_READS * FHSSNumEntries();
+//     int NUM_READS = RSSI_FLOOR_NUM_READS * FHSSgetChannelCount();
 //     float returnval = 0;
 
-//     for (uint32_t freq = 0; freq < FHSSNumEntries(); freq++)
+//     for (uint32_t freq = 0; freq < FHSSgetChannelCount(); freq++)
 //     {
 //         FHSSsetCurrIndex(freq);
 //         Radio.SetMode(SX127X_CAD);

--- a/src/src/config.h
+++ b/src/src/config.h
@@ -35,6 +35,7 @@ typedef struct {
 class TxConfig
 {
 public:
+    TxConfig() { SetModelId(0); }
     void Load();
     void Commit();
 

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -197,7 +197,7 @@ static uint8_t minLqForChaos()
     // FHSShopInterval * ceil(100 / FHSShopInterval * numfhss) or
     // FHSShopInterval * trunc((100 + (FHSShopInterval * numfhss) - 1) / (FHSShopInterval * numfhss))
     // With a interval of 4 this works out to: 2.4=4, FCC915=4, AU915=8, EU868=8, EU/AU433=36
-    const uint32_t numfhss = FHSSNumEntries();
+    const uint32_t numfhss = FHSSgetChannelCount();
     const uint8_t interval = ExpressLRS_currAirRate_Modparams->FHSShopInterval;
     return interval * ((interval * numfhss + 99) / (interval * numfhss));
 }
@@ -252,7 +252,7 @@ void SetRFLinkRate(uint8_t index) // Set speed of RF link
     Radio.Config(ModParams->bw, ModParams->sf, ModParams->cr, GetInitialFreq(), ModParams->PreambleLen, invertIQ, ModParams->PayloadLength);
 
     // Wait for (11/10) 110% of time it takes to cycle through all freqs in FHSS table (in ms)
-    cycleInterval = ((uint32_t)11U * FHSSNumEntries() * ModParams->FHSShopInterval * ModParams->interval) / (10U * 1000U);
+    cycleInterval = ((uint32_t)11U * FHSSgetChannelCount() * ModParams->FHSShopInterval * ModParams->interval) / (10U * 1000U);
 
     ExpressLRS_currAirRate_Modparams = ModParams;
     ExpressLRS_currAirRate_RFperfParams = RFperf;
@@ -746,7 +746,7 @@ void ICACHE_RAM_ATTR ProcessRFPacket()
                 || NonceRX != Radio.RXdataBuffer[2]
                 || FHSSgetCurrIndex() != Radio.RXdataBuffer[1])
              {
-                 //DBGVLN("%dx%d", NonceRX, Radio.RXdataBuffer[2]);
+                 //DBGLN("\r\n%ux%ux%u", NonceRX, Radio.RXdataBuffer[2], Radio.RXdataBuffer[1]);
                  FHSSsetCurrIndex(Radio.RXdataBuffer[1]);
                  NonceRX = Radio.RXdataBuffer[2];
                  TentativeConnection(now);

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1169,7 +1169,7 @@ void loop()
         LostConnection();
         LastSyncPacket = now;           // reset this variable to stop rf mode switching and add extra time
         RFmodeLastCycled = now;         // reset this variable to stop rf mode switching and add extra time
-        DBGLN("Air rate change req via sync");
+        DBGLN("Req air rate change %u->%u", ExpressLRS_currAirRate_Modparams->index, ExpressLRS_nextAirRateIndex);
         crsf.sendLinkStatisticsToFC();
         crsf.sendLinkStatisticsToFC(); // need to send twice, not sure why, seems like a BF bug?
     }

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -716,7 +716,6 @@ void UARTconnected()
 static void ChangeRadioParams()
 {
   ModelUpdatePending = false;
-  config.SetModelId(crsf.getModelID());
 
   SetRFLinkRate(config.GetRate());
   POWERMGNT.setPower((PowerLevels_e)config.GetPower());
@@ -736,6 +735,11 @@ void HandleUpdateParameter()
 
 void ICACHE_RAM_ATTR ModelUpdateReq()
 {
+  // There's a near 100% chance we started up transmitting at Model 0's
+  // rate before we got the set modelid command from the handset, so do
+  // the normal way of switching rates with syncspam first
+  config.SetModelId(crsf.getModelID());
+  syncSpamCounter = syncSpamAmount;
   ModelUpdatePending = true;
 }
 

--- a/src/test/fhss_native/test_fhss.cpp
+++ b/src/test/fhss_native/test_fhss.cpp
@@ -3,21 +3,27 @@
 #include <unity.h>
 #include <set>
 
+void test_fhss_first(void)
+{
+    FHSSrandomiseFHSSsequence(0x01020304L);
+    TEST_ASSERT_EQUAL(GetInitialFreq(), FHSSfreqs[sync_channel]);
+}
+
 void test_fhss_assignment(void)
 {
     FHSSrandomiseFHSSsequence(0x01020304L);
 
-    const uint32_t numFhss = FHSSNumEntries();
+    const uint32_t numFhss = FHSSgetChannelCount();
     uint32_t initFreq = GetInitialFreq();
 
-    for (unsigned int i = 0; i < 256; i++) {
-        uint32_t freq = FHSSgetNextFreq();
-
+    uint32_t freq = initFreq;
+    for (unsigned int i = 0; i < 512; i++) {
         if ((i % numFhss) == 0) {
             TEST_ASSERT_EQUAL(initFreq, freq);
         } else {
             TEST_ASSERT_NOT_EQUAL(initFreq, freq);
         }
+        freq = FHSSgetNextFreq();
     }
 }
 
@@ -25,7 +31,7 @@ void test_fhss_unique(void)
 {
     FHSSrandomiseFHSSsequence(0x01020304L);
 
-    const uint32_t numFhss = FHSSNumEntries();
+    const uint32_t numFhss = FHSSgetChannelCount();
     std::set<uint32_t> freqs;
 
     for (unsigned int i = 0; i < 256; i++) {
@@ -45,18 +51,18 @@ void test_fhss_same(void)
 {
     FHSSrandomiseFHSSsequence(0x01020304L);
 
-    const uint32_t numFhss = FHSSgetNumberOfEntries();
+    const uint32_t numFhss = FHSSgetSequenceCount();
 
     uint32_t fhss[numFhss];
 
-    for (unsigned int i = 0; i < FHSSgetNumberOfEntries(); i++) {
+    for (unsigned int i = 0; i < FHSSgetSequenceCount(); i++) {
         uint32_t freq = FHSSgetNextFreq();
         fhss[i] = freq;
     }
 
     FHSSrandomiseFHSSsequence(0x01020304L);
 
-    for (unsigned int i = 0; i < FHSSgetNumberOfEntries(); i++) {
+    for (unsigned int i = 0; i < FHSSgetSequenceCount(); i++) {
         uint32_t freq = FHSSgetNextFreq();
         TEST_ASSERT_EQUAL(fhss[i],freq);
     }
@@ -65,6 +71,7 @@ void test_fhss_same(void)
 int main(int argc, char **argv)
 {
     UNITY_BEGIN();
+    RUN_TEST(test_fhss_first);
     RUN_TEST(test_fhss_assignment);
     RUN_TEST(test_fhss_unique);
     RUN_TEST(test_fhss_same);


### PR DESCRIPTION
This PR addresses a TX soft lockup that occurs on startup when ModelID is not 0 and the per-model config was different from 0. Also it fixes the incorrect debug spam printed by the FHSS generator.

I know! They're unrelated. But I did spend a long time thinking we had a FHSS problem that we did not. There are two separate commits that should make review easy.

### Setting ModelID
The existing code would jump right to `ChangeRadioParams()` the first loop after the modelid was set. If the TX was mid-transmit, at least some of the Radio changes would not complete and the whole system would stop transmitting by around Nonce 3 to 5 since it was waiting for a TX complete ISR that would never come. To address this, I've changed it to use the same procedure as the EEPROM write:
* Syncspam the new config
* Wait for packet TX to complete
* Swap the ISR
* Change the Radio params to the new configuration
* Swap the ISR back in

I did not see this soft lock on Team2.4, but I am wondering if maybe the BUSY pin there saved us from changing the radio params during a transmit?

There also was two delays in startup of 500ms in the UART read task and 200ms in the connect handler that are unnecessary. The former I'm not sure what it is there for. The latter should have been removed when the big lua conversion came since it was originally there for a delay between sending our initial linkstatistics. That code is gone but the delay remained

### FHSS Prints
The FHSS randomizer was printing the hop table as it was generating it. Problem is that it is still swapping elements that is has already printed. I've moved the print to the end of the function and it is optimized away if DEBUG_LOG is off. It was also printing the wrong number of frequencies at the top due to our naming being a little too vague.

I've cleaned up the function names a little more to make their function more clear. 
* FHSSNumEntries -> FHSSgetChannelCount
* FHSSgetNumberOfEntries -> FHSSgetSequenceCount (see how these could be confused?!)
* FHSSgetNextFreq used to return the current frequency pointer, which pointed to the next hop, then increment the pointer. I feel it is clearer that it used the current index and then increment the pointer. This way the current index returned by FHSSgetCurrIndex actually is the current index and it makes it a lot less confusing that "current" is actually the next.
