### PR TITLE
Enable SX1280 DC-DC converter to reduce power usage

### DIFF
--- a/src/include/target/BETAFPV_2400_RX.h
+++ b/src/include/target/BETAFPV_2400_RX.h
@@ -1,4 +1,7 @@
 #define DEVICE_NAME "BETAFPV 2400RX"
+
+#define USE_SX1280_DCDC
+
 // GPIO pin definitions
 #define GPIO_PIN_NSS            15
 #define GPIO_PIN_BUSY           5

--- a/src/include/target/FM30_RX_MINI.h
+++ b/src/include/target/FM30_RX_MINI.h
@@ -8,6 +8,8 @@
     #define DEVICE_NAME "FM30 MINI"
 #endif
 
+#define USE_SX1280_DCDC
+
 // GPIO pin definitions
 #define GPIO_PIN_NSS                PA15
 #define GPIO_PIN_BUSY               PE9

--- a/src/include/target/FM30_TX.h
+++ b/src/include/target/FM30_TX.h
@@ -2,6 +2,7 @@
 
 // There is some special handling for this target
 #define TARGET_TX_FM30
+#define USE_SX1280_DCDC
 
 // GPIO pin definitions
 #define GPIO_PIN_NSS            PB12

--- a/src/include/target/HappyModel_ES24TX_2400_TX.h
+++ b/src/include/target/HappyModel_ES24TX_2400_TX.h
@@ -1,6 +1,7 @@
 #define DEVICE_NAME "HM ES24TX"
 
 #define USE_TX_BACKPACK
+#define USE_SX1280_DCDC
 
 // Output Power
 #define MinPower PWR_10mW

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -74,6 +74,9 @@ bool SX1280Driver::Begin()
     SetFrequencyReg(currFreq);                                                                                                    //Set Freq
     SetFIFOaddr(0x00, 0x00);                                                                                                      //Config FIFO addr
     SetDioIrqParams(SX1280_IRQ_RADIO_ALL, SX1280_IRQ_TX_DONE | SX1280_IRQ_RX_DONE, SX1280_IRQ_RADIO_NONE, SX1280_IRQ_RADIO_NONE); //set IRQ to both RXdone/TXdone on DIO1
+#if defined(USE_SX1280_DCDC)
+    hal.WriteCommand(SX1280_RADIO_SET_REGULATORMODE, 0x01);     // Enable DCDC converter instead of LDO
+#endif
     return true;
 }
 


### PR DESCRIPTION
Adds a new define `USE_SX1280_DCDC` to allow targets that have the required components to enable the DC-DC converter in the SX1280 to reduce power usage.

### Details
The SX1280 has a built in DC-DC converter in addition to an LDO it can use to power the RF circuitry. According to the datasheet _"The penalty for using the LDO is a doubling of current consumption."_ I noticed that the SIYI hardware includes the required inductor to make this work so I've made some code to enable it. The inductor would be attached between pin 12 and 14 of the  SX1280 and is a large black 15uH SMD inductor paired with a 470nF cap.
![image](https://user-images.githubusercontent.com/677183/139359045-755ce98e-5e4d-4449-8714-4da3c42849c9.png)

In theory this should reduce the SX1280 current draw by 7mA in receive mode and 24mA in transmit mode if the current usage is actually double. I didn't hook it up to the scope but just a quick USB power test showed about 10-15mA difference in 150Hz 1:2 mode (186mA vs 201mA for the full RX+adapter) so that seems about right.

I also tested turning it on on an EP2, which does not have a needed inductor (as far as I can tell). It still operated just fine and the signal strength of the telemetry seemed the same too. The power usage stayed the same as expected, but I thought there would be a more spectacular failure like it wouldn't work at all or would catch fire.

### Added to targets
I don't know what hardware has this inductor, so I just went off what I have. If anyone can see this inductor on their hardware let me know and I can add it to the device's target definition.
* BetaFPV 2400 RX
* SIYI FM30 TX
* SIYI FR Mini RX and RX as TX
* ES24TX -- I **think** this one has it. It definitely seems to have 2x black objects in the right place according to internet photos, so I've enabled it there.