### PR TITLE
6ch PWM support for Team900 PMWPs

### DIFF
--- a/src/include/target/DIY_900_RX_PWMP.h
+++ b/src/include/target/DIY_900_RX_PWMP.h
@@ -6,7 +6,6 @@
 // same as DIY_900_RX_ESP8285_SX127x except with no serial/button and PWM outputs
 #define GPIO_PIN_NSS            15
 #define GPIO_PIN_DIO0           4
-//#define GPIO_PIN_DIO1           5 // unused
 #define GPIO_PIN_MOSI           13
 #define GPIO_PIN_MISO           12
 #define GPIO_PIN_SCK            14
@@ -15,7 +14,7 @@
 //#define GPIO_PIN_RCSIGNAL_TX -1
 #define GPIO_PIN_LED_RED        16
 #if defined(DEBUG_LOG)
-#define GPIO_PIN_PWM_OUTPUTS    {0, 9, 10}
+#define GPIO_PIN_PWM_OUTPUTS    {0, 5, 9, 10}
 #else
-#define GPIO_PIN_PWM_OUTPUTS    {0, 1, 3, 9, 10}
+#define GPIO_PIN_PWM_OUTPUTS    {0, 1, 3, 5, 9, 10}
 #endif


### PR DESCRIPTION
As pointed out by Matek, Team900 can use pin 5 for a 6th output with a PWMP. Just want to solidify this output mapping before 2.0.