### PR TITLE
Lua: Allow changing a value when it is set to ERR

### DIFF
--- a/src/lua/elrsV2.lua
+++ b/src/lua/elrsV2.lua
@@ -355,10 +355,15 @@ local function fieldStringDisplay(field, y, attr)
 end
 
 local function fieldFolderOpen(field)
+  folderAccess = field.id
+  local backFld = fields[backButtonId]
+  -- Store the lineIndex and pageOffset to return to in the backFld
+  backFld.li = lineIndex
+  backFld.po = pageOffset
+  backFld.parent = folderAccess
+
   lineIndex = 1
   pageOffset = 0
-  folderAccess = field.id
-  fields[backButtonId].parent = folderAccess
 end
 
 local function fieldFolderDeviceOpen(field)
@@ -395,8 +400,14 @@ local function fieldCommandDisplay(field, y, attr)
 end
 
 local function UIbackExec()
+  local backFld = fields[backButtonId]
+  lineIndex = backFld.li or 1
+  pageOffset = backFld.po or 0
+
+  backFld.parent = 255
+  backFld.li = nil
+  backFld.po = nil
   folderAccess = nil
-  fields[backButtonId].parent = 255
 end
 
 local function changeDeviceId(devId) --change to selected device ID

--- a/src/lua/elrsV2.lua
+++ b/src/lua/elrsV2.lua
@@ -83,6 +83,15 @@ local function getField(line)
   end
 end
 
+local function constrain(x, low, high)
+  if x < low then
+    return low
+  elseif x > high then
+    return high
+  end
+  return x
+end
+
 -- Change display attribute to current field
 local function incrField(step)
   local field = getField(lineIndex)
@@ -111,9 +120,7 @@ local function incrField(step)
       min = 0
       max = #field.values - 1
     end
-    if (step < 0 and field.value > min) or (step > 0 and field.value < max) then
-      field.value = field.value + step
-    end
+    field.value = constrain(field.value + step, min, max)
   end
 end
 


### PR DESCRIPTION
Allows changing a selection value in Lua when it is displaying ERR. I'm not sure how the config ends up in this weird state, I can't reproduce that, but at least we can let the users change the value. When the user attempts to change the value in the current code it just blocks the change since the new value is still outside min/max. This code just constrains it to min/max when changing instead of blocking the change entirely.

I've also added code to make the BACK item / back physical button go back to the previously selected parent item when exiting a folder. I've only implemented one folder deep but if we start getting many levels deep we can address that when I can test it, as right now even Other Devices for me doesn't have enough stuff in it to fill a whole page.