### PR TITLE
Call correct interrupt to prevent Nonce slip (1.1)

### DIFF
--- a/src/lib/SX127xDriver/SX127x.h
+++ b/src/lib/SX127xDriver/SX127x.h
@@ -64,6 +64,7 @@ public:
     void Config(SX127x_Bandwidth bw, SX127x_SpreadingFactor sf, SX127x_CodingRate cr, uint32_t freq, uint8_t preambleLen, uint8_t syncWord, bool InvertIQ);
     void Config(SX127x_Bandwidth bw, SX127x_SpreadingFactor sf, SX127x_CodingRate cr, uint32_t freq, uint8_t preambleLen, bool InvertIQ);
     void SetMode(SX127x_RadioOPmodes mode);
+    void SetTxIdleMode() { SetMode(SX127x_OPMODE_STANDBY); } // set Idle mode used when switching from RX to TX
     void ConfigLoraDefaults();
 
     void SetBandwidthCodingRate(SX127x_Bandwidth bw, SX127x_CodingRate cr);
@@ -85,7 +86,8 @@ public:
     ////////////////////////////////////////////////////
 
     /////////////////Utility Funcitons//////////////////
-    void ClearIRQFlags();
+    uint8_t GetIrqFlags();
+    void ClearIrqFlags();
 
     //////////////RX related Functions/////////////////
 
@@ -97,11 +99,12 @@ public:
     int8_t GetCurrRSSI();
 
     ////////////Non-blocking TX related Functions/////////////////
-    static void TXnb(uint8_t volatile *data, uint8_t length);
-    static void TXnbISR(); //ISR for non-blocking TX routine
+    void TXnb(uint8_t volatile *data, uint8_t length);
     /////////////Non-blocking RX related Functions///////////////
-    static void RXnb();
-    static void RXnbISR(); //ISR for non-blocking RC routin
+    void RXnb();
 
 private:
+    static void ICACHE_RAM_ATTR IsrCallback();
+    void RXnbISR(); // ISR for non-blocking RX routine
+    void TXnbISR(); // ISR for non-blocking TX routine
 };

--- a/src/lib/SX127xDriver/SX127xHal.cpp
+++ b/src/lib/SX127xDriver/SX127xHal.cpp
@@ -4,12 +4,6 @@
 
 SX127xHal *SX127xHal::instance = NULL;
 
