### PR TITLE
Add ESP8266 TX

### DIFF
--- a/src/include/targets.h
+++ b/src/include/targets.h
@@ -272,29 +272,21 @@ https://github.com/jaxxzer
 #define GPIO_PIN_VRF2			        PB1  // 26SU Switch RF2
 #define GPIO_PIN_SWR			         PA0  // SWR ADC1_IN1
 
-#elif defined(TARGET_RX_ESP8266_SX1280_V1)
-#define GPIO_PIN_NSS 15
-#define GPIO_PIN_BUSY 5
-#define GPIO_PIN_DIO1 4
-#define GPIO_PIN_MOSI 13
-#define GPIO_PIN_MISO 12
-#define GPIO_PIN_SCK 14
-#define GPIO_PIN_RST 2
-#define GPIO_PIN_RCSIGNAL_RX -1 //only uses default uart pins so leave as -1
-#define GPIO_PIN_RCSIGNAL_TX -1
-#define GPIO_PIN_LED 16
-#define timerOffset -1
-#ifdef USE_DIVERSITY
-/*
-https://www.psemi.com/pdf/datasheets/pe4259ds.pdf
-By default GPIO0 is pulled high. so RF1 is selected, which equals Ant2 on the PCB.
-If flashed without USE_DIVERSITY Ant2 must be connected
-Low = Ant1
-High = Ant2
-*/
-    #define GPIO_PIN_ANTENNA_SELECT 0
+#elif defined(TARGET_RX_ESP8266_SX1280_V1) || defined(TARGET_TX_ESP8266_SX1280)
+#define GPIO_PIN_NSS            15
+#define GPIO_PIN_BUSY           5
+#define GPIO_PIN_DIO1           4
+#define GPIO_PIN_MOSI           13
+#define GPIO_PIN_MISO           12
+#define GPIO_PIN_SCK            14
+#define GPIO_PIN_RST            2
+//#define GPIO_PIN_RCSIGNAL_RX -1 // uses default uart pins
+//#define GPIO_PIN_RCSIGNAL_TX -1
+#define GPIO_PIN_LED_RED        16 // LED_RED on TX, copied to LED on RX
+#if defined(TARGET_RX) && defined(USE_DIVERSITY)
+#define GPIO_PIN_ANTENNA_SELECT 0 // Low = Ant1, High = Ant2, pulled high by external resistor
 #else
-    #define GPIO_PIN_BUTTON 0
+#define GPIO_PIN_BUTTON         0
 #endif
 
 #elif defined(TARGET_TX_ESP32_SX1280_V1)

--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -741,24 +741,22 @@ bool CRSF::UARTwdt()
             adjustMaxPacketSize();
 
             SerialOutFIFO.flush();
-            #if defined(PLATFORM_ESP8266) || defined(PLATFORM_ESP32)
-                CRSF::Port.flush();
-                CRSF::Port.updateBaudRate(UARTrequestedBaud);
-            #else
-                CRSF::Port.begin(UARTrequestedBaud);
-                #if defined(TARGET_TX_GHOST)
-                USART1->CR1 &= ~USART_CR1_UE;
-                USART1->CR3 |= USART_CR3_HDSEL;
-                USART1->CR2 |= USART_CR2_RXINV | USART_CR2_TXINV | USART_CR2_SWAP; //inverted/swapped
-                USART1->CR1 |= USART_CR1_UE;
-                #endif
-                #if defined(TARGET_TX_FM30_MINI)
-                LL_GPIO_SetPinPull(GPIOA, GPIO_PIN_2, LL_GPIO_PULL_DOWN); // default is PULLUP
-                USART2->CR1 &= ~USART_CR1_UE;
-                USART2->CR2 |= USART_CR2_RXINV | USART_CR2_TXINV; //inverted
-                USART2->CR1 |= USART_CR1_UE;
-                #endif
-            #endif
+#if defined(PLATFORM_ESP8266) || defined(PLATFORM_ESP32)
+            CRSF::Port.flush();
+            CRSF::Port.updateBaudRate(UARTrequestedBaud);
+#elif defined(TARGET_TX_GHOST)
+            CRSF::Port.begin(UARTrequestedBaud);
+            USART1->CR1 &= ~USART_CR1_UE;
+            USART1->CR3 |= USART_CR3_HDSEL;
+            USART1->CR2 |= USART_CR2_RXINV | USART_CR2_TXINV | USART_CR2_SWAP; //inverted/swapped
+            USART1->CR1 |= USART_CR1_UE;
+#elif defined(TARGET_TX_FM30_MINI)
+            CRSF::Port.begin(UARTrequestedBaud);
+            LL_GPIO_SetPinPull(GPIOA, GPIO_PIN_2, LL_GPIO_PULL_DOWN); // default is PULLUP
+            USART2->CR1 &= ~USART_CR1_UE;
+            USART2->CR2 |= USART_CR2_RXINV | USART_CR2_TXINV; //inverted
+            USART2->CR1 |= USART_CR1_UE;
+#endif
             duplex_set_RX();
             // cleanup input buffer
             flush_port_input();

