### PR TITLE
iFlight 2.4G and 900M Tx and Rx targets

### DIFF
--- a/src/include/target/BETAFPV_900_TX.h
+++ b/src/include/target/BETAFPV_900_TX.h
@@ -2,6 +2,7 @@
 
 // There is some special handling for this target
 #define TARGET_TX_BETAFPV_900_V1
+#define USE_SX1276_RFO_HF
 
 // GPIO pin definitions
 #define GPIO_PIN_NSS            5

--- a/src/include/target/iFlight_2400_RX.h
+++ b/src/include/target/iFlight_2400_RX.h
@@ -1,5 +1,7 @@
 #define DEVICE_NAME "iFlight 2400RX"
 
+#define USE_SX1280_DCDC
+
 // GPIO pin definitions
 #define GPIO_PIN_NSS                15
 #define GPIO_PIN_BUSY               4

--- a/src/include/target/iFlight_2400_RX.h
+++ b/src/include/target/iFlight_2400_RX.h
@@ -1,0 +1,19 @@
+#define DEVICE_NAME "iFlight 2400RX"
+
+// GPIO pin definitions
+#define GPIO_PIN_NSS                15
+#define GPIO_PIN_BUSY               4
+#define GPIO_PIN_DIO1               5
+#define GPIO_PIN_MOSI               13
+#define GPIO_PIN_MISO               12
+#define GPIO_PIN_SCK                14
+#define GPIO_PIN_RST                2
+#define GPIO_PIN_RX_ENABLE          9
+#define GPIO_PIN_TX_ENABLE          10
+#define GPIO_PIN_LED                16
+#define GPIO_PIN_BUTTON             0
+
+// Output Power
+#define POWER_OUTPUT_FIXED          3
+
+#define Regulatory_Domain_ISM_2400  1

--- a/src/include/target/iFlight_2400_TX.h
+++ b/src/include/target/iFlight_2400_TX.h
@@ -1,0 +1,28 @@
+#define DEVICE_NAME "iFlight 2400TX"
+
+// Any device features
+#define USE_SX1280_DCDC
+
+// GPIO pin definitions
+#define GPIO_PIN_NSS            5
+#define GPIO_PIN_BUSY           25
+#define GPIO_PIN_DIO1           16
+#define GPIO_PIN_MOSI           23
+#define GPIO_PIN_MISO           19
+#define GPIO_PIN_SCK            18
+#define GPIO_PIN_RST            22
+#define GPIO_PIN_RX_ENABLE      21
+#define GPIO_PIN_TX_ENABLE      4
+#define GPIO_PIN_RCSIGNAL_RX    13
+#define GPIO_PIN_RCSIGNAL_TX    13
+#define GPIO_PIN_LED_RED        14
+#define GPIO_PIN_LED_GREEN      27
+#define GPIO_PIN_LED_BLUE       26
+#define GPIO_PIN_BUTTON         15
+
+// Output Power
+#define MinPower PWR_10mW
+#define MaxPower PWR_250mW
+#define POWER_OUTPUT_VALUES {-18,-15,-11,-8,-4}
+
+#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/iFlight_2400_TX.h
+++ b/src/include/target/iFlight_2400_TX.h
@@ -22,7 +22,7 @@
 
 // Output Power
 #define MinPower PWR_10mW
-#define MaxPower PWR_250mW
-#define POWER_OUTPUT_VALUES {-18,-15,-11,-8,-4}
+#define MaxPower PWR_500mW
+#define POWER_OUTPUT_VALUES {-18,-15,-11,-8,-4,3}
 
 #define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/iFlight_2400_TX.h
+++ b/src/include/target/iFlight_2400_TX.h
@@ -1,6 +1,7 @@
 #define DEVICE_NAME "iFlight 2400TX"
 
 // Any device features
+#define TARGET_TX_IFLIGHT
 #define USE_SX1280_DCDC
 
 // GPIO pin definitions
@@ -21,8 +22,8 @@
 #define GPIO_PIN_BUTTON         15
 
 // Output Power
-#define MinPower PWR_10mW
-#define MaxPower PWR_500mW
-#define POWER_OUTPUT_VALUES {-18,-15,-11,-8,-4,3}
+#define MinPower                PWR_10mW
+#define MaxPower                PWR_500mW
+#define POWER_OUTPUT_VALUES     {-18,-15,-11,-8,-4,3}
 
 #define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/iFlight_2400_TX.h
