### PR TITLE
Don't touch Radio during timerCallbackIdle (master)

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -505,7 +505,8 @@ void ICACHE_RAM_ATTR timerCallbackNormal()
 void ICACHE_RAM_ATTR timerCallbackIdle()
 {
   NonceTX++;
-  HandleFHSS();
+  if ((NonceTX + 1) % ExpressLRS_currAirRate_Modparams->FHSShopInterval == 0)
+    ++FHSSptr;
 }
 
 void UARTdisconnected()
@@ -556,7 +557,9 @@ static void ConfigChangeCommit()
 
   // Write the uncommitted eeprom values
   config.Commit();
-  hwTimer.callbackTock = &timerCallbackNormal; // Resume the timer
+  // Resume the timer, will take one hop for the radio to be on the right frequency
+  // if we missed a hop
+  hwTimer.callbackTock = &timerCallbackNormal;
   devicesTriggerEvent();
 }
 


### PR DESCRIPTION
This is a port of #1007 to master, which according to @pkendall64:
> tl;dr this will probably happen on master too, just way less frequently.

Because guess what?
```
stack:
0:
  0x400816a8: HandleFHSS() at C:\Users\bmayland\Documents\GitHub Projects\ExpressLRS\src/src/tx_main.cpp:1037
  \-> inlined by: HandleFHSS() at C:\Users\bmayland\Documents\GitHub Projects\ExpressLRS\src/src/tx_main.cpp:373
0:
  0x400816f3: timerCallbackIdle() at C:\Users\bmayland\Documents\GitHub Projects\ExpressLRS\src/src/tx_main.cpp:1037
0:
  0x40082c69: hwTimer::callback() at C:\Users\bmayland\Documents\GitHub Projects\ExpressLRS\src/lib\HWTIMER/ESP32_hwTimer.cpp:21
0:
  0x400830b5: __timerISR at C:\Users\bmayland\.platformio\packages\framework-arduinoespressif32\cores\esp32/esp32-hal-timer.c:174
0:
  0x4008f8c5: _xt_lowint1 at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/xtensa_vectors.S:1154
0:
  [DATA (0x0x4006222d)]
0:
  0x400981ab: esp_rom_spiflash_read_status at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/spi_flash/spi_flash_rom_patch.c:662
0:
  0x400981e6: esp_rom_spiflash_wait_idle at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/spi_flash/spi_flash_rom_patch.c:662
0:
  0x4009858e: esp_rom_spiflash_write_status at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/spi_flash/spi_flash_rom_patch.c:662
0:
  0x400985fb: esp_rom_spiflash_unlock at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/spi_flash/spi_flash_rom_patch.c:662
0:
  0x400902f8: spi_flash_unlock at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/spi_flash/flash_ops.c:155
0:
  0x400904b3: spi_flash_write at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/spi_flash/flash_ops.c:381
0:
  0x4010c2a1: nvs::nvs_flash_write(unsigned int, void const*, unsigned int) at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/nvs_flash/src/nvs_ops.cpp:72
0:
  0x4010a6fa: nvs::Page::writeEntry(nvs::Item const&) at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/nvs_flash/src/nvs_page.cpp:871
0:
  0x4010aa32: nvs::Page::writeItem(unsigned char, nvs::ItemType, char const*, void const*, unsigned int, unsigned char) at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/nvs_flash/src/nvs_page.cpp:871
0:
  0x4010a0a6: nvs::Storage::writeItem(unsigned char, nvs::ItemType, char const*, void const*, unsigned int) at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/nvs_flash/src/nvs_storage.cpp:579
0:
  0x40108b8f: int nvs::Storage::writeItem<unsigned int>(unsigned char, char const*, unsigned int const&) at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/nvs_flash/src/nvs_api.cpp:512
  \-> inlined by: nvs_set<unsigned int> at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/nvs_flash/src/nvs_api.cpp:385
0:
  0x4010930d: nvs_set_u32 at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/nvs_flash/src/nvs_api.cpp:512
0:
  0x400d2ed7: TxConfig::Commit() at C:\Users\bmayland\Documents\GitHub Projects\ExpressLRS\src/lib/CONFIG/config.cpp:111
0:
  0x400d210e: loop() at C:\Users\bmayland\Documents\GitHub Projects\ExpressLRS\src/src/tx_main.cpp:558
  \-> inlined by: CheckConfigChangePending at C:\Users\bmayland\Documents\GitHub Projects\ExpressLRS\src/src/tx_main.cpp:592
  \-> inlined by: loop() at C:\Users\bmayland\Documents\GitHub Projects\ExpressLRS\src/src/tx_main.cpp:979
0:
  0x400d8b79: loopTask(void*) at C:\Users\bmayland\.platformio\packages\framework-arduinoespressif32\cores\esp32/main.cpp:23
0:
  0x40092c6a: vPortTaskWrapper at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/port.c:355 (discriminator 1)
```

I had considered doing a better version of this for master where the radio is updated at the end of the commit with the new frequency, so it doesn't have to wait for the next hop, but I guess that will be in 2.1 because who has time to fully test the code that would do that. This just matches 1.x's code exactly.