### PR TITLE
Add NamimnoRC OLED TX targets

### DIFF
--- a/src/include/target/NamimnoRC_FLASH_2400_OLED_TX.h
+++ b/src/include/target/NamimnoRC_FLASH_2400_OLED_TX.h
@@ -1,0 +1,45 @@
+#define TX_DEVICE_NAME "Namimno Flash OLED"
+
+#define USE_TX_BACKPACK
+#define USE_OLED
+
+// GPIO pin definitions
+#define GPIO_PIN_RST            21
+#define GPIO_PIN_BUSY           22
+#define GPIO_PIN_DIO1           17
+#define GPIO_PIN_DIO2           16
+#define GPIO_PIN_NSS            5
+#define GPIO_PIN_MOSI           23
+#define GPIO_PIN_MISO           19
+#define GPIO_PIN_SCK            18
+// SKY65383-11 front end control
+#define GPIO_PIN_RX_ENABLE      32    // CRX
+#define GPIO_PIN_TX_ENABLE      33    // CTX
+#define GPIO_PIN_PA_ENABLE      25    // CSD
+
+/* OLED definition */
+#define GPIO_PIN_OLED_CS        12
+#define GPIO_PIN_OLED_RST       27
+#define GPIO_PIN_OLED_DC        26
+#define GPIO_PIN_OLED_MOSI      15
+#define GPIO_PIN_OLED_SCK       14
+
+/* Joystick definition */
+#define GPIO_PIN_JOYSTICK       35
+
+/* S.Port input signal */
+#define GPIO_PIN_RCSIGNAL_RX    13
+#define GPIO_PIN_RCSIGNAL_TX    13
+#define GPIO_PIN_FAN_EN         2
+
+/* Backpack logger connection */
+#define GPIO_PIN_DEBUG_RX       3
+#define GPIO_PIN_DEBUG_TX       1
+
+/* WS2812 led */
+#define GPIO_PIN_LED_WS2812     4
+
+// Output Power
+#define MinPower                PWR_25mW
+#define MaxPower                PWR_1000mW
+#define POWER_OUTPUT_VALUES     {-18,-13,-10,-5,-2,3}

--- a/src/include/target/NamimnoRC_FLASH_2400_OLED_TX.h
+++ b/src/include/target/NamimnoRC_FLASH_2400_OLED_TX.h
@@ -1,5 +1,6 @@
-#define TX_DEVICE_NAME "Namimno Flash OLED"
+#define DEVICE_NAME "Namimno Flash OLED"
 
+// Features
 #define USE_TX_BACKPACK
 #define USE_OLED
 

--- a/src/include/target/NamimnoRC_VOYAGER_900_OLED_TX.h
+++ b/src/include/target/NamimnoRC_VOYAGER_900_OLED_TX.h
@@ -1,5 +1,6 @@
-#define TX_DEVICE_NAME "Namimno Voyager OLED"
+#define DEVICE_NAME "Namimno Voyager OLED"
 
+// Features
 #define USE_TX_BACKPACK
 #define USE_OLED
 

--- a/src/include/target/NamimnoRC_VOYAGER_900_OLED_TX.h
+++ b/src/include/target/NamimnoRC_VOYAGER_900_OLED_TX.h
@@ -1,0 +1,45 @@
+#define TX_DEVICE_NAME "Namimno Voyager OLED"
+
+#define USE_TX_BACKPACK
+#define USE_OLED
+
+// GPIO pin definitions
+#define GPIO_PIN_RST            21
+#define GPIO_PIN_DIO0           17
+#define GPIO_PIN_DIO1           16
+#define GPIO_PIN_NSS            5
+#define GPIO_PIN_MOSI           23
+#define GPIO_PIN_MISO           19
+#define GPIO_PIN_SCK            18
+
+/* DAC settings */
+#define GPIO_PIN_RX_ENABLE      33
+#define GPIO_PIN_RFamp_APC2     25
+
+/* OLED definition */
+#define GPIO_PIN_OLED_CS        12
+#define GPIO_PIN_OLED_RST       27
+#define GPIO_PIN_OLED_DC        26
+#define GPIO_PIN_OLED_MOSI      15
+#define GPIO_PIN_OLED_SCK       14
+
+/* Joystick definition */
+#define GPIO_PIN_JOYSTICK       35
+
+/* S.Port input signal */
+#define GPIO_PIN_RCSIGNAL_RX    13
+#define GPIO_PIN_RCSIGNAL_TX    13
+#define GPIO_PIN_FAN_EN         2
+
+/* Backpack logger connection */
+#define GPIO_PIN_DEBUG_RX       3
+#define GPIO_PIN_DEBUG_TX       1
+
+/* WS2812 led */
+#define GPIO_PIN_LED_WS2812     4
+
+// Output Power
+#define POWER_OUTPUT_DACWRITE
+#define MinPower                PWR_25mW
+#define MaxPower                PWR_2000mW
+#define POWER_OUTPUT_VALUES     {57,67,76,90,112,132,167,201}

--- a/src/targets/namimnorc_2400.ini
+++ b/src/targets/namimnorc_2400.ini
@@ -21,6 +21,22 @@ lib_deps =
 [env:NamimnoRC_FLASH_2400_TX_via_WIFI]
 extends = env:NamimnoRC_FLASH_2400_TX_via_STLINK
 
+[env:NamimnoRC_FLASH_2400_OLED_TX_via_UART]
+extends = env_common_esp32
+build_flags = 
+	${env_common_esp32.build_flags}
+	${common_env_data.build_flags_tx}
+	-include target/NamimnoRC_FLASH_2400_OLED_TX.h
+	-D VTABLES_IN_FLASH=1
+	-O2
+src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+lib_deps = 
+	${env_common_esp32.lib_deps}
+	olikraus/U8g2@^2.28.8
+
+[env:NamimnoRC_FLASH_2400_OLED_TX_via_WIFI]
+extends = env:NamimnoRC_FLASH_2400_OLED_TX_via_UART
+
 
 # ********************************
 # Receiver targets

--- a/src/targets/namimnorc_900.ini
+++ b/src/targets/namimnorc_900.ini
@@ -21,6 +21,22 @@ lib_deps =
 [env:NamimnoRC_VOYAGER_900_TX_via_WIFI]
 extends = env:NamimnoRC_VOYAGER_900_TX_via_STLINK
 
+[env:NamimnoRC_VOYAGER_900_OLED_TX_via_UART]
+extends = env_common_esp32
+build_flags = 
+	${env_common_esp32.build_flags}
+	${common_env_data.build_flags_tx}
+	-include target/NamimnoRC_VOYAGER_900_OLED_TX.h
+	-D VTABLES_IN_FLASH=1
+	-O2
+src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+lib_deps = 
+	${env_common_esp32.lib_deps}
+	olikraus/U8g2@^2.28.8
+
+[env:NamimnoRC_VOYAGER_900_OLED_TX_via_WIFI]
+extends = env:NamimnoRC_VOYAGER_900_OLED_TX_via_UART
+
 
 # ********************************
 # Receiver targets


### PR DESCRIPTION
They currently have the extra joystick pin definitions for when the unified display menu will be added.