### PR TITLE
Use NVS instead of EEPROM on ESP32

### DIFF
--- a/src/src/config.cpp
+++ b/src/src/config.cpp
@@ -4,12 +4,83 @@
 #include "OTA.h"
 #include "logging.h"
 
+#if defined(TARGET_TX)
+
+#define MODEL_CHANGED       0x01
+#define VTX_CHANGED         0x02
+#define SSID_CHANGED        0x04
+#define PASSWORD_CHANGED    0x08
+
+#if defined(PLATFORM_ESP32)
 void
 TxConfig::Load()
 {
-    // Populate the struct from eeprom
+    // Initialize NVS
+    esp_err_t err = nvs_flash_init();
+    if (err == ESP_ERR_NVS_NO_FREE_PAGES || err == ESP_ERR_NVS_NEW_VERSION_FOUND)
+    {
+        ESP_ERROR_CHECK(nvs_flash_erase());
+        err = nvs_flash_init();
+    }
+    ESP_ERROR_CHECK( err );
+    ESP_ERROR_CHECK(nvs_open("ELRS", NVS_READWRITE, &handle));
+
+    // read version field
+    if(nvs_get_u32(handle, "tx_version", &m_config.version) != ESP_ERR_NVS_NOT_FOUND)
+    {
+        uint32_t value;
+        nvs_get_u32(handle, "vtx", &value);
+        m_config.vtxBand = value >> 24;
+        m_config.vtxChannel = value >> 16;
+        m_config.vtxPower = value >> 8;
+        m_config.vtxPitmode = value;
+        value = sizeof(m_config.ssid);
+        nvs_get_str(handle, "ssid", m_config.ssid, &value);
+        value = sizeof(m_config.password);
+        nvs_get_str(handle, "password", m_config.password, &value);
+        for(int i=0 ; i<64 ; i++)
+        {
+            char model[10] = "model";
+            model_config_t value;
+            itoa(i, model+5, 10); 
+            nvs_get_u32(handle, model, (uint32_t*)&value);
+            m_config.model_config[i] = value;
+        }
+        m_modified = 0;
+        return;
+    }
+    else
+    {
+        // Read old eeprom config
+        m_eeprom->Get(0, m_config);
+
+        // Check if version number matches
+        if (m_config.version != (uint32_t)(TX_CONFIG_VERSION | TX_CONFIG_MAGIC))
+        {
+            // If the previous config schema is known, attempt an upgrade
+            if (m_config.version == 1)
+            {
+                UpgradeEepromV1ToV4();
+            }
+            else
+            {
+                // If not, revert to defaults for this version
+                DBGLN("EEPROM version mismatch! Resetting to defaults...");
+                SetDefaults();
+            }
+        }
+        nvs_set_u32(handle, "tx_version", TX_CONFIG_VERSION | TX_CONFIG_MAGIC);
+        Commit();
+    }
+    m_modified = 0;
+}
+#else
+void
+TxConfig::Load()
+{
     m_eeprom->Get(0, m_config);
 
+    m_modified = 0;
     // Check if version number matches
     if (m_config.version != (uint32_t)(TX_CONFIG_VERSION | TX_CONFIG_MAGIC))
     {
@@ -25,9 +96,9 @@ TxConfig::Load()
             SetDefaults();
         }
     }
-
-    m_modified = false;
+    Commit();
 }
+#endif
 
 void
 TxConfig::Commit()
@@ -37,12 +108,35 @@ TxConfig::Commit()
         // No changes
         return;
     }
-
+#if defined(PLATFORM_ESP32)
+    // Write parts to NVS
+    if (m_modified & MODEL_CHANGED)
+    {
+        uint32_t value = *((uint32_t *)m_model);
+        char model[10] = "model";
+        itoa(m_modelId, model+5, 10); 
+        nvs_set_u32(handle, model, value);
+    }
+    if (m_modified & VTX_CHANGED)
+    {
+        uint32_t value = 
+            m_config.vtxBand << 24 | 
+            m_config.vtxChannel << 16 |
+            m_config.vtxPower << 8 |
+            m_config.vtxPitmode;
+        nvs_set_u32(handle, "vtx", value);
+    }
+    if (m_modified & SSID_CHANGED)
+        nvs_set_str(handle, "ssid", m_config.ssid);
+    if (m_modified & PASSWORD_CHANGED)
+        nvs_set_str(handle, "password", m_config.password);
+    nvs_commit(handle);
+#else
     // Write the struct to eeprom
     m_eeprom->Put(0, m_config);
     m_eeprom->Commit();
