### PR TITLE
Separate commercial targets from DIY_2400_TX_ESP32_SX1280_E28

### DIFF
--- a/src/include/target/DIY_2400_TX_ESP32_SX1280_E28.h
+++ b/src/include/target/DIY_2400_TX_ESP32_SX1280_E28.h
@@ -1,9 +1,8 @@
-#if !defined(DEVICE_NAME)
-    #define DEVICE_NAME "DIY2400 E28"
-#endif
+#define DEVICE_NAME "DIY2400 E28"
 
 // Any device features
 #define USE_OLED_SPI
+#define USE_SX1280_DCDC
 
 // GPIO pin definitions
 #define GPIO_PIN_NSS            5
@@ -26,14 +25,8 @@
 #define GPIO_PIN_FAN_EN         17
 
 // Output Power
-#if !defined(MinPower)
-    #define MinPower            PWR_10mW
-#endif
-#if !defined(MaxPower)
-    #define MaxPower            PWR_250mW
-#endif
-#if !defined(POWER_OUTPUT_VALUES)
-    #define POWER_OUTPUT_VALUES {-15,-11,-8,-5,-1}
-#endif
+#define MinPower            PWR_10mW
+#define MaxPower            PWR_250mW
+#define POWER_OUTPUT_VALUES {-15,-11,-8,-5,-1}
 
 #define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/HGLRC_Hermes_2400_TX.h
+++ b/src/include/target/HGLRC_Hermes_2400_TX.h
@@ -1,5 +1,6 @@
 #define DEVICE_NAME "HGLRC Hermes 24"
 
+// Any device features
 #define USE_SX1280_DCDC
 
 // GPIO pin definitions

--- a/src/include/target/HGLRC_Hermes_2400_TX.h
+++ b/src/include/target/HGLRC_Hermes_2400_TX.h
@@ -1,8 +1,23 @@
 #define DEVICE_NAME "HGLRC Hermes 24"
 
+#define USE_SX1280_DCDC
+
+// GPIO pin definitions
+#define GPIO_PIN_NSS            5
+#define GPIO_PIN_BUSY           21
+#define GPIO_PIN_DIO1           4
+#define GPIO_PIN_MOSI           23
+#define GPIO_PIN_MISO           19
+#define GPIO_PIN_SCK            18
+#define GPIO_PIN_RST            14
+#define GPIO_PIN_RX_ENABLE      27
+#define GPIO_PIN_TX_ENABLE      26
+#define GPIO_PIN_RCSIGNAL_RX    13
+#define GPIO_PIN_RCSIGNAL_TX    13
+
 // Output Power
 #define MinPower PWR_10mW
 #define MaxPower PWR_250mW
 #define POWER_OUTPUT_VALUES {-18,-15,-11,-8,-4}
 
-#include "target/DIY_2400_TX_ESP32_SX1280_E28.h"
+#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/HappyModel_ES24TX_2400_TX.h
+++ b/src/include/target/HappyModel_ES24TX_2400_TX.h
@@ -3,9 +3,24 @@
 #define USE_TX_BACKPACK
 #define USE_SX1280_DCDC
 
+// GPIO pin definitions
+#define GPIO_PIN_NSS            5
+#define GPIO_PIN_BUSY           21
+#define GPIO_PIN_DIO1           4
+#define GPIO_PIN_MOSI           23
+#define GPIO_PIN_MISO           19
+#define GPIO_PIN_SCK            18
+#define GPIO_PIN_RST            14
+#define GPIO_PIN_RX_ENABLE      27
+#define GPIO_PIN_TX_ENABLE      26
+#define GPIO_PIN_RCSIGNAL_RX    13
+#define GPIO_PIN_RCSIGNAL_TX    13
+#define GPIO_PIN_LED_WS2812     15
+#define GPIO_PIN_FAN_EN         17
+
 // Output Power
 #define MinPower PWR_10mW
 #define MaxPower PWR_250mW
 #define POWER_OUTPUT_VALUES {-17,-13,-9,-6,-2}
 