+++ b/src/include/target/iFlight_2400_TX.h
@@ -6,7 +6,7 @@
 // GPIO pin definitions
 #define GPIO_PIN_NSS            5
 #define GPIO_PIN_BUSY           25
-#define GPIO_PIN_DIO1           16
+#define GPIO_PIN_DIO1           17
 #define GPIO_PIN_MOSI           23
 #define GPIO_PIN_MISO           19
 #define GPIO_PIN_SCK            18

--- a/src/include/target/iFlight_900_TX.h
+++ b/src/include/target/iFlight_900_TX.h
@@ -1,0 +1,23 @@
+#define DEVICE_NAME "iFlight 900TX"
+
+// GPIO pin definitions
+#define GPIO_PIN_NSS            5
+#define GPIO_PIN_DIO0           17
+#define GPIO_PIN_DIO1           16
+#define GPIO_PIN_MOSI           23
+#define GPIO_PIN_MISO           19
+#define GPIO_PIN_SCK            18
+#define GPIO_PIN_RST            22
+#define GPIO_PIN_RX_ENABLE      21
+#define GPIO_PIN_TX_ENABLE      4
+#define GPIO_PIN_RCSIGNAL_RX    13
+#define GPIO_PIN_RCSIGNAL_TX    13 // so we don't have to solder the extra resistor, we switch rx/tx using gpio mux
+#define GPIO_PIN_LED_RED        14
+#define GPIO_PIN_LED_GREEN      27
+#define GPIO_PIN_LED_BLUE       26
+#define GPIO_PIN_BUTTON         15
+
+// Output Power
+#define MinPower                PWR_10mW
+#define MaxPower                PWR_500mW
+#define POWER_OUTPUT_VALUES     {0,3,8,9,10,11} // only test number.

--- a/src/include/target/iFlight_900_TX.h
+++ b/src/include/target/iFlight_900_TX.h
@@ -1,5 +1,8 @@
 #define DEVICE_NAME "iFlight 900TX"
 
+// There is some special handling for this target
+#define TARGET_TX_IFLIGHT_900
+
 // GPIO pin definitions
 #define GPIO_PIN_NSS            5
 #define GPIO_PIN_DIO0           17
@@ -11,13 +14,13 @@
 #define GPIO_PIN_RX_ENABLE      21
 #define GPIO_PIN_TX_ENABLE      4
 #define GPIO_PIN_RCSIGNAL_RX    13
-#define GPIO_PIN_RCSIGNAL_TX    13 // so we don't have to solder the extra resistor, we switch rx/tx using gpio mux
+#define GPIO_PIN_RCSIGNAL_TX    13
 #define GPIO_PIN_LED_RED        14
 #define GPIO_PIN_LED_GREEN      27
 #define GPIO_PIN_LED_BLUE       26
 #define GPIO_PIN_BUTTON         15
 
 // Output Power
-#define MinPower                PWR_10mW
-#define MaxPower                PWR_500mW
-#define POWER_OUTPUT_VALUES     {0,3,8,9,10,11} // only test number.
+#define MinPower                PWR_100mW
+#define MaxPower                PWR_1000mW
+#define POWER_OUTPUT_VALUES     {0,4,7,11}

--- a/src/include/target/iFlight_900_TX.h
+++ b/src/include/target/iFlight_900_TX.h
@@ -1,7 +1,8 @@
 #define DEVICE_NAME "iFlight 900TX"
 
-// There is some special handling for this target
-#define TARGET_TX_IFLIGHT_900
+// Any device features
+#define TARGET_TX_IFLIGHT
+#define USE_SX1276_RFO_HF
 
 // GPIO pin definitions
 #define GPIO_PIN_NSS            5

--- a/src/include/targets.h
+++ b/src/include/targets.h
@@ -72,6 +72,9 @@
 #ifndef GPIO_LED_GREEN_INVERTED
 #define GPIO_LED_GREEN_INVERTED 0
 #endif
+#ifndef GPIO_LED_BLUE_INVERTED
+#define GPIO_LED_BLUE_INVERTED 0
+#endif
 
 #if defined(Regulatory_Domain_ISM_2400)
 // ISM 2400 band is use => undefine other requlatory domain defines

--- a/src/lib/BUTTON/devButton.cpp
+++ b/src/lib/BUTTON/devButton.cpp
@@ -8,7 +8,7 @@
 
 static Button<GPIO_PIN_BUTTON, GPIO_BUTTON_INVERTED> button;
 
