### PR TITLE
Non-inverted UART fix

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -813,11 +813,12 @@ bool CRSF::UARTwdt()
 void ICACHE_RAM_ATTR CRSF::ESP32uartTask(void *pvParameters)
 {
     DBGLN("ESP32 CRSF UART LISTEN TASK STARTED");
-    CRSF::duplex_set_TX();
+    portDISABLE_INTERRUPTS();
     CRSF::Port.begin(TxToHandsetBauds[UARTcurrentBaudIdx], SERIAL_8N1,
                      GPIO_PIN_RCSIGNAL_RX, GPIO_PIN_RCSIGNAL_TX,
                      false, 500);
     CRSF::duplex_set_RX();
+    portENABLE_INTERRUPTS();
     flush_port_input();
     (void)pvParameters;
     for (;;)


### PR DESCRIPTION
This attempts to fix a bug introduced in #897 where non-inverted uart config resulted in core panic:

```
About to start CRSF task...
ESP32 CRSF UART LISTEN TASK STARTED
Guru Meditation Error: Core  0 panic'ed (Interrupt wdt timeout on CPU0)
Core 0 register dump:
PC      : 0x40083217  PS      : 0x00050034  A0      : 0x40088e64  A1      : 0x3ffbfaa0  
A2      : 0x3ffbded0  A3      : 0x00000000  A4      : 0x00000001  A5      : 0x4008e288  
A6      : 0x00000000  A7      : 0x3ffbda9c  A8      : 0x00000000  A9      : 0x3ff40000  
A10     : 0x00000000  A11     : 0x00000180  A12     : 0x00000000  A13     : 0x3ffb93e0  
A14     : 0x3ffb8000  A15     : 0xbaad5678  SAR     : 0x0000001e  EXCCAUSE: 0x00000005  
EXCVADDR: 0x00000000  LBEG    : 0x400014fd  LEND    : 0x4000150d  LCOUNT  : 0xfffffff7  
Core 0 was running in ISR context:
EPC1    : 0x4000bff0  EPC2    : 0x00000000  EPC3    : 0x00000000  EPC4    : 0x40083217

ELF file SHA256: 0000000000000000

Backtrace: 0x40083217:0x3ffbfaa0 0x40088e61:0x3ffbfad0 0x4000bfed:0x3ffb9430 0x4008cd15:0x3ffb9440 0x4014156a:0x3ffb9460 0x401415c7:0x3ffb94a0 0x400dbb19:0x3ffb94d0 0x400dbbdb:0x3ffb94f0 0x400dc0bd:0x3ffb9510 0x400da325:0x3ffb9550 0x400823e6:0x3ffb9590 0x4008bba2:0x3ffb95c0

Core 1 register dump:
PC      : 0x4000cffd  PS      : 0x00060f34  A0      : 0x80082daa  A1      : 0x3ffb1f30  
A2      : 0x0008c72c  A3      : 0x00000000  A4      : 0x000003e8  A5      : 0x00000000  
A6      : 0x00000020  A7      : 0x3ffb0060  A8      : 0x80086de2  A9      : 0x3ffb1f10  
A10     : 0x00000000  A11     : 0x00000000  A12     : 0x00000050  A13     : 0x00000001  
A14     : 0x00000000  A15     : 0x00000000  SAR     : 0x0000000a  EXCCAUSE: 0x00000005  
EXCVADDR: 0x00000000  LBEG    : 0x4000c2e0  LEND    : 0x4000c2f6  LCOUNT  : 0xffffffff  

ELF file SHA256: 0000000000000000

Backtrace: 0x4000cffd:0x3ffb1f30 0x40082da7:0x3ffb1f50 0x400d253b:0x3ffb1f70 0x400d282f:0x3ffb1f90 0x400dc35d:0x3ffb1fb0 0x4008bba2:0x3ffb1fd0

Rebooting...
```

@pkendall64 could you retest the quick module restart via LUA with this branch?