### PR TITLE
R9M using wrong Idle method and EEPROM speedup

### DIFF
--- a/src/include/target/Frsky_TX_R9M.h
+++ b/src/include/target/Frsky_TX_R9M.h
@@ -5,6 +5,7 @@
 
 #define TARGET_USE_EEPROM               1
 #define TARGET_EEPROM_ADDR              0x51
+#define TARGET_EEPROM_400K
 
 // GPIO pin definitions
 #define GPIO_PIN_RFamp_APC1             PA6  //APC2 is connected through a I2C dac and is handled elsewhere

--- a/src/lib/EEPROM/elrs_eeprom.cpp
+++ b/src/lib/EEPROM/elrs_eeprom.cpp
@@ -34,7 +34,11 @@ ELRS_EEPROM::Begin()
         Wire.setSCL(GPIO_PIN_SCL);
         Wire.begin();
         /* Initialize EEPROM */
-        EEPROM.begin(extEEPROM::twiClock400kHz, &Wire);
+        #if defined(TARGET_EEPROM_400K)
+            EEPROM.begin(extEEPROM::twiClock400kHz, &Wire);
+        #else
+            EEPROM.begin(extEEPROM::twiClock100kHz, &Wire);
+        #endif
     #endif // STM32_USE_FLASH
 #else /* !PLATFORM_STM32 */
     EEPROM.begin(RESERVED_EEPROM_SIZE);

--- a/src/lib/EEPROM/elrs_eeprom.cpp
+++ b/src/lib/EEPROM/elrs_eeprom.cpp
@@ -3,7 +3,7 @@
 #include "logging.h"
 
 #if defined(PLATFORM_STM32)
-    #if TARGET_USE_EEPROM && \
+    #if defined(TARGET_USE_EEPROM) && \
             defined(GPIO_PIN_SDA) && (GPIO_PIN_SDA != UNDEF_PIN) && \
             defined(GPIO_PIN_SCL) && (GPIO_PIN_SCL != UNDEF_PIN)
         #if !defined(TARGET_EEPROM_ADDR)
@@ -15,7 +15,7 @@
         #include <extEEPROM.h>
         extEEPROM EEPROM(kbits_2, 1, 1, TARGET_EEPROM_ADDR);
     #else
-        #define STM32_USE_FLASH 1
+        #define STM32_USE_FLASH
         #include <stm32_eeprom.h>
     #endif
 #else
@@ -26,7 +26,7 @@ void
 ELRS_EEPROM::Begin()
 {
 #if defined(PLATFORM_STM32)
-    #if STM32_USE_FLASH
+    #if defined(STM32_USE_FLASH)
         eeprom_buffer_fill();
     #else // !STM32_USE_FLASH
         /* Initialize I2C */
@@ -34,7 +34,7 @@ ELRS_EEPROM::Begin()
         Wire.setSCL(GPIO_PIN_SCL);
         Wire.begin();
         /* Initialize EEPROM */
-        EEPROM.begin(extEEPROM::twiClock100kHz, &Wire);
+        EEPROM.begin(extEEPROM::twiClock400kHz, &Wire);
     #endif // STM32_USE_FLASH
 #else /* !PLATFORM_STM32 */
     EEPROM.begin(RESERVED_EEPROM_SIZE);
@@ -50,7 +50,7 @@ ELRS_EEPROM::ReadByte(const uint32_t address)
         ERRLN("EEPROM address is out of bounds");
         return 0;
     }
-#if STM32_USE_FLASH
+#if defined(STM32_USE_FLASH)
     return eeprom_buffered_read_byte(address);
 #else
     return EEPROM.read(address);
@@ -66,8 +66,10 @@ ELRS_EEPROM::WriteByte(const uint32_t address, const uint8_t value)
         ERRLN("EEPROM address is out of bounds");
         return;
     }
-#if STM32_USE_FLASH
+#if defined(STM32_USE_FLASH)
     eeprom_buffered_write_byte(address, value);
+#elif defined(PLATFORM_STM32)
+    EEPROM.update(address, value);
 #else
     EEPROM.write(address, value);
 #endif
@@ -81,7 +83,7 @@ ELRS_EEPROM::Commit()
     {
       ERRLN("EEPROM commit failed");
     }