-#if defined(TARGET_TX_BETAFPV_2400_V1) || defined(TARGET_TX_BETAFPV_900_V1)
+#if defined(TARGET_TX_BETAFPV_2400_V1) || defined(TARGET_TX_BETAFPV_900_V1) || defined(TARGET_TX_IFLIGHT_900)
 #include "POWERMGNT.h"
 void EnterBindingMode();
 
@@ -55,7 +55,7 @@ static void rxWebUpdateReboot()
 
 static void initialize()
 {
-    #if defined(TARGET_TX_BETAFPV_2400_V1) || defined(TARGET_TX_BETAFPV_900_V1)
+    #if defined(TARGET_TX_BETAFPV_2400_V1) || defined(TARGET_TX_BETAFPV_900_V1) || defined(TARGET_TX_IFLIGHT_900)
         button.OnShortPress = enterBindMode3Click;
         button.OnLongPress = cyclePower;
     #endif

--- a/src/lib/BUTTON/devButton.cpp
+++ b/src/lib/BUTTON/devButton.cpp
@@ -8,7 +8,7 @@
 
 static Button<GPIO_PIN_BUTTON, GPIO_BUTTON_INVERTED> button;
 
-#if defined(TARGET_TX_BETAFPV_2400_V1) || defined(TARGET_TX_BETAFPV_900_V1) || defined(TARGET_TX_IFLIGHT_900)
+#if defined(TARGET_TX_BETAFPV_2400_V1) || defined(TARGET_TX_BETAFPV_900_V1) || defined(TARGET_TX_IFLIGHT)
 #include "POWERMGNT.h"
 void EnterBindingMode();
 
@@ -55,7 +55,7 @@ static void rxWebUpdateReboot()
 
 static void initialize()
 {
-    #if defined(TARGET_TX_BETAFPV_2400_V1) || defined(TARGET_TX_BETAFPV_900_V1) || defined(TARGET_TX_IFLIGHT_900)
+    #if defined(TARGET_TX_BETAFPV_2400_V1) || defined(TARGET_TX_BETAFPV_900_V1) || defined(TARGET_TX_IFLIGHT)
         button.OnShortPress = enterBindMode3Click;
         button.OnLongPress = cyclePower;
     #endif

--- a/src/lib/BUTTON/devButton.h
+++ b/src/lib/BUTTON/devButton.h
@@ -3,7 +3,7 @@
 #include "device.h"
 
 #if defined(GPIO_PIN_BUTTON) && (GPIO_PIN_BUTTON != UNDEF_PIN)
-    #if (defined(TARGET_TX_BETAFPV_2400_V1) || defined(TARGET_TX_BETAFPV_900_V1) || defined(TARGET_TX_IFLIGHT_900)) || \
+    #if (defined(TARGET_TX_BETAFPV_2400_V1) || defined(TARGET_TX_BETAFPV_900_V1) || defined(TARGET_TX_IFLIGHT)) || \
         (defined(TARGET_RX) && (defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)))
         extern device_t Button_device;
         #define HAS_BUTTON

--- a/src/lib/BUTTON/devButton.h
+++ b/src/lib/BUTTON/devButton.h
@@ -3,7 +3,7 @@
 #include "device.h"
 
 #if defined(GPIO_PIN_BUTTON) && (GPIO_PIN_BUTTON != UNDEF_PIN)
-    #if (defined(TARGET_TX_BETAFPV_2400_V1) || defined(TARGET_TX_BETAFPV_900_V1)) || \
+    #if (defined(TARGET_TX_BETAFPV_2400_V1) || defined(TARGET_TX_BETAFPV_900_V1) || defined(TARGET_TX_IFLIGHT_900)) || \
         (defined(TARGET_RX) && (defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)))
         extern device_t Button_device;
         #define HAS_BUTTON

