### PR TITLE
RX Diversity improvement (#942) [1.1] #964

### DIFF
--- a/src/include/LowPassFilter.h
+++ b/src/include/LowPassFilter.h
@@ -10,6 +10,7 @@ public:
     int32_t SmoothDataFP;
     int32_t Beta = 3;     // Length = 16
     int32_t FP_Shift = 5; //Number of fractional bits
+    bool NeedReset = true; // wait for the first data to upcoming.
 
     LPF(int Beta_, int FP_Shift_)
     {
@@ -30,6 +31,12 @@ public:
 
     int32_t ICACHE_RAM_ATTR update(int32_t Indata)
     {
+        if (NeedReset)
+        {
+            init(Indata);
+            return SmoothDataINT;
+        }
+
         int RawData;
         RawData = Indata;
         RawData <<= FP_Shift; // Shift to fixed point
@@ -42,8 +49,14 @@ public:
         return SmoothDataINT;
     }
 
+    void ICACHE_RAM_ATTR reset()
+    {
+        NeedReset = true;
+    }
+
     void ICACHE_RAM_ATTR init(int32_t Indata)
     {
+        NeedReset = false;
         SmoothDataINT = Indata;
         SmoothDataFP = SmoothDataINT << FP_Shift;
     }

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -55,7 +55,7 @@ uint32_t LEDWS2812LastUpdate;
 #define LED_INTERVAL_BIND_SHORT 100
 #define LED_INTERVAL_BIND_LONG  1000
 #define SEND_LINK_STATS_TO_FC_INTERVAL 100
-#define DIVERSITY_ANTENNA_INTERVAL 30
+#define DIVERSITY_ANTENNA_INTERVAL 5
 #define DIVERSITY_ANTENNA_RSSI_TRIGGER 5
 #define PACKET_TO_TOCK_SLACK 200 // Desired buffer time between Packet ISR and Tock ISR
 ///////////////////
@@ -448,6 +448,7 @@ static inline void switchAntenna()
 {
 #if defined(GPIO_PIN_ANTENNA_SELECT) && defined(USE_DIVERSITY)
     antenna = !antenna;
+    (antenna == 0) ? LPF_UplinkRSSI0.reset() : LPF_UplinkRSSI1.reset(); // discard the outdated value after switching
     digitalWrite(GPIO_PIN_ANTENNA_SELECT, antenna);
 #endif
 }


### PR DESCRIPTION
I would like to suggest including #942 on v1.2 release. Please consider.

With Matek diversity receivers are added and deployed with the v1.2 release, this PR would immediately improve the LQ on a long-range flight with them.

ps: I was confused with the versioning scheme of the ELRS repo. :P