### PR TITLE
Change hostname when mDNS conflict occurs on ESP8266

### DIFF
--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -444,6 +444,15 @@ static void startMDNS()
     MDNS.addServiceTxt(service, "version", VERSION);
     MDNS.addServiceTxt(service, "options", String(FPSTR(compile_options)).c_str());
     MDNS.addServiceTxt(service, "type", "rx");
+    // If the probe result fails because there is another device on the network with the same name
+    // use our unique instance name as the hostname. A better way to do this would be to use
+    // MDNSResponder::indexDomain and change myHostname as well.
+    MDNS.setHostProbeResultCallback([instance](const char* p_pcDomainName, bool p_bProbeResult) {
+      if (!p_bProbeResult) {
+        WiFi.hostname(instance);
+        MDNS.setInstanceName(instance);
+      }
+    });
   #else
     MDNS.setInstanceName(instance);
     MDNS.addService("http", "tcp", 80);


### PR DESCRIPTION
When the mDNS probe notifies that there is a conflict registering the hostname, change the device's hostname to the unique instance name. Fixes #1039

### Details
On ESP8266 targets, when the wifi is activated, if there is another device with the same hostname on the network, it will abort the mDNS probe and not register the name. On ESP32 targets, the IDF automatically changes the hostname behind the scenes to resolve the conflict. This PR catches the probe failure and changes the hostname to use the unique instance name instead to resolve the conflict. The WiFi DHCP client actually will re-register with the new name as well (according to my DNS logs) and the Configurator's view is consistent.
![configurator fixed](https://cdn.discordapp.com/attachments/878664935624830986/905102049128091738/unknown.png)

### Alternative solution
The proper way to do this is probably to do it like ESP32 does and use `MDNSResponder::indexDomain()` to allocate a new hostname with a autoincrement numeric suffix, such as [in this example](https://github.com/esp8266/Arduino/blob/master/libraries/ESP8266mDNS/examples/LEAmDNS/mDNS_ServiceMonitor/mDNS_ServiceMonitor.ino). That's like 10 more lines of code though and I figure it doesn't matter if we register `elrs_rx-1.local` or `elrs_rx_70039F1D69C6.local`, right?

I feel bad about not doing it the right way and instead being lazy and capturing the instance String, but some days you just don't GAF. If someone wants to do it the right way, just push to my branch directly to fix it.