### PR TITLE
Call correct interrupt to prevent Nonce slip (master)

### DIFF
--- a/src/lib/SX127xDriver/SX127x.h
+++ b/src/lib/SX127xDriver/SX127x.h
@@ -65,6 +65,7 @@ public:
     void Config(SX127x_Bandwidth bw, SX127x_SpreadingFactor sf, SX127x_CodingRate cr, uint32_t freq, uint8_t preambleLen, uint8_t syncWord, bool InvertIQ, uint8_t PayloadLength);
     void Config(SX127x_Bandwidth bw, SX127x_SpreadingFactor sf, SX127x_CodingRate cr, uint32_t freq, uint8_t preambleLen, bool InvertIQ, uint8_t PayloadLength);
     void SetMode(SX127x_RadioOPmodes mode);
+    void SetTxIdleMode() { SetMode(SX127x_OPMODE_STANDBY); } // set Idle mode used when switching from RX to TX
     void ConfigLoraDefaults();
 
     void SetBandwidthCodingRate(SX127x_Bandwidth bw, SX127x_CodingRate cr);
@@ -87,7 +88,8 @@ public:
     ////////////////////////////////////////////////////
 
     /////////////////Utility Funcitons//////////////////
-    void ClearIRQFlags();
+    uint8_t GetIrqFlags();
+    void ClearIrqFlags();
 
     //////////////RX related Functions/////////////////
 
@@ -99,11 +101,12 @@ public:
     int8_t GetCurrRSSI();
 
     ////////////Non-blocking TX related Functions/////////////////
-    static void TXnb();
-    static void TXnbISR(); //ISR for non-blocking TX routine
+    void TXnb();
     /////////////Non-blocking RX related Functions///////////////
-    static void RXnb();
-    static void RXnbISR(); //ISR for non-blocking RC routin
+    void RXnb();
 
 private:
+    static void ICACHE_RAM_ATTR IsrCallback();
+    void RXnbISR(); // ISR for non-blocking RX routine
+    void TXnbISR(); // ISR for non-blocking TX routine
 };

--- a/src/lib/SX127xDriver/SX127xHal.cpp
+++ b/src/lib/SX127xDriver/SX127xHal.cpp
@@ -5,12 +5,6 @@
 
 SX127xHal *SX127xHal::instance = NULL;
 
