### PR TITLE
Phase Lock Updates

### DIFF
--- a/src/lib/PFD/PFD.h
+++ b/src/lib/PFD/PFD.h
@@ -8,7 +8,6 @@ class PFD
 private:
     uint32_t intEventTime = 0;
     uint32_t extEventTime = 0;
-    int32_t result;
     bool gotExtEvent;
     bool gotIntEvent;
 
@@ -31,19 +30,15 @@ public:
         gotIntEvent = false;
     }
 
-    inline void calcResult()
-    {
-        result = (gotExtEvent && gotIntEvent) ? (int32_t)(extEventTime - intEventTime) : 0;
-    }
-
     inline bool resultValid()
     {
         return gotExtEvent && gotIntEvent;
     }
     
+    // Check resultValid() before using getResult() return value
     inline int32_t getResult()
     {
-        return result;
+        return (int32_t)(extEventTime - intEventTime);
     }
 
     volatile uint32_t getIntEventTime() const { return intEventTime; }

--- a/src/lib/PFD/PFD.h
+++ b/src/lib/PFD/PFD.h
@@ -36,6 +36,11 @@ public:
         result = (gotExtEvent && gotIntEvent) ? (int32_t)(extEventTime - intEventTime) : 0;
     }
 
+    inline bool resultValid()
+    {
+        return gotExtEvent && gotIntEvent;
+    }
+    
     inline int32_t getResult()
     {
         return result;

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -625,7 +625,7 @@ void ICACHE_RAM_ATTR TentativeConnection(unsigned long now) // called when a syn
     LPF_Offset.init(0);
     LPF_OffsetDx.init(0);
     PhaseLockCounter = 0;
-    PFDloop.reset();
+    //PFDloop.reset(); // TEST the above resets should be enough
     RFmodeLastCycled = now; // give another 3 sec for lock to occur
 
 #if WS2812_LED_IS_USED

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1054,6 +1054,9 @@ static void setupRadio()
     Radio.RXdoneCallback = &RXdoneISR;
     Radio.TXdoneCallback = &TXdoneISR;
 
+    ExpressLRS_currAirRate_Modparams = get_elrs_airRateConfig(RATE_DEFAULT); // Initialize var: caused crash on ESP in SetRFLinkRate() where currAirRate is compared
+    ExpressLRS_currAirRate_RFperfParams = get_elrs_RFperfParams(RATE_DEFAULT); // Initialize var: caused crash on ESP in SetRFLinkRate() where currAirRate is compared
+
     SetRFLinkRate(RATE_DEFAULT);
     RFmodeCycleMultiplier = 1;
 }


### PR DESCRIPTION
This PR updates the phase lock function.

Three main elements are:
1. LPF function returned 0 when gotExtEvent or gotIntEvent were not recorded. As the PhaseLock has nothing to do with missed packets due to signal obstructions in between the TX and RX we should not use these values as they are "false" zeros. -> implemented resultValid() function.
2. The timers frequency correction was driven by the LPFed Offset variable. -> changed to the longer term OffsetDx which tracks the change in the offset over time.
3. Whenever a phase shift is done the value that is put in the OffsetDx LPF will be compensated by the ammount of phase shifting that has been done, so phase shifting will become invisible to OffsetDx.

Looking forward to your feedback!