### PR TITLE
Shorten Namimno OLEDs to 15 chars

### DIFF
--- a/src/include/target/NamimnoRC_FLASH_2400_OLED_TX.h
+++ b/src/include/target/NamimnoRC_FLASH_2400_OLED_TX.h
@@ -1,4 +1,4 @@
-#define DEVICE_NAME "Namimno Flash OLED"
+#define DEVICE_NAME "Nm.Flash OLED"
 
 // Features
 #define USE_TX_BACKPACK

--- a/src/include/target/NamimnoRC_VOYAGER_900_OLED_TX.h
+++ b/src/include/target/NamimnoRC_VOYAGER_900_OLED_TX.h
@@ -1,4 +1,4 @@
-#define DEVICE_NAME "Namimno Voyager OLED"
+#define DEVICE_NAME "Nm.Voyager OLED"
 
 // Features
 #define USE_TX_BACKPACK


### PR DESCRIPTION
The names of Namimno Voyager OLED and Flash OLED are too long to fit on B&W screens, running over our bad/good indicators. This shortens them to 15 chars. FOG_Yamato has asked them about the shortened names a couple of days ago and got no response so we'll just pick for them. The Flash OLED has space for two more characters but I thought it was better to be consistent with "Nm." for both.

Before:
![Before](https://cdn.discordapp.com/attachments/744445841779064863/907294402660163614/unknown.png)
After:
![Voyager](https://cdn.discordapp.com/attachments/744445841779064863/907295289679953920/unknown.png)