### PR TITLE
Target name update - HM ES24TX Pro Series 2400 TX

### DIFF
--- a/src/include/target/HappyModel_ES24TX_Pro_Series_2400_TX.h
+++ b/src/include/target/HappyModel_ES24TX_Pro_Series_2400_TX.h
@@ -1,4 +1,4 @@
-#define DEVICE_NAME "ES24TX Slim Pro"
+#define DEVICE_NAME "ES24TX Pro Series"
 
 #define USE_TX_BACKPACK
 

--- a/src/include/target/HappyModel_ES24TX_Pro_Series_2400_TX.h
+++ b/src/include/target/HappyModel_ES24TX_Pro_Series_2400_TX.h
@@ -1,4 +1,4 @@
-#define DEVICE_NAME "ES24TX Pro Series"
+#define DEVICE_NAME "ES24TX Pro Ser"
 
 #define USE_TX_BACKPACK
 

--- a/src/targets/happymodel_2400.ini
+++ b/src/targets/happymodel_2400.ini
@@ -15,7 +15,7 @@ extends = env:HappyModel_ES24TX_2400_TX_via_UART
 [env:HappyModel_ES24TX_Pro_Series_2400_TX_via_UART]
 extends = env:DIY_2400_TX_ESP32_SX1280_E28_via_UART
 build_flags =
-	-include target/HappyModel_ES24TX_Slim_Pro_2400_TX.h
+	-include target/HappyModel_ES24TX_Pro_Series_2400_TX.h
 	${env:DIY_2400_TX_ESP32_SX1280_E28_via_UART.build_flags}
 
 [env:HappyModel_ES24TX_Pro_Series_2400_TX_via_WIFI]

--- a/src/targets/happymodel_2400.ini
+++ b/src/targets/happymodel_2400.ini
@@ -12,13 +12,13 @@ build_flags =
 [env:HappyModel_ES24TX_2400_TX_via_WIFI]
 extends = env:HappyModel_ES24TX_2400_TX_via_UART
 
-[env:HappyModel_ES24TX_Slim_Pro_2400_TX_via_UART]
+[env:HappyModel_ES24TX_Pro_Series_2400_TX_via_UART]
 extends = env:DIY_2400_TX_ESP32_SX1280_E28_via_UART
 build_flags =
 	-include target/HappyModel_ES24TX_Slim_Pro_2400_TX.h
 	${env:DIY_2400_TX_ESP32_SX1280_E28_via_UART.build_flags}
 
-[env:HappyModel_ES24TX_Slim_Pro_2400_TX_via_WIFI]
+[env:HappyModel_ES24TX_Pro_Series_2400_TX_via_WIFI]
 extends = env:HappyModel_ES24TX_Slim_Pro_2400_TX_via_UART
 
 # ********************************


### PR DESCRIPTION
Updates the `Slim Pro` target name to `Pro Series`.  This make it more generic and reusable.