### PR TITLE
Crossfire LUA Compatibility

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -96,8 +96,6 @@ bool CRSF::CRSFstate = false;
 
 uint8_t CRSF::MspData[ELRS_MSP_BUFFER] = {0};
 uint8_t CRSF::MspDataLength = 0;
-
-uint32_t CRSF::luaHiddenFlags = 0;
 #endif // CRSF_TX_MODULE
 
 
@@ -242,191 +240,6 @@ void CRSF::packetQueueExtended(uint8_t type, void *data, uint8_t len)
 #ifdef PLATFORM_ESP32
     portEXIT_CRITICAL(&FIFOmux);
 #endif
-}
-
-uint8_t CRSF::setLuaHiddenFlag(uint8_t id, bool value){
-  luaHiddenFlags ^= (-value ^ luaHiddenFlags) & (1 << ((id-1)));
-  return value;
-}
-
-void CRSF::getLuaTextSelectionStructToArray(const void * luaStruct, uint8_t *outarray){
-    struct tagLuaItem_textSelection *p1 = (struct tagLuaItem_textSelection*)luaStruct;
-    char *next = stpcpy((char *)outarray,p1->label1) + 1;
-    next = stpcpy(next,p1->textOption) + 1;
-    memcpy(next,&p1->luaProperties2,sizeof(p1->luaProperties2));
-    next+=sizeof(p1->luaProperties2);
-    *next++=0; // default value
-    stpcpy(next,p1->label2);
-    
-    //outarray[4+(strlen(p1->label1)+1)+(strlen(p1->textOption)+1)] = (uint8_t)luaValues[p1->luaProperties1.id];
-}
-
-void CRSF::getLuaCommandStructToArray(const void * luaStruct, uint8_t *outarray){
-    struct tagLuaItem_command *p1 = (struct tagLuaItem_command*)luaStruct;
-    char *next = stpcpy((char *)outarray,p1->label1) + 1;
-    memcpy(next,&p1->luaProperties2,sizeof(p1->luaProperties2));
-    next+=sizeof(p1->luaProperties2);
-    stpcpy(next,p1->label2);
-    
-    //outarray[4+(strlen(p1->label1)+1)] = (uint8_t)luaValues[p1->luaProperties1.id];
-}
-
-void CRSF::getLuaUint8StructToArray(const void * luaStruct, uint8_t *outarray){
-    struct tagLuaItem_uint8 *p1 = (struct tagLuaItem_uint8*)luaStruct;
-    char *next = stpcpy((char *)outarray,p1->label1) + 1;
-    memcpy(next,&p1->luaProperties2,sizeof(p1->luaProperties2));
-    next+=sizeof(p1->luaProperties2);
-    *next++=0; // default value
-    stpcpy(next,p1->label2);
-    
-    //outarray[4+(strlen(p1->label1)+1)] = (uint8_t)luaValues[p1->luaProperties1.id];
-}
-
-void CRSF::getLuaUint16StructToArray(const void * luaStruct, uint8_t *outarray){
-    struct tagLuaItem_uint16 *p1 = (struct tagLuaItem_uint16*)luaStruct;
-    char *next = stpcpy((char *)outarray,p1->label1) + 1;
-    memcpy(next,&p1->luaProperties2,sizeof(p1->luaProperties2));
-    next+=sizeof(p1->luaProperties2);
-    *next++=0; // default value
-    stpcpy(next,p1->label2);
-    
-    //[4+(strlen(p1->label1)+1)] = (uint8_t)(luaValues[p1->luaProperties1.id] >> 8);
-    //outarray[4+(strlen(p1->label1)+2)] = (uint8_t)luaValues[p1->luaProperties1.id];
-}
-
-void CRSF::getLuaStringStructToArray(const void * luaStruct, uint8_t *outarray){
-    struct tagLuaItem_string *p1 = (struct tagLuaItem_string*)luaStruct;
-    char *next = stpcpy((char *)outarray,p1->label1) + 1;
-    stpcpy(next,p1->label2);
-}
-void CRSF::getLuaFolderStructToArray(const void * luaStruct, uint8_t *outarray){
-    struct tagLuaItem_string *p1 = (struct tagLuaItem_string*)luaStruct;
-    stpcpy((char *)outarray,p1->label1);
-}
-
-//sendCRSF param can take anytype of lua field settings
-uint8_t CRSF::sendCRSFparam(crsf_frame_type_e frame,uint8_t fieldchunk, crsf_value_type_e dataType, const void * luaData, uint8_t wholePacketSize)
-{
-    if (!CRSF::CRSFstate)
-    {
-        return 0;
-    }
-    uint8_t LUArespLength;
-    uint8_t chunks = 0;    
-    uint8_t currentPacketSize;    
-    
-    uint16_t chunkMax = maxPacketBytes-8;
-
-    /**
-     *calculate how many chunks needed for this field 
-     */
-    chunks = ((wholePacketSize-2)/(chunkMax));
-    if((wholePacketSize-2) % (chunkMax)){
-        chunks = chunks + 1;
-    }
-
-    //calculate how much byte this packet contains
-    if((chunks - (fieldchunk+1)) > 0){
-        currentPacketSize = chunkMax;
-    } else {
-        if((wholePacketSize-2) % (chunkMax)){
-            currentPacketSize = (wholePacketSize-2) % (chunkMax);
-        } else {
-            currentPacketSize = chunkMax;
-        }
-    }
-    LUArespLength = 2+2+ currentPacketSize; //2 bytes of header, fieldsetup1(fieldid, fieldchunk),
-                                        // chunk-ed packets below
-                                        //fieldsetup1(fieldparent,fieldtype),field name, 
-                                        //fieldsetup2(value,min,max,default),field unit
-    //create outbuffer size
-    uint8_t chunkBuffer[wholePacketSize];
-    uint8_t outBuffer[currentPacketSize + 5 + 2 + 2]; 
-        //it is byte op, we can use memcpy with index to
-        // destination memory.
-    switch(dataType){
-        case CRSF_TEXT_SELECTION:
-        {
-            getLuaTextSelectionStructToArray(luaData, chunkBuffer);
-            break;
-        }
-        case CRSF_COMMAND:
-        {
-            getLuaCommandStructToArray(luaData, chunkBuffer);
-            break;
-        }
-        case CRSF_UINT8:
-        {
-            getLuaUint8StructToArray(luaData,chunkBuffer);
-            break;
-        }
-        case CRSF_UINT16:
-        {
-            getLuaUint16StructToArray(luaData,chunkBuffer);
-            break;
-        }
-    // we dont have to include this for now. since we dont need it yet?
-        case CRSF_INT8:
-        {
-            //getLuaint8StructToArray(luaData,chunkBuffer);
-            break;
-        }
-        case CRSF_INT16:
-        {
-            //getLuaint16StructToArray(luaData,chunkBuffer);
-            break;
-        }
-        case CRSF_FLOAT:
-        {
-            //getLuaFloatStructToArray(luaData,chunkBuffer);
-            break;
-        }
-    //
-        case CRSF_STRING:
-        case CRSF_INFO:
-        {
-            getLuaStringStructToArray(luaData,chunkBuffer);
-            break;
-        }
-        case CRSF_FOLDER:
-        {
-            getLuaFolderStructToArray(luaData,chunkBuffer);
-            break;
-        }
-        case CRSF_OUT_OF_RANGE:
-        default:
-        break;
-
-    }
-    outBuffer[0] = CRSF_ADDRESS_RADIO_TRANSMITTER;
-    outBuffer[1] = LUArespLength + 2;   //received as #data in lua
-    outBuffer[2] = frame; //received as command in lua
-    // all below received as data in lua
-    outBuffer[3] = CRSF_ADDRESS_RADIO_TRANSMITTER;
-    outBuffer[4] = CRSF_ADDRESS_CRSF_TRANSMITTER;
-
-    outBuffer[5] = ((struct tagLuaProperties1 *)luaData)->id;
-    outBuffer[6] = ((chunks - (fieldchunk+1))); //remaining chunk to send;
-    if (fieldchunk == 0) {
-        outBuffer[7] = ((struct tagLuaProperties1 *)luaData)->parent;
-        outBuffer[8] = ((struct tagLuaProperties1 *)luaData)->type;
-        outBuffer[8] += ((luaHiddenFlags >>((((struct tagLuaProperties1 *)luaData)->id)-1)) & 1)*128;
-        memcpy(outBuffer+9,chunkBuffer,currentPacketSize-2);
-    } else {
-        memcpy(outBuffer+7,chunkBuffer+((fieldchunk*chunkMax))-2,currentPacketSize);
-    }
-    uint8_t crc = crsf_crc.calc(&outBuffer[2], LUArespLength + 1);
-    outBuffer[LUArespLength + 3] = crc;
-    
-#ifdef PLATFORM_ESP32
-    portENTER_CRITICAL(&FIFOmux);
-#endif
-    SerialOutFIFO.push(LUArespLength + 4);
-    SerialOutFIFO.pushBytes(outBuffer, LUArespLength + 4);
-#ifdef PLATFORM_ESP32
-    portEXIT_CRITICAL(&FIFOmux);
-#endif
-    return ((chunks - (fieldchunk+1)));
 }
 
 void ICACHE_RAM_ATTR CRSF::sendTelemetryToTX(uint8_t *data)