--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -5,7 +5,7 @@
 #include "helpers.h"
 
 #if defined(PLATFORM_ESP32)
-HardwareSerial CRSF::Port = SerialPort(1)
+HardwareSerial CRSF::Port = HardwareSerial(1);
 portMUX_TYPE FIFOmux = portMUX_INITIALIZER_UNLOCKED;
 TaskHandle_t xESP32uartTask = NULL;
 #elif defined(PLATFORM_ESP8266)

--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -741,7 +741,7 @@ bool CRSF::UARTwdt()
             adjustMaxPacketSize();
 
             SerialOutFIFO.flush();
-            #if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
+            #if defined(PLATFORM_ESP8266) || defined(PLATFORM_ESP32)
                 CRSF::Port.flush();
                 CRSF::Port.updateBaudRate(UARTrequestedBaud);
             #else

--- a/src/lib/HWTIMER/ESP8266_hwTimer.cpp
+++ b/src/lib/HWTIMER/ESP8266_hwTimer.cpp
@@ -16,14 +16,7 @@ bool hwTimer::running = false;
 
 void hwTimer::init()
 {
-    if (!running)
-    {
-        timer1_attachInterrupt(hwTimer::callback);
-        timer1_enable(TIM_DIV16, TIM_EDGE, TIM_LOOP); //5MHz ticks
-        timer1_write(hwTimer::HWtimerInterval >> 1);  //120000 us
-        isTick = false;
-        running = true;
-    }
+    running = false;
 }
 
 void hwTimer::stop()
@@ -38,11 +31,17 @@ void hwTimer::stop()
 
 void ICACHE_RAM_ATTR hwTimer::resume()
 {
-    init();
-    // The STM32 timer fires tock() ASAP after enabling, so mimic that behavior
-    // tock() should always be the first event to maintain consistency
-    isTick = false;
-    timer1_write(10);
+    if (!running)
+    {
+        timer1_attachInterrupt(hwTimer::callback);
+        timer1_enable(TIM_DIV16, TIM_EDGE, TIM_LOOP); //5MHz ticks
+        // The STM32 timer fires tock() ASAP after enabling, so mimic that behavior
+        // tock() should always be the first event to maintain consistency
+        isTick = false;
+        timer1_write(10);
+
+        running = true;
+    }
 }
 
 void hwTimer::updateInterval(uint32_t newTimerInterval)

--- a/src/src/WebUpdate.cpp
+++ b/src/src/WebUpdate.cpp
@@ -35,7 +35,7 @@ extern SX1280Driver Radio;
 #endif
 
 #include "config.h"
-#if defined(PLATFORM_ESP32)
+#if defined(TARGET_TX)
 extern TxConfig config;
 #else
 extern RxConfig config;

--- a/src/src/luaParams.cpp
+++ b/src/src/luaParams.cpp
@@ -88,7 +88,7 @@ struct tagLuaItem_string luaELRSversion = {
     LUA_STRING_SIZE(luaELRSversion)
 };
 
