### PR TITLE
do not process start wifi MSP on stm32

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -639,7 +639,9 @@ static void ICACHE_RAM_ATTR MspReceiveComplete()
     }
     else if (MspData[0] == MSP_ELRS_SET_RX_WIFI_MODE)
     {
+#if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
         connectionState = wifiUpdate;
+#endif
     }
     else
     {


### PR DESCRIPTION
stm32 rx should not get into wifimode state when the ``enable RX wifi`` broadcast command is received.