-#elif STM32_USE_FLASH
+#elif defined(STM32_USE_FLASH)
     eeprom_buffer_flush();
 #endif
 }

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -588,6 +588,15 @@ static void CheckConfigChangePending()
     while (pauseCycles--)
       timerCallbackIdle();
 #endif
+    // If telemetry expected in the next interval, the radio is in RX mode
+    // and will skip sending the next packet when the tiemr resumes.
+    // Return to normal send mode because if the skipped packet happened
+    // to be on the last slot of the FHSS the skip will prevent FHSS
+    if (TelemetryRcvPhase == ttrpInReceiveMode)
+    {
+      Radio.SetTxIdleMode();
+      TelemetryRcvPhase = ttrpTransmitting;
+    }
     ConfigChangeCommit();
   }
 }
@@ -603,9 +612,9 @@ void ICACHE_RAM_ATTR RXdoneISR()
 
 void ICACHE_RAM_ATTR TXdoneISR()
 {
-  busyTransmitting = false;
   HandleFHSS();
   HandlePrepareForTLM();
+  busyTransmitting = false;
 }
 
 static void UpdateConnectDisconnectStatus()

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -568,7 +568,7 @@ static void CheckConfigChangePending()
     if (syncSpamCounter > 0)
       return;
 
-#if !defined(PLATFORM_STM32) && !defined(TARGET_USE_EEPROM)
+#if !defined(PLATFORM_STM32) || defined(TARGET_USE_EEPROM)
     while (busyTransmitting); // wait until no longer transmitting
     hwTimer.callbackTock = &timerCallbackIdle;
 #else

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -568,7 +568,7 @@ static void CheckConfigChangePending()
     if (syncSpamCounter > 0)
       return;
 
-#if !defined(PLATFORM_STM32) || defined(TARGET_USE_EEPROM)
+#if !defined(PLATFORM_STM32) && !defined(TARGET_USE_EEPROM)
     while (busyTransmitting); // wait until no longer transmitting
     hwTimer.callbackTock = &timerCallbackIdle;
 #else


### PR DESCRIPTION
Proposal for fixing the woes of R9M users, who have just the worst experience when changing things in Lua. TL;DR I believe the EEPROM commit on the TX takes a full second or more, during which time the RX just falls out of sync.

Based on my commit-telemskip branch (#1127).

Ref Issue #1130

### Problem 1: Using the wrong Idle method
The code is only supposed to use the `hwTimer.pause()` method on STM32 targets that use EEPROM emulation. However, the define check would use it even if there was external EEPROM. The #else code is only designed to work around interrupts stopping while flash write is happening. and therefore I2C EEPROM should still work fine but use the Idle timer callback. I'm pretty sure this was just a mistake in the definition that went unnoticed.

I'm fairly sure the code should be: "on every platform except STM32 without extEEPROM". That's what I've got now.

### Problem 2: EEPROM.write takes a long time
I don't have an R9M but I do have an R9MM with external EEPROM, and writing the 96 byte RX config takes 386ms. If I extrapolate that to the 268 byte TX config, that's an estimated 1078ms-- over 1 second of no packets going out! If I emulate that delay on ES900TX, I lose connection to the RX quite regularly when changing values via Lua on 200Hz. The RX just can't stay in sync properly for that many packets (which is sad, I wish it worked longer). It works better at 50Hz but still isn't perfect.

To reduce the delay I've changed two things:
* Increase the I2C speed from 100kHz to 400kHz. I'm not sure if this is out of spec for the EEPROM but it seems to work fine for my R9MM RX and YeOldePirate's R9M TX. The bus speed increase only reduced the write time on the RX from 386ms to 340ms. I've added the define `TARGET_EEPROM_400K` and applied this to only the R9M TX target.
* Only write the _changed_ bytes to EEPROM. The actual physical EEPROM write is what takes a long time, changing flash is hard, yo. For STM32 with external EEPROM, I've changed the code to use `EEPROM.update()` instead of `EEPROM.write()`. This does a read and only does a write if the value is changed. This potentially doubles the I2C traffic, but in practice only 1 or 2 bytes are changed at a time so that's roughly the same traffic except a ton faster because no actual writing is taking place. Reduces the write time from 386ms to 43ms, or 17ms at 400kHz.

### Testing
Tested with YeOldePirate, it seems they can't break the connection just by changing a Lua param any more. It still is possible to desync if there's a long delay with 0 packets, this does not address that which is a completely different issue.