-#include "target/DIY_2400_TX_ESP32_SX1280_E28.h"
+#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/HappyModel_ES24TX_2400_TX.h
+++ b/src/include/target/HappyModel_ES24TX_2400_TX.h
@@ -1,5 +1,6 @@
 #define DEVICE_NAME "HM ES24TX"
 
+// Any device features
 #define USE_TX_BACKPACK
 #define USE_SX1280_DCDC
 

--- a/src/include/target/HappyModel_ES24TX_Pro_Series_2400_TX.h
+++ b/src/include/target/HappyModel_ES24TX_Pro_Series_2400_TX.h
@@ -1,5 +1,6 @@
 #define DEVICE_NAME "ES24TX Pro Ser"
 
+// Any device features
 #define USE_TX_BACKPACK
 #define USE_SX1280_DCDC
 

--- a/src/include/target/HappyModel_ES24TX_Pro_Series_2400_TX.h
+++ b/src/include/target/HappyModel_ES24TX_Pro_Series_2400_TX.h
@@ -1,10 +1,26 @@
 #define DEVICE_NAME "ES24TX Pro Ser"
 
 #define USE_TX_BACKPACK
+#define USE_SX1280_DCDC
+
+// GPIO pin definitions
+#define GPIO_PIN_NSS            5
+#define GPIO_PIN_BUSY           21
+#define GPIO_PIN_DIO1           4
+#define GPIO_PIN_MOSI           23
+#define GPIO_PIN_MISO           19
+#define GPIO_PIN_SCK            18
+#define GPIO_PIN_RST            14
+#define GPIO_PIN_RX_ENABLE      27
+#define GPIO_PIN_TX_ENABLE      26
+#define GPIO_PIN_RCSIGNAL_RX    13
+#define GPIO_PIN_RCSIGNAL_TX    13
+#define GPIO_PIN_LED_WS2812     15
+#define GPIO_PIN_FAN_EN         17
 
 // Output Power
 #define MinPower PWR_25mW
 #define MaxPower PWR_1000mW
 #define POWER_OUTPUT_VALUES {-18,-15,-12,-7,-4,2}
 
-#include "target/DIY_2400_TX_ESP32_SX1280_E28.h"
+#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/QuadKopters_JR_2400_TX.h
+++ b/src/include/target/QuadKopters_JR_2400_TX.h
@@ -1,5 +1,6 @@
 #define DEVICE_NAME "QuadKopters 24"
 
+// Any device features
 #define USE_TX_BACKPACK
 
 // GPIO pin definitions

--- a/src/include/target/QuadKopters_JR_2400_TX.h
+++ b/src/include/target/QuadKopters_JR_2400_TX.h
@@ -1,8 +1,24 @@
 #define DEVICE_NAME "QuadKopters 24"
 
+#define USE_TX_BACKPACK
+
+// GPIO pin definitions
+#define GPIO_PIN_NSS            5
+#define GPIO_PIN_BUSY           21
+#define GPIO_PIN_DIO1           4
+#define GPIO_PIN_MOSI           23
+#define GPIO_PIN_MISO           19
+#define GPIO_PIN_SCK            18
+#define GPIO_PIN_RST            14
+#define GPIO_PIN_RX_ENABLE      27
+#define GPIO_PIN_TX_ENABLE      26
+#define GPIO_PIN_RCSIGNAL_RX    13
+#define GPIO_PIN_RCSIGNAL_TX    13
+#define GPIO_PIN_LED_WS2812     15
+
 // Output Power
 #define MinPower PWR_10mW
 #define MaxPower PWR_250mW
 #define POWER_OUTPUT_VALUES {-15,-11,-8,-5,0}
 
-#include "target/DIY_2400_TX_ESP32_SX1280_E28.h"
+#define Regulatory_Domain_ISM_2400 1

--- a/src/targets/HGLRC_2400.ini
+++ b/src/targets/HGLRC_2400.ini
@@ -4,10 +4,17 @@
 # ********************************
 
 [env:HGLRC_Hermes_2400_TX_via_UART]
