### PR TITLE
Abort current telem receive if about to commit

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -588,6 +588,15 @@ static void CheckConfigChangePending()
     while (pauseCycles--)
       timerCallbackIdle();
 #endif
+    // If telemetry expected in the next interval, the radio is in RX mode
+    // and will skip sending the next packet when the tiemr resumes.
+    // Return to normal send mode because if the skipped packet happened
+    // to be on the last slot of the FHSS the skip will prevent FHSS
+    if (TelemetryRcvPhase == ttrpInReceiveMode)
+    {
+      Radio.SetTxIdleMode();
+      TelemetryRcvPhase = ttrpTransmitting;
+    }
     ConfigChangeCommit();
   }
 }
@@ -603,9 +612,9 @@ void ICACHE_RAM_ATTR RXdoneISR()
 
 void ICACHE_RAM_ATTR TXdoneISR()
 {
-  busyTransmitting = false;
   HandleFHSS();
   HandlePrepareForTLM();
+  busyTransmitting = false;
 }
 
 static void UpdateConnectDisconnectStatus()

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -568,7 +568,7 @@ static void CheckConfigChangePending()
     if (syncSpamCounter > 0)
       return;
 
-#if !defined(PLATFORM_STM32) && !defined(TARGET_USE_EEPROM)
+#if !defined(PLATFORM_STM32) || defined(TARGET_USE_EEPROM)
     while (busyTransmitting); // wait until no longer transmitting
     hwTimer.callbackTock = &timerCallbackIdle;
 #else

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -568,7 +568,7 @@ static void CheckConfigChangePending()
     if (syncSpamCounter > 0)
       return;
 
-#if !defined(PLATFORM_STM32) || defined(TARGET_USE_EEPROM)
+#if !defined(PLATFORM_STM32) && !defined(TARGET_USE_EEPROM)
     while (busyTransmitting); // wait until no longer transmitting
     hwTimer.callbackTock = &timerCallbackIdle;
 #else


### PR DESCRIPTION
This PR aborts the current (upcoming) telemetry receive that would occur during the EEPROM commit Idle period. The expected telemetry receive causes the FHSSptr fall behind the receiver if the Normal timer resumes on the last slot of the FHSS and can desync the RX.

### Details
There are only two places the FHSSptr can advance on the TX:
1. Following a successful packet transmission
1. During the idle loop used on EEPROM commit

Consider the following RX scoreboard of an EEPROM commit (separated by FHSS slot) `TsTR TsTR TsT?`. After the last syncSpam packet `TXdone` event, the TX goes into receive mode, as the next packet is expected to be a telemetry receive. This sets a flag 
 (`TelemetryRcvPhase`) that tells the next `timerCallbackNormal` to not transmit this interval because telemetry is being received. However, the idle timer does not clear this flag.

When the timer resumes on the last slot, the first Tock still has the flag set, which prevents it from sending a packet, and because no packet was transmitted the FHSSptr does not advance and therefore the TX drops one hop behind the transmitter. The the receiver can go into a sort of "5Hz Mode" where it almost stays connected on regulatory domains where there aren't a lot of hops (like 868) due to the TX and the RX happening to be on the same channel at the same time. On domains with more hops, the receiver simply times out and disconnects due to the low probability of being on the same channel so this issue is usually not noticed apart from the disconnect and immediate reconnect.

To resolve this, I think the only fix needed is to clear the `TelemetryRcvPhase` flag to go back to normal when resuming from the idle timer. To be extra sure nothing unexpected happens, I also 
* Take the Radio out of RX mode to prevent the incoming packet from throwing an interrupt during the commit and possibly messing with the state
* move the `busyTransmitting` flag clear to be the last thing that happens after TXdone. This isn't necessary because the loop() code won't preempt the interrupt code, but the flag should only be cleared once the state is resolved. If this was a multithreaded system it could cause issues but all of these bits run on the same core so this is just about being correct for future changes.

### Reproducing the bug
The only way I could reproduce this was to run my Team900 stuff in 868 mode for the low number of FHSS channels, then plug in a receiver at 200Hz and change a lua config item (TX power) while we're in Telem Boost (1:2) mode. The high number of telemetry periods really helped to bring out the problem. It doesn't seem to happen as much with just regular 1:2 mode, so there might be something about the ratio changing at the same time that interacts to make this happen.

### Draft
This is no longer a draft, there are other fixes related to R9M that will come in another PR since this does not fix those issues.