### PR TITLE
Adds override for incorrect target detection

### DIFF
--- a/src/python/BFinitPassthrough.py
+++ b/src/python/BFinitPassthrough.py
@@ -132,7 +132,7 @@ def reset_to_bootloader(args):
     flash_target = re.sub("_VIA_.*", "", args.target.upper())
     if rx_target == "":
         dbg_print("Cannot detect RX target, blindly flashing!")
-    elif rx_target != "1": #flash_target
+    elif rx_target != flash_target:
         if query_yes_no("\n\n\nWrong target selected! your RX is '%s', trying to flash '%s', continue? Y/N\n" % (rx_target, flash_target)):
             dbg_print("Ok, flashing anyway!")
         else:

--- a/src/python/BFinitPassthrough.py
+++ b/src/python/BFinitPassthrough.py
@@ -3,6 +3,7 @@ import argparse
 import serials_find
 import SerialHelper
 import bootloader
+from query_yes_no import query_yes_no
 
 SCRIPT_DEBUG = 0
 
@@ -131,8 +132,11 @@ def reset_to_bootloader(args):
     flash_target = re.sub("_VIA_.*", "", args.target.upper())
     if rx_target == "":
         dbg_print("Cannot detect RX target, blindly flashing!")
-    elif rx_target != flash_target:
-        raise WrongTargetSelected("Wrong target selected your RX is '%s', trying to flash '%s'" % (rx_target, flash_target))
+    elif rx_target != "1": #flash_target
+        if query_yes_no("\n\n\nWrong target selected! your RX is '%s', trying to flash '%s', continue? Y/N\n" % (rx_target, flash_target)):
+            dbg_print("Ok, flashing anyway!")
+        else:
+            raise WrongTargetSelected("Wrong target selected your RX is '%s', trying to flash '%s'" % (rx_target, flash_target))
     elif flash_target != "":
         dbg_print("Verified RX target '%s'" % (flash_target))
     time.sleep(.5)

--- a/src/python/inputimeout/LICENSE
+++ b/src/python/inputimeout/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Mitsuo Heijo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/python/inputimeout/README.rst
+++ b/src/python/inputimeout/README.rst
@@ -1,0 +1,54 @@
+inputimeout
+===========
+
+.. image:: https://travis-ci.org/johejo/inputimeout.svg?branch=master
+    :target: https://travis-ci.org/johejo/inputimeout
+
+.. image:: https://ci.appveyor.com/api/projects/status/2g1fbnrcoj64g8t9?svg=true
+    :target: https://ci.appveyor.com/project/johejo/inputimeout
+
+.. image:: https://img.shields.io/pypi/v/inputimeout.svg
+    :target: https://pypi.python.org/pypi/inputimeout
+
+.. image:: https://img.shields.io/github/license/mashape/apistatus.svg
+    :target: https://raw.githubusercontent.com/johejo/inputimeout/master/LICENSE
+
+.. image:: https://api.codeclimate.com/v1/badges/3d51d0efbd7b86f0b7f1/maintainability
+   :target: https://codeclimate.com/github/johejo/inputimeout/maintainability
+   :alt: Maintainability
+
+.. image:: https://api.codeclimate.com/v1/badges/3d51d0efbd7b86f0b7f1/test_coverage
+   :target: https://codeclimate.com/github/johejo/inputimeout/test_coverage
+   :alt: Test Coverage
+
+.. image:: https://codecov.io/gh/johejo/inputimeout/branch/master/graph/badge.svg
+  :target: https://codecov.io/gh/johejo/inputimeout
+
+Description
+-----------
+
+Multi platform standard input with timeout
+
+Install
+-------
+
+.. code:: bash
+
+    $ pip install inputimeout
+
+Usage
+-----
+
+.. code:: python
+
+    from inputimeout import inputimeout, TimeoutOccurred
+    try:
+        something = inputimeout(prompt='>>', timeout=5)
+    except TimeoutOccurred:
+        something = 'something'
+    print(something)
+
+License
+-------
+
+MIT

