### PR TITLE
Prevent going to 1:2 ratio when disconnected and entering Lua

### DIFF
--- a/src/include/native.h
+++ b/src/include/native.h
@@ -79,25 +79,3 @@ inline void delayMicroseconds(int delay) { }
 #define random rand
 #define srandom srand
 #endif
-
-#if defined( __APPLE__) // Byte ordering on OS X
-
-#include <libkern/OSByteOrder.h>
-#define htobe32(x) OSSwapHostToBigInt32(x)
-
-#elif defined(_WIN32) // Byte ordering on Windows
-
-#if BYTE_ORDER == LITTLE_ENDIAN
-#include <winsock2.h>
-#define htobe32(x) htonl(x)
-
-#elif BYTE_ORDER == BIG_ENDIAN
-#define htobe32(x) (x)
-
-#endif
-
-#else // Let htobe32 be the default function
-
-#include <endian.h>
-
-#endif

--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -57,6 +57,7 @@ uint32_t CRSF::GoodPktsCountResult = 0;
 uint32_t CRSF::BadPktsCountResult = 0;
 
 uint8_t CRSF::modelId = 0;
+bool CRSF::ForwardDevicePings = false;
 volatile uint8_t CRSF::ParameterUpdateData[3] = {0};
 volatile bool CRSF::elrsLUAmode = false;
 
@@ -411,8 +412,14 @@ bool ICACHE_RAM_ATTR CRSF::ProcessPacket()
     else if (packetType >= CRSF_FRAMETYPE_DEVICE_PING &&
             (SerialInBuffer[3] == CRSF_ADDRESS_FLIGHT_CONTROLLER || SerialInBuffer[3] == CRSF_ADDRESS_BROADCAST || SerialInBuffer[3] == CRSF_ADDRESS_CRSF_RECEIVER))
     {
-        const uint8_t length = CRSF::inBuffer.asRCPacket_t.header.frame_size + 2;
-        AddMspMessage(length, SerialInBuffer);
+        // Some types trigger telemburst to attempt a connection even with telm off
+        // but for pings (which are sent when the user loads Lua) do not forward
+        // unless connected
+        if (ForwardDevicePings || packetType != CRSF_FRAMETYPE_DEVICE_PING)
+        {
+            const uint8_t length = CRSF::inBuffer.asRCPacket_t.header.frame_size + 2;
+            AddMspMessage(length, SerialInBuffer);
+        }
         packetReceived = true;
     }
 

--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -441,23 +441,20 @@ bool ICACHE_RAM_ATTR CRSF::ProcessPacket()
     return packetReceived;
 }
 
-uint8_t* ICACHE_RAM_ATTR CRSF::GetMspMessage()
+void CRSF::GetMspMessage(uint8_t **data, uint8_t *len)
 {
-    if (MspDataLength > 0)
-    {
-        return MspData;
-    }
-    return NULL;
+    *len = MspDataLength;
+    *data = (MspDataLength > 0) ? MspData : nullptr;
 }
 
-void ICACHE_RAM_ATTR CRSF::ResetMspQueue()
+void CRSF::ResetMspQueue()
 {
     MspWriteFIFO.flush();
     MspDataLength = 0;
     memset(MspData, 0, ELRS_MSP_BUFFER);
 }
 