@@ -882,9 +695,11 @@ void ICACHE_RAM_ATTR CRSF::duplex_set_TX()
 void ICACHE_RAM_ATTR CRSF::adjustMaxPacketSize()
 {
     uint32_t UARTrequestedBaud = TxToHandsetBauds[UARTcurrentBaudIdx];
-    // baud / 10bits-per-byte / 2 windows (1RX, 1TX) / rate * 0.85 (leeway)
-    int maxSize = UARTrequestedBaud / 10 / 2 / (1000000/RequestedRCpacketInterval) * 85 / 100;
+    // baud / 10bits-per-byte / 2 windows (1RX, 1TX) / rate * 0.80 (leeway)
+    int maxSize = UARTrequestedBaud / 10 / 2 / (1000000/RequestedRCpacketInterval) * 80 / 100;
     maxPacketBytes = maxSize > CRSF_MAX_PACKET_LEN ? CRSF_MAX_PACKET_LEN : maxSize;
+    // we need a minimum of 10 bytes otherwise our LUA will not make progress and at 8 we'd get a divide by 0!
+    maxPacketBytes = maxPacketBytes < 10 ? 10 : maxPacketBytes;
     DBGLN("Adjusted max packet size %u", maxPacketBytes);
 }
 

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -74,7 +74,6 @@ public:
     void ICACHE_RAM_ATTR sendLinkStatisticsToTX();
     void ICACHE_RAM_ATTR sendTelemetryToTX(uint8_t *data);
 
-    uint8_t sendCRSFparam(crsf_frame_type_e frame,uint8_t fieldchunk, crsf_value_type_e dataType, const void * luaData, uint8_t wholePacketSize);
     static void packetQueueExtended(uint8_t type, void *data, uint8_t len);
 
     static void ICACHE_RAM_ATTR sendSetVTXchannel(uint8_t band, uint8_t channel);
@@ -106,9 +105,7 @@ public:
     static void AddMspMessage(mspPacket_t* packet);
     static void ResetMspQueue();
     static volatile uint32_t OpenTXsyncLastSent;
-
-    uint8_t setLuaHiddenFlag(uint8_t id, bool value);
-
+    static uint8_t GetMaxPacketBytes() { return maxPacketBytes; }
 #endif
 private:
     Stream *_dev;
@@ -154,22 +151,6 @@ private:
     static bool UARTwdt();
     static void ICACHE_RAM_ATTR adjustMaxPacketSize();
     
-    static uint32_t luaHiddenFlags;
-
-    void getLuaTextSelectionStructToArray(const void * luaStruct, uint8_t *outarray);
-    void getLuaCommandStructToArray(const void * luaStruct, uint8_t *outarray);
-    void getLuaUint8StructToArray(const void * luaStruct, uint8_t *outarray);
-    void getLuaUint16StructToArray(const void * luaStruct, uint8_t *outarray);
-    void getLuaStringStructToArray(const void * luaStruct, uint8_t *outarray);
-    void getLuaFolderStructToArray(const void * luaStruct, uint8_t *outarray);
-      /** we dont need these yet for OUR LUA, and it is not defined yet
-     void getLuaUint8StructToArray(const void * luaStruct, uint8_t *outarray);
-     void getLuaint8StructToArray(const void * luaStruct, uint8_t *outarray);
-     void getLuaUint16StructToArray(const void * luaStruct, uint8_t *outarray);
-     void getLuaint16StructToArray(const void * luaStruct, uint8_t *outarray);
-     void getLuaFloatStructToArray(const void * luaStruct, uint8_t *outarray);
-*/ 
-
 #endif
 
     static void flush_port_input(void);

