### PR TITLE
Call Event Function in LUA start

### DIFF
--- a/src/lib/LUA/devLUA.cpp
+++ b/src/lib/LUA/devLUA.cpp
@@ -470,6 +470,7 @@ static int start()
     itoa(CRSF::GoodPktsCountResult, luaBadGoodString + strlen(luaBadGoodString), 10);
     setLuaStringValue(&luaInfo, luaBadGoodString);
   });
+  event();
   return DURATION_IMMEDIATELY;
 }
 


### PR DESCRIPTION
as per @pkendall64 nudge

this PR simply adds event() function call into start() to query parameters from config.
Without this, when lua loads up at 400k on certain TX modules, it is stuck with the default settings:
50Hz
Telemetry off
Hybrid
(power values as well)

Upon changing packet rate to 150Hz or 250Hz, the saved parameters gets loaded properly and instantly.
Telemetry 1:128 (saved param)
Wide(saved param)
(power values as well)

With the fix, lua functions as it should, loading saved params after reboot.
