### PR TITLE
allow re-match modelid on sync packet

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -735,7 +735,7 @@ static bool ICACHE_RAM_ATTR ProcessRfPacket_SYNC(uint32_t now)
     if (connectionState == disconnected
         || NonceRX != Radio.RXdataBuffer[2]
         || FHSSgetCurrIndex() != Radio.RXdataBuffer[1]
-        || !connectionHasModelMatch != modelMatched)
+        || connectionHasModelMatch != modelMatched)
     {
         //DBGLN("\r\n%ux%ux%u", NonceRX, Radio.RXdataBuffer[2], Radio.RXdataBuffer[1]);
         FHSSsetCurrIndex(Radio.RXdataBuffer[1]);

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -734,7 +734,8 @@ static bool ICACHE_RAM_ATTR ProcessRfPacket_SYNC(uint32_t now)
 
     if (connectionState == disconnected
         || NonceRX != Radio.RXdataBuffer[2]
-        || FHSSgetCurrIndex() != Radio.RXdataBuffer[1])
+        || FHSSgetCurrIndex() != Radio.RXdataBuffer[1]
+        || !connectionHasModelMatch != modelMatched)
     {
         //DBGLN("\r\n%ux%ux%u", NonceRX, Radio.RXdataBuffer[2], Radio.RXdataBuffer[1]);
         FHSSsetCurrIndex(Radio.RXdataBuffer[1]);


### PR DESCRIPTION
just like what @CapnBry described ``There's a near 100% chance we started up transmitting at Model 0's``, and this causes rx to get stuck in a half connected state and doesn't check if the TX is already sending the real model id because all requirement to stop re-process the sync packet fulfilled without having the correct modelmatch. This PR just add an extra requirement to re-process the sync packet if the modelmatch is not fulfilled yet.