-
-    m_modified = false;
+#endif
+    m_modified = 0;
 }
 
 // Setters
@@ -52,7 +146,7 @@ TxConfig::SetRate(uint8_t rate)
     if (GetRate() != rate)
     {
         m_model->rate = rate;
-        m_modified = true;
+        m_modified |= MODEL_CHANGED;
     }
 }
 
@@ -62,7 +156,7 @@ TxConfig::SetTlm(uint8_t tlm)
     if (GetTlm() != tlm)
     {
         m_model->tlm = tlm;
-        m_modified = true;
+        m_modified |= MODEL_CHANGED;
     }
 }
 
@@ -72,7 +166,7 @@ TxConfig::SetPower(uint8_t power)
     if (GetPower() != power)
     {
         m_model->power = power;
-        m_modified = true;
+        m_modified |= MODEL_CHANGED;
     }
 }
 
@@ -82,7 +176,7 @@ TxConfig::SetDynamicPower(bool dynamicPower)
     if (GetDynamicPower() != dynamicPower)
     {
         m_model->dynamicPower = dynamicPower;
-        m_modified = true;
+        m_modified |= MODEL_CHANGED;
     }
 }
 
@@ -92,7 +186,7 @@ TxConfig::SetBoostChannel(uint8_t boostChannel)
     if (GetBoostChannel() != boostChannel)
     {
         m_model->boostChannel = boostChannel;
-        m_modified = true;
+        m_modified |= MODEL_CHANGED;
     }
 }
 
@@ -102,7 +196,7 @@ TxConfig::SetSwitchMode(uint8_t switchMode)
     if (GetSwitchMode() != switchMode)
     {
         m_model->switchMode = switchMode;
-        m_modified = true;
+        m_modified |= MODEL_CHANGED;
     }
 }
 
@@ -112,7 +206,7 @@ TxConfig::SetModelMatch(bool modelMatch)
     if (GetModelMatch() != modelMatch)
     {
         m_model->modelMatch = modelMatch;
-        m_modified = true;
+        m_modified |= MODEL_CHANGED;
     }
 }
 
@@ -122,7 +216,7 @@ TxConfig::SetVtxBand(uint8_t vtxBand)
     if (m_config.vtxBand != vtxBand)
     {
         m_config.vtxBand = vtxBand;
-        m_modified = true;
+        m_modified |= VTX_CHANGED;
     }
 }
 
@@ -132,7 +226,7 @@ TxConfig::SetVtxChannel(uint8_t vtxChannel)
     if (m_config.vtxChannel != vtxChannel)
     {
         m_config.vtxChannel = vtxChannel;
-        m_modified = true;
+        m_modified |= VTX_CHANGED;
     }
 }
 
@@ -142,7 +236,7 @@ TxConfig::SetVtxPower(uint8_t vtxPower)
     if (m_config.vtxPower != vtxPower)
     {
         m_config.vtxPower = vtxPower;
-        m_modified = true;
+        m_modified |= VTX_CHANGED;
     }
 }
 
@@ -152,8 +246,22 @@ TxConfig::SetVtxPitmode(uint8_t vtxPitmode)
     if (m_config.vtxPitmode != vtxPitmode)
     {
         m_config.vtxPitmode = vtxPitmode;
-        m_modified = true;
+        m_modified |= VTX_CHANGED;
     }
+}
+
+void
+TxConfig::SetSSID(const char *ssid)
+{
+    strncpy(m_config.ssid, ssid, sizeof(m_config.ssid)-1);
+    m_modified |= SSID_CHANGED;
+}
+
+void
+TxConfig::SetPassword(const char *password)
+{
+    strncpy(m_config.password, password, sizeof(m_config.password)-1);
+    m_modified |= PASSWORD_CHANGED;
 }
 
 void
@@ -236,20 +344,6 @@ TxConfig::SetStorageProvider(ELRS_EEPROM *eeprom)
     }
 }
 
