### PR TITLE
Idle callback must follow same hop logic (master)

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -488,10 +488,7 @@ void ICACHE_RAM_ATTR timerCallbackNormal()
 void ICACHE_RAM_ATTR timerCallbackIdle()
 {
   NonceTX++;
-  if ((NonceTX + 1) % ExpressLRS_currAirRate_Modparams->FHSShopInterval == 0)
-  {
-    FHSSptr++;
-  }
+  HandleFHSS();
 }
 
 void UARTdisconnected()


### PR DESCRIPTION
Fixes FHSS slip occurring when committing EEPROM by using same hop logic during the idle handler.

### Symptoms
"Telemetry Lost" when saving config from Lua, but sticks are still sort of working. Requires a reboot to the TX to fix. Most easy to reproduce at 500Hz for some reason. Affects master and 1.x.

### Details
The logic was changed with #943 so that the `NonceTX++` only happens in the Tock handler, which meant that the HandleFHSS/TLM had to look at the **next** Nonce to determine if it needed to hop/switch to receive mode for the next packet interval. The `timerCallbackIdle` (idle Tock) handler was still using the old logic of only advancing the FHSS it is occurred this interval. My thinking was that the idle tock always completed one full interval so it didn't need to look to the future.

That's wrong in the case where the idle period ends on the last slot of the FHSS (slot 3)-- the first `timerCallbackNormal` advances the NonceTX to FHSS slot 0, where it expects the FHSS has already been performed. The FHSSptr was not advanced by either code path so the TX ends up with the correct NonceTX, but it is one hop behind the RX, which did hop. In retrospect this seems like a really dumb move on my part, so I take full responsibility for looking at that code, considering it carefully, then 👍 that the idle code was fine.

Note that if the idle tock ends on a period that would be telemetry, the TX still transmits that period blasting over the RX's telemetry send. That's not great but I think that's ok given how dangerous it could be to fast-forward through multiple TX/RX mode switches.

### For Discussion
The fix is to just use the same logic in the idle tock, comparing against Nonce + 1 to know if it needs to advance the FHSSptr. However, this leaves the Radio on the wrong frequency so the connection is down one extra hop (confirmed to be true), until the natural HandleFHSS actually sets the Radio frequency. In this PR I've changed it so the radio follows the FHSSptr. There are three possible ways to remedy this:
1. yolo it and just let it last one extra hop duration. This is the safest option since it doesn't update the radio multiple times super-fast as the NonceTX fast-forwards.
1. Update the Radio every time we would have hopped, the way it is implemented in the PR. The Radio's frequency is updated multiple times rapidly on STM32 which may be unsafe?
1. ~~Update the Radio at the _end_ of the fast-forward only. I just have concerns about this on ESP32 platforms which do not fast-forward their Nonce. It is also more code too since it needs to update the FHSSptr in addition to updating the radio frequency at the end which is why I went with option 2.~~ EDIT: This is not viable because it **only** works when we end on the last slot. So option 2 is the best I think we can do without adding extra code to detect that a radio change needs to be committed.

### Testing
Tested on master and 1.1 with FM30 + FR Mini and FM30 + EP2, ES900TX + R9MM. I could never reproduce it on Team900 hardware, and only could get it to happen every few tries on the FM30 at 500Hz, 250Hz worked 20x in a row even with the broken code for some reason. Due to how this is not something that happens every time, this needs extra testing by those who have reported it to see if I am just getting lucky or it is actually fixed.

### Pick for 1.2
To be clear, I mean this should be picked to `1.1.x-maintenance` for 1.2, not to `1.2.x-maintenance` WHICH SHOULD NOT EXIST YET BECAUSE THERE IS NO 1.2 (throws a tantrum). But if it is picked to 1.2.x-maintenance, it should _also_ be picked to 1.1.x-maintenance.