### PR TITLE
TelemBurst sending one extra packet per burst (1.1)

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -287,7 +287,9 @@ bool ICACHE_RAM_ATTR HandleSendTelemetryResponse()
         case ELRS_TELEMETRY_TYPE_LINK:
             #ifdef ENABLE_TELEMETRY
             NextTelemetryType = ELRS_TELEMETRY_TYPE_DATA;
-            telemetryBurstCount = 0;
+            // Start the count at 1 because the next will be DATA and doing +1 before checking
+            // against Max below is for some reason 10 bytes more code
+            telemetryBurstCount = 1;
             #else
             NextTelemetryType = ELRS_TELEMETRY_TYPE_LINK;
             #endif


### PR DESCRIPTION
Backport of "TelemBurst sending one extra packet per burst #905"

Wow that was a confusing cherry-pick for such a small change, but easy to resolve. Also reviewed and verified that the 1.1 code is likewise affected by the bug.