### PR TITLE
Don't touch Radio during timerCallbackIdle (1.1)

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -379,7 +379,8 @@ void ICACHE_RAM_ATTR timerCallbackNormal()
 void ICACHE_RAM_ATTR timerCallbackIdle()
 {
   NonceTX++;
-  HandleFHSS();
+  if ((NonceTX + 1) % ExpressLRS_currAirRate_Modparams->FHSShopInterval == 0)
+    ++FHSSptr;
 }
 
 void sendLuaParams()
@@ -544,7 +545,9 @@ static void ConfigChangeCommit()
   // Write the uncommitted eeprom values
   Serial.println("EEPROM COMMIT");
   config.Commit();
-  hwTimer.callbackTock = &timerCallbackNormal; // Resume the timer
+  // Resume the timer, will take one hop for the radio to be on the right frequency
+  // if we missed a hop
+  hwTimer.callbackTock = &timerCallbackNormal;
   sendLuaParams();
 }
 


### PR DESCRIPTION
This returns to the old behavior of not touching the Radio during EEPROM.commit on 1.1 branch.

## Details
@deadbytefpv found a problem in pre-1.2 testing, which is that for ESP32 TX hardware, when changing params via Lua sometimes it would take more than one try and the Bad:Good numbers would reset. I reproduced it on my ES900TX

```
0:
  0x400815a4: HandleFHSS() at C:\Users\bmayland\Documents\GitHub Projects\ExpressLRS\src/src/tx_main.cpp:914
0:
  0x400815c7: timerCallbackIdle() at C:\Users\bmayland\Documents\GitHub Projects\ExpressLRS\src/src/tx_main.cpp:914
0:
  0x40082411: hwTimer::callback() at C:\Users\bmayland\Documents\GitHub Projects\ExpressLRS\src/lib\HWTIMER/ESP32_hwTimer.cpp:20
0:
  0x40082d69: __timerISR at C:\Users\bmayland\.platformio\packages\framework-arduinoespressif32\cores\esp32/esp32-hal-timer.c:174
0:
  0x40088da9: _xt_lowint1 at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/xtensa_vectors.S:1154
0:
  0x40090dc7: esp_rom_spiflash_read_data at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/spi_flash/spi_flash_rom_patch.c:662
0:
  0x4009153d: esp_rom_spiflash_read at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/spi_flash/spi_flash_rom_patch.c:662     
0:
  0x40089d00: spi_flash_read at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/spi_flash/flash_ops.c:599
0:
  0x40149089: nvs::nvs_flash_read(unsigned int, void*, unsigned int) at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/nvs_flash/src/nvs_ops.cpp:76
0:
  0x40147949: nvs::Page::readEntry(unsigned int, nvs::Item&) const at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/nvs_flash/src/nvs_page.cpp:871
0:
  0x40147b74: nvs::Page::copyItems(nvs::Page&) at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/nvs_flash/src/nvs_page.cpp:871
0:
  0x40148a54: nvs::PageManager::requestNewPage() at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/nvs_flash/src/nvs_pagemanager.cpp:179
0:
  0x401468de: nvs::Storage::writeMultiPageBlob(unsigned char, char const*, void const*, unsigned int, nvs::VerOffset) at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/nvs_flash/src/nvs_storage.cpp:579
0:
  0x40146df6: nvs::Storage::writeItem(unsigned char, nvs::ItemType, char const*, void const*, unsigned int) at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/nvs_flash/src/nvs_storage.cpp:579
0:
  0x401461fb: nvs_set_blob at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/nvs_flash/src/nvs_api.cpp:547
0:
  0x4014c674: EEPROMClass::commit() at C:\Users\bmayland\.platformio\packages\framework-arduinoespressif32\libraries\EEPROM\src/EEPROM.cpp:545
0:
  0x400da179: ELRS_EEPROM::Commit() at C:\Users\bmayland\Documents\GitHub Projects\ExpressLRS\src/lib\EEPROM/elrs_eeprom.cpp:79
0:
  0x400d1fce: TxConfig::Commit() at C:\Users\bmayland\Documents\GitHub Projects\ExpressLRS\src/src/config.cpp:169
0:
  0x400d289d: loop() at C:\Users\bmayland\Documents\GitHub Projects\ExpressLRS\src/src/tx_main.cpp:546
  \-> inlined by: CheckConfigChangePending at C:\Users\bmayland\Documents\GitHub Projects\ExpressLRS\src/src/tx_main.cpp:579
  \-> inlined by: loop() at C:\Users\bmayland\Documents\GitHub Projects\ExpressLRS\src/src/tx_main.cpp:795
0:
  0x400dc425: loopTask(void*) at C:\Users\bmayland\.platformio\packages\framework-arduinoespressif32\cores\esp32/main.cpp:23
0:
  0x4008bad2: vPortTaskWrapper at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/port.c:355 (discriminator 1)
```

It looks to me like calling Radio.SetFrequency is blowing up when the main thread is doing an SPI operation on the external flash. To fix it, I just went back to the old way where it just `++FHSptr` and lets the radio catch up on the next hop.

The question is: Is this something that happens on master? I've not seen this. pkendall64 changed master to use nvs directly to store the config so either the writes are small enough that it doesn't trigger this bug or it happens infrequently? I'm not entirely clear on if the nvs storage partition can be on the main MCU or it is always eternal on ESP32.