### PR TITLE
Add Lua power fan threshold

### DIFF
--- a/src/lib/CONFIG/config.h
+++ b/src/lib/CONFIG/config.h
@@ -12,7 +12,7 @@
 #define TX_CONFIG_MAGIC     (0b01 << 30)
 #define RX_CONFIG_MAGIC     (0b10 << 30)
 
-#define TX_CONFIG_VERSION   4
+#define TX_CONFIG_VERSION   5
 #define RX_CONFIG_VERSION   4
 #define UID_LEN             6
 
@@ -35,6 +35,7 @@ typedef struct {
     uint8_t         vtxChannel;
     uint8_t         vtxPower;
     uint8_t         vtxPitmode;
+    uint8_t         powerFanThreshold:4; // Power level to enable fan if present
     model_config_t  model_config[64];
 } tx_config_t;
 
@@ -60,6 +61,7 @@ public:
     uint8_t  GetVtxChannel() const { return m_config.vtxChannel; }
     uint8_t  GetVtxPower() const { return m_config.vtxPower; }
     uint8_t  GetVtxPitmode() const { return m_config.vtxPitmode; }
+    uint8_t GetPowerFanThreshold() const { return m_config.powerFanThreshold; }
 
     // Setters
     void SetRate(uint8_t rate);
@@ -77,13 +79,14 @@ public:
     void SetVtxChannel(uint8_t vtxChannel);
     void SetVtxPower(uint8_t vtxPower);
     void SetVtxPitmode(uint8_t vtxPitmode);
+    void SetPowerFanThreshold(uint8_t powerFanThreshold);
 
     // State setters
     bool SetModelId(uint8_t modelId);
 
 private:
     bool UpgradeEepromV1ToV4();
-    
+
     tx_config_t m_config;
     ELRS_EEPROM *m_eeprom;
     uint8_t     m_modified;

--- a/src/lib/LUA/devLUA.cpp
+++ b/src/lib/LUA/devLUA.cpp
@@ -62,6 +62,16 @@ static struct luaItem_selection luaDynamicPower = {
     "Off;On;AUX9;AUX10;AUX11;AUX12",
     emptySpace
 };
+
+#if defined(GPIO_PIN_FAN_EN)
+static struct luaItem_selection luaFanThreshold = {
+    {"Fan Thresh", CRSF_TEXT_SELECTION},
+    0, // value
+    "10mW;25mW;50mW;100mW;250mW;500mW;1000mW;2000mW;Never",
+    emptySpace // units embedded so it won't display "NevermW"
+};
+#endif
+
 //----------------------------POWER------------------
 
 static struct luaItem_selection luaSwitch = {
@@ -293,6 +303,13 @@ static void registerLuaParameters()
       config.SetDynamicPower(arg > 0);
       config.SetBoostChannel((arg - 1) > 0 ? arg - 1 : 0);
   }, luaPowerFolder.common.id);