--- a/src/python/inputimeout/__init__.py
+++ b/src/python/inputimeout/__init__.py
@@ -1,0 +1,5 @@
+from .inputimeout import inputimeout, TimeoutOccurred   # noqa
+from .__version__ import (   # noqa
+    __version__, __author__, __author_email__, __copyright__, __license__,
+    __description__, __title__, __url__,
+)

--- a/src/python/inputimeout/__version__.py
+++ b/src/python/inputimeout/__version__.py
@@ -1,0 +1,8 @@
+__title__ = 'inputimeout'
+__description__ = 'Multi platform standard input with timeout'
+__url__ = 'http://github.com/johejo/inutimeout'
+__version__ = '1.0.4'
+__author__ = 'Mitsuo Heijo'
+__author_email__ = 'mitsuo_h@outlook.com'
+__license__ = 'MIT'
+__copyright__ = 'Copyright 2018 Mitsuo Heijo'

--- a/src/python/inputimeout/inputimeout.py
+++ b/src/python/inputimeout/inputimeout.py
@@ -1,0 +1,74 @@
+import sys
+
+DEFAULT_TIMEOUT = 30.0
+INTERVAL = 0.05
+
+SP = ' '
+CR = '\r'
+LF = '\n'
+CRLF = CR + LF
+
+
+class TimeoutOccurred(Exception):
+    pass
+
+
+def echo(string):
+    sys.stdout.write(string)
+    sys.stdout.flush()
+
+
+def posix_inputimeout(prompt='', timeout=DEFAULT_TIMEOUT):
+    echo(prompt)
+    sel = selectors.DefaultSelector()
+    sel.register(sys.stdin, selectors.EVENT_READ)
+    events = sel.select(timeout)
+
+    if events:
+        key, _ = events[0]
+        return key.fileobj.readline().rstrip(LF)
+    else:
+        echo(LF)
+        termios.tcflush(sys.stdin, termios.TCIFLUSH)
+        raise TimeoutOccurred
+
+
+def win_inputimeout(prompt='', timeout=DEFAULT_TIMEOUT):
+    echo(prompt)
+    begin = time.monotonic()
+    end = begin + timeout
+    line = ''
+
+    while time.monotonic() < end:
+        if msvcrt.kbhit():
+            c = msvcrt.getwche()
+            if c in (CR, LF):
+                echo(CRLF)
+                return line
+            if c == '\003':
+                raise KeyboardInterrupt
+            if c == '\b':
+                line = line[:-1]
+                cover = SP * len(prompt + line + SP)
+                echo(''.join([CR, cover, CR, prompt, line]))
+            else:
+                line += c
+        time.sleep(INTERVAL)
+
+    echo(CRLF)
+    raise TimeoutOccurred
+
+
+try:
+    import msvcrt
+
+except ImportError:
+    import selectors
+    import termios
+
+    inputimeout = posix_inputimeout
+
+else:
+    import time
+
+    inputimeout = win_inputimeout

--- a/src/python/query_yes_no.py
+++ b/src/python/query_yes_no.py
@@ -1,0 +1,20 @@
+import sys
+from inputimeout import inputimeout, TimeoutOccurred
+
+def query_yes_no(question=''): #https://code.activestate.com/recipes/577058/
+    """Ask a yes/no question via raw_input() and return their answer.
+    "question" is a string that is presented to the user.
+    The "answer" return value is True for "yes" or False for "no".
+    """
+    valid = {"yes": True, "y": True, "ye": True, "no": False, "n": False}
+
+    while True:
+        choice = ''
+        try:
+            choice = inputimeout(prompt=question, timeout=5)
+        except TimeoutOccurred:
+            sys.stdout.write("Please respond with 'yes' or 'no' " "(or 'y' or 'n')")
+            sys.stdout.flush()
+	
+        if choice in valid:
+            return valid[choice]


### PR DESCRIPTION
Basically, adds a Y/N confirmation when an incorrect target is detected so it be can flashed anyway, work with both stm32/esp8266 targets in vscode (tested in windows). Needs testing for linux/mac. 

Does not work with configurator (yet?) as the configurator does not capture key events. 

Uses this library to capture input and handle timeouts https://github.com/johejo/inputimeout

![image](https://user-images.githubusercontent.com/22009829/134478770-21241ab1-9c27-4ac6-93c4-712e86c58869.png)
