### PR TITLE
Add back UART.begin for stm32 TXes

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -756,6 +756,8 @@ bool CRSF::UARTwdt()
             USART2->CR1 &= ~USART_CR1_UE;
             USART2->CR2 |= USART_CR2_RXINV | USART_CR2_TXINV; //inverted
             USART2->CR1 |= USART_CR1_UE;
+#else
+            CRSF::Port.begin(UARTrequestedBaud);
 #endif
             duplex_set_RX();
             // cleanup input buffer


### PR DESCRIPTION
PR #944 broke stm32 based TXes as the conditional compilation was changed slightly