### PR TITLE
Disconnect RF handlers consistently across platforms

### DIFF
--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -58,7 +58,8 @@ void SX127xDriver::End()
 {
   SetMode(SX127x_OPMODE_SLEEP);
   hal.end();
-  hal.IsrCallback = nullptr; // remove callbacks
+  TXdoneCallback = &nullCallback; // remove callbacks
+  RXdoneCallback = &nullCallback;
 }
 
 void SX127xDriver::ConfigLoraDefaults()

--- a/src/lib/SX127xDriver/SX127xHal.cpp
+++ b/src/lib/SX127xDriver/SX127xHal.cpp
@@ -15,6 +15,7 @@ void SX127xHal::end()
   RXenable(); // make sure the TX amp pin is disabled
   detachInterrupt(GPIO_PIN_DIO0);
   SPI.end();
+  IsrCallback = nullptr; // remove callbacks
 }
 
 void SX127xHal::init()

--- a/src/lib/SX1280Driver/SX1280_hal.cpp
+++ b/src/lib/SX1280Driver/SX1280_hal.cpp
@@ -34,6 +34,7 @@ void SX1280Hal::end()
     RXenable(); // make sure the TX amp pin is disabled
     detachInterrupt(GPIO_PIN_DIO1);
     SPI.end();
+    IsrCallback = nullptr; // remove callbacks
 }
 
 void SX1280Hal::init()


### PR DESCRIPTION
Make the `Radio.end()` calls consistent between SX1280 and SX127x.

### Details
I noticed this when doing the merge #946 into 1.1, that the SX1280 driver disconnected the RX/TX callbacks but not the hal callback, and the SX127x disconnected the hal callback but not the RX/TX callbacks. I've made it so both hals now disconnect their ISR callback, and both upper level drivers disconnect their RX/TX callbacks.

I don't think anyone is running into any problem with this, because the radio is already in a shutdown mode, but with the ISR callback still active there could be a call after SPI.end is called which would end poorly. It is pretty much impossible that this can happen but at least now they look the same.