### PR TITLE
fix DIY_2400_TX_ESP32_SX1280_E28 pin conflict

### DIFF
--- a/src/include/target/DIY_2400_TX_ESP32_SX1280_E28.h
+++ b/src/include/target/DIY_2400_TX_ESP32_SX1280_E28.h
@@ -15,9 +15,9 @@
 #define GPIO_PIN_RST            14
 #define GPIO_PIN_RX_ENABLE      27
 #define GPIO_PIN_TX_ENABLE      26
-#define GPIO_PIN_OLED_CS        15
+#define GPIO_PIN_OLED_CS        2
 #define GPIO_PIN_OLED_RST       16
-#define GPIO_PIN_OLED_DC        17
+#define GPIO_PIN_OLED_DC        22
 #define GPIO_PIN_OLED_MOSI      32
 #define GPIO_PIN_OLED_SCK       33
 #define GPIO_PIN_RCSIGNAL_RX    13


### PR DESCRIPTION
This PR corrects a pin conflict from https://github.com/ExpressLRS/ExpressLRS/pull/1038

@brandonrc @FOG-Yamato are either of you able to test?

![image](https://user-images.githubusercontent.com/14170229/140596138-f0f01f1c-9c99-4239-ab87-97b423d31cbc.png)
