### PR TITLE
Limit power shown in Lua to min/max power supported by TX

### DIFF
--- a/src/lib/LUA/devLUA.cpp
+++ b/src/lib/LUA/devLUA.cpp
@@ -205,15 +205,15 @@ static void luadevGeneratePowerOpts()
   // be called more than once!
   char *out = strPowerLevels;
   PowerLevels_e pwr = PWR_10mW;
-  // COMMENTED OUT: our lua forces "min" to 0, so always include PWR_10mW to MinPower in the options
   // Count the semicolons to move `out` to point to the MINth item
-  // while (pwr < MinPower)
-  // {
-  //   while (*out++ != ';') ;
-  //   pwr = (PowerLevels_e)((unsigned int)pwr + 1);
-  // }
+  while (pwr < MinPower)
+  {
+    while (*out++ != ';') ;
+    pwr = (PowerLevels_e)((unsigned int)pwr + 1);
+  }
+  // There is no min field, compensate by shifting the index when sending/receiving
   // luaPower.min = (uint8_t)MinPower;
-  // luaPower.options = (const char *)out;
+  luaPower.options = (const char *)out;
 
   // Continue until after than MAXth item and drop a null in the orginal
   // string on the semicolon (not after like the previous loop)
@@ -281,7 +281,7 @@ static void registerLuaParameters()
   registerLUAParameter(&luaPowerFolder);
   luadevGeneratePowerOpts();
   registerLUAParameter(&luaPower, [](uint8_t id, uint8_t arg){
-    config.SetPower((PowerLevels_e)constrain(arg, MinPower, MaxPower));
+    config.SetPower((PowerLevels_e)constrain(arg + MinPower, MinPower, MaxPower));
   }, luaPowerFolder.common.id);
   registerLUAParameter(&luaDynamicPower, [](uint8_t id, uint8_t arg){
       config.SetDynamicPower(arg > 0);
@@ -402,7 +402,7 @@ static int event()
   setLuaTextSelectionValue(&luaTlmRate, config.GetTlm());
   setLuaTextSelectionValue(&luaSwitch,(uint8_t)(config.GetSwitchMode() - 1)); // -1 for missing sm1Bit
   setLuaTextSelectionValue(&luaModelMatch,(uint8_t)config.GetModelMatch());
-  setLuaTextSelectionValue(&luaPower, config.GetPower());
+  setLuaTextSelectionValue(&luaPower, config.GetPower() - MinPower);
 
   uint8_t dynamic = config.GetDynamicPower() ? config.GetBoostChannel() + 1 : 0;
   setLuaTextSelectionValue(&luaDynamicPower,dynamic);

--- a/src/lib/LUA/devLUA.cpp
+++ b/src/lib/LUA/devLUA.cpp
@@ -281,16 +281,7 @@ static void registerLuaParameters()
   registerLUAParameter(&luaPowerFolder);
   luadevGeneratePowerOpts();
   registerLUAParameter(&luaPower, [](uint8_t id, uint8_t arg){
-    PowerLevels_e newPower = (PowerLevels_e)arg;
-
-    if (newPower > MaxPower)
-    {
-        newPower = MaxPower;
-    } else if (newPower < MinPower)
-    {
-        newPower = MinPower;
-    }
-    config.SetPower(newPower);
+    config.SetPower((PowerLevels_e)constrain(arg, MinPower, MaxPower));
   }, luaPowerFolder.common.id);
   registerLUAParameter(&luaDynamicPower, [](uint8_t id, uint8_t arg){
       config.SetDynamicPower(arg > 0);

--- a/src/lib/LUA/devLUA.cpp
+++ b/src/lib/LUA/devLUA.cpp
@@ -24,6 +24,7 @@ extern SX1280Driver Radio;
 static const char thisCommit[] = {LATEST_COMMIT, 0};
 static const char thisVersion[] = {LATEST_VERSION, 0};
 static const char emptySpace[1] = {0};
+static char strPowerLevels[] = "10;25;50;100;250;500;1000;2000";
 
 static struct luaItem_selection luaAirRate = {
     {"Packet Rate", CRSF_TEXT_SELECTION},
@@ -51,7 +52,7 @@ static struct luaItem_folder luaPowerFolder = {
 static struct luaItem_selection luaPower = {
     {"Max Power", CRSF_TEXT_SELECTION},
     0, // value
-    "10;25;50;100;250;500;1000;2000",
+    strPowerLevels,
     "mW"
 };
 
@@ -198,6 +199,36 @@ extern unsigned long rebootTime;
 extern void beginWebsever();
 #endif
 
+static void luadevGeneratePowerOpts()
+{
+  // This function modifies the strPowerLevels in place and must not
+  // be called more than once!
+  char *out = strPowerLevels;
+  PowerLevels_e pwr = PWR_10mW;
+  // COMMENTED OUT: our lua forces "min" to 0, so always include PWR_10mW to MinPower in the options
+  // Count the semicolons to move `out` to point to the MINth item
+  // while (pwr < MinPower)
+  // {
+  //   while (*out++ != ';') ;
+  //   pwr = (PowerLevels_e)((unsigned int)pwr + 1);
+  // }
+  // luaPower.min = (uint8_t)MinPower;
+  // luaPower.options = (const char *)out;
+
+  // Continue until after than MAXth item and drop a null in the orginal
+  // string on the semicolon (not after like the previous loop)
+  while (pwr <= MaxPower)
+  {
+    // If out still points to a semicolon from the last loop move past it
+    if (*out)
+      ++out;
+    while (*out && *out != ';')
+      ++out;
+    pwr = (PowerLevels_e)((unsigned int)pwr + 1);
+  }
+  *out = '\0';
+}
+
 static void registerLuaParameters()
 {
   registerLUAParameter(&luaAirRate, [](uint8_t id, uint8_t arg){
@@ -248,6 +279,7 @@ static void registerLuaParameters()
 
   // POWER folder
   registerLUAParameter(&luaPowerFolder);
+  luadevGeneratePowerOpts();
   registerLUAParameter(&luaPower, [](uint8_t id, uint8_t arg){
     PowerLevels_e newPower = (PowerLevels_e)arg;
 
@@ -379,7 +411,6 @@ static int event()
   setLuaTextSelectionValue(&luaTlmRate, config.GetTlm());
   setLuaTextSelectionValue(&luaSwitch,(uint8_t)(config.GetSwitchMode() - 1)); // -1 for missing sm1Bit
   setLuaTextSelectionValue(&luaModelMatch,(uint8_t)config.GetModelMatch());
-
   setLuaTextSelectionValue(&luaPower, config.GetPower());
 
   uint8_t dynamic = config.GetDynamicPower() ? config.GetBoostChannel() + 1 : 0;

--- a/src/lib/LUA/lua.h
+++ b/src/lib/LUA/lua.h
@@ -22,7 +22,7 @@ struct tagLuaDeviceProperties {
 struct luaItem_selection {
     struct luaPropertiesCommon common;
     uint8_t value;
-    const char* const options; // selection options, separated by ';'
+    const char* options; // selection options, separated by ';'
     const char* const units;
 } PACKED;
 

--- a/src/lua/README.md
+++ b/src/lua/README.md
@@ -1,20 +1,12 @@
 
 # Which file do I need?
-
-## For TX firmware 1.0.x or earlier:
-NOTE: If you are on V1.0.x please use ELRS.lua not the elrsV2.lua inside the subfolders.
+* For transmitter on master / ExpressLRS 2.0 -> elrsV2.lua
+* For transmitter on 1.x -> ELRS.lua
 
 ### Downloading from Github:
-Copy the ELRS.lua file into the /SCRIPTS/TOOLS directory of the SD card on your handset.
+Click the file link above, find the "Raw" button near the top of that page. Right-click, Save link as.., copy the .lua file into the /SCRIPTS/TOOLS directory of the SD card on your handset.
 
 ### Downloading from Configurator:
-Use the button in the image below to download the .lua script and Copy the ELRS.lua file into the /SCRIPTS/TOOLS directory of the SD card on your handset.
+Use the button shown in the image below to download the .lua script into the /SCRIPTS/TOOLS directory of the SD card on your handset.
 ![downloadlua](https://user-images.githubusercontent.com/68074253/129203116-c1234719-3e8c-4cbf-a391-b7fb8dc0262d.png)
-
-
-## For TX firmware 2.x.x or later (e.g. if you are running the master branch):
-NOTE: The scripts in these subfolders are incompatible with ExpressLRS V1.0.x and use the new ExpressLRS Configurator. They will not work on V1.0.x
-
-Use the telemetry script (elrsV2.lua), Copy the ELRS.lua file into the /SCRIPTS/TOOLS directory of the SD card on your handset.
-
 

--- a/src/lua/elrsV2.lua
+++ b/src/lua/elrsV2.lua
@@ -346,7 +346,7 @@ local function fieldTextSelectionSave(field)
 end
 
 local function fieldTextSelectionDisplay(field, y, attr)
-  lcd.drawText(COL2, y, field.values[field.value+1] .. field.unit, attr)
+  lcd.drawText(COL2, y, (field.values[field.value+1] or "ERR") .. field.unit, attr)
 end
 
 -- STRING


### PR DESCRIPTION
Users tend to be extremely confused as to why their module doesn't support 2000mW; limit the options provided to them in Lua to the MaxPower.

* Reduce the selection options string passed to Lua to MinPower -> MaxPower items. Note that all power levels between Min and Max are still presented to the user.
* The Lua itself is updated to show ERR for an invalid selection but still allow users to change the value. This is the case if they compiled with `UNLOCK_HIGHER_POWER` and set it, then compile without that setting so the list is now shorter.
* Update the README.md for the Lua directory to be more direct about answering the question it is there to answer. No user reads all of that text which split the answer into two pieces separated by extra information, so just say the answer plainly first.