### PR TITLE
Add an ELRS theme to color screen and mockup

### DIFF
--- a/src/lua/elrsV2.lua
+++ b/src/lua/elrsV2.lua
@@ -45,7 +45,7 @@ local textXoffset = 0
 local textYoffset = 1
 local textSize = 8
 local lcdIsColor
-local lcdFieldAttr
+local lcdFieldAttr, lcdSelFieldAttr
 local lcdSavedColors
 
 local function getField(line)
@@ -668,7 +668,9 @@ local function runDevicePage(event)
       elseif field.name == nil then
         lcd.drawText(textXoffset, y*textSize+textYoffset, "...")
       else
-        local attr = lineIndex == (pageOffset+y) and ((edit == true and BLINK or 0) + BOLD + INVERS) or lcdFieldAttr
+        local attr = lineIndex == (pageOffset+y)
+          and ((edit == true and BLINK or 0) + lcdSelFieldAttr + INVERS)
+          or lcdFieldAttr
         if field.type < 11 or field.type == 12 then -- if not folder, command, or back
           lcd.drawText(textXoffset, y*textSize+textYoffset, field.name, lcdFieldAttr)
         end
@@ -731,6 +733,7 @@ local function setLCDvar()
     textYoffset = 10
     textSize = 22
     lcdFieldAttr = CUSTOM_COLOR
