### PR TITLE
Korean 900MHz domain regulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ oldcode/ESP8266_OStimer.h
 src/firmware.map
 src/src/fhss_freqs.h
 src/.vscode
+.DS_Store

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -2,7 +2,7 @@
 
 #ifndef UNIT_TEST
 
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868)  || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868)  || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433) || defined(Regulatory_Domain_KR_917)
 #include "SX127xDriver.h"
 #endif
 
@@ -102,7 +102,7 @@ typedef struct expresslrs_rf_pref_params_s
 } expresslrs_rf_pref_params_s;
 
 #ifndef UNIT_TEST
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433) || defined(Regulatory_Domain_KR_917)
 #define RATE_MAX 4
 #define RATE_DEFAULT 0
 typedef struct expresslrs_mod_settings_s

--- a/src/lib/BLE/devBLE.cpp
+++ b/src/lib/BLE/devBLE.cpp
@@ -4,7 +4,7 @@
 
 #if defined(PLATFORM_ESP32)
 
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433) || defined(Regulatory_Domain_KR_917)
 extern SX127xDriver Radio;
 #elif defined(Regulatory_Domain_ISM_2400)
 extern SX1280Driver Radio;

--- a/src/lib/FHSS/FHSS.cpp
+++ b/src/lib/FHSS/FHSS.cpp
@@ -70,6 +70,24 @@ const uint32_t FHSSfreqs[] = {
     FREQ_HZ_TO_REG_VAL(865900000),
     FREQ_HZ_TO_REG_VAL(866425000),
     FREQ_HZ_TO_REG_VAL(866950000)};