--- a/src/lib/CrsfProtocol/crsf_protocol.h
+++ b/src/lib/CrsfProtocol/crsf_protocol.h
@@ -180,6 +180,10 @@ typedef enum
     CRSF_OUT_OF_RANGE = 127,
 } crsf_value_type_e;
 
+// These flags are or'ed with the field type above to hide the field from the normal LUA view
+#define CRSF_FIELD_HIDDEN 0x80          // marked as hidden in all LUA responses
+#define CRSF_FIELD_ELRS_HIDDEN 0x40     // marked as hidden when talking to ELRS specific LUA
+
 /**
  * Define the shape of a standard header
  */
@@ -364,6 +368,7 @@ struct tagLuaItem_command {
     struct tagLuaProperties1 luaProperties1;
     const char* const label1; //command name
     struct tagLuaCommandProperties luaProperties2;
+    const char *defaultInfo; //default command info message
     const char *label2; //command info
     uint8_t size;
 } PACKED;

--- a/src/lib/LED/LED.h
+++ b/src/lib/LED/LED.h
@@ -89,31 +89,38 @@ void updateLEDs(uint32_t now, connectionState_e connectionState, uint8_t rate, u
 void startupLEDs()
 {
 #if WS2812_LED_IS_USED || (defined(PLATFORM_ESP32) && defined(GPIO_PIN_LED))
-    // do startup blinkies for fun
-    constexpr uint32_t colors[8] =
-    {
-        0xFFFFFF,     // white
-        0xFF00FF,     // magenta
-        0x8000FF,     // violet
-        0x0000FF,     // blue
-        0x00FF00,     // green
-        0xFFFF00,     // yellow
-        0xFF8000,     // orange
-        0xFF0000      // red
-    };
-    constexpr uint8_t N_COLORS = sizeof(colors)/sizeof(colors[0]);
-
     WS281Binit();
-    for (uint8_t i = 0; i < N_COLORS; i++)
+
+    #ifdef PLATFORM_ESP32
+    // Only do the blinkies if it was NOT a software reboot
+    if (esp_reset_reason() != ESP_RST_SW)
+    #endif
     {
-        WS281BsetLED(colors[i]);
-        delay(1000/N_COLORS);
+        // do startup blinkies for fun
+        constexpr uint32_t colors[8] =
+        {
+            0xFFFFFF,     // white
+            0xFF00FF,     // magenta
+            0x8000FF,     // violet
+            0x0000FF,     // blue
+            0x00FF00,     // green
+            0xFFFF00,     // yellow
+            0xFF8000,     // orange
+            0xFF0000      // red
+        };
+        constexpr uint8_t N_COLORS = sizeof(colors)/sizeof(colors[0]);
+
+        for (uint8_t i = 0; i < N_COLORS; i++)
+        {
+            WS281BsetLED(colors[i]);
+            delay(1000/N_COLORS);
+        }
+        for (uint8_t i = 0; i < N_COLORS; i++)
+        {
+            WS281BsetLED(colors[N_COLORS-i-1]);
+            delay(1000/N_COLORS);
+        }
+        WS281BsetLED((uint32_t)0);
     }
-    for (uint8_t i = 0; i < N_COLORS; i++)
-    {
-        WS281BsetLED(colors[N_COLORS-i-1]);
-        delay(1000/N_COLORS);
-    }
-    WS281BsetLED((uint32_t)0);
 #endif
 }

--- a/src/lib/LUA/lua.h
+++ b/src/lib/LUA/lua.h
@@ -7,13 +7,13 @@
 
 #define LUA_DEVICE_SIZE(X) (uint8_t)(sizeof(tagLuaDeviceProperties)+strlen(X.label1)+1)
 #define LUA_TEXTSELECTION_SIZE(X) (uint8_t)(4+strlen(X.label1)+1+strlen(X.textOption)+1+sizeof(tagLuaTextSelectionProperties)+1+strlen(X.label2)+1)
-#define LUA_COMMAND_SIZE(X) (uint8_t)(4+strlen(X.label1)+1+sizeof(tagLuaCommandProperties)+strlen(X.label2)+1)
+#define LUA_COMMAND_SIZE(X) (uint8_t)(4+strlen(X.label1)+1+sizeof(tagLuaCommandProperties)+(X.label2==0?strlen(X.defaultInfo):strlen(X.label2))+1)
 #define LUA_UINT8_SIZE(X) (uint8_t)(4+strlen(X.label1)+1+sizeof(tagLuaUint8Properties)+1+strlen(X.label2)+1)
 #define LUA_UINT16_SIZE(X) (uint8_t)(4+strlen(X.label1)+1+sizeof(tagLuaUint16Properties)+2+strlen(X.label2)+1)
 #define LUA_STRING_SIZE(X) (uint8_t)(4+strlen(X.label1)+1+strlen(X.label2)+1)
 #define LUA_FOLDER_SIZE(X) (uint8_t)(4+strlen(X.label1)+1)
 
-extern void sendLuaFieldCrsf(uint8_t idx, uint8_t chunk);
+extern void sendLuaCommandResponse(struct tagLuaItem_command *cmd, uint8_t status, const char *message);
 
 extern void suppressCurrentLuaWarning(void);
 extern bool getLuaWarning(void);
@@ -27,9 +27,9 @@ void registerLUAParameter(void *definition, luaCallback callback = 0, uint8_t pa
 
 void sendLuaDevicePacket(void);
 void setLuaTextSelectionValue(struct tagLuaItem_textSelection *textSelectionStruct, uint8_t newvalue);
-void setLuaCommandValue(struct tagLuaItem_command *textSelectionStruct, uint8_t newvalue);
 void setLuaUint8Value(struct tagLuaItem_uint8 *luaStruct, uint8_t newvalue);
 void setLuaUint16Value(struct tagLuaItem_uint16 *luaStruct, uint16_t newvalue);
 void setLuaStringValue(struct tagLuaItem_string *luaStruct,const char *newvalue);
 void setLuaCommandInfo(struct tagLuaItem_command *luaStruct,const char *newvalue);
+void setLuaCommandValue(struct tagLuaItem_command *textSelectionStruct, uint8_t newvalue);
 #endif

--- a/src/lua/elrsV2.lua
+++ b/src/lua/elrsV2.lua
@@ -391,9 +391,7 @@ local function fieldCommandDisplay(field, y, attr)
 end
 
 local function UIbackExec(field)
-  fieldId, fieldChunk = 1, 0
   folderAccess = 0
-  allParamsLoaded = 0
   fields[fields_count+1].parent = 255
 end
 
@@ -560,9 +558,11 @@ local function runDevicePage(event)
       fieldData = {}
       allParamsLoaded = 0
     else
-      fieldId, fieldChunk = 1, 0
+      if folderAccess == 0 then -- only do reload if we're in the root folder
+        fieldId, fieldChunk = 1, 0
+        allParamsLoaded = 0
+      end
       folderAccess = 0
-      allParamsLoaded = 0
       fields[fields_count+1].parent = 255
     end
   elseif event == EVT_VIRTUAL_ENTER then        -- toggle editing/selecting current field
@@ -589,6 +589,7 @@ local function runDevicePage(event)
           fieldData = {}
           functions[field.type+1].save(field)
           if field.type < 11 then
+            fieldTimeout = 0 -- go fast
             allParamsLoaded = 0
             fieldId = 1
           end

--- a/src/src/ESP32_WebUpdate.cpp
+++ b/src/src/ESP32_WebUpdate.cpp
@@ -3,7 +3,7 @@
 #include <WiFi.h>
 #include <DNSServer.h>
 #include <ESPmDNS.h>
-#include <WebServer.h>
+#include <ESPAsyncWebServer.h>
 #include <Update.h>
 #include <set>
 #include <StreamString.h>
@@ -54,83 +54,85 @@ static const byte DNS_PORT = 53;
 static IPAddress apIP(10, 0, 0, 1);
 static IPAddress netMsk(255, 255, 255, 0);
 static DNSServer dnsServer;
-static WebServer server(80);
+static AsyncWebServer server(80);
 
 bool IsWebUpdateMode = false;
 
 /** Is this an IP? */
 static boolean isIp(String str)
 {
-    for (size_t i = 0; i < str.length(); i++)
+  for (size_t i = 0; i < str.length(); i++)
+  {
+    int c = str.charAt(i);
+    if (c != '.' && (c < '0' || c > '9'))
     {
-        int c = str.charAt(i);
-        if (c != '.' && (c < '0' || c > '9'))
-        {
-            return false;
-        }
+      return false;
     }
-    return true;
+  }
+  return true;
 }
 
 /** IP to String? */
 static String toStringIp(IPAddress ip)
 {
-    String res = "";
-    for (int i = 0; i < 3; i++)
-    {
-        res += String((ip >> (8 * i)) & 0xFF) + ".";
-    }
-    res += String(((ip >> 8 * 3)) & 0xFF);
-    return res;
+  String res = "";
+  for (int i = 0; i < 3; i++)
+  {
+    res += String((ip >> (8 * i)) & 0xFF) + ".";
+  }
+  res += String(((ip >> 8 * 3)) & 0xFF);
+  return res;
 }
 
-static bool captivePortal()
+static bool captivePortal(AsyncWebServerRequest *request)
 {
-    if (!isIp(server.hostHeader()) && server.hostHeader() != (String(myHostname) + ".local"))
-    {
-        DBGLN("Request redirected to captive portal");
-        server.sendHeader("Location", String("http://") + toStringIp(server.client().localIP()), true);
-        server.send(302, "text/plain", ""); // Empty content inhibits Content-length header so we have to close the socket ourselves.
-        server.client().stop();             // Stop is needed because we sent no content length
-        return true;
-    }
-    return false;
+  if (!isIp(request->host()) && request->host() != (String(myHostname) + ".local"))
+  {
+    DBGLN("Request redirected to captive portal");
+    request->redirect(String("http://") + toStringIp(request->client()->localIP()));
+    return true;
+  }
+  return false;
 }
 
-static void WebUpdateSendCSS()
+static void WebUpdateSendCSS(AsyncWebServerRequest *request)
 {
-  server.sendHeader("Content-Encoding", "gzip");
-  server.send_P(200, "text/css", CSS, sizeof(CSS));
+  AsyncWebServerResponse *response = request->beginResponse_P(200, "text/css", (uint8_t*)CSS, sizeof(CSS));
+  response->addHeader("Content-Encoding", "gzip");
+  request->send(response);
 }
 
-static void WebUpdateSendJS()
+static void WebUpdateSendJS(AsyncWebServerRequest *request)
 {
-  server.sendHeader("Content-Encoding", "gzip");
-  server.send_P(200, "text/javascript", SCAN_JS, sizeof(SCAN_JS));
+  AsyncWebServerResponse *response = request->beginResponse_P(200, "text/javascript", (uint8_t*)SCAN_JS, sizeof(SCAN_JS));
+  response->addHeader("Content-Encoding", "gzip");
+  request->send(response);
 }
 
-static void WebUpdateSendFlag()
+static void WebUpdateSendFlag(AsyncWebServerRequest *request)
 {
-  server.sendHeader("Content-Encoding", "gzip");
-  server.send_P(200, "image/svg+xml", FLAG, sizeof(FLAG));
+  AsyncWebServerResponse *response = request->beginResponse_P(200, "image/svg+xml", (uint8_t*)FLAG, sizeof(FLAG));
+  response->addHeader("Content-Encoding", "gzip");
+  request->send(response);
 }
 
-static void WebUpdateHandleRoot()
+static void WebUpdateHandleRoot(AsyncWebServerRequest *request)
 {
-  if (captivePortal())
+  if (captivePortal(request))
   { // If captive portal redirect instead of displaying the page.
     return;
   }
-  if (server.hasArg("force"))
+  if (request->hasArg("force"))
     force_update = true;
-  server.sendHeader("Cache-Control", "no-cache, no-store, must-revalidate");
-  server.sendHeader("Pragma", "no-cache");
-  server.sendHeader("Expires", "-1");
-  server.sendHeader("Content-Encoding", "gzip");
-  server.send_P(200, "text/html", INDEX_HTML, sizeof(INDEX_HTML));
+  AsyncWebServerResponse *response = request->beginResponse_P(200, "text/html", (uint8_t*)INDEX_HTML, sizeof(INDEX_HTML));
+  response->addHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+  response->addHeader("Pragma", "no-cache");
+  response->addHeader("Expires", "-1");
+  response->addHeader("Content-Encoding", "gzip");
+  request->send(response);
 }
 
-static void WebUpdateSendMode()
+static void WebUpdateSendMode(AsyncWebServerRequest *request)
 {
   String s;
   if (wifiMode == WIFI_STA) {
@@ -138,16 +140,16 @@ static void WebUpdateSendMode()
   } else {
     s = String("{\"mode\":\"AP\",\"ssid\":\"") + config.GetSSID() + "\"}";
   }
-  server.send(200, "application/json", s);
+  request->send(200, "application/json", s);
 }
 
-static void WebUpdateGetTarget()
+static void WebUpdateGetTarget(AsyncWebServerRequest *request)
 {
   String s = String("{\"target\":\"") + (const char *)&target_name[4] + "\",\"version\": \"" + VERSION + "\"}";
-  server.send(200, "application/json", s);
+  request->send(200, "application/json", s);
 }
 
-static void WebUpdateSendNetworks()
+static void WebUpdateSendNetworks(AsyncWebServerRequest *request)
 {
   int numNetworks = WiFi.scanComplete();
   if (numNetworks >= 0) {
@@ -164,79 +166,146 @@ static void WebUpdateSendNetworks()
       }
     }
     s+="]";
-    server.send(200, "application/json", s);
+    request->send(200, "application/json", s);
   } else {
-    server.send(204, "application/json", "[]");
+    request->send(204, "application/json", "[]");
   }
 }
 
