### PR TITLE
Idle callback must follow same hop logic (1.1)

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -379,10 +379,7 @@ void ICACHE_RAM_ATTR timerCallbackNormal()
 void ICACHE_RAM_ATTR timerCallbackIdle()
 {
   NonceTX++;
-  if (NonceTX % ExpressLRS_currAirRate_Modparams->FHSShopInterval == 0)
-  {
-    FHSSptr++;
-  }
+  HandleFHSS();
 }
 
 void sendLuaParams()


### PR DESCRIPTION
Backport of "Idle callback must follow same hop logic (master) (#972)"