-void ICACHE_RAM_ATTR CRSF::UnlockMspMessage()
+void CRSF::UnlockMspMessage()
 {
     // current msp message is sent so restore next buffered write
     if (MspWriteFIFO.peek() > 0)

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -52,7 +52,7 @@ public:
 
     // The model ID as received from the Transmitter
     static uint8_t modelId;
-
+    static bool ForwardDevicePings; // true if device pings should be forwarded OTA
     static volatile uint8_t ParameterUpdateData[3];
     static volatile bool elrsLUAmode;
 

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -94,7 +94,7 @@ public:
 
     static uint8_t getModelID() { return modelId; }
 
-    static uint8_t* GetMspMessage();
+    static void GetMspMessage(uint8_t **data, uint8_t *len);
     static void UnlockMspMessage();
     static void AddMspMessage(const uint8_t length, volatile uint8_t* data);
     static void AddMspMessage(mspPacket_t* packet);

--- a/src/lib/CrsfProtocol/crsf_protocol.h
+++ b/src/lib/CrsfProtocol/crsf_protocol.h
@@ -98,7 +98,7 @@ typedef enum
     CRSF_FRAMETYPE_PARAMETER_WRITE = 0x2D,
 
     //CRSF_FRAMETYPE_ELRS_STATUS = 0x2E, ELRS good/bad packet count and status flags
-    
+
     CRSF_FRAMETYPE_COMMAND = 0x32,
     // KISS frames
     CRSF_FRAMETYPE_KISS_REQ  = 0x78,
@@ -403,7 +403,6 @@ static inline uint8_t ICACHE_RAM_ATTR CalcCRCMsp(uint8_t *data, int length)
     return crc;
 }
 
-#if !defined(UNIT_TEST)
 static inline uint16_t htobe16(uint16_t val)
 {
 #if (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
@@ -421,4 +420,3 @@ static inline uint32_t htobe32(uint32_t val)
     return __builtin_bswap32(val);
 #endif
 }
-#endif

--- a/src/lib/CrsfProtocol/crsf_protocol.h
+++ b/src/lib/CrsfProtocol/crsf_protocol.h
@@ -403,6 +403,7 @@ static inline uint8_t ICACHE_RAM_ATTR CalcCRCMsp(uint8_t *data, int length)
     return crc;
 }
 
+#if !defined(__LINUX__)
 static inline uint16_t htobe16(uint16_t val)
 {
 #if (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
@@ -420,3 +421,4 @@ static inline uint32_t htobe32(uint32_t val)
     return __builtin_bswap32(val);
 #endif
 }
+#endif

--- a/src/lib/CrsfProtocol/crsf_protocol.h
+++ b/src/lib/CrsfProtocol/crsf_protocol.h
@@ -403,7 +403,7 @@ static inline uint8_t ICACHE_RAM_ATTR CalcCRCMsp(uint8_t *data, int length)
     return crc;
 }
 
-#if !defined(__LINUX__)
+#if !defined(__linux__)
 static inline uint16_t htobe16(uint16_t val)
 {
 #if (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1028,11 +1028,13 @@ void loop()
     // we are not sending so look for next msp package
     else
     {
-      uint8_t* currentMspData = crsf.GetMspMessage();
+      uint8_t* mspData;
+      uint8_t mspLen;
+      crsf.GetMspMessage(&mspData, &mspLen);
       // if we have a new msp package start sending
-      if (currentMspData != NULL)
+      if (mspData != nullptr)
       {
-        MspSender.SetDataToTransmit(ELRS_MSP_BUFFER, currentMspData, ELRS_MSP_BYTES_PER_CALL);
+        MspSender.SetDataToTransmit(mspLen, mspData, ELRS_MSP_BYTES_PER_CALL);
         mspTransferActive = true;
       }
     }

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -248,12 +248,6 @@ void ICACHE_RAM_ATTR ProcessTLMpacket()
     return;
   }
 
-  if (connectionState != connected)
-  {
-    connectionState = connected;
-    DBGLN("got downlink conn");
-  }
-
   LastTLMpacketRecvMillis = millis();
   LQCalc.add();
 
@@ -625,12 +619,18 @@ static void UpdateConnectDisconnectStatus()
   const uint32_t now = millis();
   if (lastTlmMillis && ((now - lastTlmMillis) <= msConnectionLostTimeout))
   {
-    connectionState = connected;
+    if (connectionState != connected)
+    {
+      connectionState = connected;
+      crsf.ForwardDevicePings = true;
+      DBGLN("got downlink conn");
+    }
   }
   else
   {
     connectionState = disconnected;
     connectionHasModelMatch = true;
+    crsf.ForwardDevicePings = false;
   }
 }
 

