### PR TITLE
LED Indication for other modes

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -42,8 +42,6 @@ void (*CRSF::RCdataCallback)() = &nullCallback; // called when there is new RC d
 uint32_t CRSF::GoodPktsCountResult = 0;
 uint32_t CRSF::BadPktsCountResult = 0;
 
-bool CRSF::hasEverConnected = false;
-
 volatile uint8_t CRSF::SerialInPacketLen = 0; // length of the CRSF packet as measured
 volatile uint8_t CRSF::SerialInPacketPtr = 0; // index where we are reading/writing
 
@@ -368,7 +366,6 @@ bool ICACHE_RAM_ATTR CRSF::ProcessPacket()
         LPF_OPENTX_SYNC_MARGIN.init(0);
         LPF_OPENTX_SYNC_OFFSET.init(0);
 #endif // FEATURE_OPENTX_SYNC_AUTOTUNE
-        hasEverConnected = true;
         connected();
     }
     

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -63,8 +63,6 @@ public:
     static uint32_t GoodPktsCountResult; // need to latch the results
     static uint32_t BadPktsCountResult; // need to latch the results
 
-    static bool hasEverConnected;
-
     static void Begin(); //setup timers etc
     static void End(); //stop timers etc
 

--- a/src/lib/LED/LED.h
+++ b/src/lib/LED/LED.h
@@ -199,7 +199,7 @@ static uint16_t flashLED(uint8_t onLightness, uint8_t offLightness, uint8_t hue,
     blinkyColor.v = counter % 2 == 0 ? onLightness : offLightness;
     blinkyColor.h = hue;
     WS281BsetLED(HsvToRgb());
-    if (counter == durationCounts)
+    if (counter >= durationCounts)
     {
         counter = 0;
     }

--- a/src/lib/LED/LED.h
+++ b/src/lib/LED/LED.h
@@ -211,7 +211,7 @@ constexpr uint8_t LEDSEQ_NO_CROSSFIRE[] = {  10, 90 }; // 100ms on, 900ms off (o
 
 void updateLEDs(uint32_t now, connectionState_e connectionState, uint8_t rate, uint32_t power)
 {
-    if (blinkyState == STARTUP && connectionState <= disconnectPending)
+    if (blinkyState == STARTUP && connectionState < FAILURE_STATES)
     {
         if (now - LEDupdateCounterMillis > LEDupdateInterval) {
             LEDupdateInterval = blinkyUpdate(now);

--- a/src/src/ESP32_WebUpdate.cpp
+++ b/src/src/ESP32_WebUpdate.cpp
@@ -56,8 +56,6 @@ static IPAddress netMsk(255, 255, 255, 0);
 static DNSServer dnsServer;
 static AsyncWebServer server(80);
 
-bool IsWebUpdateMode = false;
-
 /** Is this an IP? */
 static boolean isIp(String str)
 {
@@ -340,8 +338,6 @@ static void startWifi() {
 
 void BeginWebUpdate()
 {
-  IsWebUpdateMode = true;
-
   DBGLN("Stopping Radio");
   Radio.End();
 

--- a/src/src/ESP32_WebUpdate.h
+++ b/src/src/ESP32_WebUpdate.h
@@ -1,6 +1,4 @@
 #ifdef PLATFORM_ESP32
 void HandleWebUpdate();
 void BeginWebUpdate();
-
-extern bool IsWebUpdateMode;
 #endif

--- a/src/src/ESP8266_WebUpdate.cpp
+++ b/src/src/ESP8266_WebUpdate.cpp
@@ -56,8 +56,6 @@ static ESP8266WebServer server(80);
 
 static MDNSResponder::hMDNSService service;
 
-bool IsWebUpdateMode = false;
-
 /** Is this an IP? */
 static boolean isIp(String str)
 {
@@ -277,8 +275,6 @@ static void startWifi() {
 
 void BeginWebUpdate(void)
 {
-  IsWebUpdateMode = true;
-
   DBGLN("Stopping Radio");
   Radio.End();
 

--- a/src/src/ESP8266_WebUpdate.h
+++ b/src/src/ESP8266_WebUpdate.h
@@ -3,6 +3,4 @@
 
 void BeginWebUpdate(void);
 void HandleWebUpdate(void);
-
-extern bool IsWebUpdateMode;
 #endif

--- a/src/src/common.h
+++ b/src/src/common.h
@@ -37,7 +37,9 @@ typedef enum
     connected,
     tentative,
     disconnected,
-    disconnectPending // used on modelmatch change to drop the connection
+    disconnectPending, // used on modelmatch change to drop the connection
+    wifiUpdate,
+    bleJoystick
 } connectionState_e;
 
 typedef enum

--- a/src/src/common.h
+++ b/src/src/common.h
@@ -40,7 +40,8 @@ typedef enum
     disconnectPending, // used on modelmatch change to drop the connection
     wifiUpdate,
     bleJoystick,
-    radioFailed
+    radioFailed,
+    noCrossfire
 } connectionState_e;
 
 typedef enum

--- a/src/src/common.h
+++ b/src/src/common.h
@@ -39,7 +39,8 @@ typedef enum
     disconnected,
     disconnectPending, // used on modelmatch change to drop the connection
     wifiUpdate,
-    bleJoystick
+    bleJoystick,
+    radioFailed
 } connectionState_e;
 
 typedef enum

--- a/src/src/common.h
+++ b/src/src/common.h
@@ -38,10 +38,14 @@ typedef enum
     tentative,
     disconnected,
     disconnectPending, // used on modelmatch change to drop the connection
+    MODE_STATES,
+    // States below here are special mode states
     wifiUpdate,
     bleJoystick,
-    radioFailed,
-    noCrossfire
+    noCrossfire,
+    // Failure states go below here to display immediately
+    FAILURE_STATES,
+    radioFailed
 } connectionState_e;
 
 typedef enum

--- a/src/src/common.h
+++ b/src/src/common.h
@@ -40,9 +40,9 @@ typedef enum
     disconnectPending, // used on modelmatch change to drop the connection
     MODE_STATES,
     // States below here are special mode states
+    noCrossfire,
     wifiUpdate,
     bleJoystick,
-    noCrossfire,
     // Failure states go below here to display immediately
     FAILURE_STATES,
     radioFailed

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -136,7 +136,7 @@ bool buttonDown = false;     //is the button current pressed down?
 uint32_t buttonLastSampled = 0;
 uint32_t buttonLastPressed = 0;
 
-bool disableWebServer = false;
+static bool webserverPreventAutoStart = false;
 ///////////////////////////////////////////////
 
 volatile uint8_t NonceRX = 0; // nonce that we THINK we are up to.
@@ -611,7 +611,7 @@ void GotConnection(unsigned long now)
 
     connectionStatePrev = connectionState;
     connectionState = connected; //we got a packet, therefore no lost connection
-    disableWebServer = true;
+    webserverPreventAutoStart = true;
     RXtimerState = tim_tentative;
     GotConnectionMillis = now;
 
@@ -1211,12 +1211,12 @@ void loop()
     }
 
     #if defined(PLATFORM_ESP8266) && defined(AUTO_WIFI_ON_INTERVAL)
-    if (!disableWebServer && (connectionState == disconnected) && !InBindingMode && now > (AUTO_WIFI_ON_INTERVAL*1000))
+    if (!webserverPreventAutoStart && (connectionState == disconnected) && !InBindingMode && now > (AUTO_WIFI_ON_INTERVAL*1000))
     {
         beginWebsever();
     }
 
-    if (!disableWebServer && (connectionState == disconnected) && InBindingMode && now > 60000)
+    if (!webserverPreventAutoStart && (connectionState == disconnected) && InBindingMode && now > 60000)
     {
         beginWebsever();
     }
@@ -1479,7 +1479,7 @@ void OnELRSBindMSP(uint8_t* packet)
 
     FHSSrandomiseFHSSsequence(uidMacSeedGet());
 
-    disableWebServer = true;
+    webserverPreventAutoStart = true;
     ExitBindingMode();
 }
 

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1058,7 +1058,7 @@ void loop()
   #if defined(AUTO_WIFI_ON_INTERVAL)
     //if webupdate was requested before or AUTO_WIFI_ON_INTERVAL has been elapsed but uart is not detected
     //start webupdate, there might be wrong configuration flashed.
-    if(crsfSeen == false && now > (AUTO_WIFI_ON_INTERVAL * 1000) && connectionState < MODE_STATES){
+    if(crsfSeen == false && now > (AUTO_WIFI_ON_INTERVAL * 1000) && connectionState < wifiUpdate){
       DBGLN("No CRSF ever detected, starting WiFi");
       beginWebsever();
     }

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -39,9 +39,8 @@ SX1280Driver Radio;
 #endif
 #ifdef PLATFORM_ESP32
 #include "ESP32_WebUpdate.h"
-#endif
 #include "ESP32_BLE_HID.h"
-volatile bool BLEjoystickRefresh = false;
+#endif
 
 #if defined(GPIO_PIN_BUTTON) && (GPIO_PIN_BUTTON != UNDEF_PIN)
 #include "button.h"
@@ -64,7 +63,7 @@ MSP msp;
 ELRS_EEPROM eeprom;
 TxConfig config;
 
-bool crsfSeen = false;
+static bool webserverPreventAutoStart = false;
 
 #if defined(HAS_OLED)
 OLED OLED;
@@ -761,7 +760,7 @@ void UARTconnected()
 
   rfModeLastChangedMS = millis(); // force syncspam on first packets
   hwTimer.resume();
-  crsfSeen = true;
+  webserverPreventAutoStart = true;
   SetRFLinkRate(config.GetRate());
 }
 
@@ -1058,7 +1057,7 @@ void loop()
   #if defined(AUTO_WIFI_ON_INTERVAL)
     //if webupdate was requested before or AUTO_WIFI_ON_INTERVAL has been elapsed but uart is not detected
     //start webupdate, there might be wrong configuration flashed.
-    if(crsfSeen == false && now > (AUTO_WIFI_ON_INTERVAL * 1000) && connectionState < wifiUpdate){
+    if(webserverPreventAutoStart == false && now > (AUTO_WIFI_ON_INTERVAL * 1000) && connectionState < wifiUpdate){
       DBGLN("No CRSF ever detected, starting WiFi");
       beginWebsever();
     }

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -762,6 +762,7 @@ void UARTconnected()
   hwTimer.resume();
   webserverPreventAutoStart = true;
   SetRFLinkRate(config.GetRate());
+  connectionState = disconnected; // set here because SetRFLinkRate may have early exited and not set the state
 }
 
 static void ChangeRadioParams()

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -982,9 +982,11 @@ void setup()
   if (!init_success)
   {
     #ifdef PLATFORM_ESP32
+    connectionState = radioFailed;
     BeginWebUpdate();
     while (1)
     {
+      updateLEDs(millis(), radioFailed, 0, 0);
       HandleWebUpdate();
       delay(1);
     }

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1039,7 +1039,7 @@ void loop()
   uint32_t now = millis();
   static bool mspTransferActive = false;
 
-  if (connectionState <= disconnectPending)
+  if (connectionState < MODE_STATES)
   {
     UpdateConnectDisconnectStatus();
   }
@@ -1058,7 +1058,7 @@ void loop()
   #if defined(AUTO_WIFI_ON_INTERVAL)
     //if webupdate was requested before or AUTO_WIFI_ON_INTERVAL has been elapsed but uart is not detected
     //start webupdate, there might be wrong configuration flashed.
-    if(crsfSeen == false && now > (AUTO_WIFI_ON_INTERVAL * 1000) && connectionState <= disconnectPending){
+    if(crsfSeen == false && now > (AUTO_WIFI_ON_INTERVAL * 1000) && connectionState < MODE_STATES){
       DBGLN("No CRSF ever detected, starting WiFi");
       beginWebsever();
     }


### PR DESCRIPTION
With the nice LED framework in place. This PR adds indication for...
| Mode | Indication |
| --- | --- |
| Web Update | Green heartbeat |
| BLE Joystick | Blue heartbeat |
| Radio Failed | Red flashing 100ms on/off |
| No Handset Connection | One Red flash every second | 

This is in addition to the usual startup color-wheel crossfade and Rate/Connected color pulsing modes.

As part of this I have removed the boolean variables for BLE Mode and WiFi mode and merged them into the connection status enum. Ultimately I'd like to move the IsBinding into the connection status enum as well.