### PR TITLE
Fix MDNS when switching WIFI modes

### DIFF
--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -425,11 +425,46 @@ static void startWiFi(unsigned long now)
   wifiStarted = true;
 }
 
+static void startMDNS()
+{
+  if (!MDNS.begin(myHostname))
+  {
+    DBGLN("Error starting mDNS");
+    return;
+  }
+
+  String instance = String(myHostname) + "_" + WiFi.macAddress();
+  instance.replace(":", "");
+  #ifdef PLATFORM_ESP8266
+    // We have to do it differently on ESP8266 as setInstanceName has the side-effect of chainging the hostname!
+    MDNS.setInstanceName(myHostname);
+    MDNSResponder::hMDNSService service = MDNS.addService(instance.c_str(), "http", "tcp", 80);
+    MDNS.addServiceTxt(service, "vendor", "elrs");
+    MDNS.addServiceTxt(service, "target", (const char *)&target_name[4]);
+    MDNS.addServiceTxt(service, "version", VERSION);
+    MDNS.addServiceTxt(service, "options", String(FPSTR(compile_options)).c_str());
+    MDNS.addServiceTxt(service, "type", "rx");
+  #else
+    MDNS.setInstanceName(instance);
+    MDNS.addService("http", "tcp", 80);
+    MDNS.addServiceTxt("http", "tcp", "vendor", "elrs");
+    MDNS.addServiceTxt("http", "tcp", "target", (const char *)&target_name[4]);
+    MDNS.addServiceTxt("http", "tcp", "version", VERSION);
+    MDNS.addServiceTxt("http", "tcp", "options", String(FPSTR(compile_options)).c_str());
+    MDNS.addServiceTxt("http", "tcp", "type", "tx");
+  #endif
+}
+
 static void startServices()
 {
   if (servicesStarted) {
+    #if defined(PLATFORM_ESP32)
+      MDNS.end();
+      startMDNS();
+    #endif
     return;
   }
+
   server.on("/", WebUpdateHandleRoot);
   server.on("/main.css", WebUpdateSendCSS);
   server.on("/scan.js", WebUpdateSendJS);
@@ -464,32 +499,7 @@ static void startServices()
   dnsServer.start(DNS_PORT, "*", apIP);
   dnsServer.setErrorReplyCode(DNSReplyCode::NoError);
 
-  if (!MDNS.begin(myHostname))
-  {
-    DBGLN("Error starting mDNS");
-    return;
-  }
-
-  String instance = String(myHostname) + "_" + WiFi.macAddress();
-  instance.replace(":", "");
-  #ifdef PLATFORM_ESP8266
-    // We have to do it differently on ESP8266 as setInstanceName has the side-effect of chainging the hostname!
-    MDNS.setInstanceName(myHostname);
-    MDNSResponder::hMDNSService service = MDNS.addService(instance.c_str(), "http", "tcp", 80);
-    MDNS.addServiceTxt(service, "vendor", "elrs");
-    MDNS.addServiceTxt(service, "target", (const char *)&target_name[4]);
-    MDNS.addServiceTxt(service, "version", VERSION);
-    MDNS.addServiceTxt(service, "options", String(FPSTR(compile_options)).c_str());
-    MDNS.addServiceTxt(service, "type", "rx");
-  #else
-    MDNS.setInstanceName(instance);
-    MDNS.addService("http", "tcp", 80);
-    MDNS.addServiceTxt("http", "tcp", "vendor", "elrs");
-    MDNS.addServiceTxt("http", "tcp", "target", (const char *)&target_name[4]);
-    MDNS.addServiceTxt("http", "tcp", "version", VERSION);
-    MDNS.addServiceTxt("http", "tcp", "options", String(FPSTR(compile_options)).c_str());
-    MDNS.addServiceTxt("http", "tcp", "type", "tx");
-  #endif
+  startMDNS();
 
   servicesStarted = true;
   DBGLN("HTTPUpdateServer ready! Open http://%s.local in your browser", myHostname);


### PR DESCRIPTION
# Problems
1. MDNS not working in AP mode on ESP8285 RXes
2. MDNS not working on TX module when switching from AP to STA or vice-versa

# Resolution
1. MDNS on ESP8266 only works in STA or AP_STA mode, not AP mode, so we use AP_STA mode on ESP8285 devices.
2. We have to stop/start the MDNS service when switching modes in `devWIFI.cpp` so the MDNS responder can attach to the correct WIFI interface.

Fixes #988 