### PR TITLE
Force binding at 50Hz

### DIFF
--- a/src/include/common.h
+++ b/src/include/common.h
@@ -105,6 +105,7 @@ typedef struct expresslrs_rf_pref_params_s
 #if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
 #define RATE_MAX 4
 #define RATE_DEFAULT 0
+#define RATE_BINDING 2 // 50Hz bind mode
 typedef struct expresslrs_mod_settings_s
 {
     int8_t index;
@@ -124,6 +125,7 @@ typedef struct expresslrs_mod_settings_s
 #if defined(Regulatory_Domain_ISM_2400)
 #define RATE_MAX 4
 #define RATE_DEFAULT 0
+#define RATE_BINDING 3 // 50Hz bind mode
 typedef struct expresslrs_mod_settings_s
 {
     int8_t index;

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -722,8 +722,13 @@ static int timeout()
   if (!webserverPreventAutoStart && (connectionState == disconnected))
   {
     static bool pastAutoInterval = false;
+    // If InBindingMode then wait at least 60 seconds before going into wifi,
+    // regardless of if AUTO_WIFI_ON_INTERVAL is set to less
     if (!InBindingMode || AUTO_WIFI_ON_INTERVAL >= 60 || pastAutoInterval)
     {
+      // No need to ExitBindingMode(), the radio is about to be stopped. Need
+      // to change this before the mode change event so the LED is updated
+      InBindingMode = false;
       connectionState = wifiUpdate;
       return DURATION_IMMEDIATELY;
     }

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -76,7 +76,7 @@ extern bool webserverPreventAutoStart;
 #endif
 
 #if defined(GPIO_PIN_PWM_OUTPUTS)
-#include <Servo.h> 
+#include <Servo.h>
 static constexpr uint8_t SERVO_PINS[] = GPIO_PIN_PWM_OUTPUTS;
 static constexpr uint8_t SERVO_COUNT = ARRAY_SIZE(SERVO_PINS);
 static Servo *Servos[SERVO_COUNT];
@@ -670,6 +670,14 @@ static void ICACHE_RAM_ATTR MspReceiveComplete()
 
 static void ICACHE_RAM_ATTR ProcessRfPacket_MSP()
 {
+    // Always examine MSP packets for bind information if in bind mode
+    // [1] is the package index, first packet of the MSP
+    if (InBindingMode && Radio.RXdataBuffer[1] == 1 && Radio.RXdataBuffer[2] == MSP_ELRS_BIND)
+    {
+        OnELRSBindMSP((uint8_t *)&Radio.RXdataBuffer[2]);
+        return;
+    }
+
     // Must be fully connected to process MSP, prevents processing MSP
     // during sync, where packets can be received before connection
     if (connectionState != connected)
@@ -681,13 +689,7 @@ static void ICACHE_RAM_ATTR ProcessRfPacket_MSP()
     {
         NextTelemetryType = ELRS_TELEMETRY_TYPE_LINK;
     }
-
-    if (Radio.RXdataBuffer[1] == 1 && MspData[0] == MSP_ELRS_BIND)
-    {
-        OnELRSBindMSP(MspData);
-        MspReceiver.ResetState();
-    }
-    else if (MspReceiver.HasFinishedData())
+    if (MspReceiver.HasFinishedData())
     {
         MspReceiveComplete();
     }
@@ -753,8 +755,8 @@ void ICACHE_RAM_ATTR ProcessRFPacket()
     uint16_t inCRC = (((uint16_t)(Radio.RXdataBuffer[0] & 0b11111100)) << 6) | Radio.RXdataBuffer[7];
 
     // For smHybrid the CRC only has the packet type in byte 0
-    // For smHybridWide the FHSS slot is added to the CRC in byte 0 except on SYNC packets
-    if (type == SYNC_PACKET || OtaSwitchModeCurrent != smHybridWide)
+    // For smHybridWide the FHSS slot is added to the CRC in byte 0 on RC_DATA_PACKETs
+    if (type != RC_DATA_PACKET || OtaSwitchModeCurrent != smHybridWide)
     {
         Radio.RXdataBuffer[0] = type;
     }
@@ -797,7 +799,7 @@ void ICACHE_RAM_ATTR ProcessRFPacket()
         // not implimented yet
         break;
     case SYNC_PACKET: //sync packet from master
-        doStartTimer = ProcessRfPacket_SYNC(now);
+        doStartTimer = ProcessRfPacket_SYNC(now) && !InBindingMode;
         break;
     default: // code to be executed if n doesn't match any cases
         break;
@@ -1072,7 +1074,7 @@ static void servosUpdate(unsigned long now)
 
             if (Servos[ch])
                 Servos[ch]->writeMicroseconds(us);
-            else if (us >= 988U && us <= 2012U) 
+            else if (us >= 988U && us <= 2012U)
             {
                 // us might be out of bounds if this is a switch channel and it has not been
                 // received yet. Delay initializing the servo until the channel is valid
@@ -1101,6 +1103,34 @@ static void servosUpdate(unsigned long now)
     // need to sample actual millis at the end to account for any
     // waiting that happened in Servo::writeMicroseconds()
     lastUpdate = millis();
+#endif
+}
+
+static void updateBindingMode()
+{
+    // If the eeprom is indicating that we're not bound
+    // and we're not already in binding mode, enter binding
+    if (!config.GetIsBound() && !InBindingMode)
+    {
+        INFOLN("RX has not been bound, enter binding mode...");
+        EnterBindingMode();
+    }
+    // If in binding mode and the bind packet has come in, leave binding mode
+    else if (config.GetIsBound() && InBindingMode)
+    {
+        ExitBindingMode();
+    }
+
+#ifndef MY_UID
+    // If the power on counter is >=3, enter binding and clear counter
+    if (config.GetPowerOnCounter() >= 3)
+    {
+        config.SetPowerOnCounter(0);
+        config.Commit();
+
+        INFOLN("Power on counter >=3, enter binding mode...");
+        EnterBindingMode();
+    }
 #endif
 }
 
@@ -1230,26 +1260,6 @@ void loop()
         DBGLN("Timer locked");
     }
 
-    // If the eeprom is indicating that we're not bound
-    // and we're not already in binding mode, enter binding
-    if (!config.GetIsBound() && !InBindingMode)
-    {
-        INFOLN("RX has not been bound, enter binding mode...");
-        EnterBindingMode();
-    }
-
-    // If the power on counter is >=3, enter binding and clear counter
-#ifndef MY_UID
-    if (config.GetPowerOnCounter() >= 3)
-    {
-        config.SetPowerOnCounter(0);
-        config.Commit();
-
-        INFOLN("Power on counter >=3, enter binding mode...");
-        EnterBindingMode();
-    }
-#endif
-
     uint8_t *nextPayload = 0;
     uint8_t nextPlayloadSize = 0;
     if (!TelemetrySender.IsActive() && telemetry.GetNextPayload(&nextPlayloadSize, &nextPayload))
@@ -1257,6 +1267,7 @@ void loop()
         TelemetrySender.SetDataToTransmit(nextPlayloadSize, nextPayload, ELRS_TELEMETRY_BYTES_PER_CALL);
     }
     updateTelemetryBurst();
+    updateBindingMode();
 }
 
 struct bootloader {
@@ -1310,11 +1321,12 @@ void EnterBindingMode()
     UID[5] = BindingUID[5];
 
     CRCInitializer = 0;
+    config.SetIsBound(false);
     InBindingMode = true;
 
     // Start attempting to bind
     // Lock the RF rate and freq while binding
-    SetRFLinkRate(RATE_DEFAULT);
+    SetRFLinkRate(RATE_BINDING);
     Radio.SetFrequencyReg(GetInitialFreq());
     // If the Radio Params (including InvertIQ) parameter changed, need to restart RX to take effect
     Radio.RXnb();
@@ -1325,13 +1337,25 @@ void EnterBindingMode()
 
 void ExitBindingMode()
 {
-    if (!InBindingMode) {
+    if (!InBindingMode)
+    {
         // Not in binding mode
         DBGLN("Cannot exit binding mode, not in binding mode!");
         return;
     }
 
+    // Prevent any new packets from coming in
+    Radio.SetTxIdleMode();
     LostConnection();
+    // Write the values to eeprom
+    config.Commit();
+
+    CRCInitializer = (UID[4] << 8) | UID[5];
+    FHSSrandomiseFHSSsequence(uidMacSeedGet());
+
+    #if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
+    webserverPreventAutoStart = true;
+    #endif
 
     // Force RF cycling to start at the beginning immediately
     scanIndex = RATE_MAX;
@@ -1340,17 +1364,16 @@ void ExitBindingMode()
     // Do this last as LostConnection() will wait for a tock that never comes
     // if we're in binding mode
     InBindingMode = false;
+    DBGLN("Exiting binding mode");
     devicesTriggerEvent();
 }
 
-void OnELRSBindMSP(uint8_t* packet)
+void ICACHE_RAM_ATTR OnELRSBindMSP(uint8_t* packet)
 {
     for (int i = 1; i <=4; i++)
     {
         UID[i + 1] = packet[i];
     }
-
-    CRCInitializer = (UID[4] << 8) | UID[5];
 
     DBGLN("New UID = %d, %d, %d, %d, %d, %d", UID[0], UID[1], UID[2], UID[3], UID[4], UID[5]);
 
@@ -1360,15 +1383,7 @@ void OnELRSBindMSP(uint8_t* packet)
     // Set eeprom byte to indicate RX is bound
     config.SetIsBound(true);
 
-    // Write the values to eeprom
-    config.Commit();
-
-    FHSSrandomiseFHSSsequence(uidMacSeedGet());
-
-    #if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
-    webserverPreventAutoStart = true;
-    #endif
-    ExitBindingMode();
+    // EEPROM commit will happen on the main thread in ExitBindingMode()
 }
 
 void UpdateModelMatch(uint8_t model)

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1196,7 +1196,6 @@ void loop()
     }
 
     devicesUpdate(now);
-    servosUpdate(now);
 
     #if defined(PLATFORM_ESP8266) && defined(AUTO_WIFI_ON_INTERVAL)
     // If the reboot time is set and the current time is past the reboot time then reboot.
@@ -1205,7 +1204,7 @@ void loop()
     }
     #endif
 
-    if (connectionState > FAILURE_STATES)
+    if (connectionState > MODE_STATES)
     {
         return;
     }
@@ -1228,6 +1227,7 @@ void loop()
     }
 
     cycleRfMode(now);
