### PR TITLE
adds DIY_BLE_JOYSTICK_via_UART target

### DIFF
--- a/src/platformio.ini
+++ b/src/platformio.ini
@@ -20,6 +20,7 @@ extra_configs =
 	targets/quadkopters_2400.ini
 	targets/diy_900.ini
 	targets/diy_2400.ini
+	targets/diy_ble_joystick.ini
 	targets/MATEK_2400.ini
 
 # ------------------------- TARGET ENV DEFINITIONS -----------------

--- a/src/src/options.cpp
+++ b/src/src/options.cpp
@@ -42,6 +42,9 @@ const char PROGMEM compile_options[] = {
     #ifdef TLM_REPORT_INTERVAL_MS
         "-DTLM_REPORT_INTERVAL_MS=" STR(TLM_REPORT_INTERVAL_MS) " "
     #endif
+    #ifdef USE_BLE_JOYSTICK
+        "-DUSE_BLE_JOYSTICK "
+    #endif
 #endif
 
 #ifdef TARGET_RX

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -927,6 +927,11 @@ void setup()
   //Radio.currSyncWord = UID[3];
   #endif
   bool init_success = Radio.Begin();
+  
+  #if defined(USE_BLE_JOYSTICK)
+    init_success = true; // No radio is attached with a joystick only module.  So we are going to fake success so that crsf, hwTimer etc are initiated below.
+  #endif
+
   if (!init_success)
   {
     connectionState = radioFailed;
@@ -953,6 +958,13 @@ void setup()
 void loop()
 {
   uint32_t now = millis();
+
+  #if defined(PLATFORM_ESP32) && defined(USE_BLE_JOYSTICK)
+  if (connectionState != bleJoystick && connectionState != noCrossfire) // Wait until the correct crsf baud has been found
+  {
+      connectionState = bleJoystick;
+  }
+  #endif
 
   if (connectionState < MODE_STATES)
   {

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -959,7 +959,7 @@ void loop()
 {
   uint32_t now = millis();
 
-  #if defined(PLATFORM_ESP32) && defined(USE_BLE_JOYSTICK)
+  #if defined(USE_BLE_JOYSTICK)
   if (connectionState != bleJoystick && connectionState != noCrossfire) // Wait until the correct crsf baud has been found
   {
       connectionState = bleJoystick;

--- a/src/targets/diy_ble_joystick.ini
+++ b/src/targets/diy_ble_joystick.ini
@@ -1,0 +1,18 @@
+
+# ********************************
+# DIY BLE Joystick target
+# ********************************
+
+[env:DIY_BLE_JOYSTICK_via_UART]
+extends = env_common_esp32, radio_2400
+build_flags =
+    -DUSE_BLE_JOYSTICK
+	${env_common_esp32.build_flags}
+	${common_env_data.build_flags_tx}
+	${radio_2400.build_flags}
+	-include target/DIY_2400_TX_ESP32_SX1280_E28.h
+	-D VTABLES_IN_FLASH=1
+	-O2
+src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+lib_deps = 
+	${env_common_esp32.lib_deps}

--- a/src/targets/diy_ble_joystick.ini
+++ b/src/targets/diy_ble_joystick.ini
@@ -16,3 +16,4 @@ build_flags =
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 lib_deps = 
 	${env_common_esp32.lib_deps}
+	olikraus/U8g2@^2.28.8


### PR DESCRIPTION
If anyone wants to build a simple BLE only target for SIMs this is the target.

This is not necessarily for v2 and can be merged after.