### PR TITLE
Remove DIY E28 forcing I2C OLED

### DIFF
--- a/src/include/target/DIY_2400_TX_ESP32_SX1280_E28.h
+++ b/src/include/target/DIY_2400_TX_ESP32_SX1280_E28.h
@@ -1,7 +1,6 @@
 #define DEVICE_NAME "DIY2400 E28"
 
 // Any device features
-#define USE_OLED_I2C
 #if !defined(USE_OLED_I2C)
 #define USE_OLED_SPI
 #endif


### PR DESCRIPTION
This is against MASTER!

#1072 included a line in the header file that forced DIY_2400_TX_SX1280_E28 to have to use an I2C OLED. This removes it after my [conversation with pkendall64](https://github.com/ExpressLRS/ExpressLRS/pull/1072#issuecomment-971819687) (and verified on Discord).