### PR TITLE
Increase STM32 emulated EEPROM commit delay

### DIFF
--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -14,8 +14,8 @@ expresslrs_mod_settings_s ExpressLRS_AirRateConfig[RATE_MAX] = {
 expresslrs_rf_pref_params_s ExpressLRS_AirRateRFperf[RATE_MAX] = {
     {0, RATE_200HZ, -112, 4380, 3000, 2500, 600, 5000},
     {1, RATE_100HZ, -117, 8770, 3500, 2500, 600, 5000},
-    {2, RATE_50HZ, -120, 17540, 4000, 2500, 600, 5000},
-    {3, RATE_25HZ, -123, 17540, 6000, 4000, 0, 5000}};
+    {2, RATE_50HZ, -120, 18560, 4000, 2500, 600, 5000},
+    {3, RATE_25HZ, -123, 29950, 6000, 4000, 0, 5000}};
 #endif
 
 #if defined(Regulatory_Domain_ISM_2400)


### PR DESCRIPTION
This adds one packet cycle to the delay used on STM32 using emulated EEPROM to account for up to half of the cycle being consumed in busywait.  This delay was sometimes causing the receiver to get out of sync.

This was reported by discord user PSi86 who worked with me to work backward to a solution.

### Details
The EEPROM pause was 30ms, with a flash page write taking 29.1-29.5ms of that (observed across multiple F103C8). However, the code forwards the timer then waits until the current packet is done being transmitted.  This takes the majority of the first `pauseCycle` which makes the delay shorter than 30ms. The timer would be waiting once the commit finished and possibly phase shift the transmit timer.

To remedy this, the pause is now extended by one packet interval to guarantee the full 30ms to the flash write operation.

When switching rates, the code was also using the new rate to compute the number of cycles, but it should always use the existing rate, because that is the rate the timer is actually running. This was changed to use the current rate always.

### Other Changes
* The TimeOnAir member of Team900's 50Hz and 25Hz had the incorrect values. 50Hz was using 8 preamble symbols instead of the correct 10, and 25Hz was using 50Hz's timing.
* In `ConfigChangeCommit()`, changing the radio params was moved to AFTER the commit instead of before. This is because changing the RF rate will put the radio back on the sync channel, so it should happen after the commit to guarantee the idle handler doesn't overwrite this (this isn't the case currently, but would be best to have them in order in case later changes alter their code).