### PR TITLE
Update the way LUA request certain parameters

### DIFF
--- a/src/lib/LUA/lua.cpp
+++ b/src/lib/LUA/lua.cpp
@@ -11,7 +11,6 @@ extern CRSF crsf;
 static volatile bool UpdateParamReq = false;
 
 //LUA VARIABLES//
-#define LUA_PKTCOUNT_INTERVAL_MS 1000LU
 static uint8_t luaWarningFLags = false;
 static uint8_t suppressedLuaWarningFlags = true;
 
@@ -237,15 +236,13 @@ void registerLUAPopulateParams(void (*populate)())
 
 bool luaHandleUpdateParameter()
 {
-  static uint32_t LUAfieldReported = 0;
-  
-  populateHandler();
-
   if (UpdateParamReq == false)
   {
     return false;
   }
-
+  
+  populateHandler();
+  
   switch(crsf.ParameterUpdateData[0])
   {
     case CRSF_FRAMETYPE_PARAMETER_WRITE:

--- a/src/lua/elrsV2.lua
+++ b/src/lua/elrsV2.lua
@@ -444,7 +444,7 @@ local function parseDeviceInfoMessage(data)
   end
   if deviceId == id then
     deviceName = devicesName
-    deviceIsELRS = fieldGetValue(data,offset,4) == 0x454C5253
+    deviceIsELRS = fieldGetValue(data,offset,4) == 0x454C5253 -- SerialNumber = 'E L R S'
     fields_count = data[offset+12]
     reloadAllField()
     clearAllField()
@@ -596,14 +596,13 @@ local function refreshNext()
 
   if time > linkstatTimeout then
     if deviceIsELRS == false and allParamsLoaded == 1 then
-      linkstatTimeout = time + 100
       -- enable both line below to do what the legacy lua is doing which is reloading all params in an interval
       -- reloadAllField()
       -- linkstatTimeout = time + 300 --reload all param every 3s if not elrs
     else
-    crossfireTelemetryPush(0x2D, { deviceId, handsetId, 0x0, 0x0 }) --request linkstat
-    linkstatTimeout = time + 100
+      crossfireTelemetryPush(0x2D, { deviceId, handsetId, 0x0, 0x0 }) --request linkstat
     end
+    linkstatTimeout = time + 100
   end
 end
 


### PR DESCRIPTION
ELRS uses push packet to lua to update the UART packet count status and warning flags, but there is no way without adding more code, to know if a LUA is currently opened. sending this packet to handset when lua is not even opened would be useless and also taking at least 1 packet of RC_COMMAND. 

using ELRS LUA to request it at an interval would solve this issue.

this PR requires PR #997 