### PR TITLE
ESP32/ESP266 platform upgrades

### DIFF
--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -36,7 +36,7 @@ lib_deps =
 
 # ------------------------- COMMON ESP82xx DEFINITIONS -----------------
 [env_common_esp82xx]
-platform = espressif8266@3.0.0
+platform = espressif8266@3.2.0
 board = esp8285
 build_flags =
 	-D PLATFORM_ESP8266=1

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -19,7 +19,7 @@ build_flags_rx = -DTARGET_RX=1 ${common_env_data.build_flags}
 
 # ------------------------- COMMON ESP32 DEFINITIONS -----------------
 [env_common_esp32]
-platform = espressif32@3.2.0
+platform = espressif32@3.3.2
 board = esp32dev
 upload_speed = 460800
 monitor_speed = 460800


### PR DESCRIPTION
The ESP8266 platform upgrade fixes issue #780
I believe the ESP32 platform upgrade fixes #860. Also as part of the ESP upgrade, I protected the UART startup code in the extra task with a semaphore so the main task will wait for the UART task to initialise the UART before continuing.

This PR does not need to be back-ported as there is already a merge for the ESP266 platform upgrade and I don't think we should upgrade the ESP32 platform without a strong need in a bug fix release.