### PR TITLE
Backport ES900RX upload via UART target

### DIFF
--- a/src/targets/happymodel_900.ini
+++ b/src/targets/happymodel_900.ini
@@ -63,6 +63,9 @@ upload_flags =
 [env:HappyModel_RX_ES915RX_via_BetaflightPassthrough]
 extends = env:HappyModel_RX_ES915RX_via_STLINK
 
+[env:HappyModel_RX_ES900RX_via_UART]
+extends = env:DIY_900_RX_ESP8285_SX127x_via_UART
+
 [env:HappyModel_RX_ES900RX_via_WIFI]
 extends = env:DIY_900_RX_ESP8285_SX127x_via_WIFI
 upload_port = 10.0.0.1


### PR DESCRIPTION
This should allow ES900RX users to be able to flash via a FTDI adaptor. See #1034 