### PR TITLE
Refactoring: remove ISM_2400 regulatory domain from user defines

### DIFF
--- a/src/include/common.h
+++ b/src/include/common.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #ifndef UNIT_TEST
+#include "targets.h"
 
 #if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868)  || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
 #include "SX127xDriver.h"

--- a/src/include/target/BETAFPV_2400_RX.h
+++ b/src/include/target/BETAFPV_2400_RX.h
@@ -15,3 +15,5 @@
 
 // Output Power
 #define POWER_OUTPUT_FIXED      1 // -10=10mW, -6=25mW, -3=50mW, 1=100mW
+
+#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/BETAFPV_2400_TX.h
+++ b/src/include/target/BETAFPV_2400_TX.h
@@ -24,3 +24,5 @@
 #define MinPower PWR_10mW
 #define MaxPower PWR_500mW
 #define POWER_OUTPUT_VALUES {-18,-15,-13,-9,-4,3}
+
+#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/DIY_2400_RX_ESP8285_SX1280.h
+++ b/src/include/target/DIY_2400_RX_ESP8285_SX1280.h
@@ -13,3 +13,5 @@
 #endif
 
 // Output Power - use default SX1280
+
+#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/DIY_2400_RX_STM32_CCG_Nano_v0_5.h
+++ b/src/include/target/DIY_2400_RX_STM32_CCG_Nano_v0_5.h
@@ -15,3 +15,5 @@
 #define GPIO_PIN_LED_RED     PB5
 
 // Output Power - use default SX1280
+
+#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/DIY_2400_TX_ESP32_SX1280_E28.h
+++ b/src/include/target/DIY_2400_TX_ESP32_SX1280_E28.h
@@ -29,3 +29,5 @@
 #if !defined(POWER_OUTPUT_VALUES)
     #define POWER_OUTPUT_VALUES {-15,-11,-8,-5,-1}
 #endif
+
+#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/DIY_2400_TX_ESP32_SX1280_Mini.h
+++ b/src/include/target/DIY_2400_TX_ESP32_SX1280_Mini.h
@@ -15,3 +15,5 @@
 #define MinPower PWR_10mW
 #define MaxPower PWR_25mW
 #define POWER_OUTPUT_VALUES {8, 13}
+
+#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/DIY_2400_TX_ESP8285_SX1280.h
+++ b/src/include/target/DIY_2400_TX_ESP8285_SX1280.h
@@ -17,3 +17,5 @@
 #define MinPower PWR_10mW
 #define MaxPower PWR_10mW
 #define POWER_OUTPUT_VALUES {13}
+
+#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/FM30_RX_MINI.h
+++ b/src/include/target/FM30_RX_MINI.h
@@ -47,3 +47,5 @@
         #define POWER_OUTPUT_FIXED -1 // 100mW (uses values as above)
     #endif
 #endif
+
+#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/FM30_TX.h
+++ b/src/include/target/FM30_TX.h
@@ -40,3 +40,5 @@
 #define HighPower               PWR_100mW
 #define MaxPower                PWR_250mW
 #define POWER_OUTPUT_VALUES     {-15,-11,-7,-1,6}
+
+#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/GHOST_2400_TX.h
+++ b/src/include/target/GHOST_2400_TX.h
@@ -34,3 +34,5 @@
 #define POWER_OUTPUT_VALUES         {-16,-14,-11,-8,-4}
 
 #define HAS_OLED
+
+#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/GHOST_ATTO_2400_RX.h
+++ b/src/include/target/GHOST_ATTO_2400_RX.h
@@ -20,3 +20,5 @@
 //#define GPIO_PIN_BUTTON         PA12
 
 // Output Power - use default SX1280
+
+#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/MATEK_2400_RX.h
+++ b/src/include/target/MATEK_2400_RX.h
@@ -16,3 +16,5 @@
 
 // Output Power
 #define POWER_OUTPUT_FIXED          3
+
+#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/NamimnoRC_FLASH_2400_RX.h
+++ b/src/include/target/NamimnoRC_FLASH_2400_RX.h
@@ -14,3 +14,5 @@
 #define GPIO_PIN_RCSIGNAL_TX    PA9
 
 // Output Power - default for SX120
+
+#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/NamimnoRC_FLASH_2400_TX.h
+++ b/src/include/target/NamimnoRC_FLASH_2400_TX.h
@@ -38,3 +38,5 @@
 #define MinPower PWR_25mW
 #define MaxPower PWR_1000mW
 #define POWER_OUTPUT_VALUES {-18,-15,-12,-8,-5,3}
+
+#define Regulatory_Domain_ISM_2400 1