--- a/src/test/msp_native/encapsulated_msp_tests.cpp
+++ b/src/test/msp_native/encapsulated_msp_tests.cpp
@@ -38,10 +38,13 @@ void test_encapsulated_msp_send(void)
     // Ask the CRSF class to send the encapsulated packet to the stream
     crsf.AddMspMessage(&packet);
 
-    uint8_t* data = crsf.GetMspMessage();
+    uint8_t* data;
+    uint8_t len;
+    crsf.GetMspMessage(&data, &len);
 
     // Assert that the correct number of total bytes were sent to the stream
     TEST_ASSERT_NOT_EQUAL(NULL, data);
+    TEST_ASSERT_EQUAL(14, len);
 
     // Assert that each byte sent to the stream matches expected
     TEST_ASSERT_EQUAL(CRSF_ADDRESS_BROADCAST, data[0]);                  // device_addr
@@ -86,7 +89,11 @@ void test_encapsulated_msp_send_too_long(void)
     // Ask the CRSF class to send the encapsulated packet to the stream
     crsf.AddMspMessage(&packet);
 
-    uint8_t* data = crsf.GetMspMessage();
+    uint8_t* data;
+    uint8_t len;
+    crsf.GetMspMessage(&data, &len);
+
     // Assert that nothing was sent to the stream
     TEST_ASSERT_EQUAL(NULL, data);
+    TEST_ASSERT_EQUAL(0, len);
 }


### PR DESCRIPTION
Block sending DEVICE_PING messages OTA when not connected. This prevents the TX from going to telemetry boost mode (1:2) on entering Lua and confusing users with OLED display. The operative flag is the `CRSF::ForwardDevicePings` member.

### Details
Users with the OLED display that actually shows what TLM ratio the TX is actually running at are a bit confused when they configure the TX to be at 1:128 (or any ratio, including Off) and seeing that the OLED is showing the TX is in 1:2 mode. The issue is that when the user enters the Lua, a DEVICE_PING is queued to see what other connected devices are out there. In normal operation this is fine, but when disconnected the TX will stay in 1:2 mode until a receiver connects and the PING is able to be forwarded. 

However, there are circumstances when we want to go into 1:2 mode even when disconnected. This allows BF.lua and SendVTX to work even when TLM Ratio is set to Off. A receiver is out there, the user has just elected to prevent us from knowing it is out there and switching to 1:2 will create the bidirectional tunnel we need to transfer MSP packets.

Therefore, DEVICE_PING is unique in that it is not sent by user request and thus the confusion about why the radio is in 1:2. This PR modifies the TX behavior so that DEVICE_PINGs are not queued if disconnected. Wow. That's the longest PR details I've ever had before I got to what the actual PR is about.

### Other Fixes
* Our MSP sender on the TX side was always sending 65 bytes OTA for every MSP passthrough packet from the handset. I've confirmed this both on the TX side (counting the number of MSP send packets at 5 bytes each) and RX side (displaying the `currentOffset` at the end of receiving the MSP transfer). The receiving side always ignored the extra bytes. I've modified the code to only send as much MSP data as we have, 10 bytes for DEVICE_PING, 15 for BF.lua Init, etc. You'd think this would result in a massive speed boost especially at 50Hz where max MSP bandwidth is 62.5 bytes/sec, but it is barely noticeable in practice as I switched back and forth between the two transfer lengths. In any case this increases our upstream MSP bandwidth significantly (400%-600%).

```
MSP before: 238 4 40 0 234 84 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
MSP after:  238 4 40 0 234 84
```

* Since I updated the tests for this PR, I'm also trying to take a stab at fixing running the tests on Windows *and* GitHub thanks to our bswap code being double defined / not defined on some platforms when running tests vs building firmware. This might take a few pushes to get the right combo and defines. EDIT: successkid meme