+#if defined(GPIO_PIN_FAN_EN)
+  registerLUAParameter(&luaFanThreshold, [](uint8_t id, uint8_t arg){
+      config.SetPowerFanThreshold(arg);
+      POWERMGNT::setFanEnableTheshold((PowerLevels_e)arg);
+  }, luaPowerFolder.common.id);
+#endif
+  // VTX folder
   registerLUAParameter(&luaVtxFolder);
   registerLUAParameter(&luaVtxBand, [](uint8_t id, uint8_t arg){
       config.SetVtxBand(arg);
@@ -417,6 +434,7 @@ static int event()
   setLuaTextSelectionValue(&luaSwitch,(uint8_t)(config.GetSwitchMode() - 1)); // -1 for missing sm1Bit
   setLuaTextSelectionValue(&luaModelMatch,(uint8_t)config.GetModelMatch());
   setLuaTextSelectionValue(&luaPower, config.GetPower() - MinPower);
+  setLuaTextSelectionValue(&luaFanThreshold, config.GetPowerFanThreshold());
 
   uint8_t dynamic = config.GetDynamicPower() ? config.GetBoostChannel() + 1 : 0;
   setLuaTextSelectionValue(&luaDynamicPower,dynamic);

--- a/src/lib/LUA/devLUA.cpp
+++ b/src/lib/LUA/devLUA.cpp
@@ -434,7 +434,9 @@ static int event()
   setLuaTextSelectionValue(&luaSwitch,(uint8_t)(config.GetSwitchMode() - 1)); // -1 for missing sm1Bit
   setLuaTextSelectionValue(&luaModelMatch,(uint8_t)config.GetModelMatch());
   setLuaTextSelectionValue(&luaPower, config.GetPower() - MinPower);
+#if defined(GPIO_PIN_FAN_EN)
   setLuaTextSelectionValue(&luaFanThreshold, config.GetPowerFanThreshold());
+#endif
 
   uint8_t dynamic = config.GetDynamicPower() ? config.GetBoostChannel() + 1 : 0;
   setLuaTextSelectionValue(&luaDynamicPower,dynamic);

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -102,7 +102,7 @@ void POWERMGNT::init()
     analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095 2.7V
     analogWrite(GPIO_PIN_RFamp_APC2, 950);
 #endif
-#if defined(GPIO_PIN_FAN_EN) && (GPIO_PIN_FAN_EN != UNDEF_PIN)
+#if defined(GPIO_PIN_FAN_EN)
     pinMode(GPIO_PIN_FAN_EN, OUTPUT);
 #endif
     setDefaultPower();
@@ -128,14 +128,14 @@ void POWERMGNT::setDefaultPower()
 
 void POWERMGNT::updateFan()
 {
-#ifdef GPIO_PIN_FAN_EN
+#if defined(GPIO_PIN_FAN_EN)
     digitalWrite(GPIO_PIN_FAN_EN, (CurrentPower >= FanEnableThreshold) ? HIGH : LOW);
 #endif
 }
 
 void POWERMGNT::setFanEnableTheshold(PowerLevels_e Power)
 {
-#ifdef GPIO_PIN_FAN_EN
+#if defined(GPIO_PIN_FAN_EN)
     FanEnableThreshold = Power;
     updateFan();
 #endif

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -37,6 +37,7 @@ extern SX1280Driver Radio;
 #endif
 
 PowerLevels_e POWERMGNT::CurrentPower = PWR_COUNT; // default "undefined" initial value
+PowerLevels_e POWERMGNT::FanEnableThreshold = PWR_250mW;
 #if defined(POWER_OUTPUT_VALUES)
 static int16_t powerValues[] = POWER_OUTPUT_VALUES;
 #endif
@@ -125,10 +126,25 @@ void POWERMGNT::setDefaultPower()
     setPower(getDefaultPower());
 }
 
-PowerLevels_e POWERMGNT::setPower(PowerLevels_e Power)
+void POWERMGNT::updateFan()
+{
+#ifdef GPIO_PIN_FAN_EN
+    digitalWrite(GPIO_PIN_FAN_EN, (CurrentPower >= FanEnableThreshold) ? HIGH : LOW);
+#endif
+}
+
+void POWERMGNT::setFanEnableTheshold(PowerLevels_e Power)
+{
+#ifdef GPIO_PIN_FAN_EN
+    FanEnableThreshold = Power;
+    updateFan();
+#endif
+}
+
+void POWERMGNT::setPower(PowerLevels_e Power)
 {
     if (Power == CurrentPower)
-        return CurrentPower;
+        return;
 
     if (Power < MinPower)
     {
@@ -138,10 +154,6 @@ PowerLevels_e POWERMGNT::setPower(PowerLevels_e Power)
     {
         Power = MaxPower;
     }
-
-#ifdef GPIO_PIN_FAN_EN
-    digitalWrite(GPIO_PIN_FAN_EN, (Power >= PWR_250mW) ? HIGH : LOW);
-#endif
 
 #if defined(POWER_OUTPUT_DAC)
     // DAC is used e.g. for R9M, ES915TX and Voyager
@@ -166,5 +178,5 @@ PowerLevels_e POWERMGNT::setPower(PowerLevels_e Power)
 #error "[ERROR] Unknown power management!"
 #endif
     CurrentPower = Power;
-    return Power;
+    updateFan();
 }

--- a/src/lib/POWERMGNT/POWERMGNT.h
+++ b/src/lib/POWERMGNT/POWERMGNT.h
@@ -38,14 +38,17 @@ class POWERMGNT
 
 private:
     static PowerLevels_e CurrentPower;
+    static PowerLevels_e FanEnableThreshold;
+    static void updateFan();
 
 public:
-    static PowerLevels_e setPower(PowerLevels_e Power);
+    static void setPower(PowerLevels_e Power);
     static PowerLevels_e incPower();
     static PowerLevels_e decPower();
     static PowerLevels_e currPower();
     static uint8_t powerToCrsfPower(PowerLevels_e Power);
     static PowerLevels_e getDefaultPower();
     static void setDefaultPower();
+    static void setFanEnableTheshold(PowerLevels_e Power);
     static void init();
 };

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -933,6 +933,7 @@ void setup()
     TelemetryReceiver.SetDataToReceive(sizeof(CRSFinBuffer), CRSFinBuffer, ELRS_TELEMETRY_BYTES_PER_CALL);
 
     POWERMGNT.init();
+    POWERMGNT.setFanEnableTheshold((PowerLevels_e)config.GetPowerFanThreshold());
 
     // Set the pkt rate, TLM ratio, and power from the stored eeprom values
     ChangeRadioParams();


### PR DESCRIPTION
Adds a Lua config item for configuring when the fan turns on, from 10mW to Never. Fixes #1024 and #931.

* Updates TX config version to 5
* Update log messages that used "version 4" directly in them
* Remove return value from `POWERMGMT::setPower()` since this is never used and just adds code.

Side note: My Q X7 lua runs out of memory and crashes 100% of the time I set anything with it now.