### PR TITLE
Minor Lua fixes following RC2

### DIFF
--- a/src/lua/elrsV2.lua
+++ b/src/lua/elrsV2.lua
@@ -555,11 +555,11 @@ local function parseElrsInfoMessage(data)
 
   local badPkt = data[3]
   local goodPkt = (data[4]*256) + data[5]
-  local state = (bit32.btest(elrsFlags, 1) and "C") or "-"
-  goodBadPkt = string.format("%u/%u   %s", badPkt, goodPkt, state)
-
   elrsFlags = data[6]
   elrsFlagsInfo = fieldGetString(data, 7)
+
+  local state = (bit32.btest(elrsFlags, 1) and "C") or "-"
+  goodBadPkt = string.format("%u/%u   %s", badPkt, goodPkt, state)
 end
 
 local function refreshNext()

--- a/src/lua/elrsV2.lua
+++ b/src/lua/elrsV2.lua
@@ -533,7 +533,8 @@ local function parseParameterInfoMessage(data)
         allParamsLoaded = 1
         fieldId = 1
         createDeviceFields()
-      else
+      elseif allParamsLoaded == 0 then
+        -- advance to the next field if doing a full load
         fieldId = 1 + (fieldId % (#fields-1))
       end
       fieldTimeout = getTime() + 200
@@ -729,7 +730,7 @@ local function handleDevicePageEvent(event)
             -- data again, with a short delay to allow the module EEPROM to
             -- commit. Do this before save() to allow save to override
             fieldTimeout = getTime() + 20
-            fieldId, fieldChunk = field.id, 0
+            fieldId, fieldChunk, statusComplete = field.id, 0, 0
             fieldData = {}
           end
           functions[field.type+1].save(field)

--- a/src/lua/elrsV2.lua
+++ b/src/lua/elrsV2.lua
@@ -584,11 +584,6 @@ local function refreshNext()
   elseif time > devicesRefreshTimeout and fields_count < 1  then
     devicesRefreshTimeout = time + 100 -- 1s
     crossfireTelemetryPush(0x28, { 0x00, 0xEA })
-  elseif time > fieldTimeout and fields_count ~= 0 and not edit then
-    if allParamsLoaded < 1 or statusComplete == 0 then
-      crossfireTelemetryPush(0x2C, { deviceId, handsetId, fieldId, fieldChunk })
-      fieldTimeout = time + 50 -- 0.5s
-    end
   elseif time > linkstatTimeout then
     if not deviceIsELRS_TX and allParamsLoaded == 1 then
       goodBadPkt = ""
@@ -599,6 +594,11 @@ local function refreshNext()
       crossfireTelemetryPush(0x2D, { deviceId, handsetId, 0x0, 0x0 }) --request linkstat
     end
     linkstatTimeout = time + 100
+  elseif time > fieldTimeout and fields_count ~= 0 and not edit then
+    if allParamsLoaded < 1 or statusComplete == 0 then
+      crossfireTelemetryPush(0x2C, { deviceId, handsetId, fieldId, fieldChunk })
+      fieldTimeout = time + 50 -- 0.5s
+    end
   end
 
   if time > titleShowWarnTimeout then

--- a/src/lua/elrsV2.lua
+++ b/src/lua/elrsV2.lua
@@ -589,9 +589,7 @@ local function refreshNext()
       crossfireTelemetryPush(0x2C, { deviceId, handsetId, fieldId, fieldChunk })
       fieldTimeout = time + 50 -- 0.5s
     end
-  end
-
-  if time > linkstatTimeout then
+  elseif time > linkstatTimeout then
     if not deviceIsELRS_TX and allParamsLoaded == 1 then
       goodBadPkt = ""
       -- enable both line below to do what the legacy lua is doing which is reloading all params in an interval
@@ -602,6 +600,7 @@ local function refreshNext()
     end
     linkstatTimeout = time + 100
   end
+
   if time > titleShowWarnTimeout then
     -- if elrsFlags bit set is bit higher than bit 0 and bit 1, it is warning flags
     titleShowWarn = (elrsFlags > 3 and not titleShowWarn) or nil


### PR DESCRIPTION
A collection of things I was planning to fix before RC2 but you did it in my sleep!

### Details
* Fix field not actually refreshing after save. Some dumb jerk developer broke the field refreshing after you save. He said that he made it just refresh the one field instead of the whole list but instead he made it not refresh at all. This was only obvious when trying to change the Switch Mode while connected, and it would not switch back.
* Fix the "RX Connected" status indicator showing disconnected `-` instead of `C` on the first update. Again, this was the failing of that same dumb developer who reordered the code to break it after StonedDawg had it in the right order. In the nameless dumb developer's defense, he did point this out in StonedDawg's PR (which again, got it right) but then forgot about it and broke it.
* Fix the long delay before the bad/good stats show up. `crossfireTelemetryPush()` only works if there's not something already queued. The first loop through, the Lua requests both the DEVICE_PING and LINKSTATS, so only the DEVICE_PING goes to the TX. The timeout is updated, so the linkstats take a long time to update. I modified it to only send that request if no other request has gone that loop and it seems to be able to squeeze it in most of the time during loading. Here's what it looked like before for reference:

```
GC Use Scripts: 40286 bytes
ping 62597 // device ping sent
req 62597  // linkstats request
GC Use Scripts: 43065 bytes
GC Use Scripts: 48207 bytes
GC Use Scripts: 50447 bytes
GC Use Scripts: 53376 bytes
GC Use Scripts: 46168 bytes
GC Use Scripts: 49290 bytes
GC Use Scripts: 52567 bytes
GC Use Scripts: 55272 bytes
GC Use Scripts: 58118 bytes
GC Use Scripts: 49076 bytes
GC Use Scripts: 52011 bytes
req 62698 // linkstats request again
loaded 62703 // allparamsLoaded
GC Use Scripts: 55479 bytes
GC Use Scripts: 48314 bytes
req 62803 // linkstats request AGAIN?!
flags 1 C // our first linkstats response
req 62908 // normal 1s polling
flags 1 C
```

## New Issue Discovered
That's right, in tracking down why the connect status was wrong, I found that we actually go `connected` to `disconnected` status when entering the Lua. This is because the device ping sends an MSP request, which switches the TX to 1:2 boost mode. The next `loop()`, the last telemetry received is now FAR OUT OF DATE (everybody panic!) for a 1:2 ratio so the TX switches to disconnected.

I propose this solution which is just to pretend like we just got a telemetry packet if we're already connected and going into boost mode.
[See updated below](https://github.com/ExpressLRS/ExpressLRS/pull/1100#issuecomment-968074801)

Any better ideas for this? It doesn't appear to be causing us a problem but I have a feeling it could create a weird transient bug if we're briefly "disconnecting" on the TX side every time an MSP packet needs to go. Tested on my FM30 but tell me if this is a dumb solution.