### PR TITLE
Skip RF Calibration on startup on ESP8266 (master)

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1169,6 +1169,23 @@ static void cycleRfMode(unsigned long now)
     } // if cycle LED
 }
 
+#if defined(PLATFORM_ESP8266)
+// Called from core's user_rf_pre_init() function (which is called by SDK) before setup()
+RF_PRE_INIT()
+{
+    // Set whether the chip will do RF calibration or not when power up.
+    // I believe the Arduino core fakes this (byte 114 of phy_init_data.bin)
+    // to be 1, but the TX power calibration can pull over 300mA which can
+    // lock up receivers built with a underspeced LDO (such as the EP2 "SDG")
+    // Option 2 is just VDD33 measurement
+    #if defined(RF_CAL_MODE)
+    system_phy_set_powerup_option(RF_CAL_MODE);
+    #else
+    system_phy_set_powerup_option(2);
+    #endif
+}
+#endif
+
 void setup()
 {
     setupGpio();


### PR DESCRIPTION
Changes the startup behavior on ESP8266 by skipping the actual RF Calibration part of the boot-time RF Calibration. The purpose being to reduce power draw on startup to work around undespeced voltage regulators on EPx receivers.

### Root Cause
The voltage regulator on the EP receiver has the markings `SDG`

### Symptoms: Case 1 - Normal boot
* The normal boot procedure of an ESP-based receiver should be a quick flash of the LED (120ms) followed by a 1 second period blinking

### Symptoms Case 2 - Dim LED
* The worst case boot procedure is a which flash of the led (120ms) followed by the LED getting dim and staying that way for a long time. ⚠ If you see this, unplug immediately! ⚠ Your ESP will quickly pass 100C and will either go into thermal shutdown or just burn itself out. The current drawn in this mode is >300mA. Unplugging and replugging really fast can trick the ESP into skipping this and booting properly normally.

### Symptoms Case 3 - Long LED
* This is an almost functional boot, where the LED stays lit for 2-5 seconds on boot before beginning to blink. Things still are not working right, but you'll probably be able to connect once the LED starts blinking. Unplugging and replugging really fast can trick the ESP into skipping this and booting normally.

### What these look like
The yellow line is the 3.3V rail, blue is 5V input
![Boots Scope](https://cdn.discordapp.com/attachments/733424557636976692/891098872934453298/hmep2-vreg.png)

## What's happening
EPx receivers with a voltage regulator labeled `SDG` is not able to supply enough current for the ESP8285 processor to boot properly. It will either hang on boot pulling ALL THE CURRENT or hang for a little while on boot pulling ~150mA but make it through. Changing the firmware (by changing the user_defines, such as disabling `AUTO_WIFI_ON_INTERVAL`) can change from "dim led" to "long led" symptom, but what is changed is not significant, only that the firmware binary is a different size. Changing the contents of the same-sized binary does not appear to change the behavior.

## Work around
The solution is to replace the receiver's regulator, or power it with 3.3V on the far side of the regulator. There is no real software solution to trying to squeeze 300-500mA of current out of what I believe to be a 150mA regulator. This PR however changes the ESP's startup procedure by skipping RF Calibration on startup. This is where the espressif SDK turns on all the internal wifi components and calibrates its internal registers with this description
> Optimize the RF circuit conditions based on the testing results of VDD3P3

This all happens internally, so there's no way of knowing what is actually happening, but setting this to "mode 2" means it skips doing that and just measures the input voltage and moves on. In my testing with working receivers I did not see any detrimental effect to disabling the RF Calibration even on working receivers, perhaps because the defaults work ok for 3.3V input voltage? In any instance, the mode 2 override can be itself overriden by adding a user_define `RF_CAL_MODE` with one of the following values
* 1 - Normal default behavior used by the esp8266 Arduino core. RF initialization only calibrate VDD33 and Tx power which will take about 18 ms.
* 2 - (new default using this PR)  RF initialization only calibrate VDD33 which will take about 2 ms (min current).
* 3 - RF initialization will do the whole RF calibration which will take about 200 ms (max current).

The voltage regulator should be fine for operating as a ELRS receiver, since the current requirements are about 45-65mA in that mode. It is only the wifi operation that is affected, and because we lower the wifi power to 13dBm, it seems that even our wifi mode works ok, and I have uploaded firmware through the webui with no issues (at close range).

## Should I get a replacement from HappyModel
Absolutely.

Probable root cause of #921 #918 #912