### PR TITLE
Fix link rate on startup

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -758,6 +758,7 @@ void UARTconnected()
 
   rfModeLastChangedMS = millis(); // force syncspam on first packets
   hwTimer.resume();
+  SetRFLinkRate(config.GetRate());
 }
 
 static void ChangeRadioParams()


### PR DESCRIPTION
Due to the changes in #902 there was a bug when starting the handset with 500Hz set the TX would call `ChangeRadioParams` -> `SetRFLinkRate` -> `adjustPacketRateForBaud` before theres a connection to crossfire and the default baudrate is 115200, so we'd drop the link-rate to 250hz.
The radio would then continue and a CRSF connection would be made, but nothing fixes the link rate. So I've added a call set `SetRFLinkRate` in `UARTconnected` so it recalculates the valid link-rate based on the new connection speed.