-#ifdef PLATFORM_ESP32
+#if defined(PLATFORM_ESP8266) || defined(PLATFORM_ESP32)
 struct tagLuaItem_command luaWebUpdate = {
     {0,0,(uint8_t)CRSF_COMMAND},//id,type
     "WiFi Update",
@@ -96,7 +96,9 @@ struct tagLuaItem_command luaWebUpdate = {
     emptySpace,
     LUA_COMMAND_SIZE(luaWebUpdate)
 };
+#endif
 
+#if defined(PLATFORM_ESP32)
 struct tagLuaItem_command luaBLEJoystick = {
     {0,0,(uint8_t)CRSF_COMMAND},//id,type
     "BLE Joystick",

--- a/src/src/luaParams.h
+++ b/src/src/luaParams.h
@@ -10,8 +10,10 @@ extern struct tagLuaItem_command luaBind;
 extern struct tagLuaItem_string luaInfo;
 extern struct tagLuaItem_string luaELRSversion;
 
-#ifdef PLATFORM_ESP32
+#if defined(PLATFORM_ESP8266) || defined(PLATFORM_ESP32)
 extern struct tagLuaItem_command luaWebUpdate;
+#endif
+#if defined(PLATFORM_ESP32)
 extern struct tagLuaItem_command luaBLEJoystick;
 #endif
 

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1239,7 +1239,6 @@ void setup()
     Radio.RXnb();
     crsf.Begin();
     hwTimer.init();
-    hwTimer.stop();
 }
 
 void loop()

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -739,7 +739,7 @@ void UARTconnected()
   pinMode(GPIO_PIN_BUZZER, INPUT);
   #endif
 
-  #if defined(PLATFORM_ESP266) || defined(PLATFORM_ESP32)
+  #if defined(PLATFORM_ESP8266) || defined(PLATFORM_ESP32)
   webserverPreventAutoStart = true;
   #endif
   rfModeLastChangedMS = millis(); // force syncspam on first packets
@@ -967,7 +967,7 @@ void setup()
   if (!init_success)
   {
     connectionState = radioFailed;
-    #if defined(PLATFORM_ESP266) || defined(PLATFORM_ESP32)
+    #if defined(PLATFORM_ESP8266) || defined(PLATFORM_ESP32)
     while (1)
     {
       unsigned long now = millis();
@@ -1030,7 +1030,7 @@ void loop()
   HandleUpdateParameter();
   CheckConfigChangePending();
 
-  #if defined(PLATFORM_ESP266) || defined(PLATFORM_ESP32)
+  #if defined(PLATFORM_ESP8266) || defined(PLATFORM_ESP32)
     // If the reboot time is set and the current time is past the reboot time then reboot.
     if (rebootTime != 0 && now > rebootTime) {
       ESP.restart();

--- a/src/targets/diy_2400.ini
+++ b/src/targets/diy_2400.ini
@@ -40,6 +40,8 @@ build_flags =
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 
 [env:DIY_2400_TX_ESP8285_SX1280_via_UART]
+# Status: These TXes work as free-running transmitters, but do not have working halfduplex inverted UART
+# to let them work in handsets so if someone could fix that for CapnBry, he'd love you with mouth
 extends = env_common_esp82xx
 build_flags =
 	${env_common_esp82xx.build_flags}

--- a/src/targets/diy_2400.ini
+++ b/src/targets/diy_2400.ini
@@ -39,6 +39,16 @@ build_flags =
 	-O2
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 
+[env:DIY_2400_TX_ESP8285_SX1280_via_UART]
+extends = env_common_esp82xx
+build_flags =
+	${env_common_esp82xx.build_flags}
+	${common_env_data.build_flags_tx}
+	-D TARGET_TX_ESP8266_SX1280
+	-D TX_DEVICE_NAME='"DIY2400 ESP8266"'
+src_filter = ${env_common_esp82xx.src_filter} -<rx_*.cpp>
+lib_ignore = SX127xDriver
+upload_speed = 921600
 
 # ********************************
 # Receiver targets


### PR DESCRIPTION
Adds the target `DIY_2400_TX_ESP8285_SX1280_via_UART` which is our first ESP8266 transmitter target!

## Details
I need more TXes to do coexistence testing and I am not some moneybags like Jye who has 9 transmitters from the same team just sitting around. Let's just make a whole board full of EP2! This is based on the TARGET_RX_ESP8266_SX1280_V1 so it works for all the different clones.

### Does it work?
Nope. The ESP8266 doesn't have a half duplex mode, just a loopback mode where it shorts the RX and TX together. I was hoping this would work, but there seem to be larger problems that prevent even a unidirectional link from working. Calling `Serial.updateBaudRate()` 100% does not change the baud rate. It stays at whatever the first `begin()` call set.

That said, it does work as a transmitter by just turning on the hwTimer like we normally do for fakey connections. This allows me to do my testing and is why I'm making this PR. Even though it doesn't work as a handset TX, I'd like to get this into mainline so the code doesn't rot. Eventually I can revisit this and see if I can get the UART working right to allow ESP8266 TX modules, or someone else can build on it and get it working for me. 🎂

## Other Changes
* The ESP8266 timer starts enabled, unlike ESP32 and STM32 timers. I've modified it so it starts disabled like everything else. Tested on both RX and TX mode.
* I've reordered the CRSF baud rates to move 115200 out of the first slot and into the second slot. 115200 is the only restrictive baud rate we have, and loading config that requests 500Hz is immediately dropped to 250Hz, then returned to 500Hz. It could create issues we might have to work around on startup for a baud rate we're not intending to use.