### PR TITLE
Move all sendLinkStatisticsToFC() to one place

### DIFF
--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -64,8 +64,6 @@ void SX127xDriver::End()
 
 void SX127xDriver::ConfigLoraDefaults()
 {
-  DBGLN("Setting ExpressLRS LoRa reg defaults");
-
   hal.writeRegister(SX127X_REG_OP_MODE, SX127x_OPMODE_SLEEP);
   hal.writeRegister(SX127X_REG_OP_MODE, ModFSKorLoRa); //must be written in sleep mode
   SetMode(SX127x_OPMODE_STANDBY);

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -156,7 +156,8 @@ uint32_t doneProcessing;
 uint32_t LastValidPacket = 0;           //Time the last valid packet was recv
 uint32_t LastSyncPacket = 0;            //Time the last valid packet was recv
 
-uint32_t SendLinkStatstoFCintervalLastSent = 0;
+static uint32_t SendLinkStatstoFCintervalLastSent;
+static uint8_t SendLinkStatstoFCForcedSends;
 
 int16_t RFnoiseFloor; //measurement of the current RF noise floor
 #if defined(DEBUG_RX_SCOREBOARD)
@@ -1035,17 +1036,13 @@ static void cycleRfMode(unsigned long now)
     {
         RFmodeLastCycled = now;
         LastSyncPacket = now;           // reset this variable
+        SendLinkStatstoFCForcedSends = 2;
         SetRFLinkRate(scanIndex % RATE_MAX); // switch between rates
-        SendLinkStatstoFCintervalLastSent = now;
         LQCalc.reset();
         // Display the current air rate to the user as an indicator something is happening
-        INFOLN("%d", ExpressLRS_currAirRate_Modparams->interval);
         scanIndex++;
-        getRFlinkInfo();
-        crsf.sendLinkStatisticsToFC();
-        delay(100);
-        crsf.sendLinkStatisticsToFC(); // need to send twice, not sure why, seems like a BF bug?
         Radio.RXnb();
+        INFOLN("%u", ExpressLRS_currAirRate_Modparams->interval);
 
         // Switch to FAST_SYNC if not already in it (won't be if was just connected)
         RFmodeCycleMultiplier = 1;
@@ -1136,6 +1133,26 @@ static void updateBindingMode()
 #endif
 }
 
+static void checkSendLinkStatsToFc(uint32_t now)
+{
+    if (now - SendLinkStatstoFCintervalLastSent > SEND_LINK_STATS_TO_FC_INTERVAL)
+    {
+        if (connectionState == disconnected)
+        {
+            getRFlinkInfo();
+        }
+
+        if ((connectionState != disconnected && connectionHasModelMatch) ||
+            SendLinkStatstoFCForcedSends)
+        {
+            crsf.sendLinkStatisticsToFC();
+            SendLinkStatstoFCintervalLastSent = now;
+            if (SendLinkStatstoFCForcedSends)
+                --SendLinkStatstoFCForcedSends;
+        }
+    }
+}
+
 #if defined(PLATFORM_ESP8266)
 // Called from core's user_rf_pre_init() function (which is called by SDK) before setup()
 RF_PRE_INIT()
@@ -1216,8 +1233,8 @@ void loop()
         LostConnection();
         LastSyncPacket = now;           // reset this variable to stop rf mode switching and add extra time
         RFmodeLastCycled = now;         // reset this variable to stop rf mode switching and add extra time
-        crsf.sendLinkStatisticsToFC();
-        crsf.sendLinkStatisticsToFC(); // need to send twice, not sure why, seems like a BF bug?
+        SendLinkStatstoFCintervalLastSent = 0;
+        SendLinkStatstoFCForcedSends = 2;
     }
 
     if (connectionState == tentative && (now - LastSyncPacket > ExpressLRS_currAirRate_RFperfParams->RxLockTimeoutMs))
@@ -1243,18 +1260,7 @@ void loop()
         GotConnection(now);
     }
 
-    if (now > (SendLinkStatstoFCintervalLastSent + SEND_LINK_STATS_TO_FC_INTERVAL))
-    {
-        if (connectionState == disconnected)
-        {
-            getRFlinkInfo();
-        }
-        if (connectionState != disconnected && connectionHasModelMatch)
-        {
-            crsf.sendLinkStatisticsToFC();
-            SendLinkStatstoFCintervalLastSent = now;
-        }
-    }
+    checkSendLinkStatsToFc(now);
 
     if ((RXtimerState == tim_tentative) && ((now - GotConnectionMillis) > ConsiderConnGoodMillis) && (abs(OffsetDx) <= 5))
     {


### PR DESCRIPTION
Removes all the places RX code directly calls sendLinkStatisticsToFC() in favor of using the regular interval-based reporter. The purpose is to fix missed syncs while rate cycling due to the code `delay()ing` more than a third of the cycle interval.

### Details
When working on trying to reproduce the desync bug for #1127, I rebooted the receiver a lot. A couple hundred times a lot. What I noticed was that we would miss the connection attempt a flippin' lot too. When I looked a the code, when the rate cycle occurs, we set the timeout for 110% of a complete hop cycle. For 868 and 200Hz, that's 288ms. After that deadline is set, the code does sendLinkStatisticsToFC, delays 100ms, and sendLinkStatisticsToFC again **before** switching the Radio to RX mode. It just wasted more than a third of the cycle interval in a delay before it even starts!

This affects the other rates as well (868):
| Rate | CycleInterval (ms) | MAX chance of connection |
|---|---|---|
| 200Hz | 288 | 65% |
| 100Hz | 572 | 82% |
| 50Hz | 1144 | 91% |
| 25Hz | 1142 | 91% |

Having only a 65% chance to connect in the best case scenario sucks and I witnessed many times that the cycling would miss multiple opportunities and experience a slow connection. This affects **all** Teams and Regulatory Domains, even our golden 500Hz Team2.4 connection which only has an 85% chance of chance of connecting (704ms cycle interval).

This does not affect reconnects if `LOCK_ON_FIRST_CONNECTION` is true, only when rate cycling.

### A gud fix
I could have just waited to start the timeout after the radio is put into RX mode, but instead I changed all the places where sendLinkStatisticsToFC() was called directly to just have them flag that the main process should do it. This allows us to actually do it twice at 100ms intervals as the code wants to, but without delay()ing directly. The LinkStats are sent twice as the code suggests there is a bug in BF this is trying to work around so I don't want to change that behavior.

I've also reordered the code a little bit to reduce the time from when the timeout is started to when the receiver goes into RX mode. I do not think this would make much difference but it makes sense to do so anyway. Also fixed was a possible overflow when the millis timer rolled over, but that's not something we ever have to worry about either. Finally, the code was moved out of loop to its own function to clean up a bit.

### Unrelated annoying thing
Every time the rate cycled it would print `Setting ExpressLRS LoRa reg defaults` which who cares. It just spams the log window every time the rate changes, and Team2.4 doesn't say that so why does Team900.