+    lcdSelFieldAttr = BOLD
     lcdSavedColors = {
       lcd.getColor(TEXT_COLOR),
       lcd.getColor(TEXT_BGCOLOR),
@@ -745,8 +748,9 @@ local function setLCDvar()
     end  
     maxLineIndex = 6
     textXoffset = 0
-    textYoffset = 2
+    textYoffset = 3
     textSize = 8
+    lcdSelFieldAttr = 0
     lcdFieldAttr = 0
   end
 end

--- a/src/lua/elrsV2.lua
+++ b/src/lua/elrsV2.lua
@@ -43,14 +43,9 @@ local COL2 = 70
 local maxLineIndex = 7
 local textXoffset = 0
 local textYoffset = 1
-local barHeight = 10
 local textSize = 8
-local titleAdditionAttr = 0
-local barColor = GREY
-local progressBarColor = 0
-local outlineSpace = 1
-local progressBarOffset = 0
-local progressBarHeight = barHeight
+local lcdIsColor
+local lcdFieldAttr
 
 local function getField(line)
   local counter = 1
@@ -338,11 +333,10 @@ local function fieldStringSave(field)
 end
 
 local function fieldStringDisplay(field, y, attr)
-  lcd.drawText(textXoffset, y, field.name)
   if edit == true and attr then
     -- lcd.drawText(COL2, y, field.value, FIXEDWIDTH)	-- NOTE: FIXEDWIDTH unknown....
     -- lcd.drawText(134+6*charIndex, y, string.sub(field.value, charIndex, charIndex), FIXEDWIDTH + attr)	-- NOTE: FIXEDWIDTH unknown....
-	lcd.drawText(COL2, y, field.value, attr)
+    lcd.drawText(COL2, y, field.value, attr)
     lcd.drawText(COL2+6*(charIndex-1), y, string.sub(field.value, charIndex, charIndex), attr)
   else
     lcd.drawText(COL2, y, field.value, attr)
@@ -391,21 +385,21 @@ local function UIbackExec(field)
 end
 
 local functions = {
-  { load=fieldUint8Load, save=fieldUint8Save, display=fieldIntDisplay }, --1
-  { load=fieldInt8Load, save=fieldInt8Save, display=fieldIntDisplay }, --2
-  { load=fieldUint16Load, save=fieldUint16Save, display=fieldIntDisplay }, --3
-  { load=fieldInt16Load, save=fieldInt16Save, display=fieldIntDisplay }, --4
-  nil, --5
-  nil, --6
-  nil, --7
-  nil, --8
-  { load=fieldFloatLoad, save=fieldFloatSave, display=fieldFloatDisplay }, --9
-  { load=fieldTextSelectionLoad, save=fieldTextSelectionSave, display=fieldTextSelectionDisplay }, --10
-  { load=fieldStringLoad, save=fieldStringSave, display=fieldStringDisplay }, --11
-  { load=nil, save=fieldFolderOpen, display=fieldFolderDisplay }, --12
-  { load=fieldStringLoad, save=fieldStringSave, display=fieldStringDisplay }, --13
-  { load=fieldCommandLoad, save=fieldCommandSave, display=fieldCommandDisplay }, --14
-  { load=nil, save=UIbackExec, display=fieldCommandDisplay }, --15
+  { load=fieldUint8Load, save=fieldUint8Save, display=fieldIntDisplay }, --1 UINT8(0)
+  { load=fieldInt8Load, save=fieldInt8Save, display=fieldIntDisplay }, --2 INT8(1)
+  { load=fieldUint16Load, save=fieldUint16Save, display=fieldIntDisplay }, --3 UINT16(2)
+  { load=fieldInt16Load, save=fieldInt16Save, display=fieldIntDisplay }, --4  INT16(3)
+  nil,
+  nil,
+  nil,
+  nil,
+  { load=fieldFloatLoad, save=fieldFloatSave, display=fieldFloatDisplay }, --9 FLOAT(8)
+  { load=fieldTextSelectionLoad, save=fieldTextSelectionSave, display=fieldTextSelectionDisplay }, --10 SELECT(9)
+  { load=fieldStringLoad, save=fieldStringSave, display=fieldStringDisplay }, --11 STRING(10)
+  { load=nil, save=fieldFolderOpen, display=fieldFolderDisplay }, --12 FOLDER(11)
+  { load=fieldStringLoad, save=fieldStringSave, display=fieldStringDisplay }, --13 INFO(12)
+  { load=fieldCommandLoad, save=fieldCommandSave, display=fieldCommandDisplay }, --14 COMMAND(13)
+  { load=nil, save=UIbackExec, display=fieldCommandDisplay }, --15 back(14)
 }
 
 local function parseParameterInfoMessage(data)
@@ -525,16 +519,43 @@ end
 
 local function lcd_title()
   local title = (allParamsLoaded == 1 or elrsFlags > 0) and deviceName or "Loading..."
-  lcd.clear()
-  -- keep the title this way to keep the script from error when module is not set correctly
-  if allParamsLoaded ~= 1 and fields_count > 0 then
-    lcd.drawFilledRectangle(COL2, 0, LCD_W, barHeight, barColor)
-    lcd.drawGauge(0,progressBarOffset,COL2,progressBarHeight,fieldId,fields_count,progressBarColor)
+  if lcdIsColor then
+    -- Color screen
+    local EBLUE = lcd.RGB(0x43, 0x61, 0xAA)
+    local EGREEN = lcd.RGB(0x9f, 0xc7, 0x6f)
+    local barHeight = 30
+
+    lcd.setColor(CUSTOM_COLOR, EGREEN)
+    lcd.clear(CUSTOM_COLOR)
+    -- Field display area (white w/ 2px green border)
+    lcd.setColor(CUSTOM_COLOR, WHITE)
+    lcd.drawFilledRectangle(2, barHeight, LCD_W - 4, LCD_H - barHeight - 2, CUSTOM_COLOR)
+    -- title bar
+    lcd.setColor(CUSTOM_COLOR, BLACK)
+    lcd.drawText(textXoffset+1, 4, title, CUSTOM_COLOR)
+    lcd.drawText(LCD_W-3, 4, tostring(badPkt) .. "/" .. tostring(goodPkt), RIGHT + BOLD + CUSTOM_COLOR)
+    -- progress bar
+    local barW = (COL2-4)*fieldId/fields_count
+    lcd.setColor(CUSTOM_COLOR, WHITE)
+    lcd.drawFilledRectangle(2+barW, 2+20, COL2-2-barW, barHeight-5-20, CUSTOM_COLOR)
+    lcd.setColor(CUSTOM_COLOR, EBLUE)
+    lcd.drawFilledRectangle(2, 2+20, barW, barHeight-5-20, CUSTOM_COLOR)
+    -- leave EBLUE as the custom color for text
   else
-    lcd.drawFilledRectangle(0, 0, LCD_W, barHeight, barColor)
-    lcd.drawText(textXoffset, outlineSpace, title, titleAdditionAttr)
+    -- B&W screen
+    local barHeight = 9
+
+    lcd.clear()
+    lcd.drawText(LCD_W, 1, tostring(badPkt) .. "/" .. tostring(goodPkt), RIGHT)
+    -- keep the title this way to keep the script from error when module is not set correctly
+    if allParamsLoaded ~= 1 and fields_count > 0 then
+      lcd.drawFilledRectangle(COL2, 0, LCD_W, barHeight, GREY_DEFAULT)
+      lcd.drawGauge(0, 0, COL2, barHeight, fieldId, fields_count, 0)
+    else
+      lcd.drawFilledRectangle(0, 0, LCD_W, barHeight, GREY_DEFAULT)
+      lcd.drawText(textXoffset, 1, title, INVERS)
+    end
   end
-  lcd.drawText(LCD_W, outlineSpace, tostring(badPkt) .. "/" .. tostring(goodPkt), RIGHT + titleAdditionAttr)
 end
   
 
@@ -562,7 +583,9 @@ local function runDevicePage(event)
         crossfireTelemetryPush(0x2C, { deviceId, 0xEF, fieldId, fieldChunk })
       end
       folderAccess = 0
-      fields[fields_count+1].parent = 255
+      if fields_count > 0 then
+        fields[fields_count+1].parent = 255
+      end
     end
   elseif event == EVT_VIRTUAL_ENTER then        -- toggle editing/selecting current field
     if elrsFlags > 0 then
@@ -620,9 +643,9 @@ local function runDevicePage(event)
       elseif field.name == nil then
         lcd.drawText(textXoffset, y*textSize+textYoffset, "...")
       else
-        local attr = lineIndex == (pageOffset+y) and ((edit == true and BLINK or 0) + INVERS) or 0
-        if field.type < 11 then
-          lcd.drawText(textXoffset, y*textSize+textYoffset, field.name)
+        local attr = lineIndex == (pageOffset+y) and ((edit == true and BLINK or 0) + INVERS) or lcdFieldAttr
+        if field.type ~= 11 and field.type ~= 13 then -- if not folder or command
+          lcd.drawText(textXoffset, y*textSize+textYoffset, field.name, lcdFieldAttr)
         end
         if functions[field.type+1].display then
           functions[field.type+1].display(field, y*textSize+textYoffset, attr)
@@ -632,7 +655,6 @@ local function runDevicePage(event)
   end
   return 0
 end
-
 
 local function runPopupPage(event)
   if event == EVT_VIRTUAL_EXIT then             -- exit script
@@ -674,16 +696,14 @@ local function runPopupPage(event)
 end
   
 local function setLCDvar()
+  lcdIsColor = lcd.RGB ~= nil
   if LCD_W == 480 then
     COL2 = 240
     maxLineIndex = 10
-    textXoffset = 1
+    textXoffset = 3
     textYoffset = 10
-    barHeight = 32
     textSize = 22
-    progressBarOffset = 0
-    outlineSpace = (barHeight-textSize)/2
-    progressBarHeight = barHeight
+    lcdFieldAttr = CUSTOM_COLOR
   else
     if LCD_W == 212 then
       COL2 = 110
@@ -693,31 +713,28 @@ local function setLCDvar()
     maxLineIndex = 6
     textXoffset = 0
     textYoffset = 2
-    barHeight = 10
     textSize = 8
-    progressBarOffset = 0
-    outlineSpace = (barHeight-textSize)/2
-    progressBarHeight = barHeight-outlineSpace
+    lcdFieldAttr = 0
   end
 end
 
-local function setColorVar()
-    if LCD_W == 480 then
-      barColor = (TITLE_BGCOLOR or TITLE_BGCOLOR)
-      titleAdditionAttr = (WHITE or MENU_TITLE_COLOR)
-      progressBarColor = (GREEN or WARNING_COLOR)
-    else
-      barColor = GREY_DEFAULT
-      titleAdditionAttr = INVERS
-      progressBarColor = 0
-    end
-  end
+local function setMock()
+  -- Setup fields to display if running in Simulator
+  local _, rv = getVersion()
+  if string.sub(rv, -5) ~= "-simu" then return end
+  local mock = loadScript("elrsmock.lua")
+  if mock == nil then return end
+  fields, badPkt, goodPkt = mock(), 0, 500
+  fields_count = #fields - 1
+  fieldId = #fields - 3
+  initLineIndex()
+end
 
 -- Init
 local function init()
   lineIndex, edit = 0, false
   setLCDvar()
-  setColorVar()
+  setMock()
 end
 
 -- Main

--- a/src/lua/mockup/README.md
+++ b/src/lua/mockup/README.md
@@ -1,0 +1,10 @@
+This file is for development purposes only and provides field definitions for filling the screen in the OpenTX Companion Simulator. Users do not need this file on their handset's SD card!
+
+### Using
+Copy the entire mockup directory into the same directory as `elrsV2.lua` on your hard drive where you've set the OpenTX Companion "SD Structure Path". The SD structure path should look like this:
+```
+SCRIPTS/TOOLS/elrsV2.lua
+SCRIPTS/TOOLS/mockup/elrsmock.lua
+SCRIPTS/TOOLS/mockup/README.md <- this file
+```
+When you execute elrsV2.lua, the screen will be populated with fake ELRS Lua config fields.

--- a/src/lua/mockup/elrsmock.lua
+++ b/src/lua/mockup/elrsmock.lua
@@ -1,14 +1,16 @@
 return {
-    {name='Packet Rate', id=0, type=9, parent=0, values={'250(-108dBm)','500(-105dBm)'}, value=1, min=0, max=1, default=0, unit='Hz'},
-    {name='Telem Ratio', id=1, type=9, parent=0, values={'Off','1:128'}, value=1, min=0, max=1, default=0, unit=''},
-    {name='Switch Mode', id=2, type=9, parent=0, values={'Hybrid','Wide'}, value=1, min=0, max=1, default=0, unit=''},
-    {name='Model Match', id=3, type=9, parent=0, values={'Off','On'}, value=0, min=0, max=1, default=0, unit=''},
+    {name='Packet Rate', id=0, type=9, parent=0, values={'250(-108dBm)','500(-105dBm)'}, value=1, min=0, max=1, unit='Hz'},
+    {name='Telem Ratio', id=1, type=9, parent=0, values={'Off','1:128'}, value=1, min=0, max=1, unit=''},
+    {name='Switch Mode', id=2, type=9, parent=0, values={'Hybrid','Wide'}, value=1, min=0, max=1, unit=''},
+    {name='Model Match', id=3, type=9, parent=0, values={'Off','On'}, value=0, min=0, max=1, unit=''},
     {name='TX Power', id=4, type=11, parent=0},
-    {name='VTX Administrator', id=5, type=11, parent=0},
-    {name='Bind', id=6, type=13, parent=0},
-    {name='Wifi Update', id=7, type=13, parent=0},
-    {name='BLE Joystick', id=7, type=13, parent=0},
-    {name='master', id=7, type=12, parent=0, value='f00fcb'},
+      {name='Max Power', id=5, type=9, parent=4, values={'10','25','50'}, value=2, min=0, max=2, unit='mW'},
+      {name='Dynamic', id=6, type=9, parent=4, values={'Off','On','AUX9'}, value=1, min=0, max=2, unit=''},
+    {name='VTX Administrator', id=7, type=11, parent=0},
+    {name='Bind', id=8, type=13, parent=0},
+    {name='Wifi Update', id=9, type=13, parent=0},
+    {name='BLE Joystick', id=10, type=13, parent=0},
+    {name='master', id=11, type=12, parent=0, value='f00fcb'},
 
-    {name="----BACK----", id=2, type=14, parent=255}
+    {name="----BACK----", id=12, type=14, parent=255}
   }

--- a/src/lua/mockup/elrsmock.lua
+++ b/src/lua/mockup/elrsmock.lua
@@ -1,0 +1,14 @@
+return {
+    {name='Packet Rate', id=0, type=9, parent=0, values={'250(-108dBm)','500(-105dBm)'}, value=1, min=0, max=1, default=0, unit='Hz'},
+    {name='Telem Ratio', id=1, type=9, parent=0, values={'Off','1:128'}, value=1, min=0, max=1, default=0, unit=''},
+    {name='Switch Mode', id=2, type=9, parent=0, values={'Hybrid','Wide'}, value=1, min=0, max=1, default=0, unit=''},
+    {name='Model Match', id=3, type=9, parent=0, values={'Off','On'}, value=0, min=0, max=1, default=0, unit=''},
+    {name='TX Power', id=4, type=11, parent=0},
+    {name='VTX Administrator', id=5, type=11, parent=0},
+    {name='Bind', id=6, type=13, parent=0},
+    {name='Wifi Update', id=7, type=13, parent=0},
+    {name='BLE Joystick', id=7, type=13, parent=0},
+    {name='master', id=7, type=12, parent=0, value='f00fcb'},
+
+    {name="----BACK----", id=2, type=14, parent=255}
+  }


### PR DESCRIPTION
This intends to fix the color Lua script to not bomb out on OpenTX due to EdgeTX constantly changing their colors, and provides an OKish ELRS-colored theme to the color display. The fields are rendered using the handset's native display colors to prevent them from just becoming completely f'ed up. TX16S and T16 respectively:
![elrs-clr-renders2](https://user-images.githubusercontent.com/677183/133894713-f889b386-4c96-4289-b352-8754cebf527f.png)

Also adds one vertical space under the title bar on B&W screens per @AlessandroAU.
![image](https://user-images.githubusercontent.com/677183/133868782-6b2efb7c-fa82-493f-98e6-a9b605d1e9db.png)

## Bug Fixes
There's two variations on the bug on color displays
* Straight up crashing OpenTX and rebooting it into Emergency Mode on script launch due to them mishandling color definitions they do not understand
* `Attempt to perform arithmetic on nil value M...` on some versions of EdgeTX
* Fix CPU Limit killing script if scroll wheel is used before any fields load
* Fix Index nil error when exiting if no fields loaded

## Additional
* Adds a mockup lua helper script that allows for seeing how the Lua will display on any type of screen using the OpenTX Companion Simulator. I didn't mock up all the fields though, just enough to do the main screen and TX Power. More fields can be added to be able to test folders / BACK if desired.

## Broke as Heck
The color support in OpenTX is reeaaaaaaallly weird. Changing colors does not seem to be something it wants to do. If you change the TEXT_COLOR it breaks how text with no attributes renders _in the script_. Blue text becomes black text. The only way to get the color you want is to use BOLD. I think there's a font cache rendered in the actual theme color so trying to change things breaks its expectations. I've attempted to work around how changing to some colors makes the background draw in the theme color, and used CUSTOM_COLOR and setColor with BOLD to trick it somehow but this is likely fragile and could break easily leaving the script unreadable on some setups.

I think we should just go back to rendering in default colors.

## Testing
Needs testing on EdgeTX 2.4 and 2.5 nightly. I have tested this in OpenTX Companion Simulator for X9D, QX7, TX16S, and Jumper T16. Also tested on TX16S and Jumper T16 by Discord user mgtschida, many thanks!