### PR TITLE
Add I2C OLED defines to DIY target

### DIFF
--- a/src/include/target/DIY_2400_TX_ESP32_SX1280_E28.h
+++ b/src/include/target/DIY_2400_TX_ESP32_SX1280_E28.h
@@ -1,7 +1,10 @@
 #define DEVICE_NAME "DIY2400 E28"
 
 // Any device features
+#define USE_OLED_I2C
+#if !defined(USE_OLED_I2C)
 #define USE_OLED_SPI
+#endif
 #define USE_SX1280_DCDC
 
 // GPIO pin definitions
@@ -14,11 +17,17 @@
 #define GPIO_PIN_RST            14
 #define GPIO_PIN_RX_ENABLE      27
 #define GPIO_PIN_TX_ENABLE      26
+#ifdef USE_OLED_SPI
 #define GPIO_PIN_OLED_CS        2
 #define GPIO_PIN_OLED_RST       16
 #define GPIO_PIN_OLED_DC        22
 #define GPIO_PIN_OLED_MOSI      32
 #define GPIO_PIN_OLED_SCK       33
+#elif defined(USE_OLED_I2C)
+#define GPIO_PIN_OLED_SDA       32
+#define GPIO_PIN_OLED_SCK       33
+#define GPIO_PIN_OLED_RST       U8X8_PIN_NONE
+#endif
 #define GPIO_PIN_RCSIGNAL_RX    13
 #define GPIO_PIN_RCSIGNAL_TX    13
 #define GPIO_PIN_LED_WS2812     15


### PR DESCRIPTION
Hi dev, 
I'm adding define I2C OLED instead of SPI using 2 GPIO 32 and 33 to DIY E28 target 
Tested on DIY E28 module 
OLED Driver : SSD1306
Please help me to review and let me know if it have any issues