### PR TITLE
Add inverted CRSF output to ESP8266 receivers

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -862,6 +862,9 @@ static void setupSerial()
 
 #if defined(PLATFORM_ESP8266)
     Serial.begin(CRSF_RX_BAUDRATE);
+    #if defined(RCVR_INVERT_TX)
+    USC0(UART0) |= BIT(UCTXI);
+    #endif
 #endif
 
 }

--- a/src/user_defines.txt
+++ b/src/user_defines.txt
@@ -38,8 +38,17 @@
 
 ### COMPATIBILITY OPTIONS: ###
 
+# Invert the TX/RX half-duplex pin in the transmitter code. Handset external
+# modules are almost all inverted. ESP32 targets only
 -DUART_INVERTED
 
+# Invert the TX pin in the receiver code to allow an inverted RX pin on the
+# FC to be used (usually labeled SBUS input or RX1I). Inverted CRSF output.
+# RX pin (telemetry) is unaffected. ESP8266/8285 targets only
+#-DRCVR_INVERT_TX
+
+# Use the SBUS **pin** on R9MM receiver hardware, which is inverted.
+# Does not output SBUS protocol, just inverted CRSF.
 #-DUSE_R9MM_R9MINI_SBUS
 
 #-DTLM_REPORT_INTERVAL_MS=320LU

--- a/src/user_defines.txt
+++ b/src/user_defines.txt
@@ -43,8 +43,9 @@
 -DUART_INVERTED
 
 # Invert the TX pin in the receiver code to allow an inverted RX pin on the
-# FC to be used (usually labeled SBUS input or RX1I). Inverted CRSF output.
-# RX pin (telemetry) is unaffected. ESP8266/8285 targets only
+# FC to be used (usually labeled SBUS input or RXI). Inverted CRSF output.
+# RX pin (telemetry) is unaffected. Update via_BetaflightPassthrough will 
+# not work, only via_Wifi. ESP8266/8285 targets only
 #-DRCVR_INVERT_TX
 
 # Use the SBUS **pin** on R9MM receiver hardware, which is inverted.


### PR DESCRIPTION
This PR adds the define RCVR_INVERT_TX, which inverts the UART output pin on ESP8266/8285 target receivers.

## Details
Many flight controllers, particularly AIO FCs, only have an RXI pad for connecting an external SBUS receiver. This pad is inverted and can't take our CRSF output at all, leading to many users asking for "SBUS output support" in ExpressLRS since there is no uninverted RX pad exposed on the FC. However, this request isn't quite accurate, because all that's wanted is to be able to connect an ELRS RX to these FCs. We can meet this requirement easily without having to implement SBUS protocol, just using inverted CRSF output. This is similar to the `UART_INVERTED` define for transmitter modules, which allows for handsets that are inverted or regular (**the way they all should be**).

This simple define just flips the polarity of the UART signal on the receiver's TX pin **only**. The RX pin is left uninverted, since all of these FCs have their TX output pin uninverted as well. This allows a full ELRS bidirectional interface on these goofy-footed FrSky-loving fight controllers.

The ESP seems to react just fine to just directly toggling of the `UCTXI` without restarting any of the interrupts or anything. It is pretty amazing and works on every test boot I've performed. I also added some comments to a couple other user_defines to make them a little less opaque to anyone reading the source.

## Compromises
* via_Betaflight update method will not work. The ESP ROM bootloader does not support inverted UART operation so it just can't work. Someone could update the stub bootloader code to support inverting the output but gosh where did your life go wrong that that's what you want to do with your time? We have via_Wifi updating and that works just fine.
* No SBUS output still from ELRS 😭 oh no, you mean we still don't support a ~100Hz max update rate, slow transfer speed protocol? SAD!

### Tested
Using EP2 RX + Omnibus F4 Pro V3 flight controller with the solder jumper set to SBUS and a SIYI FM30 TX. Tested both in single pin mode (only our TX pin connected to SBUS pad) and bidirectional mode.  500Hz and 250Hz. VTX Administrator changes also work, but we seem to have a "bug" in that at 500Hz the connection is established so quickly on power up that the MSP packet isn't received by the FC since it isn't up and running yet.