### PR TITLE
Add backpack telemetry forwarding

### DIFF
--- a/src/lib/CONFIG/config.cpp
+++ b/src/lib/CONFIG/config.cpp
@@ -198,6 +198,16 @@ TxConfig::SetSwitchMode(uint8_t switchMode)
 }
 
 void
+TxConfig::SetTelemetryForward(uint8_t telemetryForward)
+{
+    if (GetTelemetryForward() != telemetryForward)
+    {
+        m_model->telemetryForward = telemetryForward;
+        m_modified |= MODEL_CHANGED;
+    }
+}
+
+void
 TxConfig::SetModelMatch(bool modelMatch)
 {
     if (GetModelMatch() != modelMatch)

--- a/src/lib/CONFIG/config.h
+++ b/src/lib/CONFIG/config.h
@@ -25,6 +25,7 @@ typedef struct {
     uint8_t     modelMatch:1;
     uint8_t     dynamicPower:1;
     uint8_t     boostChannel:3;
+    uint8_t     telemetryForward:1;
 } model_config_t;
 
 typedef struct {
@@ -62,6 +63,7 @@ public:
     uint8_t  GetVtxPower() const { return m_config.vtxPower; }
     uint8_t  GetVtxPitmode() const { return m_config.vtxPitmode; }
     uint8_t GetPowerFanThreshold() const { return m_config.powerFanThreshold; }
+    uint8_t GetTelemetryForward() const { return m_model->telemetryForward; }
 
     // Setters
     void SetRate(uint8_t rate);
@@ -80,6 +82,7 @@ public:
     void SetVtxPower(uint8_t vtxPower);
     void SetVtxPitmode(uint8_t vtxPitmode);
     void SetPowerFanThreshold(uint8_t powerFanThreshold);
+    void SetTelemetryForward(uint8_t telemetryForward);
 
     // State setters
     bool SetModelId(uint8_t modelId);

--- a/src/lib/LUA/devLUA.cpp
+++ b/src/lib/LUA/devLUA.cpp
@@ -88,6 +88,15 @@ static struct luaItem_selection luaModelMatch = {
     emptySpace
 };
 
+#if defined(USE_TX_BACKPACK)
+static struct luaItem_selection luaTelemetryForward = {
+    {"Telemetry Forward", CRSF_TEXT_SELECTION},
+    0, // value
+    "Off;On",
+    emptySpace
+};
+#endif
+
 static struct luaItem_command luaBind = {
     {"Bind", CRSF_COMMAND},
     0, // step
@@ -292,6 +301,11 @@ static void registerLuaParameters()
       CRSF::AddMspMessage(&msp);
     }
   });
+#if defined(USE_TX_BACKPACK)
+  registerLUAParameter(&luaTelemetryForward, [](uint8_t id, uint8_t arg){
+    config.SetTelemetryForward(arg);
+  });
+#endif
 
   // POWER folder
   registerLUAParameter(&luaPowerFolder);
@@ -445,6 +459,9 @@ static int event()
   setLuaTextSelectionValue(&luaVtxChannel,config.GetVtxChannel());
   setLuaTextSelectionValue(&luaVtxPwr,config.GetVtxPower());
   setLuaTextSelectionValue(&luaVtxPit,config.GetVtxPitmode());
+  #if defined(USE_TX_BACKPACK)
+  setLuaTextSelectionValue(&luaTelemetryForward, config.GetTelemetryForward());
+  #endif
   #if defined(TARGET_TX_FM30)
     setLuaTextSelectionValue(&luaBluetoothTelem, !digitalRead(GPIO_PIN_BLUETOOTH_EN));
   #endif

--- a/src/lib/MSP/msp.h
+++ b/src/lib/MSP/msp.h
@@ -4,9 +4,10 @@
 
 // TODO: MSP_PORT_INBUF_SIZE should be changed to
 // dynamically allocate array length based on the payload size
-// Hardcoding payload size to 8 bytes for now, since MSP is
-// limited to a 4 byte payload on the BF side
-#define MSP_PORT_INBUF_SIZE 8
+// Hardcoding payload size to 64 bytes for now, since 
+// MSP is limited to a 4 byte payload on the BF side, and
+// max crsf packet is 48 bytes so far (to accomodate crsf embeding). 
+#define MSP_PORT_INBUF_SIZE 64
 
 #define CHECK_PACKET_PARSING() \
   if (packet->readError) {\

--- a/src/lib/MSP/msptypes.h
+++ b/src/lib/MSP/msptypes.h
@@ -18,6 +18,9 @@
 #define MSP_ELRS_SET_VRX_BACKPACK_WIFI_MODE 0x0D
 #define MSP_ELRS_SET_RX_WIFI_MODE           0x0E
 
+// msp encapsulated CRSF packet
+# define MSP_CRSF_PACKET                        0xFF01
+
 // CRSF encapsulated msp defines
 #define ENCAPSULATED_MSP_PAYLOAD_SIZE 4
 #define ENCAPSULATED_MSP_FRAME_LEN    8


### PR DESCRIPTION
This add a forwarding option to forward the telemetry to backpack, so the backpack can forward it to another device to consume it, such as antenna tracker. 

Like packets to vrx module, it is send out using esp-now, so it is a bit more restrictive to consume than using bluetooth serial telemetry. 

This add a msp type to wrap crsf packet. I'm not that familiar with the convention in msp type. From what I read in inav or betaflight, the usage of msp type seems to be pretty liberal, so i just add 0xFF01 as CRSF wrap. If there is an existing type suitable for this or a better code for it, please let me know. 

It also expands the MSP_PORT_INBUF_SIZE to 64 bytes, so it will have space for the largest telemetry packet. It probably doesn't need to be that large, but there are only limited instance of the msp buffer at a time, so it shouldn't be a big memory concern. 

Tested and works with HM ES24TX and another esp32 dev board. 