### PR TITLE
Perform more complete RF shutdown when entering WebUpdate mode

### DIFF
--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -57,6 +57,7 @@ bool SX127xDriver::Begin()
 
 void SX127xDriver::End()
 {
+  instance->SetMode(SX127x_OPMODE_SLEEP);
   hal.end();
   instance->TXdoneCallback = &nullCallback; // remove callbacks
   instance->RXdoneCallback = &nullCallback;

--- a/src/lib/SX127xDriver/SX127xHal.cpp
+++ b/src/lib/SX127xDriver/SX127xHal.cpp
@@ -18,6 +18,7 @@ SX127xHal::SX127xHal()
 
 void SX127xHal::end()
 {
+  RXenable(); // make sure the TX amp pin is disabled
   SPI.end();
   detachInterrupt(GPIO_PIN_DIO0);
 }

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -41,6 +41,7 @@ SX1280Driver::SX1280Driver()
 
 void SX1280Driver::End()
 {
+    instance->SetMode(SX1280_MODE_SLEEP);
     hal.end();
     instance->TXdoneCallback = &nullCallback; // remove callbacks
     instance->RXdoneCallback = &nullCallback;

--- a/src/lib/SX1280Driver/SX1280_hal.cpp
+++ b/src/lib/SX1280Driver/SX1280_hal.cpp
@@ -36,6 +36,7 @@ SX1280Hal::SX1280Hal()
 
 void SX1280Hal::end()
 {
+    RXenable(); // make sure the TX amp pin is disabled
     SPI.end();
     detachInterrupt(GPIO_PIN_DIO1);
 }

--- a/src/src/ESP32_WebUpdate.cpp
+++ b/src/src/ESP32_WebUpdate.cpp
@@ -21,9 +21,6 @@ extern SX127xDriver Radio;
 extern SX1280Driver Radio;
 #endif
 
-#include "ESP32_hwTimer.h"
-extern hwTimer hwTimer;
-
 #include "CRSF.h"
 extern CRSF crsf;
 
@@ -273,7 +270,6 @@ static void startWifi() {
 void BeginWebUpdate()
 {
     DBGLN("Stopping Radio");
-    hwTimer.stop();
     Radio.End();
     crsf.End();
 

--- a/src/src/ESP32_WebUpdate.cpp
+++ b/src/src/ESP32_WebUpdate.cpp
@@ -56,6 +56,8 @@ static IPAddress netMsk(255, 255, 255, 0);
 static DNSServer dnsServer;
 static WebServer server(80);
 
+bool IsWebUpdateMode = false;
+
 /** Is this an IP? */
 static boolean isIp(String str)
 {
@@ -269,6 +271,8 @@ static void startWifi() {
 
 void BeginWebUpdate()
 {
+    IsWebUpdateMode = true;
+
     DBGLN("Stopping Radio");
     Radio.End();
     crsf.End();

--- a/src/src/ESP32_WebUpdate.h
+++ b/src/src/ESP32_WebUpdate.h
@@ -1,4 +1,6 @@
 #ifdef PLATFORM_ESP32
 void HandleWebUpdate();
 void BeginWebUpdate();
+
+extern bool IsWebUpdateMode;
 #endif

--- a/src/src/ESP8266_WebUpdate.cpp
+++ b/src/src/ESP8266_WebUpdate.cpp
@@ -56,6 +56,8 @@ static ESP8266WebServer server(80);
 
 static MDNSResponder::hMDNSService service;
 
+bool IsWebUpdateMode = false;
+
 /** Is this an IP? */
 static boolean isIp(String str)
 {
@@ -275,6 +277,8 @@ static void startWifi() {
 
 void BeginWebUpdate(void)
 {
+  IsWebUpdateMode = true;
+
   DBGLN("Stopping Radio");
   Radio.End();
 

--- a/src/src/ESP8266_WebUpdate.cpp
+++ b/src/src/ESP8266_WebUpdate.cpp
@@ -23,9 +23,6 @@ extern SX127xDriver Radio;
 extern SX1280Driver Radio;
 #endif
 
-#include "ESP8266_hwTimer.h"
-extern hwTimer hwTimer;
-
 #include "config.h"
 extern RxConfig config;
 
@@ -278,11 +275,6 @@ static void startWifi() {
 
 void BeginWebUpdate(void)
 {
-  hwTimer.stop();
-
-  Radio.RXdoneCallback = NULL;
-  Radio.TXdoneCallback = NULL;
-
   DBGLN("Stopping Radio");
   Radio.End();
 

--- a/src/src/ESP8266_WebUpdate.h
+++ b/src/src/ESP8266_WebUpdate.h
@@ -3,4 +3,6 @@
 
 void BeginWebUpdate(void);
 void HandleWebUpdate(void);
+
+extern bool IsWebUpdateMode;
 #endif

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -772,10 +772,16 @@ void ICACHE_RAM_ATTR ProcessRFPacket()
         hwTimer.resume(); // will throw an interrupt immediately
 }
 
-void beginWebsever()
+static void beginWebsever()
 {
 #if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
     hwTimer.stop();
+
+    // Set transmit power to minimum
+    POWERMGNT P;
+    P.init();
+    P.setPower(MinPower);
+
     BeginWebUpdate();
     webUpdateMode = true;
 #endif

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -771,9 +771,9 @@ void ICACHE_RAM_ATTR ProcessRFPacket()
         hwTimer.resume(); // will throw an interrupt immediately
 }
 
+#if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
 static void beginWebsever()
 {
-#if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
     hwTimer.stop();
 
     // Set transmit power to minimum
@@ -782,8 +782,8 @@ static void beginWebsever()
     P.setPower(MinPower);
 
     BeginWebUpdate();
-#endif
 }
+#endif
 
 void sampleButton(unsigned long now)
 {
@@ -1073,7 +1073,11 @@ static void updateTelemetryBurst()
  */
 static void cycleRfMode(unsigned long now)
 {
-    if (connectionState == connected || InBindingMode || IsWebUpdateMode)
+#if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
+    if (IsWebUpdateMode)
+        return;
+ #endif
+    if (connectionState == connected || InBindingMode)
         return;
 
     // Actually cycle the RF mode if not LOCK_ON_FIRST_CONNECTION
@@ -1346,8 +1350,8 @@ void EnterBindingMode()
         DBGLN("Cannot enter binding mode!");
         return;
     }
-    if (IsWebUpdateMode) {
 #if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
+    if (IsWebUpdateMode) {
         wifiOff();
         IsWebUpdateMode = false;
         Radio.RXdoneCallback = &RXdoneISR;
@@ -1355,8 +1359,8 @@ void EnterBindingMode()
         Radio.Begin();
         crsf.Begin();
         hwTimer.resume();
-#endif
     }
+#endif
 
     // Set UID to special binding values
     UID[0] = BindingUID[0];

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -802,10 +802,12 @@ void sampleButton(unsigned long now)
 
     if ((now > buttonLastPressed + WEB_UPDATE_PRESS_INTERVAL) && buttonDown)
     { // button held down for WEB_UPDATE_PRESS_INTERVAL
+#if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
         if (!IsWebUpdateMode)
         {
             beginWebsever();
         }
+#endif
     }
     if ((now > buttonLastPressed + BUTTON_RESET_INTERVAL) && buttonDown)
     {

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -135,7 +135,6 @@ bool buttonDown = false;     //is the button current pressed down?
 uint32_t buttonLastSampled = 0;
 uint32_t buttonLastPressed = 0;
 
-bool webUpdateMode = false;
 bool disableWebServer = false;
 ///////////////////////////////////////////////
 
@@ -783,7 +782,6 @@ static void beginWebsever()
     P.setPower(MinPower);
 
     BeginWebUpdate();
-    webUpdateMode = true;
 #endif
 }
 
@@ -804,7 +802,7 @@ void sampleButton(unsigned long now)
 
     if ((now > buttonLastPressed + WEB_UPDATE_PRESS_INTERVAL) && buttonDown)
     { // button held down for WEB_UPDATE_PRESS_INTERVAL
-        if (!webUpdateMode)
+        if (!IsWebUpdateMode)
         {
             beginWebsever();
         }
@@ -1075,7 +1073,7 @@ static void updateTelemetryBurst()
  */
 static void cycleRfMode(unsigned long now)
 {
-    if (connectionState == connected || InBindingMode || webUpdateMode)
+    if (connectionState == connected || InBindingMode || IsWebUpdateMode)
         return;
 
     // Actually cycle the RF mode if not LOCK_ON_FIRST_CONNECTION
@@ -1154,17 +1152,17 @@ void loop()
     }
 
     #if defined(PLATFORM_ESP8266) && defined(AUTO_WIFI_ON_INTERVAL)
-    if (!disableWebServer && (connectionState == disconnected) && !webUpdateMode && !InBindingMode && now > (AUTO_WIFI_ON_INTERVAL*1000))
+    if (!disableWebServer && (connectionState == disconnected) && !IsWebUpdateMode && !InBindingMode && now > (AUTO_WIFI_ON_INTERVAL*1000))
     {
         beginWebsever();
     }
 
-    if (!disableWebServer && (connectionState == disconnected) && !webUpdateMode && InBindingMode && now > 60000)
+    if (!disableWebServer && (connectionState == disconnected) && !IsWebUpdateMode && InBindingMode && now > 60000)
     {
         beginWebsever();
     }
 
-    if (webUpdateMode)
+    if (IsWebUpdateMode)
     {
         WebUpdateLoop(now);
         return;
@@ -1348,10 +1346,10 @@ void EnterBindingMode()
         DBGLN("Cannot enter binding mode!");
         return;
     }
-    if (webUpdateMode) {
+    if (IsWebUpdateMode) {
 #if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
         wifiOff();
-        webUpdateMode = false;
+        IsWebUpdateMode = false;
         Radio.RXdoneCallback = &RXdoneISR;
         Radio.TXdoneCallback = &TXdoneISR;
         Radio.Begin();

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -72,9 +72,6 @@ char commitStr[7] = {LATEST_COMMIT , 0};
 
 volatile uint8_t NonceTX;
 
-#ifdef PLATFORM_ESP32
-bool webUpdateMode = false;
-#endif
 //// MSP Data Handling ///////
 bool NextPacketIsMspData = false;  // if true the next packet will contain the msp data
 
@@ -489,12 +486,9 @@ static void beginWebsever()
 {
 #if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
     hwTimer.stop();
-
     // Set transmit power to minimum
     POWERMGNT.setPower(MinPower);
-
     BeginWebUpdate();
-    webUpdateMode = true;
 #endif
 }
 
@@ -1006,12 +1000,12 @@ void loop()
   #if defined(AUTO_WIFI_ON_INTERVAL)
     //if webupdate was requested before or AUTO_WIFI_ON_INTERVAL has been elapsed but uart is not detected
     //start webupdate, there might be wrong configuration flashed.
-    if(crsf.hasEverConnected == false && now > (AUTO_WIFI_ON_INTERVAL * 1000) && !webUpdateMode){
+    if(crsf.hasEverConnected == false && now > (AUTO_WIFI_ON_INTERVAL * 1000) && !IsWebUpdateMode){
       DBGLN("No CRSF ever detected, starting WiFi");
       beginWebsever();
     }
   #endif
-  if (webUpdateMode)
+  if (IsWebUpdateMode)
   {
     HandleWebUpdate();
     return;

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -640,11 +640,7 @@ void registerLuaParameters() {
         crsf.setSyncParams(5000); // 100hz
         delay(1000);
         crsf.disableOpentxSync();
-  #if defined(Regulatory_Domain_ISM_2400)
-        Radio.SetMode(SX1280_MODE_SLEEP);
-  #else
-        Radio.SetMode(SX127x_OPMODE_SLEEP);
-  #endif
+        POWERMGNT.setPower(MinPower);
         Radio.End();
         BluetoothJoystickBegin();
       } else if (arg > 0 && arg < 4) //start command, 1 = start

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -485,6 +485,19 @@ void ICACHE_RAM_ATTR timerCallbackIdle()
   }
 }
 
+static void beginWebsever()
+{
+#if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
+    hwTimer.stop();
+
+    // Set transmit power to minimum
+    POWERMGNT.setPower(MinPower);
+
+    BeginWebUpdate();
+    webUpdateMode = true;
+#endif
+}
+
 void registerLuaParameters() {
   registerLUAParameter(&luaAirRate, [](uint8_t id, uint8_t arg){
     if ((arg < RATE_MAX) && (arg >= 0))
@@ -603,9 +616,8 @@ void registerLuaParameters() {
         //since ELRS LUA can do 2 step confirmation, it needs confirmation to start wifi to prevent stuck on
         //unintentional button press.
         setLuaCommandValue(&luaWebUpdate,2); //running status
-        webUpdateMode = true;
         DBGLN("Wifi Update Mode Requested!");
-        BeginWebUpdate();
+        beginWebsever();
       } else if (arg > 0 && arg < 4) //start command, 1 = start
                               //2 = running
                               //3 = request confirmation
@@ -996,8 +1008,7 @@ void loop()
     //start webupdate, there might be wrong configuration flashed.
     if(crsf.hasEverConnected == false && now > (AUTO_WIFI_ON_INTERVAL * 1000) && !webUpdateMode){
       DBGLN("No CRSF ever detected, starting WiFi");
-      webUpdateMode = true;
-      BeginWebUpdate();
+      beginWebsever();
     }
   #endif
   if (webUpdateMode)

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -482,15 +482,15 @@ void ICACHE_RAM_ATTR timerCallbackIdle()
   }
 }
 
+#if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
 static void beginWebsever()
 {
-#if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
     hwTimer.stop();
     // Set transmit power to minimum
     POWERMGNT.setPower(MinPower);
     BeginWebUpdate();
-#endif
 }
+#endif
 
 void registerLuaParameters() {
   registerLUAParameter(&luaAirRate, [](uint8_t id, uint8_t arg){


### PR DESCRIPTION
This PR makes sure that when entering WebUpdate mode the Radio is in its lowest power mode, with the PA off, and the RF chip is set to sleep mode. This is intended to reduce power usage and more importantly heat when in WebUpdate mode.

## Details
When we enter WebUpdate mode, we disconnect from the radio chip and let it keep doing whatever it is doing. Unfortunately, WebUpdate uses a lot of power and heats up receivers like the EP2 to an almost dangerous level (85C+), so it makes sense to make sure everything else is forced into the lowest power mode possible.  I've went through and disabled as much as possible before entering this mode:
* Set any TX frontend hardware into RX mode, disabling the PA on hardware with that.
* Set the RF chip into SLEEP mode. EP2 current measurements on 5V before starting the webserver:
  * 51mA - Receive mode
  * 43mA - FS mode, we go into this after TX
  * 27mA - Standby RC (FS mode except the FS is off too)
  * 25mA - Sleep mode. This is the mode I am forcing before webupdate
* Set power management to MinPower. I'm not 100% sure this is needed since the PA shutdown above should prevent it from actually being powered up, but better safe than sorry?
* I didn't do this, but it might be worth it to do a `while (busyTransmitting) ;` after stopping the timer but I don't really think this could be the case. At least on the RX it is impossible, and I think the TX generally has been working without it, so maybe not needed there either?

Power reduction is in the ballpark of 20mA down to ~100mA in WebUpdate mode from ~120mA. Temperature is reduced close to 12C from 85C to 73C. Left is master, right is with this PR.
![Orig](https://user-images.githubusercontent.com/677183/132429282-d6c6dd0c-7187-4bc6-b04d-d35ac2e3b296.jpg) ![Shutdown](https://user-images.githubusercontent.com/677183/132429279-2e3d3103-79b4-476f-90f2-05f4572fd78b.jpg)

## Tangential
* I've consolidated IsWebUpdateMode into the webupdate modules instead of having it in rx_main / tx_main.
* Fixed a possible bug where `Radio.RXdoneCallback` and `Radio.TXdoneCallback` are set to NULL, and no radio code checks to make sure they're not null before calling them which could result in a crash. The Radio sets them itself on end to valid handlers that won't crash it.
* Stopping hwTimer is now the responsibility of the caller to WebUpdate. This is disabled early before any changes to state is done. One set of code had it one place, one had it the other, but if we think it is ok to change power before stopping it (move it entirely into StartWebUpdate) that's fine by me too.