-void
-TxConfig::SetSSID(const char *ssid)
-{
-    strncpy(m_config.ssid, ssid, sizeof(m_config.ssid)-1);
-    m_modified = true;
-}
-
-void
-TxConfig::SetPassword(const char *password)
-{
-    strncpy(m_config.password, password, sizeof(m_config.password)-1);
-    m_modified = true;
-}
-
 /**
  * Sets ModelId used for subsequent per-model config gets
  * Returns: true if the model has changed
@@ -261,13 +355,18 @@ TxConfig::SetModelId(uint8_t modelId)
     if (newModel != m_model)
     {
         m_model = newModel;
+        m_modelId = modelId;
         return true;
     }
 
     return false;
 }
 
+#endif
+
 /////////////////////////////////////////////////////
+
+#if defined(TARGET_RX)
 
 void
 RxConfig::Load()
@@ -377,3 +476,5 @@ RxConfig::SetPassword(const char *password)
     strncpy(m_config.password, password, sizeof(m_config.password)-1);
     m_modified = true;
 }
+
+#endif

--- a/src/src/config.h
+++ b/src/src/config.h
@@ -41,7 +41,7 @@ typedef struct {
 class TxConfig
 {
 public:
-    TxConfig() { SetModelId(0); }
+    TxConfig();
     void Load();
     void Commit();
 
@@ -71,7 +71,6 @@ public:
     void SetModelMatch(bool modelMatch);
     void SetDefaults();
     void UpgradeEepromV1ToV4();
-    void SetStorageProvider(ELRS_EEPROM *eeprom);
     void SetSSID(const char *ssid);
     void SetPassword(const char *password);
     void SetVtxBand(uint8_t vtxBand);
@@ -84,7 +83,7 @@ public:
 
 private:
     tx_config_t m_config;
-    ELRS_EEPROM *m_eeprom;
+    ELRS_EEPROM m_eeprom;
     uint8_t     m_modified;
     model_config_t *m_model;
     uint8_t     m_modelId;

--- a/src/src/config.h
+++ b/src/src/config.h
@@ -3,6 +3,11 @@
 #include "targets.h"
 #include "elrs_eeprom.h"
 
+#if defined(PLATFORM_ESP32)
+#include <nvs_flash.h>
+#include <nvs.h>
+#endif
+
 // CONFIG_MAGIC is ORed with CONFIG_VERSION in the version field
 #define TX_CONFIG_MAGIC     (0b01 << 30)
 #define RX_CONFIG_MAGIC     (0b10 << 30)
@@ -11,6 +16,7 @@
 #define RX_CONFIG_VERSION   3
 #define UID_LEN             6
 
+#if defined(TARGET_TX)
 typedef struct {
     uint8_t     rate:3;
     uint8_t     tlm:3;
@@ -79,12 +85,18 @@ public:
 private:
     tx_config_t m_config;
     ELRS_EEPROM *m_eeprom;
-    bool        m_modified;
+    uint8_t     m_modified;
     model_config_t *m_model;
+    uint8_t     m_modelId;
+#if defined(PLATFORM_ESP32)
+    nvs_handle  handle;
+#endif
 };
+#endif
 
 ///////////////////////////////////////////////////
 
+#if defined(TARGET_RX)
 typedef struct {
     uint32_t    version;
     bool        isBound;
@@ -131,3 +143,4 @@ private:
     ELRS_EEPROM *m_eeprom;
     bool        m_modified;
 };
+#endif

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -20,7 +20,6 @@ SX1280Driver Radio;
 #include "msp.h"
 #include "msptypes.h"
 #include <OTA.h>
-#include "elrs_eeprom.h"
 #include "options.h"
 #include "config.h"
 #include "hwTimer.h"
@@ -60,7 +59,6 @@ GENERIC_CRC14 ota_crc(ELRS_CRC14_POLY);
 CRSF crsf;
 POWERMGNT POWERMGNT;
 MSP msp;
-ELRS_EEPROM eeprom;
 TxConfig config;
 
 static bool webserverPreventAutoStart = false;
@@ -974,8 +972,6 @@ void setup()
   hwTimer.callbackTock = &timerCallbackNormal;
   DBGLN("ExpressLRS TX Module Booted...");
 
-  eeprom.Begin(); // Init the eeprom
-  config.SetStorageProvider(&eeprom); // Pass pointer to the Config class for access to storage
   config.Load(); // Load the stored values from eeprom
 
   Radio.currFreq = GetInitialFreq(); //set frequency first or an error will occur!!!


### PR DESCRIPTION
By using NVS on ESP32 rather than the EEPROM class we can write just the parts of the config that change.
i.e. just the model config for a specific model, VTX config, SSID or password.

NVS uses a transaction log format and is only limited by the size of the "nvs" partition on the ESP, which defaults to 0x5000 bytes (20K).

This fixes the problem of 500Hz 1:2 telemetry ratio not saving its settings.