### PR TITLE
Upgrade Arduino Platform

### DIFF
--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -33,7 +33,7 @@ lib_deps = NeoPixelBus
 
 # ------------------------- COMMON ESP82xx DEFINITIONS -----------------
 [env_common_esp82xx]
-platform = espressif8266@3.0.0
+platform = espressif8266@3.2.0
 board = esp8285
 build_flags =
 	-D PLATFORM_ESP8266=1


### PR DESCRIPTION
This seems to fix the problem that some users have been having of not being able to upgrade to 1.0.0 or 1.0.1 from RC9.