--- a/src/include/targets.h
+++ b/src/include/targets.h
@@ -72,3 +72,18 @@
 #ifndef GPIO_LED_GREEN_INVERTED
 #define GPIO_LED_GREEN_INVERTED 0
 #endif
+
+#if defined(Regulatory_Domain_ISM_2400)
+// ISM 2400 band is use => undefine other requlatory domain defines
+#undef Regulatory_Domain_AU_915
+#undef Regulatory_Domain_EU_868
+#undef Regulatory_Domain_IN_866
+#undef Regulatory_Domain_FCC_915
+#undef Regulatory_Domain_AU_433
+#undef Regulatory_Domain_EU_433
+
+#elif !(defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_FCC_915) || \
+        defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || \
+        defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433))
+#error "Regulatory_Domain is not defined for 900MHz devices. Check user_defines.txt!"
+#endif

--- a/src/include/targets.h
+++ b/src/include/targets.h
@@ -84,6 +84,7 @@
 
 #elif !(defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_FCC_915) || \
         defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || \
-        defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433))
+        defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433) || \
+        defined(UNIT_TEST))
 #error "Regulatory_Domain is not defined for 900MHz devices. Check user_defines.txt!"
 #endif

--- a/src/lib/FHSS/FHSS.h
+++ b/src/lib/FHSS/FHSS.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "targets.h"
+
 #if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
 #include "SX127xDriver.h"
 #elif Regulatory_Domain_ISM_2400

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -1,6 +1,5 @@
 #include "POWERMGNT.h"
 #include "DAC.h"
