### PR TITLE
Prevent crash when using BACK item when lua is reloading

### DIFF
--- a/src/lib/CrsfProtocol/crsf_protocol.h
+++ b/src/lib/CrsfProtocol/crsf_protocol.h
@@ -98,7 +98,7 @@ typedef enum
     CRSF_FRAMETYPE_PARAMETER_WRITE = 0x2D,
 
     //CRSF_FRAMETYPE_ELRS_STATUS = 0x2E, ELRS good/bad packet count and status flags
-    
+
     CRSF_FRAMETYPE_COMMAND = 0x32,
     // KISS frames
     CRSF_FRAMETYPE_KISS_REQ  = 0x78,
@@ -176,8 +176,9 @@ typedef enum
 } crsf_value_type_e;
 
 // These flags are or'ed with the field type above to hide the field from the normal LUA view
-#define CRSF_FIELD_HIDDEN 0x80          // marked as hidden in all LUA responses
-#define CRSF_FIELD_ELRS_HIDDEN 0x40     // marked as hidden when talking to ELRS specific LUA
+#define CRSF_FIELD_HIDDEN       0x80     // marked as hidden in all LUA responses
+#define CRSF_FIELD_ELRS_HIDDEN  0x40     // marked as hidden when talking to ELRS specific LUA
+#define CRSF_FIELD_TYPE_MASK    ~(CRSF_FIELD_HIDDEN|CRSF_FIELD_ELRS_HIDDEN)
 
 /**
  * Define the shape of a standard header

--- a/src/lib/LUA/lua.cpp
+++ b/src/lib/LUA/lua.cpp
@@ -305,7 +305,7 @@ bool luaHandleUpdateParameter()
       {
         uint8_t fieldId = crsf.ParameterUpdateData[1];
         uint8_t fieldChunk = crsf.ParameterUpdateData[2];
-        DBGVLN("Read lua param %u %u", fieldId, chunkNo);
+        DBGVLN("Read lua param %u %u", fieldId, fieldChunk);
         if (fieldId < LUA_MAX_PARAMS && paramDefinitions[fieldId])
         {
           struct luaItem_command *field = (struct luaItem_command *)paramDefinitions[fieldId];

--- a/src/lib/LUA/lua.cpp
+++ b/src/lib/LUA/lua.cpp
@@ -303,9 +303,9 @@ bool luaHandleUpdateParameter()
 
     case CRSF_FRAMETYPE_PARAMETER_READ:
       {
-        uint8_t fieldChunk = crsf.ParameterUpdateData[2];
-        DBGVLN("Read lua param %u %u", crsf.ParameterUpdateData[1], chunkNo);
         uint8_t fieldId = crsf.ParameterUpdateData[1];
+        uint8_t fieldChunk = crsf.ParameterUpdateData[2];
+        DBGVLN("Read lua param %u %u", fieldId, chunkNo);
         if (fieldId < LUA_MAX_PARAMS && paramDefinitions[fieldId])
         {
           struct luaItem_command *field = (struct luaItem_command *)paramDefinitions[fieldId];

--- a/src/lib/LUA/lua.cpp
+++ b/src/lib/LUA/lua.cpp
@@ -305,9 +305,10 @@ bool luaHandleUpdateParameter()
       {
         uint8_t fieldChunk = crsf.ParameterUpdateData[2];
         DBGVLN("Read lua param %u %u", crsf.ParameterUpdateData[1], chunkNo);
-        struct luaItem_command *field = (struct luaItem_command *)paramDefinitions[crsf.ParameterUpdateData[1]];
-        if (field)
+        uint8_t fieldId = crsf.ParameterUpdateData[1];
+        if (fieldId < LUA_MAX_PARAMS && paramDefinitions[fieldId])
         {
+          struct luaItem_command *field = (struct luaItem_command *)paramDefinitions[fieldId];
           uint8_t dataType = field->common.type & CRSF_FIELD_TYPE_MASK;
           // On first chunk of a command, reset the step/info of the command
           if (dataType == CRSF_COMMAND && fieldChunk == 0)

--- a/src/lua/elrsV2.lua
+++ b/src/lua/elrsV2.lua
@@ -375,7 +375,6 @@ local function fieldCommandLoad(field, data, offset)
   field.timeout = data[offset+1]
   field.info = fieldGetString(data, offset+2)
   if field.status == 0 then
-    field.previousInfo = field.info
     fieldPopup = nil
   end
 end
@@ -725,14 +724,15 @@ local function handleDevicePageEvent(event)
           edit = not edit
         end
         if not edit then
-          functions[field.type+1].save(field)
-          if field.type < 11 then
-            -- Request this field's data again, with a short delay
-            -- to allow the module EEPROM to commit
+          if field.type < 11 or field.type == 13 then
+            -- For editable field types and commands, request this field's
+            -- data again, with a short delay to allow the module EEPROM to
+            -- commit. Do this before save() to allow save to override
             fieldTimeout = getTime() + 20
             fieldId, fieldChunk = field.id, 0
             fieldData = {}
           end
+          functions[field.type+1].save(field)
         end
       end
     end


### PR DESCRIPTION
Fixes #1076

### Details
The root cause here was that the code in Lua was sort of a mishmash where it would set up to just request an update to the single field that was changed, then refresh all the fields if it was an editable field. Since the back button is not editable it would just request the `backbuttonId` field over and over and over again until the TX would respond or another field is edited. Of course, that field is not valid on the TX so the TX would crash or send garbage data.

### Fix
I'm not sure why the Lua reloads all fields when you edit a field. It makes the user think more is happening than actually is or needs to be. I've modified the Lua so it now only requests an update to the field you're editing when you save. This is going to be jarring for sure for users who are used to the progress bar appearing when they save and make them think _"Nothing happened when I changed the parameter"_ but they're going to get used to it that not only did it send the modified value, but also reloaded the field instantly with no progress bar. People coming from 1.x won't notice but I know poor deadbyte is going to respond to this "bug report" 100x from people who have gotten used to a progress bar for every field change. I'm so sorry deadbyte, I love you!

Pressing the physical Exit / Back / RTN button on the handset while at the top level of the Lua will still do a full refresh of all parameters.

In addition, I've also modified the lua.cpp so it doesn't crash when someone tries to request an invalid fieldId (i.e. not do a `sendCRSFparam()` for fields that are not in `paramDefinitions`). The fieldId is bounds checked and the validity of the field is now checked before `sendCRSFparam`.

Stack trace of crash
```
  0x400d421d: _ZL13sendCRSFparam17crsf_frame_type_ehP19luaPropertiesCommon$constprop$3 at C:\Users\bmayland\Documents\GitHub Projects\ExpressLRS\src/lib/LUA/lua.cpp:83
  0x400d477e: luaHandleUpdateParameter() at C:\Users\bmayland\Documents\GitHub Projects\ExpressLRS\src/lib/LUA/lua.cpp:312
  0x400d3c3b: timeout() at C:\Users\bmayland\Documents\GitHub Projects\ExpressLRS\src/lib/LUA/devLUA.cpp:456
  0x400d3499: devicesUpdate(unsigned long) at C:\Users\bmayland\Documents\GitHub Projects\ExpressLRS\src/lib/DEVICE/device.cpp:67
  0x400d2035: loop() at C:\Users\bmayland\Documents\GitHub Projects\ExpressLRS\src/src/tx_main.cpp:963
  0x400d8e89: loopTask(void*) at C:\Users\bmayland\.platformio\packages\framework-arduinoespressif32\cores\esp32/main.cpp:23
  0x40092bfa: vPortTaskWrapper at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/port.c:355 (discriminator 1)
```