### PR TITLE
Update LQ even when no packets received

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -221,7 +221,7 @@ void ICACHE_RAM_ATTR getRFlinkInfo()
     crsf.LinkStatistics.uplink_RSSI_1 = -rssiDBM0;
     crsf.LinkStatistics.active_antenna = antenna;
     crsf.LinkStatistics.uplink_SNR = Radio.LastPacketSNR;
-    crsf.LinkStatistics.uplink_Link_quality = uplinkLQ;
+    //crsf.LinkStatistics.uplink_Link_quality = uplinkLQ; // handled in Tick
     crsf.LinkStatistics.rf_Mode = (uint8_t)RATE_4HZ - (uint8_t)ExpressLRS_currAirRate_Modparams->enum_rate;
     //DBGLN(crsf.LinkStatistics.uplink_RSSI_1);
     #if defined(DEBUG_BF_LINK_STATS)
@@ -419,6 +419,7 @@ void ICACHE_RAM_ATTR HWtimerCallbackTick() // this is 180 out of phase with the 
 
     // Save the LQ value before the inc() reduces it by 1
     uplinkLQ = LQCalc.getLQ();
+    crsf.LinkStatistics.uplink_Link_quality = uplinkLQ;
     // Only advance the LQI period counter if we didn't send Telemetry this period
     if (!alreadyTLMresp)
         LQCalc.inc();


### PR DESCRIPTION
I have a microchange! Currently we only update the receiver's LQ in the LinkStatistics when a packet is received. This PR changes it so the UplinkLQ is updated every packet cycle which keeps the value accurate even when the receiver isn't getting packets (i.e. the LQ is dropping).

This will track LQ in BetaFlight/iNav more accurately instead of, say, freezing at 100 LQ then immediately dropping to some other number on the first packet is received. It also feeds into Dynamic Power on the TX a lot better, because if the receiver stops getting packets, it will keep sending LQ=100 to the TX, which will prevent the TX from ramping up power.

Note that I did **not** update the antenna field the same way. It will be changing too on a diversity system as the RX desperately tries to receive a packet. However, everything relies on antenna pointing to which RSSI is valid, and having it toggle back and forth without the RSSI updating creates bogus data.