### PR TITLE
Commit after each model is upgraded for NVS

### DIFF
--- a/src/src/config.h
+++ b/src/src/config.h
@@ -70,7 +70,7 @@ public:
     void SetSwitchMode(uint8_t switchMode);
     void SetModelMatch(bool modelMatch);
     void SetDefaults();
-    void UpgradeEepromV1ToV4();
+    void SetStorageProvider(ELRS_EEPROM *eeprom);
     void SetSSID(const char *ssid);
     void SetPassword(const char *password);
     void SetVtxBand(uint8_t vtxBand);
@@ -82,8 +82,10 @@ public:
     bool SetModelId(uint8_t modelId);
 
 private:
+    bool UpgradeEepromV1ToV4();
+    
     tx_config_t m_config;
-    ELRS_EEPROM m_eeprom;
+    ELRS_EEPROM *m_eeprom;
     uint8_t     m_modified;
     model_config_t *m_model;
     uint8_t     m_modelId;

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -59,6 +59,7 @@ GENERIC_CRC14 ota_crc(ELRS_CRC14_POLY);
 CRSF crsf;
 POWERMGNT POWERMGNT;
 MSP msp;
+ELRS_EEPROM eeprom;
 TxConfig config;
 
 static bool webserverPreventAutoStart = false;
@@ -972,6 +973,8 @@ void setup()
   hwTimer.callbackTock = &timerCallbackNormal;
   DBGLN("ExpressLRS TX Module Booted...");
 
+  eeprom.Begin(); // Init the eeprom
+  config.SetStorageProvider(&eeprom); // Pass pointer to the Config class for access to storage
   config.Load(); // Load the stored values from eeprom
 
   Radio.currFreq = GetInitialFreq(); //set frequency first or an error will occur!!!


### PR DESCRIPTION
Move eeprom begin back to tx_main. Doesn’t work in config class!
Also, strangely, the EEPROM would not work if it was in the config class, so I had to put it back into tx_main.