### PR TITLE
Removes an old (deprecated) Frsky target

### DIFF
--- a/src/targets/frsky.ini
+++ b/src/targets/frsky.ini
@@ -3,23 +3,6 @@
 # Transmitter targets
 # ********************************
 
-[env:Frsky_TX_R9M_via_STLINK_OLD_BOOTLOADER_DEPRECATED]
-extends = env_common_stm32
-build_flags =
-	${env_common_stm32.build_flags}
-	${common_env_data.build_flags_tx}
-	-D TARGET_R9M_TX
-	-D TX_DEVICE_NAME='"FrSky R9M"'
-	-D TARGET_USE_EEPROM=1
-	-D TARGET_EEPROM_ADDR=0x51
-	-D HSE_VALUE=12000000U
-	-DVECT_TAB_OFFSET=0x2000U
-board_build.ldscript = variants/R9M_ldscript_old_bl.ld
-board_build.flash_offset = 0x2000
-src_filter = ${env_common_stm32.src_filter} -<rx_*.cpp>
-lib_deps =
-	https://github.com/PaoloP74/extEEPROM.git
-
 ## TODO: R9M STLINK/stock and R9M Lite targets can be merged
 [env:Frsky_TX_R9M_via_STLINK]
 extends = env_common_stm32


### PR DESCRIPTION
Removes ``[env:Frsky_TX_R9M_via_STLINK_OLD_BOOTLOADER_DEPRECATED]``