+#elif defined Regulatory_Domain_KR_917
+/**
+ * Frequency bands for LoRa (LR-WPANs) in Republic of Korea (South Korea) are taken from TTAK.KO-06.0246/R1
+ * https://www.tta.or.kr/data/ttas_view.jsp?&pk_num=TTAK.KO-06.0246%2FR1
+ * Allowed frequencies: 917-923.5 Mhz, Max. allowed power is 25 mW
+ * 10 channels are allowed for 600 kHz BW, calculated by 917.5+(n-1)*0.6 MHz
+ */
+const uint32_t FHSSfreqs[] = {
+    FREQ_HZ_TO_REG_VAL(917500000),
+    FREQ_HZ_TO_REG_VAL(918100000),
+    FREQ_HZ_TO_REG_VAL(918700000),
+    FREQ_HZ_TO_REG_VAL(919300000),
+    FREQ_HZ_TO_REG_VAL(919900000),
+    FREQ_HZ_TO_REG_VAL(920500000),
+    FREQ_HZ_TO_REG_VAL(921100000),
+    FREQ_HZ_TO_REG_VAL(921700000),
+    FREQ_HZ_TO_REG_VAL(922300000),
+    FREQ_HZ_TO_REG_VAL(922900000)};
 #elif defined Regulatory_Domain_EU_433
 /* Frequency band G, taken from https://wetten.overheid.nl/BWBR0036378/2016-12-28#Bijlagen
  * Note: As is the case with the 868Mhz band, these frequencies only comply to the license free portion
@@ -273,6 +291,8 @@ void FHSSrandomiseFHSSsequence(const uint32_t seed)
     INFOLN("Setting 433MHz AU Mode");
 #elif defined Regulatory_Domain_EU_433
     INFOLN("Setting 433MHz EU Mode");
+#elif defined Regulatory_Domain_KR_917
+    INFOLN("Setting 917MHz KR Mode");
 #elif defined Regulatory_Domain_ISM_2400
     INFOLN("Setting 2400MHz Mode");
 #else

--- a/src/lib/FHSS/FHSS.h
+++ b/src/lib/FHSS/FHSS.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433) || defined(Regulatory_Domain_KR_917)
 #include "SX127xDriver.h"
 #elif Regulatory_Domain_ISM_2400
 #include "SX1280Driver.h"
@@ -22,8 +22,10 @@
 #define Regulatory_Domain_Index 6
 #elif defined Regulatory_Domain_IN_866
 #define Regulatory_Domain_Index 7
-#else
+#elif defined Regulatory_Domain_KR_917
 #define Regulatory_Domain_Index 8
+#else
+#define Regulatory_Domain_Index 9
 #endif
 
 #define FreqCorrectionMax ((int32_t)(100000/FREQ_STEP))

--- a/src/lib/LUA/devLUA.cpp
+++ b/src/lib/LUA/devLUA.cpp
@@ -11,7 +11,7 @@
 #include "OTA.h"
 #include "hwTimer.h"
 
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433) || defined(Regulatory_Domain_KR_917)
 #include "SX127xDriver.h"
 extern SX127xDriver Radio;
 #elif defined(Regulatory_Domain_ISM_2400)
@@ -28,7 +28,7 @@ static const char emptySpace[1] = {0};
 struct tagLuaItem_textSelection luaAirRate = {
     {0,0,(uint8_t)CRSF_TEXT_SELECTION}, //id,type
     "Packet Rate",
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433) 
+#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433) || defined(Regulatory_Domain_KR_917)
     "25(-123dbm);50(-120dbm);100(-117dbm);200(-112dbm)",
 #elif defined(Regulatory_Domain_ISM_2400)
     "50(-117dbm);150(-112dbm);250(-108dbm);500(-105dbm)",

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -3,7 +3,7 @@
 #include "targets.h"
 
 
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433) || defined(Regulatory_Domain_KR_917)
 extern SX127xDriver Radio;
 #elif Regulatory_Domain_ISM_2400
 extern SX1280Driver Radio;

--- a/src/lib/POWERMGNT/POWERMGNT.h
+++ b/src/lib/POWERMGNT/POWERMGNT.h
@@ -4,7 +4,7 @@
 #include "targets.h"
 #include "DAC.h"
 
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433) || defined(Regulatory_Domain_KR_917)
 #include "SX127xDriver.h"
 #elif Regulatory_Domain_ISM_2400
 #include "SX1280Driver.h"

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -26,7 +26,7 @@
 
 #include "WebContent.h"
 
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433) || defined(Regulatory_Domain_KR_917)
 #include "SX127xDriver.h"
 extern SX127xDriver Radio;
 #endif

--- a/src/python/build_flags.py
+++ b/src/python/build_flags.py
@@ -175,6 +175,9 @@ elif fnmatch.filter(env['BUILD_FLAGS'], '*Regulatory_Domain_EU_868*'):
 elif fnmatch.filter(env['BUILD_FLAGS'], '*Regulatory_Domain_IN_866*'):
     sys.stdout.write("\u001b[32mBuilding for SX1276 866IN\n")
 
+elif fnmatch.filter(env['BUILD_FLAGS'], '*Regulatory_Domain_KR_917*'):
+    sys.stdout.write("\u001b[32mBuilding for SX1276 917KR\n")
+
 elif fnmatch.filter(env['BUILD_FLAGS'], '*Regulatory_Domain_AU_433*'):
     sys.stdout.write("\u001b[32mBuilding for SX1278 433AU\n")
 

--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -1,6 +1,6 @@
 #include "common.h"
 
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433) || defined(Regulatory_Domain_KR_917)
 
 #include "SX127xDriver.h"
 extern SX127xDriver Radio;

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -2,7 +2,7 @@
 #include "common.h"
 #include "LowPassFilter.h"
 
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433) || defined(Regulatory_Domain_KR_917)
 #include "SX127xDriver.h"
 SX127xDriver Radio;
 #elif defined(Regulatory_Domain_ISM_2400)

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1,7 +1,7 @@
 #include "targets.h"
 #include "common.h"
 
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433) || defined(Regulatory_Domain_KR_917)
 #include "SX127xDriver.h"
 SX127xDriver Radio;
 #elif defined(Regulatory_Domain_ISM_2400)


### PR DESCRIPTION
Added Korean domain frequency regulation for Team900 (917 - 923 Mhz)

* Reference: TTAK.KO-06.0246/R1
  https://www.tta.or.kr/data/ttas_view.jsp?&pk_num=TTAK.KO-06.0246%2FR1