### PR TITLE
adds lua general functions

### DIFF
--- a/src/lib/CrsfProtocol/crsf_protocol.h
+++ b/src/lib/CrsfProtocol/crsf_protocol.h
@@ -106,6 +106,10 @@ typedef enum
     CRSF_FRAMETYPE_MSP_WRITE = 0x7C, // write with 8 byte chunked binary (OpenTX outbound telemetry buffer limit)
     // Ardupilot frames
     CRSF_FRAMETYPE_ARDUPILOT_RESP = 0x80,
+    // LUA Functions - https://doc.open-tx.org/opentx-2-2-lua-reference-guide/part_iii_-_opentx_lua_api_reference/general_functions
+    CRSF_FRAMETYPE_LUA_PLAYNUMBER = 0xA0,
+    CRSF_FRAMETYPE_LUA_PLAYTONE = 0xA1,
+    CRSF_FRAMETYPE_LUA_PLAYHAPTIC = 0xA2,
 } crsf_frame_type_e;
 
 typedef enum {

--- a/src/lib/LUA/lua.cpp
+++ b/src/lib/LUA/lua.cpp
@@ -189,7 +189,7 @@ void sendELRSstatus()
   // and copied into params->msg (with trailing null)
   params->msg[0] = '\0';
 
-  crsf.packetQueueExtended(0x2E, &buffer, sizeof(buffer));
+  crsf.packetQueueExtended(0x2E, &buffer, sizeof(buffer)); // 0x2E magic number :|
 }
 
 void ICACHE_RAM_ATTR luaParamUpdateReq()
@@ -308,6 +308,40 @@ void sendLuaDevicePacket(void)
   device->fieldCnt = lastLuaField;
 
   crsf.packetQueueExtended(CRSF_FRAMETYPE_DEVICE_INFO, buffer, sizeof(buffer));
+}
+
+void sendLuaPlayHaptic(uint16_t durationMillisSec)
+{
+  uint8_t buffer[2];
+  
+  buffer[0] = (uint8_t)(durationMillisSec & 0xFF);
+  buffer[1] = (uint8_t)(durationMillisSec >> 8);
+
+  crsf.packetQueueExtended(CRSF_FRAMETYPE_LUA_PLAYHAPTIC, buffer, sizeof(buffer));
+}
+
+void sendLuaPlayTone(uint16_t frequency, uint16_t durationMillisSec)
+{
+  uint8_t buffer[4];
+  
+  buffer[0] = (uint8_t)(frequency & 0xFF);
+  buffer[1] = (uint8_t)(frequency >> 8);
+  buffer[2] = (uint8_t)(durationMillisSec & 0xFF);
+  buffer[3] = (uint8_t)(durationMillisSec >> 8);
+
+  crsf.packetQueueExtended(CRSF_FRAMETYPE_LUA_PLAYTONE, buffer, sizeof(buffer));
+}
+
+void sendLuaPlayNumber(uint16_t number)
+{
+  uint8_t buffer[4];
+  
+  buffer[0] = (uint8_t)(number & 0xFF);
+  buffer[1] = (uint8_t)(number >> 8);
+  buffer[2] = UNIT_SECONDS; // not working
+  buffer[3] = PREC2; // not working
+
+  crsf.packetQueueExtended(CRSF_FRAMETYPE_LUA_PLAYNUMBER, buffer, sizeof(buffer));
 }
 
 #endif

--- a/src/lib/LUA/lua.h
+++ b/src/lib/LUA/lua.h
@@ -4,6 +4,7 @@
 
 #include "targets.h"
 #include "crsf_protocol.h"
+#include "luaDefines.h"
 
 struct luaPropertiesCommon {
     const char* const name;    // display name
@@ -121,4 +122,9 @@ inline void setLuaInt16Value(struct luaItem_int16 *luaStruct, int16_t newvalue) 
 inline void setLuaStringValue(struct luaItem_string *luaStruct, const char *newvalue) {
     luaStruct->value = newvalue;
 }
+
+void sendLuaPlayHaptic(uint16_t durationMillisSec);
+void sendLuaPlayTone(uint16_t frequency, uint16_t durationMillisSec);
+void sendLuaPlayNumber(uint16_t number);
+
 #endif

--- a/src/lib/LUA/luaDefines.h
+++ b/src/lib/LUA/luaDefines.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#ifdef TARGET_TX
+
+// https://doc.open-tx.org/opentx-2-2-lua-reference-guide/part_vii_-_appendix/units
+#define UNIT_RAW                       0
+#define UNIT_SECONDS                   57
+
+#define PREC1                          0x20
+#define PREC2                          0x30
+
+#endif

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -978,6 +978,7 @@ void EnterBindingMode()
   sendLuaPlayHaptic((uint16_t)250);
   sendLuaPlayTone((uint16_t)1000, (uint16_t)250);
   sendLuaPlayNumber((uint16_t)1345);
+  sendLuaPlayNumber((uint16_t)(1345 % 10) * 100); // hack to get second decimal place
   
 }
 

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -973,6 +973,12 @@ void EnterBindingMode()
 #if defined(USE_TX_BACKPACK)
   BackpackBinding();
 #endif // USE_TX_BACKPACK
+
+  // REMOVE AFTER TESTING
+  sendLuaPlayHaptic((uint16_t)250);
+  sendLuaPlayTone((uint16_t)1000, (uint16_t)250);
+  sendLuaPlayNumber((uint16_t)1345);
+  
 }
 
 void ExitBindingMode()


### PR DESCRIPTION
This PR attempts to make some of the lua general functions available dynamically to ELRS.  Future planned features will make use of these, and they could easily be used with other features e.g. power call outs when dyn power changes.

Very much a draft state and looking for feedback on which lib to stick these functions, and do the new `crsf_frame_type_e` potentially cause any conflicts?

For demo purposes I have added the funcs to the Bind button.  Press it to vibrate, beep, and call out a value.

Broken stuff currently includes PREC2 and the Units define.  Plus I think PlayHaptic does not obey the duration.

... so many things to do.

https://doc.open-tx.org/opentx-2-2-lua-reference-guide/part_iii_-_opentx_lua_api_reference/general_functions