### PR TITLE
Add Third-Party RX Targets (Flywoo, JHEMCU, HiYounger)

### DIFF
--- a/src/platformio.ini
+++ b/src/platformio.ini
@@ -23,6 +23,7 @@ extra_configs =
 	targets/diy_ble_joystick.ini
 	targets/MATEK_2400.ini
 	targets/flywoo_2400.ini
+	targets/jhemcu_2400.ini
 
 # ------------------------- TARGET ENV DEFINITIONS -----------------
 

--- a/src/platformio.ini
+++ b/src/platformio.ini
@@ -22,6 +22,7 @@ extra_configs =
 	targets/diy_2400.ini
 	targets/diy_ble_joystick.ini
 	targets/MATEK_2400.ini
+	targets/flywoo_2400.ini
 
 # ------------------------- TARGET ENV DEFINITIONS -----------------
 

--- a/src/platformio.ini
+++ b/src/platformio.ini
@@ -23,6 +23,7 @@ extra_configs =
 	targets/diy_ble_joystick.ini
 	targets/MATEK_2400.ini
 	targets/flywoo_2400.ini
+	targets/jhemcu_900.ini
 	targets/jhemcu_2400.ini
 
 # ------------------------- TARGET ENV DEFINITIONS -----------------

--- a/src/platformio.ini
+++ b/src/platformio.ini
@@ -26,6 +26,7 @@ extra_configs =
 	targets/jhemcu_900.ini
 	targets/jhemcu_2400.ini
 	targets/hiyounger_900.ini
+	targets/hiyounger_2400.ini
 
 # ------------------------- TARGET ENV DEFINITIONS -----------------
 

--- a/src/platformio.ini
+++ b/src/platformio.ini
@@ -25,6 +25,7 @@ extra_configs =
 	targets/flywoo_2400.ini
 	targets/jhemcu_900.ini
 	targets/jhemcu_2400.ini
+	targets/hiyounger_900.ini
 
 # ------------------------- TARGET ENV DEFINITIONS -----------------
 

--- a/src/targets/flywoo_2400.ini
+++ b/src/targets/flywoo_2400.ini
@@ -10,7 +10,7 @@ extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART
 extends = env:DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough
 
 [env:Flywoo_EL24E_2400_RX_via_WIFI]
-extends = env:Flywoo_EL24E_2400_RX_via_UART
+extends = env:DIY_2400_RX_ESP8285_SX1280_via_WIFI
 
 [env:Flywoo_EL24P_2400_RX_via_UART]
 extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART
@@ -19,4 +19,4 @@ extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART
 extends = env:DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough
 
 [env:Flywoo_EL24P_2400_RX_via_WIFI]
-extends = env:Flywoo_EL24P_2400_RX_via_UART
+extends = env:DIY_2400_RX_ESP8285_SX1280_via_WIFI

--- a/src/targets/flywoo_2400.ini
+++ b/src/targets/flywoo_2400.ini
@@ -11,3 +11,12 @@ extends = env:DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough
 
 [env:Flywoo_EL24E_2400_RX_via_WIFI]
 extends = env:Flywoo_EL24E_2400_RX_via_UART
+
+[env:Flywoo_EL24P_2400_RX_via_UART]
+extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART
+
+[env:Flywoo_EL24P_2400_RX_via_BetaflightPassthrough]
+extends = env:DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough
+
+[env:Flywoo_EL24P_2400_RX_via_WIFI]
+extends = env:Flywoo_EL24P_2400_RX_via_UART

--- a/src/targets/flywoo_2400.ini
+++ b/src/targets/flywoo_2400.ini
@@ -1,0 +1,13 @@
+
+# ********************************
+# Receiver targets
+# ********************************
+
+[env:Flywoo_EL24E_2400_RX_via_UART]
+extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART
+
+[env:Flywoo_EL24E_2400_RX_via_BetaflightPassthrough]
+extends = env:DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough
+
+[env:Flywoo_EL24E_2400_RX_via_WIFI]
+extends = env:Flywoo_EL24E_2400_RX_via_UART

--- a/src/targets/hiyounger_2400.ini
+++ b/src/targets/hiyounger_2400.ini
@@ -1,0 +1,41 @@
+
+# ********************************
+# Transmitter targets
+# ********************************
+
+[env:HiYOUNGER_TX2G4_2400_TX_via_UART]
+extends = env:BETAFPV_2400_TX_via_UART
+
+[env:HiYOUNGER_TX2G4_2400_via_WIFI]
+extends = env:BETAFPV_2400_TX_via_WIFI
+
+# ********************************
+# Receiver targets
+# ********************************
+
+[env:HiYOUNGER_SP24S_2400_RX_via_UART]
+extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART
+
+[env:HiYOUNGER_SP24S_2400_RX_via_BetaflightPassthrough]
+extends = env:DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough
+
+[env:HiYOUNGER_SP24S_2400_RX_via_WIFI]
+extends = env:DIY_2400_RX_ESP8285_SX1280_via_WIFI
+
+[env:HiYOUNGER_EP24S_2400_RX_via_UART]
+extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART
+
+[env:HiYOUNGER_EP24S_2400_RX_via_BetaflightPassthrough]
+extends = env:DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough
+
+[env:HiYOUNGER_EP24S_2400_RX_via_WIFI]
+extends = env:DIY_2400_RX_ESP8285_SX1280_via_WIFI
+
+[env:HiYOUNGER_RX24T_2400_RX_via_UART]
+extends = env:BETAFPV_2400_RX_via_UART
+
+[env:HiYOUNGER_RX24T_2400_RX_via_BetaflightPassthrough]
+extends = env:BETAFPV_2400_RX_via_BetaflightPassthrough
+
+[env:HiYOUNGER_RX24T_2400_RX_via_WIFI]
+extends = env:BETAFPV_2400_RX_via_WIFI

