### PR TITLE
Lock FM30 TX antenna to left

### DIFF
--- a/src/include/target/FM30_TX.h
+++ b/src/include/target/FM30_TX.h
@@ -11,9 +11,8 @@
 #define GPIO_PIN_MISO           PB14
 #define GPIO_PIN_SCK            PB13
 #define GPIO_PIN_RST            PB3
-//#define GPIO_PIN_RX_ENABLE    UNDEF_PIN
 #define GPIO_PIN_TX_ENABLE      PB9 // CTX on SE2431L
-#define GPIO_PIN_ANT_CTRL_2     PB4 // Low for left (stock), high for right (empty)
+#define GPIO_PIN_ANT_CTRL       PB4 // Low for left (stock), high for right (empty)
 #define GPIO_PIN_RCSIGNAL_RX    PA10 // UART1
 #define GPIO_PIN_RCSIGNAL_TX    PA9  // UART1
 #define GPIO_PIN_BUFFER_OE      PB7
@@ -23,18 +22,21 @@
 #define GPIO_PIN_LED_GREEN      PA7 // Left Green LED (active low)
 #define GPIO_LED_GREEN_INVERTED 1
 #define GPIO_PIN_BUTTON         PB0 // active low
-//#define GPIO_PIN_BUZZER       UNDEF_PIN
-#define GPIO_PIN_DIP1           PA0 // Rotary Switch 0001
-#define GPIO_PIN_DIP2           PA1 // Rotary Switch 0010
-//#define GPIO_PIN_FAN_EN       UNDEF_PIN
 #define GPIO_PIN_DEBUG_RX       PA3 // UART2 (bluetooth)
 #define GPIO_PIN_DEBUG_TX       PA2 // UART2 (bluetooth)
+#define GPIO_PIN_BLUETOOTH_EN   PA8 // Bluetooth power on (active low)
 // GPIO not currently used (but initialized)
 #define GPIO_PIN_LED_RED_GREEN  PB1 // Right Green LED (active low)
 #define GPIO_PIN_LED_GREEN_RED  PA15 // Left Red LED (active low)
 #define GPIO_PIN_UART3RX_INVERT PB5 // Standalone inverter
-#define GPIO_PIN_BLUETOOTH_EN   PA8 // Bluetooth power on (active low)
 #define GPIO_PIN_UART1RX_INVERT PB6 // XOR chip
+#define GPIO_PIN_DIP1           PA0 // Rotary Switch 0001
+#define GPIO_PIN_DIP2           PA1 // Rotary Switch 0010
+#define GPIO_PIN_DIP3           PA4 // Rotary Switch 0100
+#define GPIO_PIN_DIP4           PA5 // Rotary Switch 1000
+//#define GPIO_PIN_RX_ENABLE    UNDEF_PIN
+//#define GPIO_PIN_BUZZER       UNDEF_PIN
+//#define GPIO_PIN_FAN_EN       UNDEF_PIN
 
 // Power output
 #define MinPower                PWR_10mW

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -888,6 +888,8 @@ static void setupTarget()
   digitalWrite(GPIO_PIN_BLUETOOTH_EN, HIGH);
   pinMode(GPIO_PIN_UART1RX_INVERT, OUTPUT); // RX1 inverter (TX handled in CRSF)
   digitalWrite(GPIO_PIN_UART1RX_INVERT, HIGH);
+  pinMode(GPIO_PIN_ANT_CTRL, OUTPUT);
+  digitalWrite(GPIO_PIN_ANT_CTRL, LOW); // LEFT antenna
   HardwareSerial *uart2 = new HardwareSerial(USART2);
   uart2->begin(57600);
   CRSF::PortSecondary = uart2;


### PR DESCRIPTION
Updates the SIYI FM30 TX to only use the left antenna. Fixes regression added in #992 

### Details
In the target definitions refactor, the code in SX1280_hal was changed from a define that only affected GHOST_LITE to anything that had `GPIO_PIN_ANT_CTRL_2` defined. This meant that the FM30 would now start toggling its antenna pin instead of it being locked to a single antenna, which means the FM30 started receiving telemetry on its second antenna which is not populated.

Because there is only one antenna in the FM30, to fix I just stop using GPIO_PIN_ANT_CTRL_2 and do a fixed setting of that pin to LOW on startup.

I also added two new pins to the header that aren't currently used that apparently I forgot to include originally, and organize them back into order.