--- a/src/lib/LED/devLED.cpp
+++ b/src/lib/LED/devLED.cpp
@@ -52,7 +52,7 @@ static uint16_t flashLED(uint8_t pin, uint8_t pin_inverted, const uint8_t durati
 static void initialize()
 {
     #if defined(TARGET_TX)
-        #if defined(TARGET_TX_BETAFPV_2400_V1) || defined(TARGET_TX_BETAFPV_900_V1)
+        #if defined(TARGET_TX_BETAFPV_2400_V1) || defined(TARGET_TX_BETAFPV_900_V1) || defined(TARGET_TX_IFLIGHT_900)
             pinMode(GPIO_PIN_LED_BLUE, OUTPUT);
         #endif
         #if defined(GPIO_PIN_LED_GREEN) && (GPIO_PIN_LED_GREEN != UNDEF_PIN)
@@ -115,6 +115,36 @@ static void setPowerLEDs()
         default:
             digitalWrite(GPIO_PIN_LED_BLUE, HIGH);
             digitalWrite(GPIO_PIN_LED_GREEN, LOW);
+            break;
+        }
+    #endif
+
+    #if defined(TARGET_TX_IFLIGHT_900)
+        switch (POWERMGNT::currPower())
+        {
+        case PWR_250mW:
+            digitalWrite(GPIO_PIN_LED_RED, LOW);
+            digitalWrite(GPIO_PIN_LED_GREEN, HIGH);
+            digitalWrite(GPIO_PIN_LED_BLUE, LOW);
+            break;
+        case PWR_500mW:
+            digitalWrite(GPIO_PIN_LED_RED, LOW);
+            digitalWrite(GPIO_PIN_LED_GREEN, LOW);
+            digitalWrite(GPIO_PIN_LED_BLUE, HIGH);
+            break;
+        case PWR_1000mW:
+            digitalWrite(GPIO_PIN_LED_RED, HIGH);
+            digitalWrite(GPIO_PIN_LED_GREEN, HIGH);
+            digitalWrite(GPIO_PIN_LED_BLUE, HIGH);
+            break;
+        case PWR_10mW:
+        case PWR_25mW:
+        case PWR_50mW:
+        case PWR_100mW:
+        default:
+            digitalWrite(GPIO_PIN_LED_RED, HIGH);
+            digitalWrite(GPIO_PIN_LED_GREEN, LOW);
+            digitalWrite(GPIO_PIN_LED_BLUE, LOW);
             break;
         }
     #endif

--- a/src/lib/LED/devLED.cpp
+++ b/src/lib/LED/devLED.cpp
@@ -51,10 +51,12 @@ static uint16_t flashLED(uint8_t pin, uint8_t pin_inverted, const uint8_t durati
 
 static void initialize()
 {
+    // TODO for future PR, remove TARGET_TX, TARGET_RX, and TARGET_TX_FM30 defines.
     #if defined(TARGET_TX)
-        #if defined(TARGET_TX_BETAFPV_2400_V1) || defined(TARGET_TX_BETAFPV_900_V1) || defined(TARGET_TX_IFLIGHT_900)
+        #if defined(GPIO_PIN_LED_BLUE) && (GPIO_PIN_LED_BLUE != UNDEF_PIN)
             pinMode(GPIO_PIN_LED_BLUE, OUTPUT);
-        #endif
+            digitalWrite(GPIO_PIN_LED_BLUE, LOW ^ GPIO_LED_BLUE_INVERTED);
+        #endif // GPIO_PIN_BLUE_GREEN
         #if defined(GPIO_PIN_LED_GREEN) && (GPIO_PIN_LED_GREEN != UNDEF_PIN)
             pinMode(GPIO_PIN_LED_GREEN, OUTPUT);
             digitalWrite(GPIO_PIN_LED_GREEN, HIGH ^ GPIO_LED_GREEN_INVERTED);
@@ -119,17 +121,32 @@ static void setPowerLEDs()
         }
     #endif
 
-    #if defined(TARGET_TX_IFLIGHT_900)
+    #if defined(TARGET_TX_IFLIGHT)
         switch (POWERMGNT::currPower())
         {
-        case PWR_250mW:
+        case PWR_10mW:
+            digitalWrite(GPIO_PIN_LED_RED, HIGH);
+            digitalWrite(GPIO_PIN_LED_GREEN, LOW);
+            digitalWrite(GPIO_PIN_LED_BLUE, LOW);
+            break;
+        case PWR_25mW:
             digitalWrite(GPIO_PIN_LED_RED, LOW);
             digitalWrite(GPIO_PIN_LED_GREEN, HIGH);
             digitalWrite(GPIO_PIN_LED_BLUE, LOW);
             break;
-        case PWR_500mW:
+        case PWR_50mW:
             digitalWrite(GPIO_PIN_LED_RED, LOW);
             digitalWrite(GPIO_PIN_LED_GREEN, LOW);
+            digitalWrite(GPIO_PIN_LED_BLUE, HIGH);
+            break;
+        case PWR_250mW:
+            digitalWrite(GPIO_PIN_LED_RED, HIGH);
+            digitalWrite(GPIO_PIN_LED_GREEN, LOW);
+            digitalWrite(GPIO_PIN_LED_BLUE, HIGH);
+            break;
+        case PWR_500mW:
+            digitalWrite(GPIO_PIN_LED_RED, LOW);
+            digitalWrite(GPIO_PIN_LED_GREEN, HIGH);
             digitalWrite(GPIO_PIN_LED_BLUE, HIGH);
             break;
         case PWR_1000mW:
@@ -137,13 +154,10 @@ static void setPowerLEDs()
             digitalWrite(GPIO_PIN_LED_GREEN, HIGH);
             digitalWrite(GPIO_PIN_LED_BLUE, HIGH);
             break;
-        case PWR_10mW:
-        case PWR_25mW:
-        case PWR_50mW:
         case PWR_100mW:
         default:
             digitalWrite(GPIO_PIN_LED_RED, HIGH);
-            digitalWrite(GPIO_PIN_LED_GREEN, LOW);
+            digitalWrite(GPIO_PIN_LED_GREEN, HIGH);
             digitalWrite(GPIO_PIN_LED_BLUE, LOW);
             break;
         }

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -159,7 +159,7 @@ void SX127xDriver::SetSyncWord(uint8_t syncWord)
 void SX127xDriver::SetOutputPower(uint8_t Power)
 {
   SetMode(SX127x_OPMODE_STANDBY);
-  #ifdef TARGET_TX_BETAFPV_900_V1
+  #if defined(TARGET_TX_BETAFPV_900_V1) || defined(TARGET_TX_IFLIGHT_900)
     hal.writeRegister(SX127X_REG_PA_CONFIG, SX127X_PA_SELECT_RFO | SX127X_MAX_OUTPUT_POWER | Power);
   #else
     hal.writeRegister(SX127X_REG_PA_CONFIG, SX127X_PA_SELECT_BOOST | SX127X_MAX_OUTPUT_POWER | Power);

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -159,7 +159,7 @@ void SX127xDriver::SetSyncWord(uint8_t syncWord)
 void SX127xDriver::SetOutputPower(uint8_t Power)
 {
   SetMode(SX127x_OPMODE_STANDBY);
-  #if defined(TARGET_TX_BETAFPV_900_V1) || defined(TARGET_TX_IFLIGHT_900)
+  #if defined(USE_SX1276_RFO_HF)
     hal.writeRegister(SX127X_REG_PA_CONFIG, SX127X_PA_SELECT_RFO | SX127X_MAX_OUTPUT_POWER | Power);
   #else
     hal.writeRegister(SX127X_REG_PA_CONFIG, SX127X_PA_SELECT_BOOST | SX127X_MAX_OUTPUT_POWER | Power);

--- a/src/lib/SX127xDriver/SX127xRegs.h
+++ b/src/lib/SX127xDriver/SX127xRegs.h
@@ -104,7 +104,7 @@ typedef enum
 #define SX127X_PA_SELECT_RFO 0b00000000    //  7     7     RFO pin output, power limited to +14 dBm
 #define SX127X_PA_SELECT_BOOST 0b10000000  //  7     7     PA_BOOST pin output, power limited to +20 dBm
 #define SX127X_OUTPUT_POWER 0b00001111     //  3     0     output power: P_out = 17 - (15 - OUTPUT_POWER) [dBm] for PA_SELECT_BOOST
-#if defined(TARGET_TX_BETAFPV_900_V1) || defined(TARGET_TX_IFLIGHT_900)
+#if defined(USE_SX1276_RFO_HF)
     #define SX127X_MAX_OUTPUT_POWER 0b00000000 //              Enable max output power
 #else
     #define SX127X_MAX_OUTPUT_POWER 0b01110000 //              Enable max output power

--- a/src/lib/SX127xDriver/SX127xRegs.h
+++ b/src/lib/SX127xDriver/SX127xRegs.h
@@ -104,7 +104,7 @@ typedef enum
 #define SX127X_PA_SELECT_RFO 0b00000000    //  7     7     RFO pin output, power limited to +14 dBm
 #define SX127X_PA_SELECT_BOOST 0b10000000  //  7     7     PA_BOOST pin output, power limited to +20 dBm
 #define SX127X_OUTPUT_POWER 0b00001111     //  3     0     output power: P_out = 17 - (15 - OUTPUT_POWER) [dBm] for PA_SELECT_BOOST
-#ifdef TARGET_TX_BETAFPV_900_V1
+#if defined(TARGET_TX_BETAFPV_900_V1) || defined(TARGET_TX_IFLIGHT_900)
     #define SX127X_MAX_OUTPUT_POWER 0b00000000 //              Enable max output power
 #else
     #define SX127X_MAX_OUTPUT_POWER 0b01110000 //              Enable max output power

--- a/src/platformio.ini
+++ b/src/platformio.ini
@@ -21,6 +21,7 @@ extra_configs =
 	targets/diy_900.ini
 	targets/diy_2400.ini
 	targets/MATEK_2400.ini
+	targets/iFlight_900.ini
 	targets/iFlight_2400.ini
 
 # ------------------------- TARGET ENV DEFINITIONS -----------------

--- a/src/platformio.ini
+++ b/src/platformio.ini
@@ -21,6 +21,7 @@ extra_configs =
 	targets/diy_900.ini
 	targets/diy_2400.ini
 	targets/MATEK_2400.ini
+	targets/iFlight_2400.ini
 
 # ------------------------- TARGET ENV DEFINITIONS -----------------
 

--- a/src/targets/iFlight_2400.ini
+++ b/src/targets/iFlight_2400.ini
@@ -1,0 +1,42 @@
+
+# ********************************
+# Transmitter targets
+# ********************************
+
+[env:iFlight_2400_TX_via_UART]
+extends = env_common_esp32, radio_2400
+build_flags =
+	${env_common_esp32.build_flags}
+	${common_env_data.build_flags_tx}
+	${radio_2400.build_flags}
+	-include target/iFlight_2400_TX.h
+	-D VTABLES_IN_FLASH=1
+	-O2
+src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+lib_deps = 
+	${env_common_esp32.lib_deps}
+
+[env:iFlight_2400_TX_via_WIFI]
+extends = env:iFlight_2400_TX_via_UART
+
+# ********************************
+# Receiver targets
+# ********************************
+
+[env:iFlight_2400_RX_via_UART]
+extends = env_common_esp82xx, radio_2400
+build_flags =
+	${env_common_esp82xx.build_flags}
+	${common_env_data.build_flags_rx}
+	${radio_2400.build_flags}
+	-include target/iFlight_2400_RX.h
+src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
+
+[env:iFlight_2400_RX_via_BetaflightPassthrough]
+extends = env:iFlight_2400_RX_via_UART
+upload_protocol = custom
+upload_speed = 420000
+upload_command = ${env_common_esp82xx.bf_upload_command}
+
+[env:iFlight_2400_RX_via_WIFI]
+extends = env:iFlight_2400_RX_via_UART

--- a/src/targets/iFlight_900.ini
+++ b/src/targets/iFlight_900.ini
@@ -1,0 +1,29 @@
+# ********************************
+# Transmitter targets
+# ********************************
+
+[env:iFlight_900_TX_via_UART]
+extends = env_common_esp32, radio_900
+build_flags =
+	${env_common_esp32.build_flags}
+	${common_env_data.build_flags_tx}
+	${radio_900.build_flags}
+	-include target/iFlight_900_TX.h
+upload_speed = 460800
+src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+
+[env:iFlight_900_TX_via_WIFI]
+extends = env:iFlight_900_TX_via_UART
+
+# ********************************
+# Receiver targets
+# ********************************
+
+[env:iFlight_900_RX_via_UART]
+extends = env:DIY_900_RX_ESP8285_SX127x_via_UART
+
+[env:iFlight_900_RX_via_WIFI]
+extends = env:DIY_900_RX_ESP8285_SX127x_via_WIFI
+
+[env:iFlight_900_RX_via_BetaflightPassthrough]
+extends = env:DIY_900_RX_ESP8285_SX127x_via_BetaflightPassthrough


### PR DESCRIPTION
This PR adds iFlight TX and RX targets for 2.4G and 900M.

It also adds USE_SX1276_RFO_HF for targets that use the sx1276 RFO_HF pin instead of PA_BOOST.  It should be added to the target file and used in a similar manner to how USE_SX1280_DCDC is used for sx1280 hardware.