### PR TITLE
devLED copy paste bug

### DIFF
--- a/src/lib/LED/devLED.h
+++ b/src/lib/LED/devLED.h
@@ -8,7 +8,7 @@ extern device_t RGB_device;
 #endif
 
 #if (defined(GPIO_PIN_LED) && (GPIO_PIN_LED != UNDEF_PIN)) \
-    || (defined(GPIO_PIN_LED_RED) && (GPIO_PIN_LED_BLUE != UNDEF_PIN)) \
+    || (defined(GPIO_PIN_LED_RED) && (GPIO_PIN_LED_RED != UNDEF_PIN)) \
     || (defined(GPIO_PIN_LED_GREEN) && (GPIO_PIN_LED_GREEN != UNDEF_PIN)) \
     || (defined(GPIO_PIN_LED_BLUE) && (GPIO_PIN_LED_BLUE != UNDEF_PIN))
 extern device_t LED_device;


### PR DESCRIPTION
Showstopping major bug, everybody panic! Fix immediately!

Just kidding. The devLED check to see if there is a LED device has a copy paste bug in it where BLUE is referenced twice when one should be RED.

This isn't affecting anything currently since anything that has a BLUE and not a RED still gets the device but it could be an issue if there ever was a target that defined `GPIO_PIN_LED_RED -1` or something.