-volatile SX127x_InterruptAssignment SX127xHal::InterruptAssignment = SX127x_INTERRUPT_NONE;
-
-void inline SX127xHal::nullCallback(void) { return; }
-void (*SX127xHal::TXdoneCallback)() = &nullCallback;
-void (*SX127xHal::RXdoneCallback)() = &nullCallback;
-
 SX127xHal::SX127xHal()
 {
   instance = this;
@@ -200,8 +194,6 @@ void ICACHE_RAM_ATTR SX127xHal::writeRegister(uint8_t reg, uint8_t data)
 
 void ICACHE_RAM_ATTR SX127xHal::TXenable()
 {
-  instance->InterruptAssignment = SX127x_INTERRUPT_TX_DONE;
-
 #if defined(GPIO_PIN_RX_ENABLE) && (GPIO_PIN_RX_ENABLE != UNDEF_PIN)
     digitalWrite(GPIO_PIN_RX_ENABLE, LOW);
 #endif
@@ -215,8 +207,6 @@ void ICACHE_RAM_ATTR SX127xHal::TXenable()
 
 void ICACHE_RAM_ATTR SX127xHal::RXenable()
 {
-  instance->InterruptAssignment = SX127x_INTERRUPT_RX_DONE;
-
 #if defined(GPIO_PIN_RX_ENABLE) && (GPIO_PIN_RX_ENABLE != UNDEF_PIN)
     digitalWrite(GPIO_PIN_RX_ENABLE, HIGH);
 #endif
@@ -230,8 +220,6 @@ void ICACHE_RAM_ATTR SX127xHal::RXenable()
 
 void ICACHE_RAM_ATTR SX127xHal::TXRXdisable()
 {
-  instance->InterruptAssignment = SX127x_INTERRUPT_NONE;
-
 #if defined(GPIO_PIN_RX_ENABLE) && (GPIO_PIN_RX_ENABLE != UNDEF_PIN)
     digitalWrite(GPIO_PIN_RX_ENABLE, LOW);
 #endif
@@ -245,14 +233,8 @@ void ICACHE_RAM_ATTR SX127xHal::TXRXdisable()
 
 void ICACHE_RAM_ATTR SX127xHal::dioISR()
 {
-  if (instance->InterruptAssignment == SX127x_INTERRUPT_TX_DONE)
-  {
-    TXdoneCallback();
-  }
-  else if (instance->InterruptAssignment == SX127x_INTERRUPT_RX_DONE)
-  {
-    RXdoneCallback();
-  }
+    if (instance->IsrCallback)
+        instance->IsrCallback();
 }
 
 #endif // UNIT_TEST

--- a/src/lib/SX127xDriver/SX127xHal.h
+++ b/src/lib/SX127xDriver/SX127xHal.h
@@ -6,14 +6,6 @@
 #include <SPI.h>
 #endif
 
-typedef enum
-{
-    SX127x_INTERRUPT_NONE,
-    SX127x_INTERRUPT_RX_DONE,
-    SX127x_INTERRUPT_TX_DONE,
-    SX127x_INTERRUPT_CAD
-} SX127x_InterruptAssignment;
-
 class SX127xHal
 {
 
@@ -26,9 +18,7 @@ public:
     void end();
 
     static void ICACHE_RAM_ATTR dioISR();
-    static void inline nullCallback(void);
-    static void (*TXdoneCallback)(); //function pointer for callback
-    static void (*RXdoneCallback)(); //function pointer for callback
+    void (*IsrCallback)(); //function pointer for callback
 
     void ICACHE_RAM_ATTR TXenable();
     void ICACHE_RAM_ATTR RXenable();
@@ -44,6 +34,4 @@ public:
     void ICACHE_RAM_ATTR writeRegisterFIFO(volatile uint8_t *data, uint8_t numBytes);
     void ICACHE_RAM_ATTR readRegisterFIFO(volatile uint8_t *data, uint8_t numBytes);
     void ICACHE_RAM_ATTR writeRegisterBurst(uint8_t reg, uint8_t *data, uint8_t numBytes);
-
-    static volatile SX127x_InterruptAssignment InterruptAssignment;
 };

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -29,10 +29,12 @@ txBaseAddress and rxBaseAddress are offset relative to the beginning of the data
 5. Define the modulation parameter signal BW SF CR
 */
 
-uint32_t beginTX;
-uint32_t endTX;
+#if defined(DEBUG_SX1280_OTA_TIMING)
+static uint32_t beginTX;
+static uint32_t endTX;
+#endif
 
-void ICACHE_RAM_ATTR SX1280Driver::nullCallback(void) {return;}
+void ICACHE_RAM_ATTR SX1280Driver::nullCallback(void) {}
 
 SX1280Driver::SX1280Driver()
 {
@@ -41,17 +43,16 @@ SX1280Driver::SX1280Driver()
 
 void SX1280Driver::End()
 {
-    instance->SetMode(SX1280_MODE_SLEEP);
+    SetMode(SX1280_MODE_SLEEP);
     hal.end();
-    instance->TXdoneCallback = &nullCallback; // remove callbacks
-    instance->RXdoneCallback = &nullCallback;
+    TXdoneCallback = &nullCallback; // remove callbacks
+    RXdoneCallback = &nullCallback;
 }
 
 bool SX1280Driver::Begin()
 {
     hal.init();
-    hal.TXdoneCallback = &SX1280Driver::TXnbISR;
-    hal.RXdoneCallback = &SX1280Driver::RXnbISR;
+    hal.IsrCallback = &SX1280Driver::IsrCallback;
 
     hal.reset();
     DBGLN("SX1280 Begin");
@@ -64,24 +65,24 @@ bool SX1280Driver::Begin()
         return false;
     }
 
-    this->SetMode(SX1280_MODE_STDBY_RC);                                                                                                //step 1 put in STDBY_RC mode
-    hal.WriteCommand(SX1280_RADIO_SET_PACKETTYPE, SX1280_PACKET_TYPE_LORA);                                                             //Step 2: set packet type to LoRa
-    this->ConfigLoRaModParams(currBW, currSF, currCR);                                                                                      //Step 5: Configure Modulation Params
-    hal.WriteCommand(SX1280_RADIO_SET_AUTOFS, 0x01);                                                                                    //enable auto FS
-    hal.WriteRegister(0x0891, (hal.ReadRegister(0x0891) | 0xC0));                                                                       //default is low power mode, switch to high sensitivity instead
-    this->SetPacketParams(12, SX1280_LORA_PACKET_IMPLICIT, 8, SX1280_LORA_CRC_OFF, SX1280_LORA_IQ_NORMAL);                              //default params
-    this->SetFrequencyReg(this->currFreq);                                                                                              //Step 3: Set Freq
-    this->SetFIFOaddr(0x00, 0x00);                                                                                                      //Step 4: Config FIFO addr
-    this->SetDioIrqParams(SX1280_IRQ_RADIO_ALL, SX1280_IRQ_TX_DONE | SX1280_IRQ_RX_DONE, SX1280_IRQ_RADIO_NONE, SX1280_IRQ_RADIO_NONE); //set IRQ to both RXdone/TXdone on DIO1
+    SetMode(SX1280_MODE_STDBY_RC);                                                                                                //Put in STDBY_RC mode
+    hal.WriteCommand(SX1280_RADIO_SET_PACKETTYPE, SX1280_PACKET_TYPE_LORA);                                                       //Set packet type to LoRa
+    ConfigLoRaModParams(currBW, currSF, currCR);                                                                                  //Configure Modulation Params
+    hal.WriteCommand(SX1280_RADIO_SET_AUTOFS, 0x01);                                                                              //Enable auto FS
+    hal.WriteRegister(0x0891, (hal.ReadRegister(0x0891) | 0xC0));                                                                 //default is low power mode, switch to high sensitivity instead
+    SetPacketParams(12, SX1280_LORA_PACKET_IMPLICIT, 8, SX1280_LORA_CRC_OFF, SX1280_LORA_IQ_NORMAL);                              //default params
+    SetFrequencyReg(currFreq);                                                                                                    //Set Freq
+    SetFIFOaddr(0x00, 0x00);                                                                                                      //Config FIFO addr
+    SetDioIrqParams(SX1280_IRQ_RADIO_ALL, SX1280_IRQ_TX_DONE | SX1280_IRQ_RX_DONE, SX1280_IRQ_RADIO_NONE, SX1280_IRQ_RADIO_NONE); //set IRQ to both RXdone/TXdone on DIO1
     return true;
 }
 
 void SX1280Driver::Config(SX1280_RadioLoRaBandwidths_t bw, SX1280_RadioLoRaSpreadingFactors_t sf, SX1280_RadioLoRaCodingRates_t cr, uint32_t freq, uint8_t PreambleLength, bool InvertIQ, uint8_t PayloadLength)
 {
-    instance->PayloadLength = PayloadLength;
+    PayloadLength = PayloadLength;
     IQinverted = InvertIQ;
-    this->SetMode(SX1280_MODE_STDBY_XOSC);
-    instance->ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
+    SetMode(SX1280_MODE_STDBY_XOSC);
+    ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
     ConfigLoRaModParams(bw, sf, cr);
     SetPacketParams(PreambleLength, SX1280_LORA_PACKET_IMPLICIT, PayloadLength, SX1280_LORA_CRC_OFF, (SX1280_RadioLoRaIQModes_t)((uint8_t)!IQinverted << 6)); // TODO don't make static etc. LORA_IQ_STD = 0x40, LORA_IQ_INVERTED = 0x00
     SetFrequencyReg(freq);
@@ -271,6 +272,14 @@ void SX1280Driver::SetDioIrqParams(uint16_t irqMask, uint16_t dio1Mask, uint16_t
     hal.WriteCommand(SX1280_RADIO_SET_DIOIRQPARAMS, buf, sizeof(buf));
 }
 
+uint16_t ICACHE_RAM_ATTR SX1280Driver::GetIrqStatus()
+{
+    uint8_t status[2];
+
+    hal.ReadCommand(SX1280_RADIO_GET_IRQSTATUS, status, 2);
+    return status[0] << 8 | status[1];
+}
+
 void ICACHE_RAM_ATTR SX1280Driver::ClearIrqStatus(uint16_t irqMask)
 {
     uint8_t buf[2];
@@ -283,34 +292,28 @@ void ICACHE_RAM_ATTR SX1280Driver::ClearIrqStatus(uint16_t irqMask)
 
 void ICACHE_RAM_ATTR SX1280Driver::TXnbISR()
 {
-    instance->currOpmode = SX1280_MODE_FS; // radio goes to FS after TX
+    currOpmode = SX1280_MODE_FS; // radio goes to FS after TX
 #ifdef DEBUG_SX1280_OTA_TIMING
     endTX = micros();
-#endif
-    instance->ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
-
-#ifdef DEBUG_SX1280_OTA_TIMING
     DBGLN("TOA: %d", endTX - beginTX);
 #endif
-    //instance->GetStatus();
-    instance->TXdoneCallback();
+    TXdoneCallback();
 }
 
 uint8_t FIFOaddr = 0;
 
 void ICACHE_RAM_ATTR SX1280Driver::TXnb()
 {
-    if (instance->currOpmode == SX1280_MODE_TX) //catch TX timeout
+    if (currOpmode == SX1280_MODE_TX) //catch TX timeout
     {
         //DBGLN("Timeout!");
-        instance->ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
-        instance->SetMode(SX1280_MODE_FS);
+        SetMode(SX1280_MODE_FS);
         TXnbISR();
         return;
     }
-    instance->ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
+    ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
     hal.TXenable();                      // do first to allow PA stablise
-    hal.WriteBuffer(0x00, instance->TXdataBuffer, instance->PayloadLength); //todo fix offset to equal fifo addr
+    hal.WriteBuffer(0x00, TXdataBuffer, PayloadLength); //todo fix offset to equal fifo addr
     instance->SetMode(SX1280_MODE_TX);
 #ifdef DEBUG_SX1280_OTA_TIMING
     beginTX = micros();
@@ -319,19 +322,19 @@ void ICACHE_RAM_ATTR SX1280Driver::TXnb()
 
 void ICACHE_RAM_ATTR SX1280Driver::RXnbISR()
 {
-    instance->currOpmode = SX1280_MODE_FS;
-    instance->ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
-    uint8_t FIFOaddr = instance->GetRxBufferAddr();
-    hal.ReadBuffer(FIFOaddr, instance->RXdataBuffer, instance->PayloadLength);
-    instance->GetLastPacketStats();
-    instance->RXdoneCallback();
+    // In continuous receive mode, the device stays in Rx mode
+    //currOpmode = SX1280_MODE_FS;
+    uint8_t FIFOaddr = GetRxBufferAddr();
+    hal.ReadBuffer(FIFOaddr, RXdataBuffer, PayloadLength);
+    GetLastPacketStats();
+    RXdoneCallback();
 }
 
 void ICACHE_RAM_ATTR SX1280Driver::RXnb()
 {
     hal.RXenable();
-    instance->ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
-    instance->SetMode(SX1280_MODE_RX);
+    ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
+    SetMode(SX1280_MODE_RX);
 }
 
 uint8_t ICACHE_RAM_ATTR SX1280Driver::GetRxBufferAddr()
@@ -361,12 +364,21 @@ bool ICACHE_RAM_ATTR SX1280Driver::GetFrequencyErrorbool()
     return 0;
 }
 
-
 void ICACHE_RAM_ATTR SX1280Driver::GetLastPacketStats()
 {
     uint8_t status[2];
 
     hal.ReadCommand(SX1280_RADIO_GET_PACKETSTATUS, status, 2);
-    instance->LastPacketRSSI = -(int8_t)(status[0] / 2);
-    instance->LastPacketSNR = (int8_t)status[1] / 4;
+    LastPacketRSSI = -(int8_t)(status[0] / 2);
+    LastPacketSNR = (int8_t)status[1] / 4;
+}
+
+void ICACHE_RAM_ATTR SX1280Driver::IsrCallback()
+{
+    uint16_t irqStatus = instance->GetIrqStatus();
+    instance->ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
+    if ((irqStatus & SX1280_IRQ_TX_DONE))
+        instance->TXnbISR();
+    else if ((irqStatus & SX1280_IRQ_RX_DONE))
+        instance->RXnbISR();
 }

--- a/src/lib/SX1280Driver/SX1280.h
+++ b/src/lib/SX1280Driver/SX1280.h
@@ -4,18 +4,8 @@
 #include "SX1280_Regs.h"
 #include "SX1280_hal.h"
 
-void ICACHE_RAM_ATTR TXnbISR();
-
-enum InterruptAssignment_
-{
-    NONE,
-    RX_DONE,
-    TX_DONE
-};
-
 class SX1280Driver
 {
-
 public:
     ///////Callback Function Pointers/////
     static void ICACHE_RAM_ATTR nullCallback(void);
@@ -25,9 +15,6 @@ public:
 
     static void (*TXtimeout)(); //function pointer for callback
     static void (*RXtimeout)(); //function pointer for callback
-
-    InterruptAssignment_ InterruptAssignment = NONE;
-    /////////////////////////////
 
     ///////////Radio Variables////////
     #define TXRXBuffSize 16
@@ -74,6 +61,7 @@ public:
     bool Begin();
     void End();
     void SetMode(SX1280_RadioOperatingModes_t OPmode);
+    void SetTxIdleMode() { SetMode(SX1280_MODE_FS); }; // set Idle mode used when switching from RX to TX
     void Config(SX1280_RadioLoRaBandwidths_t bw, SX1280_RadioLoRaSpreadingFactors_t sf, SX1280_RadioLoRaCodingRates_t cr, uint32_t freq, uint8_t PreambleLength, bool InvertIQ, uint8_t PayloadLength);
     void ConfigLoRaModParams(SX1280_RadioLoRaBandwidths_t bw, SX1280_RadioLoRaSpreadingFactors_t sf, SX1280_RadioLoRaCodingRates_t cr);
     void SetPacketParams(uint8_t PreambleLength, SX1280_RadioLoRaPacketLengthsModes_t HeaderType, uint8_t PayloadLength, SX1280_RadioLoRaCrcModes_t crc, SX1280_RadioLoRaIQModes_t InvertIQ);
@@ -85,13 +73,11 @@ public:
 
     int32_t ICACHE_RAM_ATTR GetFrequencyError();
 
-    static void TXnb();
-    static void TXnbISR(); //ISR for non-blocking TX routine
+    void TXnb();
+    void RXnb();
 
-    static void RXnb();
-    static void RXnbISR(); //ISR for non-blocking RC routine
-
-    void  ClearIrqStatus(uint16_t irqMask);
+    uint16_t GetIrqStatus();
+    void ClearIrqStatus(uint16_t irqMask);
 
     void GetStatus();
 
@@ -102,4 +88,7 @@ public:
     void GetLastPacketStats();
 
 private:
+    static void ICACHE_RAM_ATTR IsrCallback();
+    void RXnbISR(); // ISR for non-blocking RX routine
+    void TXnbISR(); // ISR for non-blocking TX routine
 };

--- a/src/lib/SX1280Driver/SX1280_hal.cpp
+++ b/src/lib/SX1280Driver/SX1280_hal.cpp
@@ -24,11 +24,6 @@ Modified and adapted by Alessandro Carcione for ELRS project
 
 SX1280Hal *SX1280Hal::instance = NULL;
 
-void ICACHE_RAM_ATTR SX1280Hal::nullCallback(void) {}
-
-void (*SX1280Hal::TXdoneCallback)() = &nullCallback;
-void (*SX1280Hal::RXdoneCallback)() = &nullCallback;
-
 SX1280Hal::SX1280Hal()
 {
     instance = this;
@@ -339,20 +334,12 @@ bool ICACHE_RAM_ATTR SX1280Hal::WaitOnBusy()
 
 void ICACHE_RAM_ATTR SX1280Hal::dioISR()
 {
-    if (instance->InterruptAssignment == SX1280_INTERRUPT_RX_DONE)
-    {
-        RXdoneCallback();
-    }
-    else if (instance->InterruptAssignment == SX1280_INTERRUPT_TX_DONE)
-    {
-        TXdoneCallback();
-    }
+    if (instance->IsrCallback)
+        instance->IsrCallback();
 }
 
 void ICACHE_RAM_ATTR SX1280Hal::TXenable()
 {
-    instance->InterruptAssignment = SX1280_INTERRUPT_TX_DONE;
-
 #if defined(GPIO_PIN_PA_ENABLE) && (GPIO_PIN_PA_ENABLE != UNDEF_PIN)
     digitalWrite(GPIO_PIN_PA_ENABLE, HIGH);
 #endif
@@ -373,8 +360,6 @@ void ICACHE_RAM_ATTR SX1280Hal::TXenable()
 
 void ICACHE_RAM_ATTR SX1280Hal::RXenable()
 {
-    instance->InterruptAssignment = SX1280_INTERRUPT_RX_DONE;
-
 #if defined(GPIO_PIN_PA_ENABLE) && (GPIO_PIN_PA_ENABLE != UNDEF_PIN)
     digitalWrite(GPIO_PIN_PA_ENABLE, HIGH);
 #endif
@@ -395,8 +380,6 @@ void ICACHE_RAM_ATTR SX1280Hal::RXenable()
 
 void ICACHE_RAM_ATTR SX1280Hal::TXRXdisable()
 {
-    this->InterruptAssignment = SX1280_INTERRUPT_NONE;
-
 #if defined(GPIO_PIN_RX_ENABLE) && (GPIO_PIN_RX_ENABLE != UNDEF_PIN)
     digitalWrite(GPIO_PIN_RX_ENABLE, LOW);
 #endif

--- a/src/lib/SX1280Driver/SX1280_hal.h
+++ b/src/lib/SX1280Driver/SX1280_hal.h
@@ -21,13 +21,6 @@ Heavily modified/simplified by Alessandro Carcione 2020 for ELRS project
 #include "SX1280_Regs.h"
 #include "SX1280.h"
 
-enum SX1280_InterruptAssignment_
-{
-    SX1280_INTERRUPT_NONE,
-    SX1280_INTERRUPT_RX_DONE,
-    SX1280_INTERRUPT_TX_DONE
-};
-
 enum SX1280_BusyState_
 {
     SX1280_NOT_BUSY = true,
@@ -36,10 +29,6 @@ enum SX1280_BusyState_
 
 class SX1280Hal
 {
-
-private:
-    volatile SX1280_InterruptAssignment_ InterruptAssignment = SX1280_INTERRUPT_NONE;
-
 public:
     static SX1280Hal *instance;
 
@@ -61,17 +50,14 @@ public:
     void ICACHE_RAM_ATTR WriteBuffer(uint8_t offset, volatile uint8_t *buffer, uint8_t size); // Writes and Reads to FIFO
     void ICACHE_RAM_ATTR ReadBuffer(uint8_t offset, volatile uint8_t *buffer, uint8_t size);
 
-    static void ICACHE_RAM_ATTR nullCallback(void);
-    
     bool ICACHE_RAM_ATTR WaitOnBusy();
-    static ICACHE_RAM_ATTR void dioISR();
     
     void ICACHE_RAM_ATTR TXenable();
     void ICACHE_RAM_ATTR RXenable();
     void ICACHE_RAM_ATTR TXRXdisable();
 
-    static void (*TXdoneCallback)(); //function pointer for callback
-    static void (*RXdoneCallback)(); //function pointer for callback
+    static ICACHE_RAM_ATTR void dioISR();
+    void (*IsrCallback)(); //function pointer for callback
 
 #if defined(GPIO_PIN_BUSY) && (GPIO_PIN_BUSY != UNDEF_PIN)
     void BusyDelay(uint32_t duration) const { (void)duration; };

--- a/src/src/common.h
+++ b/src/src/common.h
@@ -48,6 +48,17 @@ typedef enum
     radioFailed
 } connectionState_e;
 
+/**
+ * On the TX, tracks what to do when the Tock timer fires
+ **/
+typedef enum
+{
+    ttrpTransmitting,     // Transmitting RC channels as normal
+    ttrpInReceiveMode,    // Has switched to Receive mode for telemetry on the next slot (set on TX done)
+    ttrpWindowInProgress  // Tock has fired while in receive mode, receiving telemetry on this slot
+                          // Next slot will go back to ttrsTransmitting
+} TxTlmRcvPhase_e;
+
 typedef enum
 {
     tim_disconnected = 0,

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -93,8 +93,6 @@ static volatile bool ModelUpdatePending;
 
 char luaBadGoodString[10] = {"xxxxx/yyy"};
 
-bool WaitRXresponse = false;
-
 bool InBindingMode = false;
 uint8_t BindingPackage[5];
 uint8_t BindingSendCount = 0;
@@ -105,6 +103,7 @@ void VtxConfigToMSPOut();
 void eepromWriteToMSPOut();
 uint8_t VtxConfigReadyToSend = false;
 
+static TxTlmRcvPhase_e TelemetryRcvPhase = ttrpTransmitting;
 StubbornReceiver TelemetryReceiver(ELRS_TELEMETRY_MAX_PACKAGES);
 StubbornSender MspSender(ELRS_MSP_MAX_PACKAGES);
 uint8_t CRSFinBuffer[CRSF_MAX_PACKET_LEN+1];
@@ -352,62 +351,27 @@ void ICACHE_RAM_ATTR SetRFLinkRate(uint8_t index) // Set speed of RF link (hz)
 
 void ICACHE_RAM_ATTR HandleFHSS()
 {
-  if (InBindingMode)
-  {
-    return;
-  }
-
-  uint8_t modresult = (NonceTX) % ExpressLRS_currAirRate_Modparams->FHSShopInterval;
-
-  if (modresult == 0) // if it time to hop, do so.
+  uint8_t modresult = (NonceTX + 1) % ExpressLRS_currAirRate_Modparams->FHSShopInterval;
+  // If the next packet should be on the next FHSS frequency, do the hop
+  if (!InBindingMode && modresult == 0)
   {
     Radio.SetFrequencyReg(FHSSgetNextFreq());
   }
 }
 
-void ICACHE_RAM_ATTR HandleTLM()
+void ICACHE_RAM_ATTR HandlePrepareForTLM()
 {
-  if (ExpressLRS_currAirRate_Modparams->TLMinterval > 0)
+  uint8_t modresult = (NonceTX + 1) % TLMratioEnumToValue(ExpressLRS_currAirRate_Modparams->TLMinterval);
+  // If next packet is going to be telemetry, start listening to have a large receive window (time-wise)
+  if (ExpressLRS_currAirRate_Modparams->TLMinterval != TLM_RATIO_NO_TLM && modresult == 0)
   {
-    uint8_t modresult = (NonceTX) % TLMratioEnumToValue(ExpressLRS_currAirRate_Modparams->TLMinterval);
-    if (modresult != 0) // wait for tlm response because it's time
-    {
-      return;
-    }
     Radio.RXnb();
-    WaitRXresponse = true;
+    TelemetryRcvPhase = ttrpInReceiveMode;
   }
 }
 
 void ICACHE_RAM_ATTR SendRCdataToRF()
 {
-  uint8_t *data;
-  uint8_t maxLength;
-  uint8_t packageIndex;
-#ifdef FEATURE_OPENTX_SYNC
-  crsf.JustSentRFpacket(); // tells the crsf that we want to send data now - this allows opentx packet syncing
-#endif
-
-  /////// This Part Handles the Telemetry Response ///////
-  if ((uint8_t)ExpressLRS_currAirRate_Modparams->TLMinterval > 0)
-  {
-    uint8_t modresult = (NonceTX) % TLMratioEnumToValue(ExpressLRS_currAirRate_Modparams->TLMinterval);
-    if (modresult == 0)
-    { // wait for tlm response
-      if (WaitRXresponse == true)
-      {
-        WaitRXresponse = false;
-        crsf.LinkStatistics.downlink_Link_quality = LQCalc.getLQ();
-        LQCalc.inc();
-        return;
-      }
-      else
-      {
-        NonceTX++;
-      }
-    }
-  }
-
   uint32_t now = millis();
   static uint8_t syncSlot;
 #if defined(NO_SYNC_ON_ARM)
@@ -438,6 +402,9 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
   {
     if (NextPacketIsMspData && MspSender.IsActive())
     {
+      uint8_t *data;
+      uint8_t maxLength;
+      uint8_t packageIndex;
       MspSender.GetCurrentPayload(&packageIndex, &maxLength, &data);
       Radio.TXdataBuffer[0] = MSP_DATA_PACKET & 0b11;
       Radio.TXdataBuffer[1] = packageIndex;
@@ -477,10 +444,35 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
 }
 
 /*
- * Called as the timer ISR when transmitting
+ * Called as the TOCK timer ISR when there is a CRSF connection from the handset
  */
 void ICACHE_RAM_ATTR timerCallbackNormal()
 {
+  #ifdef FEATURE_OPENTX_SYNC
+  // Sync OpenTX to this point
+  crsf.JustSentRFpacket();
+  #endif
+
+  // Nonce advances on every timer tick
+  NonceTX++;
+
+  // If HandleTLM has started Receive mode, TLM packet reception should begin shortly
+  // Skip transmitting on this slot
+  if (TelemetryRcvPhase == ttrpInReceiveMode)
+  {
+    TelemetryRcvPhase = ttrpWindowInProgress;
+    crsf.LinkStatistics.downlink_Link_quality = LQCalc.getLQ();
+    LQCalc.inc();
+    return;
+  }
+  // TLM packet reception was the previous slot, transmit this slot (below)
+  if (TelemetryRcvPhase == ttrpWindowInProgress)
+  {
+    // Stop Receive mode if it is still active
+    Radio.SetTxIdleMode();
+    TelemetryRcvPhase = ttrpTransmitting;
+  }
+
   // Do not send a stale channels packet to the RX if one has not been received from the handset
   // *Do* send data if a packet has never been received from handset and the timer is running
   //     this is the case when bench testing and TXing without a handset
@@ -829,6 +821,9 @@ static void CheckConfigChangePending()
 
 void ICACHE_RAM_ATTR RXdoneISR()
 {
+  // There isn't enough time to receive two packets during one telemetry slot
+  // Stop receiving to prevent a second packet preamble from starting a second receive
+  Radio.SetTxIdleMode();
   ProcessTLMpacket();
   busyTransmitting = false;
 }
@@ -836,9 +831,8 @@ void ICACHE_RAM_ATTR RXdoneISR()
 void ICACHE_RAM_ATTR TXdoneISR()
 {
   busyTransmitting = false;
-  NonceTX++; // must be done before callback
   HandleFHSS();
-  HandleTLM();
+  HandlePrepareForTLM();
 }
 
 static void UpdateConnectDisconnectStatus()


### PR DESCRIPTION
Reorganize the Radio ISR code to prevent the wrong interrupt routine from being called on the TX which is causing the NonceTX to advance prematurely, such as in #934. This dangerous bug affects all regulatory domains, and both 1.x and master.

### Details
We've seen plenty of symptoms of Nonce desync, where a receiver suddenly will drop to under 75 LQ even with good RSSI. This can either be healed by a sync packet to bring it back in step, but on 1.0 if it gets out of sync by 2 (50 LQ) it will never recover. This is something we haven't been able to reproduce in test setups so it has been difficult to track down and why it took me dozens of hours to narrow in on the cause. This is due to the fact that this bug can only present itself with multiple transmitters running at the same time.

The slip (actually the TX is double-advancing) is caused by the reception of multiple packets by the TX module during the telemetry interval. Once the nonce slips one position though, it is highly likely to slip again, because the transmitter will be listening for telemetry on a clear FHSS channel, which increases the likelyhood of hearing another transmitter which is not synced to our schedule and will generate a bad interrupt at a time to exploit the bug again.

What's happening:
* TX module goes into receive mode to receive telemetry. Regardless of if it receive the TLM packet or not, it stays in continuous receive mode until the next packet is ready to transmit.
* During this time, a second transmitter sends a packet with the same RF parameters so the RF chip starts receiving this second packet.
* The TX module switches to TX mode in our code
* The RF chip throws an interrupt to let us know that there's a new received packet available
* Because we've set our state to be "Transmit", the interrupt is interpreted as a TXDone interrupt, which advances the NonceTX even though the packet we have to send hasn't been sent yet.
* The packet actually transmits, generates an actual TXDone interrupt, and now has advanced the NonceTX twice in one period.

### Solution
The meat of this PR is to change the ISR handler from a stateful version that calls RXISR or TXISR depending on the value *we* set, to using the RF chip's status register to **tell us** what interrupt it is. Replacing code like this:
```
void ICACHE_RAM_ATTR SX1280Hal::dioISR()
{
    if (instance->InterruptAssignment == SX1280_INTERRUPT_RX_DONE)
    {
        RXdoneCallback();
    }
    else if (instance->InterruptAssignment == SX1280_INTERRUPT_TX_DONE)
    {
        TXdoneCallback();
    }
}
```
with code like this
```
void ICACHE_RAM_ATTR SX1280Driver::IsrCallback()
{
    uint16_t irqStatus = instance->GetIrqStatus();
    instance->ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
    if ((irqStatus & SX1280_IRQ_TX_DONE))
        instance->TXnbISR();
    else if ((irqStatus & SX1280_IRQ_RX_DONE))
        instance->RXnbISR();
}
```

### Other changes
* The NonceTX++ has been removed from being in two places in the transmitter: the TXDone interrupt, and the implied telemetry happened handler. Now it just lives in the Tock handler and is always advanced one time per Tock.
* To make it clearer how the Telemetry receive progresses, I've replaced the single boolean `WaitRXresponse` that also relies on the NonceTX staying frozen for two intervals with a proper 3 state enum.
  *  The way it used to work: The TXDoneISR would call HandleTLM which would set the boolean, then the next Tock's `SendRCdataToRF` would check if the Nonce was a TLM nonce, clear the flag, leave the nonce its previous value, and return. The next Tock, the Nonce would still be the previous Nonce, which was interpreted to mean we just did telemetry, so the NonceTX would be incremented now, and later in the same period incremented again by the next TXDoneISR. Not confusing at all!
  * The way it works now: The TXDoneISR, sets the state variable indicating it is ready to receive telemetry. Now the Tock sees that it is receiving telemetry, advances the state, returns. The next Tock advances the state again back to normal Transmit. The NonceTX is consistent across all of these operations, ticking once per Tock trigger.
* `crsf.JustSentRFpacket();` has been moved from `SendRCdataToRF` to the Tock handler. This was broken. If we didn't have fresh RC channels data, the OpenTX sync variable would not update and could cause mayhem in the sync calculation. I don't think anyone ever has run into this because that would mean our receiving data from OpenTX wasn't working but for some reason we would still be sending sync packets ok? Not likely.

## The best way to test
The bug addressed by this PR can only ever occur when there are multiple transmitters running the same RF Rate. I've run for days with a single TX and never had any problems with Nonce sync. Add a second TX and it happens somewhat rarely. To make this happen frequently, increase the telemetry ratio on the pair under test (I used 1:8). A higher packet rate helps as well (I used 250Hz) but all transmitters must be set to this rate. To increase the chance of collisions on the same FHSS, I also reduced Team2.4's hop list down to 10 channels. This presented the bug usually within 2-5 minutes.

I've tested using two Team2.4 setups to verify it works on systems both with and without a busy pin. All devices of the same band were active at the same time
* SIYI FM30 TX + BetaFPV 2400 RX (no Busy pin test)
* SIYI FR Mini RX as TX + EP2 RX (Busy pin test)
In addition I've tested Team900
* HappyModel ES900TX + FrSky R9MM
* TTGO Lora32 V1 just set to blast out packets continuously

## Backporting
I will backport these changes to 1.1-maintenance as well in a separate PR, since I'm worried just trying to cherry-pick this could merge poorly in a way that might not be obvious. The changes themselves are straightforward, but I am not looking forward to having to flash allllllllll this gear back to 1.1 to run all the testing again. It is not fun 🤮