### PR TITLE
Stop calling MSP.resetState and always force

### DIFF
--- a/src/lib/StubbornSender/stubborn_sender.cpp
+++ b/src/lib/StubbornSender/stubborn_sender.cpp
@@ -9,20 +9,24 @@ StubbornSender::StubbornSender(uint8_t maxPackageIndex)
 
 void StubbornSender::ResetState()
 {
-    data = 0;
+    data = nullptr;
     bytesPerCall = 1;
     currentOffset = 0;
     currentPackage = 0;
     length = 0;
     waitUntilTelemetryConfirm = true;
     waitCount = 0;
-    maxWaitCount = 1000;
+    // 80 corresponds to UpdateTelemetryRate(ANY, 2, 1), which is what the TX uses in boost mode
+    maxWaitCount = 80;
     senderState = SENDER_IDLE;
 }
 
+/***
+ * Queues a message to send, will abort the current message if one is currently being transmitted
+ ***/
 void StubbornSender::SetDataToTransmit(uint8_t lengthToTransmit, uint8_t* dataToTransmit, uint8_t bytesPerCall)
 {
-    if (senderState != SENDER_IDLE || lengthToTransmit / bytesPerCall >= maxPackageIndex)
+    if (lengthToTransmit / bytesPerCall >= maxPackageIndex)
     {
         return;
     }
@@ -33,7 +37,7 @@ void StubbornSender::SetDataToTransmit(uint8_t lengthToTransmit, uint8_t* dataTo
     currentPackage = 1;
     waitCount = 0;
     this->bytesPerCall = bytesPerCall;
-    senderState = SENDING;
+    senderState = (senderState == SENDER_IDLE) ? SENDING : SEND_NEXT;
 }
 
 bool StubbornSender::IsActive()
@@ -103,8 +107,8 @@ void StubbornSender::ConfirmCurrentPayload(bool telemetryConfirmValue)
         {
             nextSenderState = WAIT_UNTIL_NEXT_CONFIRM;
         }
-
         break;
+
     case RESYNC:
     case WAIT_UNTIL_NEXT_CONFIRM:
         if (telemetryConfirmValue == waitUntilTelemetryConfirm)
@@ -122,10 +126,14 @@ void StubbornSender::ConfirmCurrentPayload(bool telemetryConfirmValue)
                 nextSenderState = RESYNC;
             }
         }
-
         break;
-    case SENDER_IDLE:
+
     case SEND_NEXT:
+        nextSenderState = SENDER_IDLE;
+        waitUntilTelemetryConfirm = !telemetryConfirmValue;
+        break;
+
+    case SENDER_IDLE:
         break;
     }
 

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -218,7 +218,7 @@ void DynamicPower_Update()
     POWERMGNT.incPower();
   }
   if (avg_rssi > rssi_dec_threshold) {
-    DBGLN("Power decrease");
+    DBGVLN("Power decrease");
     POWERMGNT.decPower();
   }
 
@@ -685,7 +685,6 @@ void BackpackBinding()
 static void SendRxWiFiOverMSP()
 {
   MSPDataPackage[0] = MSP_ELRS_SET_RX_WIFI_MODE;
-  MspSender.ResetState();
   MspSender.SetDataToTransmit(1, MSPDataPackage, ELRS_MSP_BYTES_PER_CALL);
 }
 
@@ -770,7 +769,6 @@ void SendUIDOverMSP()
   MSPDataPackage[2] = MasterUID[3];
   MSPDataPackage[3] = MasterUID[4];
   MSPDataPackage[4] = MasterUID[5];
-  MspSender.ResetState();
   BindingSendCount = 0;
   MspSender.SetDataToTransmit(5, MSPDataPackage, ELRS_MSP_BYTES_PER_CALL);
 }
@@ -835,7 +833,6 @@ void ExitBindingMode()
 
   InBindingMode = false;
 
-  MspSender.ResetState();
   SetRFLinkRate(config.GetRate()); //return to original rate
 
   DBGLN("Exiting binding mode");


### PR DESCRIPTION
This removes the `MspSender.ResetState()` calls from the TX, which has always been the wrong thing to do, and changes `StubbornSender::SetDataToTransmit()` to force clear the current payload to send if something is in transmission. The purpose of these changes is to resolve #1132 and fix forced-sending a MSP payload when the RX is expecting a FALSE stubborn bit.

### Details
`MspSender.ResetState()` was meant to be a one-time called function, or used in the tests to get everything back to the initial state. The problem is that when calling `SendRxWiFiOverMSP()` to push the RX into wifi, `ResetState()` forces the stubbornsender to expect a `waitUntilTelemetryConfirm` of TRUE coming back in LinkStats telemetry. However, when the RX has a FALSE value already, it just keeps sending FALSE and eventually we time out and cancel the send. In normal operation, this timeout would flip `waitUntilTelemetryConfirm` and allow the next send to work, but because `SendRxWiFiOverMSP()` always resets the state back to TRUE again, it will fail every time.

The solution is just remove the calls to `ResetState()`. However, because the code expects these MSP messages to take priority over everything I've also changed StubbornSender to always reset when calling `SetDataToTransmit()` and start sending the new data on the next opportunity, using the next `telemetryConfirmValue` received to force a resync and start a new send.

### Other Changes
* Changed Dynamic Power's "Power decrease" message to a verbose-level message, since it spams like crazy when in 1:2 mode.
* `ResetState()` sets the number of retries to 1000, but this is a lot because it expects the app to call `UpdateTelemetryRate()` as needed to set the retries to a sane value. The TX never called this (the RX does), so it would always get 1000 retries. I've changed the default to the number of retries expected at 1:2 w/ 1 burst, which is correct for the TX instead of having the TX call `UpdateTelemetryRate(x, 2, 1)` to save code. The RX still dynamically adjusts.