-#include "targets.h"
 
 /*
  * Moves the power management values and special cases out of the main code and into `targets.h`.

--- a/src/python/build_flags.py
+++ b/src/python/build_flags.py
@@ -152,8 +152,9 @@ condense_flags()
 if not fnmatch.filter(build_flags, '*-DRegulatory_Domain*'):
     print_error('Please define a Regulatory_Domain in user_defines.txt')
 
-if fnmatch.filter(build_flags, '*Regulatory_Domain_ISM_2400*'):
-    # remove ISM_2400 domain flag, it is defined per target config
+if fnmatch.filter(build_flags, '*Regulatory_Domain_ISM_2400*') and \
+        env.get('PIOENV', '').upper() != "NATIVE":
+    # Remove ISM_2400 domain flag if not unit test, it is defined per target config
     build_flags = [f for f in build_flags if "Regulatory_Domain_ISM_2400" not in f]
 
 env['BUILD_FLAGS'] = build_flags

--- a/src/python/build_flags.py
+++ b/src/python/build_flags.py
@@ -15,11 +15,11 @@ define = ""
 
 def print_error(error):
     time.sleep(1)
-    sys.stdout.write("\033[47;31m%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n")
+    sys.stdout.write("\n\n\033[47;31m%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n")
     sys.stdout.write("\033[47;31m!!!             ExpressLRS Warning Below             !!!\n")
     sys.stdout.write("\033[47;31m%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n")
     sys.stdout.write("\033[47;30m  %s \n" % error)
-    sys.stdout.write("\033[47;31m%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n")
+    sys.stdout.write("\033[47;31m%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n\n\n")
     sys.stdout.flush()
     time.sleep(3)
     raise Exception('!!! %s !!!' % error)
@@ -91,7 +91,7 @@ def get_git_sha():
             git_root = git_repo.git.rev_parse("--show-toplevel")
             ExLRS_Repo = git.Repo(git_root)
             sha = ExLRS_Repo.head.object.hexsha
-            
+
         except git.InvalidGitRepositoryError:
             pass
     if not sha:
@@ -149,45 +149,29 @@ build_flags.append("-DLATEST_VERSION=" + get_git_version())
 build_flags.append("-DTARGET_NAME=" + re.sub("_VIA_.*", "", env['PIOENV'].upper()))
 condense_flags()
 
-env['BUILD_FLAGS'] = build_flags
-print("build flags: %s" % env['BUILD_FLAGS'])
-
-if not fnmatch.filter(env['BUILD_FLAGS'], '*-DRegulatory_Domain*'):
+if not fnmatch.filter(build_flags, '*-DRegulatory_Domain*'):
     print_error('Please define a Regulatory_Domain in user_defines.txt')
 
-if fnmatch.filter(env['BUILD_FLAGS'], '*PLATFORM_ESP32*'):
+if fnmatch.filter(build_flags, '*Regulatory_Domain_ISM_2400*'):
+    # remove ISM_2400 domain flag, it is defined per target config
+    build_flags = [f for f in build_flags if "Regulatory_Domain_ISM_2400" not in f]
+
+env['BUILD_FLAGS'] = build_flags
+sys.stdout.write("\nbuild flags: %s\n\n" % build_flags)
+
+if fnmatch.filter(build_flags, '*PLATFORM_ESP32*'):
     sys.stdout.write("\u001b[32mBuilding for ESP32 Platform\n")
-elif fnmatch.filter(env['BUILD_FLAGS'], '*PLATFORM_STM32*'):
+elif fnmatch.filter(build_flags, '*PLATFORM_STM32*'):
     sys.stdout.write("\u001b[32mBuilding for STM32 Platform\n")
-elif fnmatch.filter(env['BUILD_FLAGS'], '*PLATFORM_ESP8266*'):
+elif fnmatch.filter(build_flags, '*PLATFORM_ESP8266*'):
     sys.stdout.write("\u001b[32mBuilding for ESP8266/ESP8285 Platform\n")
-    if fnmatch.filter(env['BUILD_FLAGS'], '-DAUTO_WIFI_ON_INTERVAL*'):
+    if fnmatch.filter(build_flags, '-DAUTO_WIFI_ON_INTERVAL*'):
         sys.stdout.write("\u001b[32mAUTO_WIFI_ON_INTERVAL = ON\n")
     else:
         sys.stdout.write("\u001b[32mAUTO_WIFI_ON_INTERVAL = OFF\n")
 
-if fnmatch.filter(env['BUILD_FLAGS'], '*Regulatory_Domain_AU_915*'):
-    sys.stdout.write("\u001b[32mBuilding for SX1276 915AU\n")
-
-elif fnmatch.filter(env['BUILD_FLAGS'], '*Regulatory_Domain_EU_868*'):
-    sys.stdout.write("\u001b[32mBuilding for SX1276 868EU\n")
-
-elif fnmatch.filter(env['BUILD_FLAGS'], '*Regulatory_Domain_IN_866*'):
-    sys.stdout.write("\u001b[32mBuilding for SX1276 866IN\n")
-
-elif fnmatch.filter(env['BUILD_FLAGS'], '*Regulatory_Domain_AU_433*'):
-    sys.stdout.write("\u001b[32mBuilding for SX1278 433AU\n")
-
-elif fnmatch.filter(env['BUILD_FLAGS'], '*Regulatory_Domain_EU_433*'):
-    sys.stdout.write("\u001b[32mBuilding for SX1278 433AU\n")
-
-elif fnmatch.filter(env['BUILD_FLAGS'], '*Regulatory_Domain_FCC_915*'):
-    sys.stdout.write("\u001b[32mBuilding for SX1276 915FCC\n")
-
-elif fnmatch.filter(env['BUILD_FLAGS'], '*Regulatory_Domain_ISM_2400*'):
-    sys.stdout.write("\u001b[32mBuilding for SX1280 2400ISM\n")
-
-time.sleep(1)
+sys.stdout.flush()
+time.sleep(.5)
 
 # Set upload_protovol = 'custom' for STM32 MCUs
 #  otherwise firmware.bin is not generated

--- a/src/python/build_flags.py
+++ b/src/python/build_flags.py
@@ -8,10 +8,10 @@ import time
 import re
 import melodyparser
 
-
-build_flags = env['BUILD_FLAGS']
+build_flags = env.get('BUILD_FLAGS', [])
 UIDbytes = ""
 define = ""
+target_name = env.get('PIOENV', '').upper()
 
 def print_error(error):
     time.sleep(1)
@@ -146,14 +146,16 @@ process_flags("user_defines.txt")
 process_flags("super_defines.txt") # allow secret super_defines to override user_defines
 build_flags.append("-DLATEST_COMMIT=" + get_git_sha())
 build_flags.append("-DLATEST_VERSION=" + get_git_version())
-build_flags.append("-DTARGET_NAME=" + re.sub("_VIA_.*", "", env['PIOENV'].upper()))
+build_flags.append("-DTARGET_NAME=" + re.sub("_VIA_.*", "", target_name))
 condense_flags()
 
-if not fnmatch.filter(build_flags, '*-DRegulatory_Domain*'):
+if "_2400" not in target_name and \
+        not fnmatch.filter(build_flags, '-DRADIO_2400=1') and \
+        not fnmatch.filter(build_flags, '*-DRegulatory_Domain*'):
     print_error('Please define a Regulatory_Domain in user_defines.txt')
 
 if fnmatch.filter(build_flags, '*Regulatory_Domain_ISM_2400*') and \
-        env.get('PIOENV', '').upper() != "NATIVE":
+        target_name != "NATIVE":
     # Remove ISM_2400 domain flag if not unit test, it is defined per target config
     build_flags = [f for f in build_flags if "Regulatory_Domain_ISM_2400" not in f]
 

--- a/src/targets/MATEK_2400.ini
+++ b/src/targets/MATEK_2400.ini
@@ -3,10 +3,11 @@
 # ********************************
 
 [env:MATEK_2400_RX_via_UART]
-extends = env_common_esp82xx
+extends = env_common_esp82xx, radio_2400
 build_flags =
 	${env_common_esp82xx.build_flags}
 	${common_env_data.build_flags_rx}
+	${radio_2400.build_flags}
 	-include target/MATEK_2400_RX.h
 src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 

--- a/src/targets/betafpv_2400.ini
+++ b/src/targets/betafpv_2400.ini
@@ -3,10 +3,11 @@
 # ********************************
 
 [env:BETAFPV_2400_TX_via_UART]
-extends = env_common_esp32
+extends = env_common_esp32, radio_2400
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
+	${radio_2400.build_flags}
 	-include target/BETAFPV_2400_TX.h
 	-D VTABLES_IN_FLASH=1
 	-O2
@@ -21,10 +22,11 @@ extends = env:BETAFPV_2400_TX_via_UART
 # ********************************
 
 [env:BETAFPV_2400_RX_via_UART]
-extends = env_common_esp82xx
+extends = env_common_esp82xx, radio_2400
 build_flags =
 	${env_common_esp82xx.build_flags}
 	${common_env_data.build_flags_rx}
+	${radio_2400.build_flags}
 	-include target/BETAFPV_2400_RX.h
 src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 

--- a/src/targets/betafpv_900.ini
+++ b/src/targets/betafpv_900.ini
@@ -3,10 +3,11 @@
 # ********************************
 
 [env:BETAFPV_900_TX_via_UART]
-extends = env_common_esp32
+extends = env_common_esp32, radio_900
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
+	${radio_900.build_flags}
 	-include target/BETAFPV_900_TX.h
 upload_speed = 460800
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
@@ -19,10 +20,11 @@ extends = env:BETAFPV_900_TX_via_UART
 # ********************************
 
 [env:BETAFPV_900_RX_via_UART]
-extends = env_common_esp82xx
+extends = env_common_esp82xx, radio_900
 build_flags =
 	${env_common_esp82xx.build_flags}
 	${common_env_data.build_flags_rx}
+	${radio_900.build_flags}
 	-include target/DIY_900_RX_ESP8285_SX127x.h
 src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -16,6 +16,13 @@ build_flags = -Wall -Iinclude
 build_flags_tx = -DTARGET_TX=1 ${common_env_data.build_flags}
 build_flags_rx = -DTARGET_RX=1 ${common_env_data.build_flags}
 
+[radio_900]
+build_flags = -DRADIO_900=1
+lib_ignore = SX1280Driver
+
+[radio_2400]
+build_flags = -DRADIO_2400=1
+lib_ignore = SX127xDriver
 
 # ------------------------- COMMON ESP32 DEFINITIONS -----------------
 [env_common_esp32]
@@ -34,7 +41,7 @@ build_flags =
 	-D CONFIG_TCPIP_LWIP=1
 	-D BEARSSL_SSL_BASIC
 src_filter = ${common_env_data.src_filter} -<ESP8266*.*> -<STM32*.*>
-lib_deps = 
+lib_deps =
 	makuna/NeoPixelBus @ ^2.6.7
 	ottowinter/ESPAsyncWebServer-esphome @ ^1.3.0
 	lemmingdev/ESP32-BLE-Gamepad @ ^0.3.3

--- a/src/targets/diy_2400.ini
+++ b/src/targets/diy_2400.ini
@@ -4,20 +4,22 @@
 # ********************************
 
 [env:DIY_2400_TX_ESP32_SX1280_Mini_via_UART]
-extends = env_common_esp32
+extends = env_common_esp32, radio_2400
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
+	${radio_2400.build_flags}
 	-include target/DIY_2400_TX_ESP32_SX1280_Mini.h
 	-D VTABLES_IN_FLASH=1
 	-O2
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 
 [env:DIY_2400_TX_ESP32_SX1280_E28_via_UART]
-extends = env_common_esp32
+extends = env_common_esp32, radio_2400
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
+	${radio_2400.build_flags}
 	-include target/DIY_2400_TX_ESP32_SX1280_E28.h
 	-D VTABLES_IN_FLASH=1
 	-O2
@@ -27,10 +29,11 @@ src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 extends = env:DIY_2400_TX_ESP32_SX1280_E28_via_UART
 
 [env:DIY_2400_TX_ESP32_SX1280_LORA1280F27_via_UART]
-extends = env_common_esp32
+extends = env_common_esp32, radio_2400
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
+	${radio_2400.build_flags}
 	-include target/DIY_2400_TX_ESP32_SX1280_LORA1280F27.h
 	-D VTABLES_IN_FLASH=1
 	-O2
@@ -39,13 +42,13 @@ src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 [env:DIY_2400_TX_ESP8285_SX1280_via_UART]
 # Status: These TXes work as free-running transmitters, but do not have working halfduplex inverted UART
 # to let them work in handsets so if someone could fix that for CapnBry, he'd love you with mouth
-extends = env_common_esp82xx
+extends = env_common_esp82xx, radio_2400
 build_flags =
 	${env_common_esp82xx.build_flags}
 	${common_env_data.build_flags_tx}
+	${radio_2400.build_flags}
 	-include target/DIY_2400_TX_ESP8285_SX1280.h
 src_filter = ${env_common_esp82xx.src_filter} -<rx_*.cpp>
-lib_ignore = SX127xDriver
 upload_speed = 921600
 
 # ********************************
@@ -53,10 +56,11 @@ upload_speed = 921600
 # ********************************
 
 [env:DIY_2400_RX_ESP8285_SX1280_via_UART]
-extends = env_common_esp82xx
+extends = env_common_esp82xx, radio_2400
 build_flags =
 	${env_common_esp82xx.build_flags}
 	${common_env_data.build_flags_rx}
+	${radio_2400.build_flags}
 	-include target/DIY_2400_RX_ESP8285_SX1280.h
 src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 
@@ -70,7 +74,7 @@ upload_command = ${env_common_esp82xx.bf_upload_command}
 extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART
 
 [env:DIY_2400_RX_STM32_CCG_Nano_v0_5_via_STLINK]
-extends = env_common_stm32
+extends = env_common_stm32, radio_2400
 platform = ststm32@9.0.0
 board = l432kb
 # max size = 131072 - 0x4000 = 114688
@@ -78,6 +82,7 @@ board_upload.maximum_size = 114688
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_rx}
+	${radio_2400.build_flags}
 	-include target/DIY_2400_RX_STM32_CCG_Nano_v0_5.h
 	-D HAL_RTC_MODULE_DISABLED=1
 	-D HAL_ADC_MODULE_DISABLED=1
@@ -93,8 +98,6 @@ src_filter = ${env_common_stm32.src_filter} -<tx_*.cpp>
 upload_flags =
     BOOTLOADER=bootloader/bootloader_sx1280_rx_ccg_nano_v05.bin
     VECT_OFFSET=0x4000
-lib_deps =
-lib_ignore = SX127xDriver
 
 [env:DIY_2400_RX_STM32_CCG_Nano_v0_5_via_BetaflightPassthrough]
 extends = env:DIY_2400_RX_STM32_CCG_Nano_v0_5_via_STLINK

--- a/src/targets/diy_900.ini
+++ b/src/targets/diy_900.ini
@@ -4,38 +4,42 @@
 # ********************************
 
 [env:DIY_900_TX_TTGO_V1_SX127x_via_UART]
-extends = env_common_esp32
+extends = env_common_esp32, radio_900
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
+	${radio_900.build_flags}
 	-include target/DIY_900_TX_TTGO_V1_SX127x.h
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 lib_deps = 	${env_common_esp32.lib_deps}
 		olikraus/U8g2@^2.28.8
 
 [env:DIY_900_TX_TTGO_V2_SX127x_via_UART]
-extends = env_common_esp32
+extends = env_common_esp32, radio_900
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
+	${radio_900.build_flags}
 	-include target/DIY_900_TX_TTGO_V2_SX127x.h
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 lib_deps = 	${env_common_esp32.lib_deps}
 		olikraus/U8g2@^2.28.8
 
 [env:DIY_900_TX_ESP32_SX127x_E19_via_UART]
-extends = env_common_esp32
+extends = env_common_esp32, radio_900
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
+	${radio_900.build_flags}
 	-include target/DIY_900_TX_ESP32_SX127x_E19.h
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 
 [env:DIY_900_TX_ESP32_SX127x_RFM95_via_UART]
-extends = env_common_esp32
+extends = env_common_esp32, radio_900
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
+	${radio_900.build_flags}
 	-include target/DIY_900_TX_ESP32_SX127x_RFM95.h
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 
@@ -45,12 +49,13 @@ src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 # ********************************
 
 [env:DIY_900_RX_ESP8285_SX127x_via_UART]
-extends = env_common_esp82xx
+extends = env_common_esp82xx, radio_900
 upload_resetmethod = nodemcu
 upload_speed = 460800
 build_flags =
 	${env_common_esp82xx.build_flags}
 	${common_env_data.build_flags_rx}
+	${radio_900.build_flags}
 	-include target/DIY_900_RX_ESP8285_SX127x.h
 src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 
@@ -64,10 +69,11 @@ upload_command = ${env_common_esp82xx.bf_upload_command}
 extends = env:DIY_900_RX_ESP8285_SX127x_via_UART
 
 [env:DIY_900_RX_HUZZAH_RFM95W_via_UART]
-extends = env_common_esp82xx
+extends = env_common_esp82xx, radio_900
 build_flags =
 	${env_common_esp82xx.build_flags}
 	${common_env_data.build_flags_rx}
+	${radio_900.build_flags}
 	-include target/DIY_900_RX_HUZZAH_RFM95W.h
 src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 

--- a/src/targets/frsky.ini
+++ b/src/targets/frsky.ini
@@ -5,10 +5,11 @@
 
 ## TODO: R9M STLINK/stock and R9M Lite targets can be merged
 [env:Frsky_TX_R9M_via_STLINK]
-extends = env_common_stm32
+extends = env_common_stm32, radio_900
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_tx}
+	${radio_900.build_flags}
 	-include target/Frsky_TX_R9M.h
 	-D HSE_VALUE=12000000U
 	-DVECT_TAB_OFFSET=0x4000U
@@ -40,12 +41,13 @@ build_flags =
 extends = env:Frsky_TX_R9M_LITE_via_STLINK
 
 [env:Frsky_TX_R9M_LITE_PRO_via_STLINK]
-extends = env_common_stm32
+extends = env_common_stm32, radio_900
 platform = ststm32@9.0.0
 board = robotdyn_blackpill_f303cc
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_tx}
+	${radio_900.build_flags}
 	-include target/Frsky_TX_R9M_LITE_PRO.h
 	-D HSE_VALUE=12000000U
 	-O2
@@ -65,11 +67,12 @@ lib_deps =
 # ********************************
 
 [env:Frsky_RX_R9MM_R9MINI_via_STLINK]
-extends = env_common_stm32
+extends = env_common_stm32, radio_900
 board = R9MM
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_rx}
+	${radio_900.build_flags}
 	-include target/Frsky_RX_R9M.h
 	-D HSE_VALUE=24000000U
 	-DVECT_TAB_OFFSET=0x08008000U
@@ -88,10 +91,11 @@ upload_flags =
     VECT_OFFSET=0x8000
 
 [env:Frsky_RX_R9SLIM_via_BetaflightPassthrough]
-extends = env_common_stm32
+extends = env_common_stm32, radio_900
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_rx}
+	${radio_900.build_flags}
 	-D TARGET_R9SLIM_RX
 	-include target/Frsky_RX_R9M.h
 	-D HSE_VALUE=12000000U
@@ -109,11 +113,12 @@ upload_flags =
     VECT_OFFSET=0x8000
 
 [env:Frsky_RX_R9SLIMPLUS_via_BetaflightPassthrough]
-extends = env_common_stm32
+extends = env_common_stm32, radio_900
 board_build.ldscript = variants/R9MM/R9MM_ldscript.ld
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_rx}
+	${radio_900.build_flags}
 	-D TARGET_R9SLIMPLUS_RX
 	-include target/Frsky_RX_R9M.h
 	-D HSE_VALUE=12000000U
@@ -131,11 +136,12 @@ upload_flags =
 extends = env:Frsky_RX_R9SLIMPLUS_OTA_via_STLINK
 
 [env:Frsky_RX_R9MX_via_STLINK]
-extends = env_common_stm32
+extends = env_common_stm32, radio_900
 board = r9mx
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_rx}
+	${radio_900.build_flags}
 	-D TARGET_R9MX_RX
 	-include target/Frsky_RX_R9M.h
 	-DVECT_TAB_OFFSET=0x08008000U
@@ -156,10 +162,11 @@ upload_flags =
     VECT_OFFSET=0x8000
 
 [env:Jumper_RX_R900MINI_via_BetaflightPassthrough]
-extends = env_common_stm32
+extends = env_common_stm32, radio_900
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_rx}
+	${radio_900.build_flags}
 	-D TARGET_R900MINI_RX
 	-include target/Frsky_RX_R9M.h
 	-D HSE_VALUE=12000000U

--- a/src/targets/happymodel_900.ini
+++ b/src/targets/happymodel_900.ini
@@ -4,10 +4,11 @@
 # ********************************
 
 [env:HappyModel_TX_ES915TX_via_STLINK]
-extends = env_common_stm32
+extends = env_common_stm32, radio_900
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_tx}
+	${radio_900.build_flags}
 	-include target/HappyModel_TX_ES915TX.h
 	-D HSE_VALUE=12000000U
 	-D VECT_TAB_OFFSET=0x4000U
@@ -25,10 +26,11 @@ extends = env:HappyModel_TX_ES915TX_via_STLINK
 extends = env:HappyModel_TX_ES915TX_via_STLINK
 
 [env:HappyModel_TX_ES900TX_via_UART]
-extends = env_common_esp32
+extends = env_common_esp32, radio_900
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
+	${radio_900.build_flags}
 	-include target/HappyModel_TX_ES900TX.h
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 
@@ -41,11 +43,12 @@ extends = env:HappyModel_TX_ES900TX_via_UART
 # ********************************
 
 [env:HappyModel_RX_ES915RX_via_STLINK]
-extends = env_common_stm32
+extends = env_common_stm32, radio_900
 board = R9MM
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_rx}
+	${radio_900.build_flags}
 	-include target/Frsky_RX_R9M.h
 	-D HSE_VALUE=24000000U
 	-DVECT_TAB_OFFSET=0x08008000U

--- a/src/targets/imrc.ini
+++ b/src/targets/imrc.ini
@@ -4,12 +4,13 @@
 # ********************************
 
 [env:GHOST_2400_TX_via_STLINK]
-extends = env_common_stm32
+extends = env_common_stm32, radio_2400
 platform = ststm32@11.0.0
 board = GHOST_TX
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_tx}
+	${radio_2400.build_flags}
 	-include target/GHOST_2400_TX.h
 	-D DEBUG=1
  	-D HSE_VALUE=32000000U
@@ -19,7 +20,7 @@ src_filter = ${env_common_stm32.src_filter} -<rx_*.cpp>
 upload_flags =
 	BOOTLOADER=bootloader/ghost/ghost_tx_bootloader.bin
 	VECT_OFFSET=0x4000
-lib_deps = 
+lib_deps =
 	${env_common_stm32.lib_deps}
 	olikraus/U8g2@^2.28.8
 
@@ -34,12 +35,13 @@ build_flags =
 # ********************************
 
 [env:GHOST_ATTO_2400_RX_via_STLINK]
-extends = env_common_stm32
+extends = env_common_stm32, radio_2400
 platform = ststm32@11.0.0
 board = GHOST_ATTO
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_rx}
+	${radio_2400.build_flags}
  	-include target/GHOST_ATTO_2400_RX.h
  	-D HSE_VALUE=32000000U
 	-DVECT_TAB_OFFSET=0x08004000U

--- a/src/targets/namimnorc_2400.ini
+++ b/src/targets/namimnorc_2400.ini
@@ -4,10 +4,11 @@
 # ********************************
 
 [env:NamimnoRC_FLASH_2400_TX_via_STLINK]
-extends = env_common_stm32
+extends = env_common_stm32, radio_2400
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_tx}
+	${radio_2400.build_flags}
 	-D HSE_VALUE=12000000U
 	-D VECT_TAB_OFFSET=0x4000U
 	-include target/NamimnoRC_FLASH_2400_TX.h
@@ -16,7 +17,6 @@ src_filter = ${env_common_stm32.src_filter} -<rx_*.cpp>
 upload_flags =
     BOOTLOADER=bootloader/namimnorc/tx/firmware.bin
     VECT_OFFSET=0x4000
-lib_deps =
 
 [env:NamimnoRC_FLASH_2400_TX_via_WIFI]
 extends = env:NamimnoRC_FLASH_2400_TX_via_STLINK
@@ -27,10 +27,11 @@ extends = env:NamimnoRC_FLASH_2400_TX_via_STLINK
 # ********************************
 
 [env:NamimnoRC_FLASH_2400_RX_via_STLINK]
-extends = env_common_stm32
+extends = env_common_stm32, radio_2400
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_rx}
+	${radio_2400.build_flags}
 	-D HSE_VALUE=12000000U
 	-D VECT_TAB_OFFSET=0x8000U
 	-include target/NamimnoRC_FLASH_2400_RX.h
@@ -39,7 +40,6 @@ src_filter = ${env_common_stm32.src_filter} -<tx_*.cpp>
 upload_flags =
     BOOTLOADER=bootloader/namimnorc/rx/flash_2400_bootloader.bin
     VECT_OFFSET=0x8000
-lib_deps =
 
 [env:NamimnoRC_FLASH_2400_RX_via_BetaflightPassthrough]
 extends = env:NamimnoRC_FLASH_2400_RX_via_STLINK

--- a/src/targets/namimnorc_900.ini
+++ b/src/targets/namimnorc_900.ini
@@ -4,10 +4,11 @@
 # ********************************
 
 [env:NamimnoRC_VOYAGER_900_TX_via_STLINK]
-extends = env_common_stm32
+extends = env_common_stm32, radio_900
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_tx}
+	${radio_900.build_flags}
 	-D HSE_VALUE=12000000U
 	-D VECT_TAB_OFFSET=0x4000U
 	-include target/NamimnoRC_VOYAGER_900_TX.h
@@ -27,10 +28,11 @@ extends = env:NamimnoRC_VOYAGER_900_TX_via_STLINK
 # ********************************
 
 [env:NamimnoRC_VOYAGER_900_RX_via_STLINK]
-extends = env_common_stm32
+extends = env_common_stm32, radio_900
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_rx}
+	${radio_900.build_flags}
 	-D HSE_VALUE=12000000U
 	-D VECT_TAB_OFFSET=0x8000U
 	-include target/NamimnoRC_VOYAGER_900_RX.h
@@ -45,10 +47,11 @@ lib_deps =
 extends = env:NamimnoRC_VOYAGER_900_RX_via_STLINK
 
 [env:NamimnoRC_VOYAGER_900_ESP_RX_via_UART]
-extends = env_common_esp82xx
+extends = env_common_esp82xx, radio_900
 build_flags =
 	${env_common_esp82xx.build_flags}
 	${common_env_data.build_flags_rx}
+	${radio_900.build_flags}
 	-include target/NamimnoRC_VOYAGER_900_ESP_RX.h
 src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 

--- a/src/targets/siyi.ini
+++ b/src/targets/siyi.ini
@@ -3,12 +3,13 @@
 # ********************************
 
 [env:FM30_TX_via_STLINK]
-extends = env_common_stm32
+extends = env_common_stm32, radio_2400
 board = FM30
 debug_tool = stlink
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_tx}
+	${radio_2400.build_flags}
 	-include target/FM30_TX.h
     -DUSBCON
     -DPIO_FRAMEWORK_ARDUINO_ENABLE_CDC
@@ -19,8 +20,6 @@ src_filter = ${env_common_stm32.src_filter} -<rx_*.cpp>
 upload_flags =
 	BOOTLOADER=bootloader/fm30_bootloader.bin
 	VECT_OFFSET=0x1000
-lib_ignore = SX127xDriver
-lib_deps =
 
 [env:FM30_TX_via_DFU]
 extends = env:FM30_TX_via_STLINK
@@ -30,12 +29,13 @@ extends = env:FM30_TX_via_STLINK
 # ********************************
 
 [env:FM30_RX_MINI_via_STLINK]
-extends = env_common_stm32
+extends = env_common_stm32, radio_2400
 platform = ststm32@13.0.0
 board = FM30_mini
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_rx}
+	${radio_2400.build_flags}
 	-include target/FM30_RX_MINI.h
 	-D HSE_VALUE=16000000U
 	-D VECT_TAB_OFFSET=0x4000U
@@ -44,19 +44,18 @@ upload_flags =
 	BOOTLOADER=bootloader/fm30_mini_bootloader.bin
 	VECT_OFFSET=0x4000
 src_filter = ${env_common_stm32.src_filter} -<tx_*.cpp>
-lib_ignore = SX127xDriver
-lib_deps =
 
 [env:FM30_RX_MINI_via_BetaflightPassthrough]
 extends = env:FM30_RX_MINI_via_STLINK
 
 [env:FM30_RX_MINI_AS_TX_via_STLINK]
-extends = env_common_stm32
+extends = env_common_stm32, radio_2400
 platform = ststm32@13.0.0
 board = FM30_mini
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_tx}
+	${radio_2400.build_flags}
 	-D RX_AS_TX
 	-include target/FM30_RX_MINI.h
 	-D HSE_VALUE=16000000U
@@ -66,8 +65,6 @@ upload_flags =
 	BOOTLOADER=bootloader/fm30_mini_rxtx_bootloader.bin
 	VECT_OFFSET=0x4000
 src_filter = ${env_common_stm32.src_filter} -<rx_*.cpp>
-lib_ignore = SX127xDriver
-lib_deps =
 
 [env:FM30_RX_MINI_AS_TX_via_UART]
 extends = env:FM30_RX_MINI_AS_TX_via_STLINK

--- a/src/user_defines.txt
+++ b/src/user_defines.txt
@@ -16,13 +16,13 @@
 
 ### REGULATORY DOMAIN: ###
 
+# Domain is used to define correct frequency band for 900MHz hardware.
 #-DRegulatory_Domain_AU_915
 #-DRegulatory_Domain_EU_868
 #-DRegulatory_Domain_IN_866
 #-DRegulatory_Domain_AU_433
 #-DRegulatory_Domain_EU_433
 #-DRegulatory_Domain_FCC_915
-#-DRegulatory_Domain_ISM_2400
 
 ### PERFORMANCE OPTIONS: ###
 


### PR DESCRIPTION
This PR removes dependency to `-DRegulatory_Domain_ISM_2400` definition since it is global band. It is defined per HW target now. 
User still has to define a regulatory domain to be used for 900MHz band.

This PR is based on #992 which needs to merged first.