### PR TITLE
fixes trying to flash nonbootloader target

### DIFF
--- a/src/python/upload_via_esp8266_backpack.py
+++ b/src/python/upload_via_esp8266_backpack.py
@@ -55,7 +55,6 @@ def on_upload(source, target, env):
         try:
             if  bootloader_target is not None:  
                 print("** Flashing Bootloader...")
-                print(cmd_bootloader,cmd)
                 subprocess.check_call(cmd_bootloader + [addr])
                 print("** Bootloader Flashed!")
                 print()


### PR DESCRIPTION
flashing via wifi fails because bootloader_file is of None type from upload_flags being empty