### PR TITLE
Start dynamic power low instead of high

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -529,8 +529,9 @@ static void ChangeRadioParams()
   ModelUpdatePending = false;
 
   SetRFLinkRate(config.GetRate());
-  POWERMGNT.setPower((PowerLevels_e)config.GetPower());
   OtaSetSwitchMode((OtaSwitchMode_e)config.GetSwitchMode());
+  // Dynamic Power starts at MinPower and will boost if switch is set or IsArmed and disconnected
+  POWERMGNT.setPower(config.GetDynamicPower() ? MinPower : (PowerLevels_e)config.GetPower());
   // TLM interval is set on the next SYNC packet
 }
 


### PR DESCRIPTION
This PR starts the TX at MinPower instead of configured (max) power on startup or packet rate switch when dynamic power is enabled.

### Why change it?
I think most users expect that when they turn their handset on, the TX is going to be in low power mode instead of high power mode. For almost 100% of the cases, this is going to be the desired behavior and the receiver is almost always close to the transmitter on power up, making MinPower sufficient for connection.

### Why it was the way it was
The thinking with the existing code was that it was the safest thing to do. If the handset is powered while the receiver was far away and ELRS is in an "idle" state, there was no way for the power to increase which means we might not ever get a connection when it is needed most. This might be the case if
* The handset battery dies on a long range flight and needs to be swapped
* The handset crashes due to a Lua problem and needs a reboot or goes into Emergency Mode on its own
* Dropping the handset knocks the batteries and causes it to lose power

The way it works now guarantees full power on startup for the best chance of establishing a connection, however, this thinking was before we added the IsArmed check to the mix. The IsArmed check forces max configured power if armed and the TX is in a "disconnected" state. This provides the stimulus needed to go from low to high power in the above cases on power up. If any of those occur, it is always going to be with the craft armed already, so the existing logic will immediately boost the power due to being disconnected with the arm switch high.

### Drawbacks
Anyone with dynamic power enabled that does not have an arm switch OR dynamic power on a switch will be screwed if one of the above cases happens in flight. I don't think this is a common use case and if that's a concern then that use should have dynamic power on a switch for an emergency reconnect. Generally MinPower is going to be sufficient for a connection even with that scenario due to the 💪 range of ExpressLRS anyway.