### PR TITLE
Limit packet rate to 250Hz for 115k baud

### DIFF
--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -106,6 +106,7 @@ public:
     static void ResetMspQueue();
     static volatile uint32_t OpenTXsyncLastSent;
     static uint8_t GetMaxPacketBytes() { return maxPacketBytes; }
+    static uint32_t GetCurrentBaudRate() { return TxToHandsetBauds[UARTcurrentBaudIdx]; }
 #endif
 private:
     Stream *_dev;

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -317,8 +317,14 @@ uint8_t adjustPacketRateForBaud(uint8_t rate)
 {
   #if defined(Regulatory_Domain_ISM_2400)
     // Packet rate limited to 250Hz if we are on 115k baud
-    if (crsf.GetCurrentBaudRate() == 115200 && rate == 0) {
-      rate = 1;
+    if (crsf.GetCurrentBaudRate() == 115200) {
+      while(rate < RATE_MAX) {
+        expresslrs_mod_settings_s *const ModParams = get_elrs_airRateConfig(rate);
+        if (ModParams->enum_rate >= RATE_250HZ) {
+          break;
+        }
+        rate++;
+      }
     }
   #endif
   return rate;

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -701,8 +701,8 @@ void registerLuaParameters() {
 }
 
 void resetLuaParams(){
-  uint8_t rate = adjustPacketRateForBaud(RATE_MAX - 1 - config.GetRate());
-  setLuaTextSelectionValue(&luaAirRate, rate);
+  uint8_t rate = adjustPacketRateForBaud(config.GetRate());
+  setLuaTextSelectionValue(&luaAirRate, RATE_MAX - 1 - rate);
   setLuaTextSelectionValue(&luaTlmRate, config.GetTlm());
   setLuaTextSelectionValue(&luaSwitch,(uint8_t)(config.GetSwitchMode() - 1)); // -1 for missing sm1Bit
   setLuaTextSelectionValue(&luaModelMatch,(uint8_t)config.GetModelMatch());

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -313,8 +313,20 @@ void ICACHE_RAM_ATTR GenerateSyncPacketData()
     --syncSpamCounter;
 }
 
+uint8_t adjustPacketRateForBaud(uint8_t rate)
+{
+  #if defined(Regulatory_Domain_ISM_2400)
+    // Packet rate limited to 250Hz if we are on 115k baud
+    if (crsf.GetCurrentBaudRate() == 115200 && rate == 0) {
+      rate = 1;
+    }
+  #endif
+  return rate;
+}
+
 void ICACHE_RAM_ATTR SetRFLinkRate(uint8_t index) // Set speed of RF link (hz)
 {
+  index = adjustPacketRateForBaud(index);
   expresslrs_mod_settings_s *const ModParams = get_elrs_airRateConfig(index);
   expresslrs_rf_pref_params_s *const RFperf = get_elrs_RFperfParams(index);
   bool invertIQ = UID[5] & 0x01;
@@ -504,7 +516,9 @@ void registerLuaParameters() {
     if ((arg < RATE_MAX) && (arg >= 0))
     {
       DBGLN("Request AirRate: %d", arg);
-      config.SetRate(RATE_MAX - 1 - arg);
+      uint8_t rate = RATE_MAX - 1 - arg;
+      rate = adjustPacketRateForBaud(rate);
+      config.SetRate(rate);
       #if defined(HAS_OLED)
         OLED.updateScreen(OLED.getPowerString((PowerLevels_e)POWERMGNT.currPower()),
                           OLED.getRateString((expresslrs_RFrates_e)RATE_MAX - arg),
@@ -681,7 +695,8 @@ void registerLuaParameters() {
 }
 
 void resetLuaParams(){
-  setLuaTextSelectionValue(&luaAirRate, RATE_MAX - 1 - config.GetRate());
+  uint8_t rate = adjustPacketRateForBaud(RATE_MAX - 1 - config.GetRate());
+  setLuaTextSelectionValue(&luaAirRate, rate);
   setLuaTextSelectionValue(&luaTlmRate, config.GetTlm());
   setLuaTextSelectionValue(&luaSwitch,(uint8_t)(config.GetSwitchMode() - 1)); // -1 for missing sm1Bit
   setLuaTextSelectionValue(&luaModelMatch,(uint8_t)config.GetModelMatch());


### PR DESCRIPTION
Forces the packet rate to a maximum of 250Hz if the connection to the radio is 115k baud.

The problem with 115k baud at 500Hz is that there is a maximum of 10bytes that can be transferred in the allotted window, and the LUA has an 8 byte overhead, so we end up transferring 2 bytes of payload each time which make using the LUA interminably slow. Added to this is that the link between the radio and module seems to naturally go to 250Hz-ish. If we limit the rate to 250Hz then the link is stable and we have 18 bytes of data in the window available so the LUA loading is not terrible.