### PR TITLE
Prevent lua crash when scrolling before first field loads

### DIFF
--- a/src/lua/elrsV2.lua
+++ b/src/lua/elrsV2.lua
@@ -578,7 +578,7 @@ local function handleDevicePageEvent(event)
       crossfireTelemetryPush(0x2D, { deviceId, 0xEF, 0x2E, 0x00 })
     else
       local field = getField(lineIndex)
-      if field and field.type then
+      if field and field.name then
         if field.type == 10 then
           if edit == false then
             edit = true


### PR DESCRIPTION
There's window between the time where the Lua has received the device_info packet (and therefore has fields/field_count) but there are no valid field definitions to select. This means `selectField(1 / -1)` will not have any fields that satisfy its condition to select and will loop endlessly or crash the script.

To remedy this, this PR just makes the lineIndex start at 1 instead of 0. This allows the code to loop through all the fields and come back around to 1 and exit safely. In the old code it would loop back around to 1, but the old index was 0, so it just kept looping.

Scrolling the other way, if it started at 0, it would subtract 1, which made it -1, which doesn't loop back around either, it just keeps getting more negative. That's also solved by starting at 1, but I've also updated the compare to make sure if it ever goes negative it wraps properly.

* Fixes infinite loop when scrolling before any field definitions are loaded: initLineIndex is always just lineIndex = 1 now.
* Prevents going into edit mode before any field definitions are loaded (would crash with "attempt to index field (a nil value)")
* Displays '...' again for unloaded fields
* Removes redundant code checking the same thing twice or initializing a table value to nil which does nothing.
* Prevents refreshing by pressing EXIT/RTN while still loading. This was causing multiple pushes where receiving the response first one would continue, but then the second response would come in and move it back, and sort of ping pong with double the bandwidth used and make the loading slower.
* There was code to never select a folder item as the active item during loading, which I have removed because why not select a folder item while loading?

### To Reproduce
To reproduce the original bug that started this:
* Launch the ELRSv2.lua
* When it says "Loading..." on the top of the screen, but before the progress bar appears, attempt to scroll or press enter.

### User Complaint
Discord user MS reports that tapping the screen or swiping at any time in our script causes their RadioMaster TX16S to go into Emergency Mode on EdgeTX 2.5.0 release. I can not reproduce this in the EdgeTX simulator. There are no events thrown when there is a tap or a swipe action (in our script anyway, event=0) so I can't imagine this is something we are doing, but it would be nice if someone with a touchscreen tested this.