-volatile SX127x_InterruptAssignment SX127xHal::InterruptAssignment = SX127x_INTERRUPT_NONE;
-
-void inline SX127xHal::nullCallback(void) { return; }
-void (*SX127xHal::TXdoneCallback)() = &nullCallback;
-void (*SX127xHal::RXdoneCallback)() = &nullCallback;
-
 SX127xHal::SX127xHal()
 {
   instance = this;
@@ -17,8 +11,10 @@ SX127xHal::SX127xHal()
 
 void SX127xHal::end()
 {
-  SPI.end();
+  RXenable(); // make sure the TX amp pin is disabled
   detachInterrupt(GPIO_PIN_DIO0);
+  SPI.end();
+  IsrCallback = nullptr;
 }
 
 void SX127xHal::init()
@@ -201,8 +197,6 @@ void ICACHE_RAM_ATTR SX127xHal::writeRegister(uint8_t reg, uint8_t data)
 
 void ICACHE_RAM_ATTR SX127xHal::TXenable()
 {
-  instance->InterruptAssignment = SX127x_INTERRUPT_TX_DONE;
-
 #if defined(GPIO_PIN_RX_ENABLE) && (GPIO_PIN_RX_ENABLE != UNDEF_PIN)
     digitalWrite(GPIO_PIN_RX_ENABLE, LOW);
 #endif
@@ -216,8 +210,6 @@ void ICACHE_RAM_ATTR SX127xHal::TXenable()
 
 void ICACHE_RAM_ATTR SX127xHal::RXenable()
 {
-  instance->InterruptAssignment = SX127x_INTERRUPT_RX_DONE;
-
 #if defined(GPIO_PIN_RX_ENABLE) && (GPIO_PIN_RX_ENABLE != UNDEF_PIN)
     digitalWrite(GPIO_PIN_RX_ENABLE, HIGH);
 #endif
@@ -231,8 +223,6 @@ void ICACHE_RAM_ATTR SX127xHal::RXenable()
 
 void ICACHE_RAM_ATTR SX127xHal::TXRXdisable()
 {
-  instance->InterruptAssignment = SX127x_INTERRUPT_NONE;
-
 #if defined(GPIO_PIN_RX_ENABLE) && (GPIO_PIN_RX_ENABLE != UNDEF_PIN)
     digitalWrite(GPIO_PIN_RX_ENABLE, LOW);
 #endif
@@ -246,14 +236,8 @@ void ICACHE_RAM_ATTR SX127xHal::TXRXdisable()
 
 void ICACHE_RAM_ATTR SX127xHal::dioISR()
 {
-  if (instance->InterruptAssignment == SX127x_INTERRUPT_TX_DONE)
-  {
-    TXdoneCallback();
-  }
-  else if (instance->InterruptAssignment == SX127x_INTERRUPT_RX_DONE)
-  {
-    RXdoneCallback();
-  }
+    if (instance->IsrCallback)
+        instance->IsrCallback();
 }
 
 #endif // UNIT_TEST

--- a/src/lib/SX127xDriver/SX127xHal.h
+++ b/src/lib/SX127xDriver/SX127xHal.h
@@ -6,14 +6,6 @@
 #include <SPI.h>
 #endif
 
-typedef enum
-{
-    SX127x_INTERRUPT_NONE,
-    SX127x_INTERRUPT_RX_DONE,
-    SX127x_INTERRUPT_TX_DONE,
-    SX127x_INTERRUPT_CAD
-} SX127x_InterruptAssignment;
-
 class SX127xHal
 {
 
@@ -26,9 +18,7 @@ public:
     void end();
 
     static void ICACHE_RAM_ATTR dioISR();
-    static void inline nullCallback(void);
-    static void (*TXdoneCallback)(); //function pointer for callback
-    static void (*RXdoneCallback)(); //function pointer for callback
+    void (*IsrCallback)(); //function pointer for callback
 
     void ICACHE_RAM_ATTR TXenable();
     void ICACHE_RAM_ATTR RXenable();
@@ -44,6 +34,4 @@ public:
     void ICACHE_RAM_ATTR writeRegisterFIFO(volatile uint8_t *data, uint8_t numBytes);
     void ICACHE_RAM_ATTR readRegisterFIFO(volatile uint8_t *data, uint8_t numBytes);
     void ICACHE_RAM_ATTR writeRegisterBurst(uint8_t reg, uint8_t *data, uint8_t numBytes);
-
-    static volatile SX127x_InterruptAssignment InterruptAssignment;
 };

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -28,10 +28,12 @@ txBaseAddress and rxBaseAddress are offset relative to the beginning of the data
 5. Define the modulation parameter signal BW SF CR
 */
 
-uint32_t beginTX;
-uint32_t endTX;
+#if defined(DEBUG_SX1280_OTA_TIMING)
+static uint32_t beginTX;
+static uint32_t endTX;
+#endif
 
-void ICACHE_RAM_ATTR SX1280Driver::nullCallback(void) {return;}
+void ICACHE_RAM_ATTR SX1280Driver::nullCallback(void) {}
 
 SX1280Driver::SX1280Driver()
 {
@@ -40,16 +42,16 @@ SX1280Driver::SX1280Driver()
 
 void SX1280Driver::End()
 {
+    SetMode(SX1280_MODE_SLEEP);
     hal.end();
-    instance->TXdoneCallback = &nullCallback; // remove callbacks
-    instance->RXdoneCallback = &nullCallback;
+    TXdoneCallback = &nullCallback; // remove callbacks
+    RXdoneCallback = &nullCallback;
 }
 
 bool SX1280Driver::Begin()
 {
     hal.init();
-    hal.TXdoneCallback = &SX1280Driver::TXnbISR;
-    hal.RXdoneCallback = &SX1280Driver::RXnbISR;
+    hal.IsrCallback = &SX1280Driver::IsrCallback;
 
     hal.reset();
     Serial.println("SX1280 Begin");
@@ -63,23 +65,23 @@ bool SX1280Driver::Begin()
         return false;
     }
 
-    this->SetMode(SX1280_MODE_STDBY_RC);                                                                                                //step 1 put in STDBY_RC mode
-    hal.WriteCommand(SX1280_RADIO_SET_PACKETTYPE, SX1280_PACKET_TYPE_LORA);                                                             //Step 2: set packet type to LoRa
-    this->ConfigLoRaModParams(currBW, currSF, currCR);                                                                                      //Step 5: Configure Modulation Params
-    hal.WriteCommand(SX1280_RADIO_SET_AUTOFS, 0x01);                                                                                    //enable auto FS
-    hal.WriteRegister(0x0891, (hal.ReadRegister(0x0891) | 0xC0));                                                                       //default is low power mode, switch to high sensitivity instead
-    this->SetPacketParams(12, SX1280_LORA_PACKET_IMPLICIT, 8, SX1280_LORA_CRC_OFF, SX1280_LORA_IQ_NORMAL);                              //default params
-    this->SetFrequencyReg(this->currFreq);                                                                                              //Step 3: Set Freq
-    this->SetFIFOaddr(0x00, 0x00);                                                                                                      //Step 4: Config FIFO addr
-    this->SetDioIrqParams(SX1280_IRQ_RADIO_ALL, SX1280_IRQ_TX_DONE | SX1280_IRQ_RX_DONE, SX1280_IRQ_RADIO_NONE, SX1280_IRQ_RADIO_NONE); //set IRQ to both RXdone/TXdone on DIO1
+    SetMode(SX1280_MODE_STDBY_RC);                                                                                                //Put in STDBY_RC mode
+    hal.WriteCommand(SX1280_RADIO_SET_PACKETTYPE, SX1280_PACKET_TYPE_LORA);                                                       //Set packet type to LoRa
+    ConfigLoRaModParams(currBW, currSF, currCR);                                                                                  //Configure Modulation Params
+    hal.WriteCommand(SX1280_RADIO_SET_AUTOFS, 0x01);                                                                              //Enable auto FS
+    hal.WriteRegister(0x0891, (hal.ReadRegister(0x0891) | 0xC0));                                                                 //default is low power mode, switch to high sensitivity instead
+    SetPacketParams(12, SX1280_LORA_PACKET_IMPLICIT, 8, SX1280_LORA_CRC_OFF, SX1280_LORA_IQ_NORMAL);                              //default params
+    SetFrequencyReg(currFreq);                                                                                                    //Set Freq
+    SetFIFOaddr(0x00, 0x00);                                                                                                      //Config FIFO addr
+    SetDioIrqParams(SX1280_IRQ_RADIO_ALL, SX1280_IRQ_TX_DONE | SX1280_IRQ_RX_DONE, SX1280_IRQ_RADIO_NONE, SX1280_IRQ_RADIO_NONE); //set IRQ to both RXdone/TXdone on DIO1
     return true;
 }
 
 void SX1280Driver::Config(SX1280_RadioLoRaBandwidths_t bw, SX1280_RadioLoRaSpreadingFactors_t sf, SX1280_RadioLoRaCodingRates_t cr, uint32_t freq, uint8_t PreambleLength, bool InvertIQ)
 {
     IQinverted = InvertIQ;
-    this->SetMode(SX1280_MODE_STDBY_XOSC);
-    instance->ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
+    SetMode(SX1280_MODE_STDBY_XOSC);
+    ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
     ConfigLoRaModParams(bw, sf, cr);
     SetPacketParams(PreambleLength, SX1280_LORA_PACKET_IMPLICIT, 8, SX1280_LORA_CRC_OFF, (SX1280_RadioLoRaIQModes_t)((uint8_t)!IQinverted << 6)); // TODO don't make static etc. LORA_IQ_STD = 0x40, LORA_IQ_INVERTED = 0x00
     SetFrequencyReg(freq);
@@ -270,6 +272,14 @@ void SX1280Driver::SetDioIrqParams(uint16_t irqMask, uint16_t dio1Mask, uint16_t
     hal.WriteCommand(SX1280_RADIO_SET_DIOIRQPARAMS, buf, sizeof(buf));
 }
 
+uint16_t ICACHE_RAM_ATTR SX1280Driver::GetIrqStatus()
+{
+    uint8_t status[2];
+
+    hal.ReadCommand(SX1280_RADIO_GET_IRQSTATUS, status, 2);
+    return status[0] << 8 | status[1];
+}
+
 void ICACHE_RAM_ATTR SX1280Driver::ClearIrqStatus(uint16_t irqMask)
 {
     uint8_t buf[2];
@@ -282,33 +292,26 @@ void ICACHE_RAM_ATTR SX1280Driver::ClearIrqStatus(uint16_t irqMask)
 
 void ICACHE_RAM_ATTR SX1280Driver::TXnbISR()
 {
-    instance->currOpmode = SX1280_MODE_FS; // radio goes to FS after TX
+    currOpmode = SX1280_MODE_FS; // radio goes to FS after TX
 #ifdef DEBUG_SX1280_OTA_TIMING
     endTX = micros();
+    DBGLN("TOA: %d", endTX - beginTX);
 #endif
-    instance->ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
-
-#ifdef DEBUG_SX1280_OTA_TIMING
-    Serial.print("TOA: ");
-    Serial.println(endTX - beginTX);
-#endif
-    //instance->GetStatus();
-    instance->TXdoneCallback();
+    TXdoneCallback();
 }
 
 uint8_t FIFOaddr = 0;
 
 void ICACHE_RAM_ATTR SX1280Driver::TXnb(volatile uint8_t *data, uint8_t length)
 {
-    if (instance->currOpmode == SX1280_MODE_TX) //catch TX timeout
+    if (currOpmode == SX1280_MODE_TX) //catch TX timeout
     {
         //Serial.println("Timeout!");
-        instance->ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
-        instance->SetMode(SX1280_MODE_FS);
+        SetMode(SX1280_MODE_FS);
         TXnbISR();
         return;
     }
-    instance->ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
+    ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
     hal.TXenable();                      // do first to allow PA stablise
     hal.WriteBuffer(0x00, data, length); //todo fix offset to equal fifo addr
     instance->SetMode(SX1280_MODE_TX);
@@ -319,19 +322,19 @@ void ICACHE_RAM_ATTR SX1280Driver::TXnb(volatile uint8_t *data, uint8_t length)
 
 void ICACHE_RAM_ATTR SX1280Driver::RXnbISR()
 {
-    instance->currOpmode = SX1280_MODE_FS;
-    instance->ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
-    uint8_t FIFOaddr = instance->GetRxBufferAddr();
-    hal.ReadBuffer(FIFOaddr, instance->RXdataBuffer, TXRXBuffSize);
-    instance->GetLastPacketStats();
-    instance->RXdoneCallback();
+    // In continuous receive mode, the device stays in Rx mode
+    //currOpmode = SX1280_MODE_FS;
+    uint8_t FIFOaddr = GetRxBufferAddr();
+    hal.ReadBuffer(FIFOaddr, RXdataBuffer, TXRXBuffSize);
+    GetLastPacketStats();
+    RXdoneCallback();
 }
 
 void ICACHE_RAM_ATTR SX1280Driver::RXnb()
 {
     hal.RXenable();
-    instance->ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
-    instance->SetMode(SX1280_MODE_RX);
+    ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
+    SetMode(SX1280_MODE_RX);
 }
 
 uint8_t ICACHE_RAM_ATTR SX1280Driver::GetRxBufferAddr()
@@ -382,6 +385,16 @@ void ICACHE_RAM_ATTR SX1280Driver::GetLastPacketStats()
     uint8_t status[2];
 
     hal.ReadCommand(SX1280_RADIO_GET_PACKETSTATUS, status, 2);
-    instance->LastPacketRSSI = -(int8_t)(status[0] / 2);
-    instance->LastPacketSNR = (int8_t)status[1] / 4;
+    LastPacketRSSI = -(int8_t)(status[0] / 2);
+    LastPacketSNR = (int8_t)status[1] / 4;
+}
+
+void ICACHE_RAM_ATTR SX1280Driver::IsrCallback()
+{
+    uint16_t irqStatus = instance->GetIrqStatus();
+    instance->ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
+    if ((irqStatus & SX1280_IRQ_TX_DONE))
+        instance->TXnbISR();
+    else if ((irqStatus & SX1280_IRQ_RX_DONE))
+        instance->RXnbISR();
 }

--- a/src/lib/SX1280Driver/SX1280.h
+++ b/src/lib/SX1280Driver/SX1280.h
@@ -4,18 +4,8 @@
 #include "SX1280_Regs.h"
 #include "SX1280_hal.h"
 
-void ICACHE_RAM_ATTR TXnbISR();
-
-enum InterruptAssignment_
-{
-    NONE,
-    RX_DONE,
-    TX_DONE
-};
-
 class SX1280Driver
 {
-
 public:
     ///////Callback Function Pointers/////
     static void ICACHE_RAM_ATTR nullCallback(void);
@@ -26,12 +16,8 @@ public:
     static void (*TXtimeout)(); //function pointer for callback
     static void (*RXtimeout)(); //function pointer for callback
 
-    InterruptAssignment_ InterruptAssignment = NONE;
-    /////////////////////////////
-
     ///////////Radio Variables////////
     #define TXRXBuffSize 8 
-
     volatile uint8_t TXdataBuffer[TXRXBuffSize]; // ELRS uses max of 8 bytes
     volatile uint8_t RXdataBuffer[TXRXBuffSize];
 
@@ -73,6 +59,7 @@ public:
     bool Begin();
     void End();
     void SetMode(SX1280_RadioOperatingModes_t OPmode);
+    void SetTxIdleMode() { SetMode(SX1280_MODE_FS); }; // set Idle mode used when switching from RX to TX
     void Config(SX1280_RadioLoRaBandwidths_t bw, SX1280_RadioLoRaSpreadingFactors_t sf, SX1280_RadioLoRaCodingRates_t cr, uint32_t freq, uint8_t PreambleLength, bool InvertIQ);
     void ConfigLoRaModParams(SX1280_RadioLoRaBandwidths_t bw, SX1280_RadioLoRaSpreadingFactors_t sf, SX1280_RadioLoRaCodingRates_t cr);
     void SetPacketParams(uint8_t PreambleLength, SX1280_RadioLoRaPacketLengthsModes_t HeaderType, uint8_t PayloadLength, SX1280_RadioLoRaCrcModes_t crc, SX1280_RadioLoRaIQModes_t InvertIQ);
@@ -83,13 +70,11 @@ public:
 
     int32_t ICACHE_RAM_ATTR GetFrequencyError();
 
-    static void TXnb(volatile uint8_t *data, uint8_t length);
-    static void TXnbISR(); //ISR for non-blocking TX routine
+    void TXnb(volatile uint8_t *data, uint8_t length);
+    void RXnb();
 
-    static void RXnb();
-    static void RXnbISR(); //ISR for non-blocking RC routine
-
-    void  ClearIrqStatus(uint16_t irqMask);
+    uint16_t GetIrqStatus();
+    void ClearIrqStatus(uint16_t irqMask);
 
     void GetStatus();
 
@@ -100,4 +85,7 @@ public:
     void GetLastPacketStats();
 
 private:
+    static void ICACHE_RAM_ATTR IsrCallback();
+    void RXnbISR(); // ISR for non-blocking RX routine
+    void TXnbISR(); // ISR for non-blocking TX routine
 };

--- a/src/lib/SX1280Driver/SX1280_hal.cpp
+++ b/src/lib/SX1280Driver/SX1280_hal.cpp
@@ -23,11 +23,6 @@ Modified and adapted by Alessandro Carcione for ELRS project
 
 SX1280Hal *SX1280Hal::instance = NULL;
 
-void ICACHE_RAM_ATTR SX1280Hal::nullCallback(void) {}
-
-void (*SX1280Hal::TXdoneCallback)() = &nullCallback;
-void (*SX1280Hal::RXdoneCallback)() = &nullCallback;
-
 SX1280Hal::SX1280Hal()
 {
     instance = this;
@@ -35,8 +30,10 @@ SX1280Hal::SX1280Hal()
 
 void SX1280Hal::end()
 {
-    SPI.end();
+    RXenable(); // make sure the TX amp pin is disabled
     detachInterrupt(GPIO_PIN_DIO1);
+    SPI.end();
+    IsrCallback = nullptr;
 }
 
 void SX1280Hal::init()
@@ -341,20 +338,12 @@ bool ICACHE_RAM_ATTR SX1280Hal::WaitOnBusy()
 
 void ICACHE_RAM_ATTR SX1280Hal::dioISR()
 {
-    if (instance->InterruptAssignment == SX1280_INTERRUPT_RX_DONE)
-    {
-        RXdoneCallback();
-    }
-    else if (instance->InterruptAssignment == SX1280_INTERRUPT_TX_DONE)
-    {
-        TXdoneCallback();
-    }
+    if (instance->IsrCallback)
+        instance->IsrCallback();
 }
 
 void ICACHE_RAM_ATTR SX1280Hal::TXenable()
 {
-    instance->InterruptAssignment = SX1280_INTERRUPT_TX_DONE;
-
 #if defined(GPIO_PIN_PA_ENABLE) && (GPIO_PIN_PA_ENABLE != UNDEF_PIN)
     digitalWrite(GPIO_PIN_PA_ENABLE, HIGH);
 #endif
@@ -375,8 +364,6 @@ void ICACHE_RAM_ATTR SX1280Hal::TXenable()
 
 void ICACHE_RAM_ATTR SX1280Hal::RXenable()
 {
-    instance->InterruptAssignment = SX1280_INTERRUPT_RX_DONE;
-
 #if defined(GPIO_PIN_PA_ENABLE) && (GPIO_PIN_PA_ENABLE != UNDEF_PIN)
     digitalWrite(GPIO_PIN_PA_ENABLE, HIGH);
 #endif
@@ -397,8 +384,6 @@ void ICACHE_RAM_ATTR SX1280Hal::RXenable()
 
 void ICACHE_RAM_ATTR SX1280Hal::TXRXdisable()
 {
-    this->InterruptAssignment = SX1280_INTERRUPT_NONE;
-
 #if defined(GPIO_PIN_RX_ENABLE) && (GPIO_PIN_RX_ENABLE != UNDEF_PIN)
     digitalWrite(GPIO_PIN_RX_ENABLE, LOW);
 #endif

--- a/src/lib/SX1280Driver/SX1280_hal.h
+++ b/src/lib/SX1280Driver/SX1280_hal.h
@@ -21,13 +21,6 @@ Heavily modified/simplified by Alessandro Carcione 2020 for ELRS project
 #include "SX1280_Regs.h"
 #include "SX1280.h"
 
-enum SX1280_InterruptAssignment_
-{
-    SX1280_INTERRUPT_NONE,
-    SX1280_INTERRUPT_RX_DONE,
-    SX1280_INTERRUPT_TX_DONE
-};
-
 enum SX1280_BusyState_
 {
     SX1280_NOT_BUSY = true,
@@ -36,10 +29,6 @@ enum SX1280_BusyState_
 
 class SX1280Hal
 {
-
-private:
-    volatile SX1280_InterruptAssignment_ InterruptAssignment = SX1280_INTERRUPT_NONE;
-
 public:
     static SX1280Hal *instance;
 
@@ -61,17 +50,14 @@ public:
     void ICACHE_RAM_ATTR WriteBuffer(uint8_t offset, volatile uint8_t *buffer, uint8_t size); // Writes and Reads to FIFO
     void ICACHE_RAM_ATTR ReadBuffer(uint8_t offset, volatile uint8_t *buffer, uint8_t size);
 
-    static void ICACHE_RAM_ATTR nullCallback(void);
-    
     bool ICACHE_RAM_ATTR WaitOnBusy();
-    static ICACHE_RAM_ATTR void dioISR();
     
     void ICACHE_RAM_ATTR TXenable();
     void ICACHE_RAM_ATTR RXenable();
     void ICACHE_RAM_ATTR TXRXdisable();
 
-    static void (*TXdoneCallback)(); //function pointer for callback
-    static void (*RXdoneCallback)(); //function pointer for callback
+    static ICACHE_RAM_ATTR void dioISR();
+    void (*IsrCallback)(); //function pointer for callback
 
 #if defined(GPIO_PIN_BUSY) && (GPIO_PIN_BUSY != UNDEF_PIN)
     void BusyDelay(uint32_t duration) const { (void)duration; };

--- a/src/src/common.h
+++ b/src/src/common.h
@@ -41,6 +41,17 @@ typedef enum
     disconnected = 0
 } connectionState_e;
 
+/**
+ * On the TX, tracks what to do when the Tock timer fires
+ **/
+typedef enum
+{
+    ttrpTransmitting,     // Transmitting RC channels as normal
+    ttrpInReceiveMode,    // Has switched to Receive mode for telemetry on the next slot (set on TX done)
+    ttrpWindowInProgress  // Tock has fired while in receive mode, receiving telemetry on this slot
+                          // Next slot will go back to ttrsTransmitting
+} TxTlmRcvPhase_e;
+
 typedef enum
 {
     tim_disconnected = 0,


### PR DESCRIPTION
Backport of #943

This is a straight merge of that PR, with great care taken to examine the surrounding code to be sure there isn't going to be any new surprises due to the incoming code's expectations.

One thing that is different that came from master that is included here is the RF library part of #883 (Perform more complete RF shutdown when entering WebUpdate mode) where the RF chip is put into standby/sleep mode and the HAL is set to RX mode to disable any TX PA. It just made the code easier to compare and should be some benefit to 1.1ers.

The SX1280 code was clearing the RX/TX callbacks but not the hal callback on `End()`, but the SX127x was clearing the hal callback but not the RX/TX callbacks. I've made them consistent and will also post this as a PR to master (#947), but it shouldn't be affecting anything and would just mean that maybe a transition to wifi would reboot itself instead of transitioning, but it would be unlikely to happen more than once (or at all).

## Tested
* A couple hours on the Team2.4 setup with two transmitters, 10 channel FHSS, and having the RX only send telemetry every 10th slot it is supposed to (since it allows more possibility of a misaligned packet reception if the air is completely dead)
* About 30 mins on the Team900 pair.