### PR TITLE
Fix MATEK power fix

### DIFF
--- a/src/lib/POWERMGNT/POWERMGNT.h
+++ b/src/lib/POWERMGNT/POWERMGNT.h
@@ -75,7 +75,7 @@
 #define DefaultPowerEnum PWR_50mW
 #define MinPower PWR_10mW
 
-#else
+#elif defined(TARGET_TX)
 // Default is "100mW module"
 //  ==> average ouput is 50mW with high duty cycle
 #define MaxPower PWR_50mW


### PR DESCRIPTION
After a quick chat with @CapnBry on discord, we think the simplest fix for 1.1 is to only fall through to the default definition of `TARGET_100mW_MODULE` for TX modules. This was any RXes that have specific needs have their own defines and subsequent power management sections and all others should fall-through to the end of the power management code and if a specific value is set in `TARGET_RX_DEFAULT_POWER` then that is used otherwise it falls back to 13 for SX1280 or 15 (0b1111) for SX127x.

In `master` there is the power management cleanup PR #971 which should resolve theses issues once and for all.