--- a/src/targets/hiyounger_900.ini
+++ b/src/targets/hiyounger_900.ini
@@ -1,0 +1,23 @@
+
+# ********************************
+# Transmitter targets
+# ********************************
+
+[env:HiYOUNGER_900_TX_via_UART]
+extends = env:BETAFPV_900_TX_via_UART
+
+[env:HiYOUNGER_900_TX_via_WIFI]
+extends = env:BETAFPV_900_TX_via_WIFI
+
+# ********************************
+# Receiver targets
+# ********************************
+
+[env:HiYOUNGER_900_RX_via_UART]
+extends = env:BETAFPV_900_RX_via_UART
+
+[env:HiYOUNGER_900_RX_via_WIFI]
+extends = env:BETAFPV_900_RX_via_WIFI
+
+[env:HiYOUNGER_900_RX_via_BetaflightPassthrough]
+extends = env:BETAFPV_900_RX_via_BetaflightPassthrough

--- a/src/targets/jhemcu_2400.ini
+++ b/src/targets/jhemcu_2400.ini
@@ -10,7 +10,7 @@ extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART
 extends = env:DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough
 
 [env:JHEMCU_SP24S_2400_RX_via_WIFI]
-extends = env:JHEMCU_SP24S_2400_RX_via_UART
+extends = env:DIY_2400_RX_ESP8285_SX1280_via_WIFI
 
 [env:JHEMCU_EP24S_2400_RX_via_UART]
 extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART
@@ -19,4 +19,4 @@ extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART
 extends = env:DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough
 
 [env:JHEMCU_EP24S_2400_RX_via_WIFI]
-extends = env:JHEMCU_EP24S_2400_RX_via_UART
+extends = env:DIY_2400_RX_ESP8285_SX1280_via_WIFI

--- a/src/targets/jhemcu_2400.ini
+++ b/src/targets/jhemcu_2400.ini
@@ -20,3 +20,12 @@ extends = env:DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough
 
 [env:JHEMCU_EP24S_2400_RX_via_WIFI]
 extends = env:DIY_2400_RX_ESP8285_SX1280_via_WIFI
+
+[env:JHEMCU_RX24T_2400_RX_via_UART]
+extends = env:BETAFPV_2400_RX_via_UART
+
+[env:JHEMCU_RX24T_2400_RX_via_BetaflightPassthrough]
+extends = env:BETAFPV_2400_RX_via_BetaflightPassthrough
+
+[env:JHEMCU_RX24T_2400_RX_via_WIFI]
+extends = env:BETAFPV_2400_RX_via_WIFI

--- a/src/targets/jhemcu_2400.ini
+++ b/src/targets/jhemcu_2400.ini
@@ -1,0 +1,22 @@
+
+# ********************************
+# Receiver targets
+# ********************************
+
+[env:JHEMCU_SP24S_2400_RX_via_UART]
+extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART
+
+[env:JHEMCU_SP24S_2400_RX_via_BetaflightPassthrough]
+extends = env:DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough
+
+[env:JHEMCU_SP24S_2400_RX_via_WIFI]
+extends = env:JHEMCU_SP24S_2400_RX_via_UART
+
+[env:JHEMCU_EP24S_2400_RX_via_UART]
+extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART
+
+[env:JHEMCU_EP24S_2400_RX_via_BetaflightPassthrough]
+extends = env:DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough
+
+[env:JHEMCU_EP24S_2400_RX_via_WIFI]
+extends = env:JHEMCU_EP24S_2400_RX_via_UART

--- a/src/targets/jhemcu_900.ini
+++ b/src/targets/jhemcu_900.ini
@@ -1,0 +1,13 @@
+
+# ********************************
+# Receiver targets
+# ********************************
+
+[env:JHEMCU_900_RX_via_UART]
+extends = env:DIY_900_RX_ESP8285_SX127x_via_UART
+
+[env:JHEMCU_900_RX_via_WIFI]
+extends = env:DIY_900_RX_ESP8285_SX127x_via_WIFI
+
+[env:JHEMCU_900_RX_via_BetaflightPassthrough]
+extends = env:DIY_900_RX_ESP8285_SX127x_via_BetaflightPassthrough


### PR DESCRIPTION
I've using the Flywoo EL24E Receivers. The manufacturer mentions that you should use the DIY target in the configurator. 
https://flywoo.net/products/0-4g-flywoo-2-4g-expresslrs-elrs-el24e-el24p
This works for me. I just copied the DIY target and used it to create the target for the Flywoo receiver. I will also create a PR for the Configurator.