### PR TITLE
Prevent possible crash when setting SwitchMode on RX

### DIFF
--- a/src/lib/OTA/OTA.cpp
+++ b/src/lib/OTA/OTA.cpp
@@ -299,7 +299,7 @@ bool ICACHE_RAM_ATTR UnpackChannelDataHybridWide(volatile uint8_t* Buffer, CRSF 
 #endif
 
 OtaSwitchMode_e OtaSwitchModeCurrent;
-void OtaSetSwitchMode(OtaSwitchMode_e switchMode)
+void ICACHE_RAM_ATTR OtaSetSwitchMode(OtaSwitchMode_e switchMode)
 {
     switch(switchMode)
     {


### PR DESCRIPTION
Move OtaSetSwitchMode to IRAM since it is called from the receive ISR. I'm not 100% sure this is the cause of the exception I was getting, but when a connection was established, my EP2 receiver would reboot itself.
```
Exception: 29 (StoreProhibited: A store referenced a page mapped with an attribute that does not permit stores)

epc1:     0x40202305: OtaSetSwitchMode(OtaSwitchMode_e) at ??:?
epc2:     0x00000000
epc3:     0x00000000
excvaddr: 0x05a70000
depc:     0x00000000

ctx:      cont

sp:       0x3ffffb90
end:      0x3fffffc0
offset:   0x00000190

stack:
3ffffd20:
  0x00000008
  0x00000001
  0x0000000f
  0x402022fc: OtaSetSwitchMode(OtaSwitchMode_e) at ??:?
3ffffd30:
  0x00000002
  0x00001097
  0x3ffef890
  0x40100ce8: ProcessRFPacket() at ??:?
// etc
```

If I turned on `-DDEBUG_LOG` `-DDEBUG_RX_SCOREBOARD` and `-DDEBUG_CRSF_NO_OUTPUT` it would work just fine so my fix may just be shuffling things around and makes it work by mistake? I believe this should have the IRAM attribute though since it is called from the ISR.

If someone else has a better explanation, I'm all ears. EDIT: To further add to the confusion, if I build and flash from the configurator it works fine. Then I flashed master again without this change, and it worked fine. So I really do not understand what happened here.