-static void sendResponse(const String &msg, WiFiMode_t mode) {
-  server.sendHeader("Connection", "close");
-  server.send(200, "text/plain", msg);
-  server.client().stop();
+static void sendResponse(AsyncWebServerRequest *request, const String &msg, WiFiMode_t mode) {
+  AsyncWebServerResponse *response = request->beginResponse(200, "text/plain", msg);
+  response->addHeader("Connection", "close");
+  request->send(response);
+  request->client()->close();
   changeTime = millis();
   changeMode = mode;
 }
 
-static void WebUpdateAccessPoint(void)
+static void WebUpdateAccessPoint(AsyncWebServerRequest *request)
 {
   DBGLN("Starting Access Point");
   String msg = String("Access Point starting, please connect to access point '") + ssid + "' with password '" + password + "'";
-  sendResponse(msg, WIFI_AP);
+  sendResponse(request, msg, WIFI_AP);
 }
 
-static void WebUpdateConnect(void)
+static void WebUpdateConnect(AsyncWebServerRequest *request)
 {
   DBGLN("Connecting to home network");
   String msg = String("Connected to network '") + config.GetSSID() + "', connect to http://elrs_tx.local from a browser on that network";
-  sendResponse(msg, WIFI_STA);
+  sendResponse(request, msg, WIFI_STA);
 }
 
-static void WebUpdateSetHome(void)
+static void WebUpdateSetHome(AsyncWebServerRequest *request)
 {
-  String ssid = server.arg("network");
-  String password = server.arg("password");
+  String ssid = request->arg("network");
+  String password = request->arg("password");
 
   DBGLN("Setting home network %s", ssid.c_str());
   config.SetSSID(ssid.c_str());
   config.SetPassword(password.c_str());
   config.Commit();
-  WebUpdateConnect();
+  WebUpdateConnect(request);
 }
 
-static void WebUpdateForget(void)
+static void WebUpdateForget(AsyncWebServerRequest *request)
 {
   DBGLN("Forget home network");
   config.SetSSID("");
   config.SetPassword("");
   config.Commit();
   String msg = String("Home network forgotten, please connect to access point '") + ssid + "' with password '" + password + "'";
-  sendResponse(msg, WIFI_AP);
+  sendResponse(request, msg, WIFI_AP);
 }
 
-static void WebUpdateHandleNotFound()
+static void WebUpdateHandleNotFound(AsyncWebServerRequest *request)
 {
-    if (captivePortal())
-    { // If captive portal redirect instead of displaying the error page.
-        return;
-    }
-    String message = F("File Not Found\n\n");
-    message += F("URI: ");
-    message += server.uri();
-    message += F("\nMethod: ");
-    message += (server.method() == HTTP_GET) ? "GET" : "POST";
-    message += F("\nArguments: ");
-    message += server.args();
-    message += F("\n");
+  if (captivePortal(request))
+  { // If captive portal redirect instead of displaying the error page.
+    return;
+  }
+  String message = F("File Not Found\n\n");
+  message += F("URI: ");
+  message += request->url();
+  message += F("\nMethod: ");
+  message += (request->method() == HTTP_GET) ? "GET" : "POST";
+  message += F("\nArguments: ");
+  message += request->args();
+  message += F("\n");
 
-    for (uint8_t i = 0; i < server.args(); i++)
-    {
-        message += String(F(" ")) + server.argName(i) + F(": ") + server.arg(i) + F("\n");
+  for (uint8_t i = 0; i < request->args(); i++)
+  {
+    message += String(F(" ")) + request->argName(i) + F(": ") + request->arg(i) + F("\n");
+  }
+  AsyncWebServerResponse *response = request->beginResponse(404, "text/plain", message);
+  response->addHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+  response->addHeader("Pragma", "no-cache");
+  response->addHeader("Expires", "-1");
+  request->send(response);
+}
+
+static void WebUploadResponseHander(AsyncWebServerRequest *request) {
+  if (target_seen) {
+    if (Update.hasError()) {
+      StreamString p = StreamString();
+      Update.printError(p);
+      request->send(200, "application/json", String("{\"status\": \"error\", \"msg\": \"") + p + "\"}");
+    } else {
+      AsyncWebServerResponse *response = request->beginResponse(200, "application/json", "{\"status\": \"ok\", \"msg\": \"Update complete, please wait 10 seconds before powering off the module\"}");
+      response->addHeader("Connection", "close");
+      request->send(response);
+      request->client()->close();
+      delay(100);
+      ESP.restart();
     }
-    server.sendHeader("Cache-Control", "no-cache, no-store, must-revalidate");
-    server.sendHeader("Pragma", "no-cache");
-    server.sendHeader("Expires", "-1");
-    server.send(404, "text/plain", message);
+  } else {
+    request->send(200, "application/json", "{\"status\": \"error\", \"msg\": \"Wrong firmware uploaded, does not match Transmitter module type\"}");
+  }
+}
+
+static void WebUploadDataHandler(AsyncWebServerRequest *request, const String& filename, size_t index, uint8_t *data, size_t len, bool final) {
+  static uint32_t totalSize;
+  if (index == 0) {
+    Serial.setDebugOutput(true);
+    DBGLN("Update: %s", filename.c_str());
+    if (!Update.begin()) { //start with max available size
+      Update.printError(Serial);
+    }
+    target_seen = false;
+    target_pos = 0;
+    totalSize = 0;
+  }
+  if (Update.write(data, len)) {
+    Update.printError(Serial);
+  }
+  if (force_update)
+    target_seen = true;
+  if (!target_seen) {
+    for (int i=0 ; i<len ;i++) {
+      if (data[i] == target_name[target_pos]) {
+        ++target_pos;
+        if (target_pos >= target_name_size) {
+          target_seen = true;
+        }
+      }
+      else {
+        target_pos = 0; // Startover
+      }
+    }
+  }
+  totalSize += len;
+  if (final) {
+    if (target_seen) {
+      if (Update.end(true)) { //true to set the size to the current progress
+        DBGLN("Upload Success: %ubytes\nPlease wait for LED to resume blinking before disconnecting power", totalSize);
+      } else {
+        Update.printError(Serial);
+      }
+    } else {
+      Update.abort();
+      DBGLN("Wrong firmware uploaded, not %s, update aborted", &target_name[4]);
+    }
+    Serial.setDebugOutput(false);
+  } 
 }
 
 static void startWifi() {
@@ -271,150 +340,89 @@ static void startWifi() {
 
 void BeginWebUpdate()
 {
-    IsWebUpdateMode = true;
+  IsWebUpdateMode = true;
 
-    DBGLN("Stopping Radio");
-    Radio.End();
-    crsf.End();
+  DBGLN("Stopping Radio");
+  Radio.End();
 
-    INFOLN("Begin Webupdater");
-    startWifi();
+  INFOLN("Begin Webupdater");
+  startWifi();
 
-    server.on("/", WebUpdateHandleRoot);
-    server.on("/main.css", WebUpdateSendCSS);
-    server.on("/scan.js", WebUpdateSendJS);
-    server.on("/flag.svg", WebUpdateSendFlag);
-    server.on("/mode.json", WebUpdateSendMode);
-    server.on("/networks.json", WebUpdateSendNetworks);
-    server.on("/sethome", WebUpdateSetHome);
-    server.on("/forget", WebUpdateForget);
-    server.on("/connect", WebUpdateConnect);
-    server.on("/access", WebUpdateAccessPoint);
-    server.on("/target", WebUpdateGetTarget);
+  server.on("/", WebUpdateHandleRoot);
+  server.on("/main.css", WebUpdateSendCSS);
+  server.on("/scan.js", WebUpdateSendJS);
+  server.on("/flag.svg", WebUpdateSendFlag);
+  server.on("/mode.json", WebUpdateSendMode);
+  server.on("/networks.json", WebUpdateSendNetworks);
+  server.on("/sethome", WebUpdateSetHome);
+  server.on("/forget", WebUpdateForget);
+  server.on("/connect", WebUpdateConnect);
+  server.on("/access", WebUpdateAccessPoint);
+  server.on("/target", WebUpdateGetTarget);
 
-    server.on("/generate_204", WebUpdateHandleRoot); // handle Andriod phones doing shit to detect if there is 'real' internet and possibly dropping conn.
-    server.on("/gen_204", WebUpdateHandleRoot);
-    server.on("/library/test/success.html", WebUpdateHandleRoot);
-    server.on("/hotspot-detect.html", WebUpdateHandleRoot);
-    server.on("/connectivity-check.html", WebUpdateHandleRoot);
-    server.on("/check_network_status.txt", WebUpdateHandleRoot);
-    server.on("/ncsi.txt", WebUpdateHandleRoot);
-    server.on("/fwlink", WebUpdateHandleRoot);
-    server.onNotFound(WebUpdateHandleNotFound);
+  server.on("/generate_204", WebUpdateHandleRoot); // handle Andriod phones doing shit to detect if there is 'real' internet and possibly dropping conn.
+  server.on("/gen_204", WebUpdateHandleRoot);
+  server.on("/library/test/success.html", WebUpdateHandleRoot);
+  server.on("/hotspot-detect.html", WebUpdateHandleRoot);
+  server.on("/connectivity-check.html", WebUpdateHandleRoot);
+  server.on("/check_network_status.txt", WebUpdateHandleRoot);
+  server.on("/ncsi.txt", WebUpdateHandleRoot);
+  server.on("/fwlink", WebUpdateHandleRoot);
 
-    server.on(
-        "/update", HTTP_POST, []() {
-          if (target_seen) {
-            if (Update.hasError()) {
-              StreamString p = StreamString();
-              Update.printError(p);
-              server.send(200, "application/json", String("{\"status\": \"error\", \"msg\": \"") + p + "\"}");
-            } else {
-              server.sendHeader("Connection", "close");
-              server.send(200, "application/json", "{\"status\": \"ok\", \"msg\": \"Update complete, please wait 10 seconds before powering off the module\"}");
-              server.client().stop();
-              delay(100);
-              ESP.restart();
-            }
-          } else {
-            server.send(200, "application/json", "{\"status\": \"error\", \"msg\": \"Wrong firmware uploaded, does not match Transmitter module type\"}");
-          }
-      },
-    []() {
-      HTTPUpload& upload = server.upload();
-      if (upload.status == UPLOAD_FILE_START) {
-        Serial.setDebugOutput(true);
-        DBGLN("Update: %s", upload.filename.c_str());
-        if (!Update.begin()) { //start with max available size
-          Update.printError(Serial);
-        }
-        target_seen = false;
-        target_pos = 0;
-      } else if (upload.status == UPLOAD_FILE_WRITE) {
-        if (Update.write(upload.buf, upload.currentSize) != upload.currentSize) {
-          Update.printError(Serial);
-        }
-        if (force_update)
-          target_seen = true;
-        if (!target_seen) {
-          for (int i=0 ; i<upload.currentSize ;i++) {
-            if (upload.buf[i] == target_name[target_pos]) {
-              ++target_pos;
-              if (target_pos >= target_name_size) {
-                target_seen = true;
-              }
-            }
-            else {
-              target_pos = 0; // Startover
-            }
-          }
-        }
-      } else if (upload.status == UPLOAD_FILE_END) {
-        if (target_seen) {
-          if (Update.end(true)) { //true to set the size to the current progress
-            DBGLN("Upload Success: %ubytes\nPlease wait for LED to resume blinking before disconnecting power", upload.totalSize);
-          } else {
-            Update.printError(Serial);
-          }
-        } else {
-          Update.abort();
-          DBGLN("Wrong firmware uploaded, not %s, update aborted", &target_name[4]);
-        }
-        Serial.setDebugOutput(false);
-      } else if(upload.status == UPLOAD_FILE_ABORTED){
-        Update.abort();
-        DBGLN("Update was aborted");
-      } });
+  server.on("/update", HTTP_POST, WebUploadResponseHander, WebUploadDataHandler);
 
-    dnsServer.start(DNS_PORT, "*", apIP);
-    dnsServer.setErrorReplyCode(DNSReplyCode::NoError);
+  server.onNotFound(WebUpdateHandleNotFound);
 
-    if (!MDNS.begin(myHostname))
-    {
-      DBGLN("Error starting mDNS");
-      return;
-    }
+  dnsServer.start(DNS_PORT, "*", apIP);
+  dnsServer.setErrorReplyCode(DNSReplyCode::NoError);
 
-    String instance = String(myHostname) + "_" + WiFi.macAddress();
-    instance.replace(":", "");
-    MDNS.setInstanceName(instance);
+  if (!MDNS.begin(myHostname))
+  {
+    DBGLN("Error starting mDNS");
+    return;
+  }
 
-    MDNS.addService("http", "tcp", 80);
-    MDNS.addServiceTxt("http", "tcp", "vendor", "elrs");
-    MDNS.addServiceTxt("http", "tcp", "type", "tx");
-    MDNS.addServiceTxt("http", "tcp", "target", (const char *)&target_name[4]);
-    MDNS.addServiceTxt("http", "tcp", "version", VERSION);
-    MDNS.addServiceTxt("http", "tcp", "options", String(FPSTR(compile_options)).c_str());
+  String instance = String(myHostname) + "_" + WiFi.macAddress();
+  instance.replace(":", "");
+  MDNS.setInstanceName(instance);
 
-    server.begin();
+  MDNS.addService("http", "tcp", 80);
+  MDNS.addServiceTxt("http", "tcp", "vendor", "elrs");
+  MDNS.addServiceTxt("http", "tcp", "type", "tx");
+  MDNS.addServiceTxt("http", "tcp", "target", (const char *)&target_name[4]);
+  MDNS.addServiceTxt("http", "tcp", "version", VERSION);
+  MDNS.addServiceTxt("http", "tcp", "options", String(FPSTR(compile_options)).c_str());
+
+  server.begin();
 }
 
 void HandleWebUpdate()
 {
   wl_status_t status = WiFi.status();
+  unsigned long now = millis();
   if (status != laststatus && wifiMode == WIFI_STA) {
-        DBGLN("WiFi status %d", status);
-        switch(status) {
-          case WL_NO_SSID_AVAIL:
-          case WL_CONNECT_FAILED:
-          case WL_CONNECTION_LOST:
-            changeTime = millis();
-            changeMode = WIFI_AP;
-            break;
-          case WL_DISCONNECTED: // try reconnection
-            changeTime = millis();
-            break;
-          default:
-            break;
-        }
-        laststatus = status;
+    DBGLN("WiFi status %d", status);
+    switch(status) {
+      case WL_NO_SSID_AVAIL:
+      case WL_CONNECT_FAILED:
+      case WL_CONNECTION_LOST:
+        changeTime = now;
+        changeMode = WIFI_AP;
+        break;
+      case WL_DISCONNECTED: // try reconnection
+        changeTime = now;
+        break;
+      default:
+        break;
+    }
+    laststatus = status;
   }
-  if (status != WL_CONNECTED && wifiMode == WIFI_STA && (changeTime+30000) < millis()) {
-    changeTime = millis();
+  if (status != WL_CONNECTED && wifiMode == WIFI_STA && (changeTime+30000) < now) {
+    changeTime = now;
     changeMode = WIFI_AP;
     DBGLN("Connection failed %d", status);
   }
-  if (changeMode != wifiMode && changeMode != WIFI_MODE_NULL && (changeTime+500) < millis()) {
+  if (changeMode != wifiMode && changeMode != WIFI_MODE_NULL && (changeTime+500) < now) {
     switch(changeMode) {
       case WIFI_AP:
         DBGLN("Changing to AP mode");
@@ -429,7 +437,7 @@ void HandleWebUpdate()
         DBGLN("Connecting to home network '%s'", config.GetSSID());
         WiFi.mode(WIFI_STA);
         wifiMode = WIFI_STA;
-        changeTime = millis();
+        changeTime = now;
         WiFi.begin(config.GetSSID(), config.GetPassword());
       default:
         break;
@@ -437,8 +445,6 @@ void HandleWebUpdate()
     changeMode = WIFI_MODE_NULL;
   }
   dnsServer.processNextRequest();
-  server.handleClient();
-  yield();
 }
 
 #endif

--- a/src/src/luaParams.cpp
+++ b/src/src/luaParams.cpp
@@ -72,11 +72,12 @@ struct tagLuaItem_command luaBind = {
     {0,0,(uint8_t)CRSF_COMMAND},//id,type
     "Bind",
     {0,200},//status,timeout
-    "binding...",
+    "Enter Bind Mode?",
+    0,
     LUA_COMMAND_SIZE(luaBind)
 };
 struct tagLuaItem_string luaInfo = {
-    {0,0,(uint8_t)CRSF_INFO},//id,type
+    {0,0,(uint8_t)CRSF_INFO|CRSF_FIELD_ELRS_HIDDEN},//id,type
     "Bad/Good",
     thisCommit,
     LUA_STRING_SIZE(luaInfo)
@@ -93,7 +94,8 @@ struct tagLuaItem_command luaWebUpdate = {
     {0,0,(uint8_t)CRSF_COMMAND},//id,type
     "WiFi Update",
     {0,200},//status,timeout
-    "Proceed WiFi Update Mode?",
+    "Enter WiFi Update Mode?",
+    0,
     LUA_COMMAND_SIZE(luaWebUpdate)
 };
 
@@ -101,7 +103,8 @@ struct tagLuaItem_command luaBLEJoystick = {
     {0,0,(uint8_t)CRSF_COMMAND},//id,type
     "BLE Joystick",
     {0,200},//status,timeout
-    "Enable BLE Joystick?",
+    "Start BLE Joystick?",
+    0,
     LUA_COMMAND_SIZE(luaBLEJoystick)
 };
 #endif
@@ -154,6 +157,7 @@ struct tagLuaItem_command luaVtxSend = {
     "Send VTx",
     {0,200},//status,timeout
     emptySpace,
+    0,
     LUA_COMMAND_SIZE(luaVtxSend)
 };
 

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -631,7 +631,7 @@ void registerLuaParameters() {
       }
       else
       {
-        sendLuaCommandResponse(&luaWebUpdate, IsWebUpdateMode ? 2 : 0, IsWebUpdateMode ? "Wifi Running..." : "WiFi Cancelled");
+        sendLuaCommandResponse(&luaWebUpdate, luaWebUpdate.luaProperties2.status, luaWebUpdate.label2);
       }
     });
 
@@ -667,7 +667,7 @@ void registerLuaParameters() {
       }
       else
       {
-        sendLuaCommandResponse(&luaBLEJoystick, BLEjoystickActive ? 2 : 0, BLEjoystickActive ? "Joystick Running..." : "Joystick Cancelled");
+        sendLuaCommandResponse(&luaBLEJoystick, luaBLEJoystick.luaProperties2.status, luaBLEJoystick.label2);
       }
     });
 

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -641,7 +641,6 @@ void registerLuaParameters() {
         //confirm run on ELRSv2.lua or start command from CRSF configurator,
         //since ELRS LUA can do 2 step confirmation, it needs confirmation to start wifi to prevent stuck on
         //unintentional button press.
-        sendLuaCommandResponse(&luaBLEJoystick, 2, "Joystick Running...");
         BLEjoystickActive = true;
         DBGLN("BLE Joystick Mode Requested!");
         hwTimer.stop();
@@ -653,6 +652,7 @@ void registerLuaParameters() {
         POWERMGNT.setPower(MinPower);
         Radio.End();
         BluetoothJoystickBegin();
+        sendLuaCommandResponse(&luaBLEJoystick, 2, "Joystick Running...");
       }
       else if (arg > 0 && arg < 4) //start command, 1 = start, 2 = running, 3 = request confirmation
       {

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1245,9 +1245,9 @@ void EnterBindingMode()
       return;
   }
 
-  // wait for any TX to complete then disable the TX timer
-  while (busyTransmitting);
+  // Disable the TX timer and wait for any TX to complete
   hwTimer.stop();
+  while (busyTransmitting);
 
   // Queue up sending the Master UID as MSP packets
   SendUIDOverMSP();

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -656,7 +656,7 @@ void registerLuaParameters() {
       }
       else if (arg > 0 && arg < 4) //start command, 1 = start, 2 = running, 3 = request confirmation
       {
-        sendLuaCommandResponse(&luaBLEJoystick, 3, "Start BLE Joystck?");
+        sendLuaCommandResponse(&luaBLEJoystick, 3, "Start BLE Joystick?");
       }
       else if (arg == 5)
       {

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -21,6 +21,7 @@ build_flags_rx = -DTARGET_RX=1 ${common_env_data.build_flags}
 [env_common_esp32]
 platform = espressif32@3.3.2
 board = esp32dev
+board_build.partitions = min_spiffs.csv
 upload_speed = 460800
 monitor_speed = 460800
 upload_resetmethod = nodemcu
@@ -31,6 +32,8 @@ build_flags =
 src_filter = ${common_env_data.src_filter} -<ESP8266*.*> -<STM32*.*>
 lib_deps = 
 	NeoPixelBus
+	FS
+	ESP Async WebServer
 	https://github.com/lemmingDev/ESP32-BLE-Gamepad.git#NimBLE
 
 


### PR DESCRIPTION
# Research

After a lot of research into how the crossfire LUA communicates with a module and how the module responds to those messages. I created an example sequence diagram of the workflow.

![command workflow](https://user-images.githubusercontent.com/512740/132930415-70efcfc4-ad2e-4a57-b0a7-5f0c5fa9cc27.png)

# Resulting code changes

LUA Handling on TX
- Move LUA specific functions to LUA library
- Simplification of the LUA library
- Cleanup and clarify the LUA code handling
- Adjust status code and info in polling callback based on actual state
- Fix-up some debugging
- Updates to LUA handling based on research
- Rework the webserver to use AsyncWebServer, so we can exit wifi update & joystick from LUA
- Reduce the SPIFFS partition for more app flash

LUA Changes
- Add validation of packet
    Once we've already seen a packet and we have the expected parent and type we can validate them on subsequent messages.
    This fixes a problem where we get missed chunks and if we miss chunk zero then the rest of the chunks are shifted down and causes an error in the script.
- INFO type is not to be changes
- Add code to detect missing chunks and ignore the update if there are any
- Add command running indicator
- Changes to support current CRSF protocol implementation

MIscellaneous
- Increase leeway for 115k baud @ 250Hz
- Update timer for reboot