### PR TITLE
Fix intermittent crash in uartBegin() when starting module

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -964,6 +964,7 @@ bool CRSF::UARTwdt()
 void ICACHE_RAM_ATTR CRSF::ESP32uartTask(void *pvParameters)
 {
     DBGLN("ESP32 CRSF UART LISTEN TASK STARTED");
+    CRSF::duplex_set_TX();
     CRSF::Port.begin(TxToHandsetBauds[UARTcurrentBaudIdx], SERIAL_8N1,
                      GPIO_PIN_RCSIGNAL_RX, GPIO_PIN_RCSIGNAL_TX,
                      false, 500);


### PR DESCRIPTION
When testing the new LUA code which does a quick module restart when stopping WiFi or BLE, the call to `uartBegin(...)` in `CRSF.cpp` would sometimes crash stack traces as below, sometimes on different lines.
```
0x4008343a: _uart_isr at /Users/paul/.platformio/packages/framework-arduinoespressif32/cores/esp32/esp32-hal-uart.c:78
0x4008fe2d: _xt_lowint1 at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/xtensa_vectors.S:1154
0x4000bfed: ?? ??:0
0x40093d95: vTaskExitCritical at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/tasks.c:4274
0x40151f7e: esp_intr_alloc_intrstatus at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp32/intr_alloc.c:668
0x40151fdb: esp_intr_alloc at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp32/intr_alloc.c:688
0x400e7a75: uartEnableInterrupt at /Users/paul/.platformio/packages/framework-arduinoespressif32/cores/esp32/esp32-hal-uart.c:110 (discriminator 12)
0x400e7b37: uartAttachRx at /Users/paul/.platformio/packages/framework-arduinoespressif32/cores/esp32/esp32-hal-uart.c:151
0x400e8019: uartBegin at /Users/paul/.platformio/packages/framework-arduinoespressif32/cores/esp32/esp32-hal-uart.c:219
0x400e6215: HardwareSerial::begin(unsigned long, unsigned int, signed char, signed char, bool, unsigned long) at /Users/paul/.platformio/packages/framework-arduinoespressif32/cores/esp32/HardwareSerial.cpp:55
0x400824db: CRSF::ESP32uartTask(void*) at /Users/paul/Projects/Quad/ExpressLRS/src/lib/CRSF/CRSF.cpp:785
```
This exception stack trace shows that the UART RX interrupt is in the process of being installed when a interrupt is fired. The problem is that the UART is not fully initialised yet and the crash occurs.

This simple fix is to put the UART pins into TX mode prior to calling begin which means that there is no way the interrupt can occur at the time that the UART is being set up.

I have tried with this fix in place over a dozen or so restarts and the exception is no longer thrown. Without the fix in place I get the problem ~ 1 in 3 restarts.
