### PR TITLE
Fix intermittent crash when disabling the radio

### DIFF
--- a/src/lib/SX127xDriver/SX127xHal.cpp
+++ b/src/lib/SX127xDriver/SX127xHal.cpp
@@ -19,8 +19,8 @@ SX127xHal::SX127xHal()
 void SX127xHal::end()
 {
   RXenable(); // make sure the TX amp pin is disabled
-  SPI.end();
   detachInterrupt(GPIO_PIN_DIO0);
+  SPI.end();
 }
 
 void SX127xHal::init()

--- a/src/lib/SX1280Driver/SX1280_hal.cpp
+++ b/src/lib/SX1280Driver/SX1280_hal.cpp
@@ -37,8 +37,8 @@ SX1280Hal::SX1280Hal()
 void SX1280Hal::end()
 {
     RXenable(); // make sure the TX amp pin is disabled
-    SPI.end();
     detachInterrupt(GPIO_PIN_DIO1);
+    SPI.end();
 }
 
 void SX1280Hal::init()


### PR DESCRIPTION
# Problem

When working on the LUA updates and testing the wifi and BLE code it was found then there were intermittent crashes with the following backtraces.

```
0x4009571a: vListInsert at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/list.c:188
0x40094740: vTaskPlaceOnEventList at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/tasks.c:2901
0x40092a5b: xQueueGenericReceive at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/queue.c:1590
0x4019a285: spiTransferBytes at /Users/paul/.platformio/packages/framework-arduinoespressif32/cores/esp32/esp32-hal-spi.c:676 (discriminator 1)
0x40186990: SPIClass::transferBytes(unsigned char const*, unsigned char*, unsigned int) at /Users/paul/.platformio/packages/framework-arduinoespressif32/libraries/SPI/src/SPI.cpp:246
0x401869a6: SPIClass::transfer(unsigned char*, unsigned int) at /Users/paul/.platformio/packages/framework-arduinoespressif32/libraries/SPI/src/SPI.cpp:219
0x400829ae: SX1280Hal::WriteCommand(RadioCommands_u, unsigned char*, unsigned char) at /Users/paul/Projects/Quad/ExpressLRS/src/lib/SX1280Driver/SX1280_hal.cpp:166
0x40082669: SX1280Driver::ClearIrqStatus(unsigned short) at /Users/paul/Projects/Quad/ExpressLRS/src/lib/SX1280Driver/SX1280.cpp:280
0x40082682: SX1280Driver::TXnbISR() at /Users/paul/Projects/Quad/ExpressLRS/src/lib/SX1280Driver/SX1280.cpp:289
0x400827ad: SX1280Hal::dioISR() at /Users/paul/Projects/Quad/ExpressLRS/src/lib/SX1280Driver/SX1280_hal.cpp:347
0x40082dad: __onPinInterrupt at /Users/paul/.platformio/packages/framework-arduinoespressif32/cores/esp32/esp32-hal-gpio.c:220
0x4008fe2d: _xt_lowint1 at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/xtensa_vectors.S:1154
0x40199b4c: spiInitBus at /Users/paul/.platformio/packages/framework-arduinoespressif32/cores/esp32/esp32-hal-spi.c:395
0x4019a07d: spiStopBus at /Users/paul/.platformio/packages/framework-arduinoespressif32/cores/esp32/esp32-hal-spi.c:409
0x4018692b: SPIClass::end() at /Users/paul/.platformio/packages/framework-arduinoespressif32/libraries/SPI/src/SPI.cpp:79
0x400e46c5: SX1280Hal::end() at /Users/paul/Projects/Quad/ExpressLRS/src/lib/SX1280Driver/SX1280_hal.cpp:39
0x400e439a: SX1280Driver::End() at /Users/paul/Projects/Quad/ExpressLRS/src/lib/SX1280Driver/SX1280.cpp:44
0x400d2925: BeginWebUpdate() at /Users/paul/Projects/Quad/ExpressLRS/src/src/ESP32_WebUpdate.cpp:346
0x400d4281: operator() at /Users/paul/Projects/Quad/ExpressLRS/src/src/tx_main.cpp:611
 (inlined by) _FUN at /Users/paul/Projects/Quad/ExpressLRS/src/src/tx_main.cpp:628
0x400e5f5d: luaHandleUpdateParameter() at /Users/paul/Projects/Quad/ExpressLRS/src/lib/LUA/lua.cpp:273
0x400d47eb: HandleUpdateParameter() at /Users/paul/Projects/Quad/ExpressLRS/src/src/tx_main.cpp:748
0x400d509f: loop() at /Users/paul/Projects/Quad/ExpressLRS/src/src/tx_main.cpp:1008
0x400e82a9: loopTask(void*) at /Users/paul/.platformio/packages/framework-arduinoespressif32/cores/esp32/main.cpp:23
0x40092c22: vPortTaskWrapper at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/port.c:143
```

# Solution

Move the `detachInterrupt(...)` line to before the `SPI.end()` call