+    servosUpdate(now);
 
     uint32_t localLastValidPacket = LastValidPacket; // Required to prevent race condition due to LastValidPacket getting updated from ISR
     if ((connectionState == disconnectPending) ||


### PR DESCRIPTION
This PR fixes a slew of problem relating to traditional bind mode. Fixes #976

### Details
* Main issue: Binding was always done at the highest packet rate. Because 115200 baud can't do 500Hz (250Hz max), the transmitter can't switch to this rate, so binding can not happen. Resolution: changed all binding to happen at 50Hz which is achievable on all hardware and has plenty of slack in the half-duplex serial to fit any Lua packets in.
* MSP packets were only processed if in "connected" state. That meant the receiver would have to go through Sync -> Multiple Packets receiver (to meet the min connected threshold) -> Connected, THEN process MSP to receive the bind packet. Resolution: will now inspect MSP packets for bind information if InBindingMode.
* If set to wide switch mode MSP packets include the Nonce in the CRC, which meant that the receiver had to properly sync before it could process decode an MSP packet. Resolution: Only do this on RC_DATA_PACKET type packet (was only !SYNC packets).
* Receiver would LockOnFirstConnection at the binding packet rate and would need a reboot after binding to go back to cycling. Resolution: Do not allow the receiver to reach Connected state to lock.
* Transmitter would get stuck InBindingMode if the receiver would ACK the MSP packet before it was transmitted 6x and leave binding mode. Resolution: Again, preventing the receiver from connecting prevents telemetry which avoids acking the packet so the transmitter will send 6x and exit binding mode as it expects.
* When the bind packet was received, the entire processing of it would happen in the interrupt handler, including an EEPROM write. This is just begging for a crash. Resolution: the UID is copied in the interrupt but the commit and return to normal operation (rate cycling) is handled in the main loop.
* The reception of the bind packet would trigger the "slow" rf rate cycle following the bind, which would lead to a really slow initial connect. Resolution: Leaving bind mode from the main loop properly clears the slow rate flag, but to be sure I also put the Radio into idle mode when exiting bind.
* The receiver wasn't properly indicating when it went to wifi mode due to the InBindingMode flag being set still. Resolution: clear the flag when entering wifi mode, and do not execute most of `loop()` in wifi mode to prevent it from going back into binding mode

### How is binding mode supposed to work?
I questioned as I was working on this, how is it _supposed_ to work? Should the TX send sync packets? Should the RX send telemetry? A jedi knows not the answers to these questions. I've therefore coded in the following:
* The FHSS MUST be set to the sync channel. (existing)
* The transmitter MUST always send all 6 bind packets at 50Hz before returning to normal operation.
* The transmitter MUST NOT send any sync packets. A sync packet starts a new connection on the RX and this should be avoided.
* The Nonce should NOT advance in bind mode.
* The receiver should NOT send telemetry, nor should the TX listen for telemetry.
* The transmitter MAY send a channels packets between bind packets in a 1:1 split. The receiver shouldn't care and I didn't want to add code to make it not.

### Tested
* FM30 TX (stm32) on 50hz and 250hz with FR Mini RX (stm32) and EP2 (esp) with traditional binding. 
* Namimno OLED (esp32) on 150hz with FR Mini
* Will fully test with bind phrase on Saturday to make sure there are no regressions