### PR TITLE
Async Startup LEDs

### DIFF
--- a/src/lib/LED/LED.h
+++ b/src/lib/LED/LED.h
@@ -104,7 +104,7 @@ void startupLEDs()
     #endif
     blinkyColor.h = 0;
     blinkyColor.s = 255;
-    blinkyColor.v = 12;
+    blinkyColor.v = 128;
 
     LEDupdateCounterMillis = 0;
     LEDupdateInterval = 0;

--- a/src/lib/LED/LED.h
+++ b/src/lib/LED/LED.h
@@ -68,8 +68,7 @@ static uint32_t HsvToRgb(uint8_t hue, uint8_t saturation, uint8_t lightness)
     }
 }
 
-static void blinkyUpdate() {
-    unsigned long now = millis();
+static void blinkyUpdate(unsigned long now) {
     if (blinkyUpdateTime > now)
     {
         return;
@@ -109,7 +108,7 @@ void updateLEDs(uint32_t now, connectionState_e connectionState, uint8_t rate, u
 {
     if (state == STARTUP)
     {
-        blinkyUpdate();
+        blinkyUpdate(now);
         return;
     }
 

--- a/src/lib/LED/LED.h
+++ b/src/lib/LED/LED.h
@@ -29,86 +29,95 @@ void WS281BsetLED(uint32_t color)
 static enum {
     STARTUP = 0,
     NORMAL = 1
-} state;
-static unsigned long blinkyUpdateTime;
-static uint8_t hue = 0, saturation = 255, lightness = 128;
-static uint8_t hueStepValue = 1;
-static uint8_t lightnessStep = 5;
+} blinkyState;
+static struct blinkColor_t {
+  uint8_t h, s, v;
+} blinkyColor;
 
-static uint32_t HsvToRgb(uint8_t hue, uint8_t saturation, uint8_t lightness)
+static uint32_t LEDupdateCounterMillis;
+static uint32_t LEDupdateInterval;
+#define NORMAL_UPDATE_INTERVAL 50
+
+static uint32_t HsvToRgb()
 {
     uint8_t region, remainder, p, q, t;
 
-    if (saturation == 0)
+    if (blinkyColor.s == 0)
     {
-        return lightness << 16 | lightness << 8 | lightness;
+        return blinkyColor.v << 16 | blinkyColor.v << 8 | blinkyColor.v;
     }
 
-    region = hue / 43;
-    remainder = (hue - (region * 43)) * 6; 
+    region = blinkyColor.h / 43;
+    remainder = (blinkyColor.h - (region * 43)) * 6; 
 
-    p = (lightness * (255 - saturation)) >> 8;
-    q = (lightness * (255 - ((saturation * remainder) >> 8))) >> 8;
-    t = (lightness * (255 - ((saturation * (255 - remainder)) >> 8))) >> 8;
+    p = (blinkyColor.v * (255 - blinkyColor.s)) >> 8;
+    q = (blinkyColor.v * (255 - ((blinkyColor.s * remainder) >> 8))) >> 8;
+    t = (blinkyColor.v * (255 - ((blinkyColor.s * (255 - remainder)) >> 8))) >> 8;
 
     switch (region)
     {
         case 0:
-            return lightness << 16 | t << 8 | p;
+            return blinkyColor.v << 16 | t << 8 | p;
         case 1:
-            return q << 16 | lightness << 8 | p;
+            return q << 16 | blinkyColor.v << 8 | p;
         case 2:
-            return p << 16 | lightness << 8 | t;
+            return p << 16 | blinkyColor.v << 8 | t;
         case 3:
-            return p << 16 | q << 8 | lightness;
+            return p << 16 | q << 8 | blinkyColor.v;
         case 4:
-            return t << 16 | p << 8 | lightness;
+            return t << 16 | p << 8 | blinkyColor.v;
         default:
-            return lightness << 16 | p << 8 | q;
+            return blinkyColor.v << 16 | p << 8 | q;
     }
 }
 
-static void blinkyUpdate(unsigned long now) {
-    if (blinkyUpdateTime > now)
-    {
-        return;
-    }
+static int blinkyUpdate(unsigned long now) {
+    static constexpr uint8_t hueStepValue = 1;
+    static constexpr uint8_t lightnessStep = 5;
 
-    uint32_t rgb = HsvToRgb(hue, saturation, lightness);
+    uint32_t rgb = HsvToRgb();
     WS281BsetLED(rgb);
-    DBGVLN("LED hue %u", hue);
-    if ((int)hue + hueStepValue > 255) {
-        if ((int)lightness - lightnessStep < 0) {
-            state = NORMAL;
-            return;
+    DBGVLN("LED hue %u", blinkyColor.h);
+
+    if ((int)blinkyColor.h + hueStepValue > 255) {
+        if ((int)blinkyColor.v - lightnessStep < 0) {
+            blinkyState = NORMAL;
+            return NORMAL_UPDATE_INTERVAL;
         }
-        lightness -= lightnessStep;
+        blinkyColor.v -= lightnessStep;
     } else {
-        hue += hueStepValue;
+        blinkyColor.h += hueStepValue;
     }
-    blinkyUpdateTime = now + 3000/(256/hueStepValue);
+    return 3000/(256/hueStepValue);
 }
 
 void startupLEDs()
 {
     WS281Binit();
-    state = STARTUP;
+    blinkyState = STARTUP;
     #ifdef PLATFORM_ESP32
     // Only do the blinkies if it was NOT a software reboot
     if (esp_reset_reason() == ESP_RST_SW) {
-        state = NORMAL;
+        blinkyState = NORMAL;
+        LEDupdateInterval = NORMAL_UPDATE_INTERVAL;
     }
     #endif
-    blinkyUpdateTime = 0;
-    hue = 0;
-    lightness = 128;
+    blinkyColor.h = 0;
+    blinkyColor.s = 255;
+    blinkyColor.v = 12;
+
+    LEDupdateCounterMillis = 0;
+    LEDupdateInterval = 0;
 }
 
 void updateLEDs(uint32_t now, connectionState_e connectionState, uint8_t rate, uint32_t power)
 {
-    if (state == STARTUP)
+    if (blinkyState == STARTUP)
     {
-        blinkyUpdate(now);
+        if (now - LEDupdateCounterMillis > LEDupdateInterval) {
+            LEDupdateInterval = blinkyUpdate(now);
+            LEDupdateCounterMillis = now;
+        }
         return;
     }
 
@@ -119,14 +128,12 @@ void updateLEDs(uint32_t now, connectionState_e connectionState, uint8_t rate, u
         21,     // 150/50 hz   orange
         0      // 50/25 hz    red
     };
-    constexpr uint32_t LEDupdateInterval = 50;
-    static uint32_t nextUpdateTime = 0;
 
     static connectionState_e lastState = disconnected;
     static uint8_t lastRate = 0xFF;
     static uint32_t lastPower = 0xFFFFFFFF;
 
-    if ((connectionState == disconnected) && (now > nextUpdateTime))
+    if ((connectionState == disconnected) && (now - LEDupdateCounterMillis > LEDupdateInterval))
     {
         static uint8_t lightness = 0;
         static int8_t dir = 1;
@@ -141,17 +148,25 @@ void updateLEDs(uint32_t now, connectionState_e connectionState, uint8_t rate, u
         }
 
         lightness += dir;
-        nextUpdateTime = now + LEDupdateInterval;
         lastState = connectionState;
-        WS281BsetLED(HsvToRgb(rate_hue[rate], 255, lightness));
+
+        blinkyColor.h = rate_hue[rate];
+        blinkyColor.v = lightness;
+        WS281BsetLED(HsvToRgb());
+
+        LEDupdateCounterMillis = now;
     }
     if (((connectionState != disconnected) && (lastState == disconnected)) || lastRate != rate || lastPower != power)
     {
         lastState = connectionState;
-        lastRate = rate;
         lastPower = power;
-        uint8_t lightness = fmap(power, 0, PWR_COUNT-1, 10, 128);
-        WS281BsetLED(HsvToRgb(rate_hue[rate], 255, lightness));
+        if (rate != lastRate)
+        {
+            blinkyColor.h = rate_hue[rate];
+            lastRate = rate;
+        }
+        blinkyColor.v = fmap(power, 0, PWR_COUNT-1, 10, 128);
+        WS281BsetLED(HsvToRgb());
     }
 }
 #else

--- a/src/lib/LED/LED.h
+++ b/src/lib/LED/LED.h
@@ -41,13 +41,13 @@ static uint8_t hue = 0, saturation = 200, lightness = 255;
 static uint8_t hueStepValue = 1;
 static uint8_t lightnessStep = 10;
 
-static RgbColor HsvToRgb(uint8_t hue, uint8_t saturation, uint8_t lightness)
+static uint32_t HsvToRgb(uint8_t hue, uint8_t saturation, uint8_t lightness)
 {
     uint8_t region, remainder, p, q, t;
 
     if (saturation == 0)
     {
-        return RgbColor(lightness, lightness, lightness);
+        return lightness << 16 | lightness << 8 | lightness;
     }
 
     region = hue / 43;
@@ -60,17 +60,17 @@ static RgbColor HsvToRgb(uint8_t hue, uint8_t saturation, uint8_t lightness)
     switch (region)
     {
         case 0:
-            return RgbColor(lightness, t, p);
+            return lightness << 16 | t << 8 | p;
         case 1:
-            return RgbColor(q, lightness, p);
+            return q << 16 | lightness << 8 | p;
         case 2:
-            return RgbColor(p, lightness, t);
+            return p << 16 | lightness << 8 | t;
         case 3:
-            return RgbColor(p, q, lightness);
+            return p << 16 | q << 8 | lightness;
         case 4:
-            return RgbColor(t, p, lightness);
+            return t << 16 | p << 8 | lightness;
         default:
-            return RgbColor(lightness, p, q);
+            return lightness << 16 | p << 8 | q;
     }
 }
 
@@ -81,8 +81,8 @@ static void blinkyUpdate() {
         return;
     }
 
-    RgbColor rgb = HsvToRgb(hue, saturation, lightness);
-    WS281BsetLED(rgb.R, rgb.G, rgb.B);
+    uint32_t rgb = HsvToRgb(hue, saturation, lightness);
+    WS281BsetLED(rgb);
     DBGVLN("LED hue %u", hue);
     if ((int)hue + hueStepValue > 255) {
         if ((int)lightness - lightnessStep < 0) {


### PR DESCRIPTION
Because @JyeSmith threatened to remove the LEDs I had to resort to making them asynchronous so they don't hold up the module start up.

As part of this, and because we're not holding up the normal startup I thought we could make the LEDs even more beautiful and smooth, so I introduced an HSV function and we adjust the hue then fade down over 3 seconds before moving into "normal" mode and displaying the packet rate and connection status.
