### PR TITLE
Forgot to remove IRQ clear code

### DIFF
--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -70,8 +70,6 @@ void SX127xDriver::ConfigLoraDefaults()
   hal.writeRegister(SX127X_REG_OP_MODE, ModFSKorLoRa); //must be written in sleep mode
   SetMode(SX127x_OPMODE_STANDBY);
 
-  ClearIrqFlags();
-
   hal.writeRegister(SX127X_REG_PAYLOAD_LENGTH, PayloadLength);
   SetSyncWord(currSyncWord);
   hal.writeRegister(SX127X_REG_FIFO_TX_BASE_ADDR, SX127X_FIFO_TX_BASE_ADDR_MAX);
@@ -305,7 +303,6 @@ void ICACHE_RAM_ATTR SX127xDriver::RXnb()
   //   DBGLN("abort RX");
   //   return; // we were already TXing so abort
   // }
-  ClearIrqFlags();
   SetMode(SX127x_OPMODE_STANDBY);
   hal.RXenable();
   hal.writeRegister(SX127X_REG_FIFO_ADDR_PTR, SX127X_FIFO_RX_BASE_ADDR_MAX);

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -85,7 +85,6 @@ void SX1280Driver::Config(SX1280_RadioLoRaBandwidths_t bw, SX1280_RadioLoRaSprea
     PayloadLength = PayloadLength;
     IQinverted = InvertIQ;
     SetMode(SX1280_MODE_STDBY_XOSC);
-    ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
     ConfigLoRaModParams(bw, sf, cr);
     SetPacketParams(PreambleLength, SX1280_LORA_PACKET_IMPLICIT, PayloadLength, SX1280_LORA_CRC_OFF, (SX1280_RadioLoRaIQModes_t)((uint8_t)!IQinverted << 6)); // TODO don't make static etc. LORA_IQ_STD = 0x40, LORA_IQ_INVERTED = 0x00
     SetFrequencyReg(freq);
@@ -314,7 +313,6 @@ void ICACHE_RAM_ATTR SX1280Driver::TXnb()
         TXnbISR();
         return;
     }
-    ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
     hal.TXenable();                      // do first to allow PA stablise
     hal.WriteBuffer(0x00, TXdataBuffer, PayloadLength); //todo fix offset to equal fifo addr
     instance->SetMode(SX1280_MODE_TX);
@@ -336,7 +334,6 @@ void ICACHE_RAM_ATTR SX1280Driver::RXnbISR()
 void ICACHE_RAM_ATTR SX1280Driver::RXnb()
 {
     hal.RXenable();
-    ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
     SetMode(SX1280_MODE_RX);
 }
 


### PR DESCRIPTION
This removes the manual clearing of the IRQ flags in SX1280 and SX127x. It is impossible for any flags to be set, due to how the IRQ architecture code clears them immediately when they are set.

### Details
Phobos contacted me about the fact that I had removed one of the IRQClears in 1.2.x as part of the IRQ refactor. It was a mistake on my part, but they pointed out that it would be impossible for any flags to be set, since if an IRQ flag is set we would have gotten an interrupt, which would have already cleared it. For implementing ELRS SPI 1.2, Phobos removed the extra clear calls and I promised to evaluate our code and do the same. But then I forgot. :(

This follows through on that promise to remove the useless code. I've run two full day tests now (one at full signal strength, one at low LQ) and had no issues with the connection getting funky. 

### Who cares?
Removing the code reduces end-to-end latency by 15us. That's right, we're wasting time! This is because before every packet is transmitted, the IRQFlags are cleared and that transfer takes 15-16us on STM32F103 SX1280. This _would_ take 10-11us on ESP32 SX127x but due to my error this has already been removed from SX127x code (I added it back to test).