### PR TITLE
Move all build git queries to one function

### DIFF
--- a/src/python/build_flags.py
+++ b/src/python/build_flags.py
@@ -1,7 +1,6 @@
 Import("env")
 import os
 import sys
-import subprocess
 import hashlib
 import fnmatch
 import time

--- a/src/python/build_html.py
+++ b/src/python/build_html.py
@@ -1,8 +1,6 @@
 Import("env")
 import os
 import re
-import sys
-import subprocess
 import io
 import tempfile
 import filecmp

--- a/src/python/elrs_helpers.py
+++ b/src/python/elrs_helpers.py
@@ -1,4 +1,3 @@
-import sys
 import os
 import re
 
@@ -10,6 +9,8 @@ def get_git(env):
     try:
         import git
     except ImportError:
+        import sys
+        import subprocess
         sys.stdout.write("Installing GitPython")
         subprocess.check_call([sys.executable, "-m", "pip", "install", "GitPython"])
         try:

--- a/src/python/elrs_helpers.py
+++ b/src/python/elrs_helpers.py
@@ -1,3 +1,4 @@
+import sys
 import os
 import re
 

--- a/src/python/elrs_helpers.py
+++ b/src/python/elrs_helpers.py
@@ -1,0 +1,64 @@
+import os
+import re
+
+def get_git(env):
+    """
+    Returns a git.Repo class for a git repo in the current directory
+    installing GitPython if neeeded
+    """
+    try:
+        import git
+    except ImportError:
+        sys.stdout.write("Installing GitPython")
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "GitPython"])
+        try:
+            import git
+        except ImportError:
+            env.Execute("$PYTHONEXE -m pip install GitPython")
+            try:
+                import git
+            except ImportError:
+                return None
+
+    try:
+        # Check one directory up for a git repo
+        orig_dir = os.path.abspath(os.path.join(os.getcwd(), os.pardir))
+        git_repo = git.Repo(orig_dir, search_parent_directories=False)
+        # If that succeeded then find out where the top level is and open that
+        git_root = git_repo.git.rev_parse("--show-toplevel")
+        if orig_dir != git_root:
+            git_repo = git.Repo(git_root, search_parent_directories=False)
+        return git_repo
+    except git.InvalidGitRepositoryError:
+        pass
+
+    return None
+
+def get_git_version(env):
+    """
+    Return a dict with keys
+    version: The version tag if HEAD is a version, or branch otherwise
+    sha: the 6 character short sha for the current HEAD revison, falling back to
+        VERSION file if not in a git repo
+    """
+    ver = "ver.unknown"
+    sha = "000000"
+
+    git_repo = get_git(env)
+    if git_repo:
+        import git
+        sha = git_repo.head.object.hexsha
+        try:
+            ver = re.sub(r".*/", "", git_repo.git.describe("--all", "--exact-match"))
+        except git.exc.GitCommandError:
+            try:
+                ver = git_repo.git.symbolic_ref("-q", "--short", "HEAD")
+            except git.exc.GitCommandError:
+                pass
+    elif os.path.exists("VERSION"):
+        with open("VERSION") as _f:
+            data = _f.readline()
+            _f.close()
+        sha = data.split()[1].strip()
+
+    return dict(version=ver, sha=sha[:6])


### PR DESCRIPTION
Refactors the build process's way of querying the git version/sha into a single function.

Issue reported by discord user trying to build `DIY_2400_TX_ESP32_SX1280_E28` from a zip file, would not build with error "hash used before assignment" in build_html.py. For some reason, every time we want to get some git info, there's a copy paste of the same giant chunk of code that tries to install GitPython etc. This refactors it into one function that is used for all three places that use it, and fixes the bug that was originally reported.

This should allow us to get these values consistently and have the same value reported everywhere. For example, the VERSION file was only used in the build_flags, not the webui.

```
# elrs_helpers.py
def get_git_version(env):
    """
    Return a dict with keys
    version: The version tag if HEAD is a version, or branch otherwise
    sha: the 6 character short sha for the current HEAD revison, falling back to
        VERSION file if not in a git repo
    """

### Example
def get_git_version():
    ver = elrs_helpers.get_git_version(env)['version']
    return ",".join(["%s" % ord(char) for char in ver])
```

Note that the tests used to always return a fixed string for ver and hash (for the build flags, not the webui), but I have removed that. That really was just a workaround for there not being a git repo and now we handle that properly so I think is good to have the tests have the right version info.