### PR TITLE
Send RSSI as positive value to handset

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -248,8 +248,8 @@ void ICACHE_RAM_ATTR ProcessTLMpacket()
             crsf.LinkStatistics.active_antenna = Radio.RXdataBuffer[2] >> 7;
             // RSSI received is signed, inverted polarity (positive value = -dBm)
             // OpenTX's value is signed and will display +dBm and -dBm properly
-            crsf.LinkStatistics.uplink_RSSI_1 = -(Radio.RXdataBuffer[2] & 0x7f);
-            crsf.LinkStatistics.uplink_RSSI_2 = -(Radio.RXdataBuffer[3]);
+            crsf.LinkStatistics.uplink_RSSI_1 = Radio.RXdataBuffer[2] & 0x7f;
+            crsf.LinkStatistics.uplink_RSSI_2 = Radio.RXdataBuffer[3];
             crsf.LinkStatistics.uplink_SNR = Radio.RXdataBuffer[4];
             crsf.LinkStatistics.uplink_Link_quality = Radio.RXdataBuffer[5];
             crsf.LinkStatistics.downlink_SNR = Radio.LastPacketSNR;
@@ -705,7 +705,7 @@ void loop()
     UpdateConnectDisconnectStatus();
   }
 
-  // Update UI devices 
+  // Update UI devices
   devicesUpdate(now);
 
   CheckConfigChangePending();
@@ -724,7 +724,7 @@ void loop()
   #if defined(GPIO_PIN_BUTTON) && (GPIO_PIN_BUTTON != UNDEF_PIN)
     button.update();
   #endif
-  
+
   if (connectionState > MODE_STATES)
   {
     return;


### PR DESCRIPTION
Crossfire sends a positive RSSI value to the handset.
ELRS sends a negative value and the scaling of existing lua scripts does not work with this negative value.