### PR TITLE
Don't abort if we're asking the user!

### DIFF
--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -437,11 +437,6 @@ static void WebUploadDataHandler(AsyncWebServerRequest *request, const String& f
       } else {
         Update.printError(Serial);
       }
-    } else {
-      #if defined(PLATFORM_ESP32)
-        Update.abort();
-      #endif
-      DBGLN("Wrong firmware uploaded, not %s, update aborted", &target_name[4]);
     }
   }
 }


### PR DESCRIPTION
Stupid error when porting over code from the backpack.
I forgot to remove the part where it aborted the upload on mismatched firmware when we are only supposed to do that it the user says to abort.