-extends = env:DIY_2400_TX_ESP32_SX1280_E28_via_UART
+extends = env_common_esp32, radio_2400
 build_flags =
+	${env_common_esp32.build_flags}
+	${common_env_data.build_flags_tx}
+	${radio_2400.build_flags}
 	-include target/HGLRC_Hermes_2400_TX.h
-	${env:DIY_2400_TX_ESP32_SX1280_E28_via_UART.build_flags}
+	-D VTABLES_IN_FLASH=1
+	-O2
+src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+lib_deps = 
+	${env_common_esp32.lib_deps}
 
 [env:HGLRC_Hermes_2400_TX_via_WIFI]
 extends = env:HGLRC_Hermes_2400_TX_via_UART

--- a/src/targets/happymodel_2400.ini
+++ b/src/targets/happymodel_2400.ini
@@ -4,19 +4,33 @@
 # ********************************
 
 [env:HappyModel_ES24TX_2400_TX_via_UART]
-extends = env:DIY_2400_TX_ESP32_SX1280_E28_via_UART
+extends = env_common_esp32, radio_2400
 build_flags =
+	${env_common_esp32.build_flags}
+	${common_env_data.build_flags_tx}
+	${radio_2400.build_flags}
 	-include target/HappyModel_ES24TX_2400_TX.h
-	${env:DIY_2400_TX_ESP32_SX1280_E28_via_UART.build_flags}
+	-D VTABLES_IN_FLASH=1
+	-O2
+src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+lib_deps = 
+	${env_common_esp32.lib_deps}
 
 [env:HappyModel_ES24TX_2400_TX_via_WIFI]
 extends = env:HappyModel_ES24TX_2400_TX_via_UART
 
 [env:HappyModel_ES24TX_Pro_Series_2400_TX_via_UART]
-extends = env:DIY_2400_TX_ESP32_SX1280_E28_via_UART
+extends = env_common_esp32, radio_2400
 build_flags =
+	${env_common_esp32.build_flags}
+	${common_env_data.build_flags_tx}
+	${radio_2400.build_flags}
 	-include target/HappyModel_ES24TX_Pro_Series_2400_TX.h
-	${env:DIY_2400_TX_ESP32_SX1280_E28_via_UART.build_flags}
+	-D VTABLES_IN_FLASH=1
+	-O2
+src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+lib_deps = 
+	${env_common_esp32.lib_deps}
 
 [env:HappyModel_ES24TX_Pro_Series_2400_TX_via_WIFI]
 extends = env:HappyModel_ES24TX_Pro_Series_2400_TX_via_UART

--- a/src/targets/quadkopters_2400.ini
+++ b/src/targets/quadkopters_2400.ini
@@ -4,10 +4,17 @@
 # ********************************
 
 [env:QuadKopters_JR_2400_TX_via_UART]
-extends = env:DIY_2400_TX_ESP32_SX1280_E28_via_UART
+extends = env_common_esp32, radio_2400
 build_flags =
+	${env_common_esp32.build_flags}
+	${common_env_data.build_flags_tx}
+	${radio_2400.build_flags}
 	-include target/QuadKopters_JR_2400_TX.h
-	${env:DIY_2400_TX_ESP32_SX1280_E28_via_UART.build_flags}
+	-D VTABLES_IN_FLASH=1
+	-O2
+src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+lib_deps = 
+	${env_common_esp32.lib_deps}
 
 [env:QuadKopters_JR_2400_TX_via_WIFI]
 extends = env:QuadKopters_JR_2400_TX_via_UART


### PR DESCRIPTION
A number of target reused the DIY_2400_TX_ESP32_SX1280_E28 pins and defines, but not all have a fan or OLED.  To remove any issues with future changes to DIY_2400_TX_ESP32_SX1280_E28 the commercial targets should live on their own and be updated independently.

@satyagupta I do not have a QuadKopters TX to test.  Can you please check everything is working as expected.  I am not sure if your design includes an inductor on the sx1280.  If it does let me know and I will update the target with `USE_SX1280_DCDC`.

I have tested everything else but a double/triple check by others would be great.