### PR TITLE
Adding 5s delay after WiFi firmware upload

### DIFF
--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -251,7 +251,7 @@ function uploadFile() {
 
 function progressHandler(event) {
     //_("loaded_n_total").innerHTML = "Uploaded " + event.loaded + " bytes of " + event.total;
-    var percent = Math.round((event.loaded / event.total) * 100);
+    var percent = Math.round((event.loaded / event.total) * 99);
     _("progressBar").value = percent;
     _("status").innerHTML = percent + "% uploaded... please wait";
 }
@@ -261,11 +261,15 @@ function completeHandler(event) {
     _("progressBar").value = 0;
     var data = JSON.parse(event.target.responseText);
     if (data.status === 'ok') {
-        cuteAlert({
-            type: 'success',
-            title: "Update Succeeded",
-            message: data.msg
-        });
+        setTimeout(() => {
+            _("progressBar").value = 100;
+            _("status").innerHTML = "100% uploaded.";
+            cuteAlert({
+                type: 'success',
+                title: "Update Succeeded",
+                message: data.msg
+            });
+        }, 5000);
     } else if (data.status === 'mismatch') {
         cuteAlert({
             type: 'question',

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -272,12 +272,12 @@ function completeHandler(event) {
         var percent = 0;
         var interval = setInterval(()=>{
             percent = percent + 2;
-            _("progressBar_" + type_suffix).value = percent;
-            _("status_" + type_suffix).innerHTML = percent + "% flashed... please wait";
+            _("progressBar_").value = percent;
+            _("status_").innerHTML = percent + "% flashed... please wait";
             if (percent == 100) {
                 clearInterval(interval);
-                _("status_" + type_suffix).innerHTML = "";
-                _("progressBar_" + type_suffix).value = 0;
+                _("status_").innerHTML = "";
+                _("progressBar_").value = 0;
                 show_message();
             }
         }, 100);

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -272,12 +272,12 @@ function completeHandler(event) {
         var percent = 0;
         var interval = setInterval(()=>{
             percent = percent + 2;
-            _("progressBar_").value = percent;
-            _("status_").innerHTML = percent + "% flashed... please wait";
+            _("progressBar").value = percent;
+            _("status").innerHTML = percent + "% flashed... please wait";
             if (percent == 100) {
                 clearInterval(interval);
-                _("status_").innerHTML = "";
-                _("progressBar_").value = 0;
+                _("status").innerHTML = "";
+                _("progressBar").value = 0;
                 show_message();
             }
         }, 100);

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -251,25 +251,36 @@ function uploadFile() {
 
 function progressHandler(event) {
     //_("loaded_n_total").innerHTML = "Uploaded " + event.loaded + " bytes of " + event.total;
-    var percent = Math.round((event.loaded / event.total) * 99);
+    var percent = Math.round((event.loaded / event.total) * 100);
     _("progressBar").value = percent;
     _("status").innerHTML = percent + "% uploaded... please wait";
 }
 
 function completeHandler(event) {
-    _("status").innerHTML = "Processing...";
+    _("status").innerHTML = "";
     _("progressBar").value = 0;
     var data = JSON.parse(event.target.responseText);
     if (data.status === 'ok') {
-        setTimeout(() => {
-            _("progressBar").value = 100;
-            _("status").innerHTML = "100% uploaded.";
+        function show_message() {
             cuteAlert({
                 type: 'success',
                 title: "Update Succeeded",
                 message: data.msg
             });
-        }, 5000);
+        }
+        // This is basically a delayed display of the success dialog with a fake progress
+        var percent = 0;
+        var interval = setInterval(()=>{
+            percent = percent + 2;
+            _("progressBar_" + type_suffix).value = percent;
+            _("status_" + type_suffix).innerHTML = percent + "% flashed... please wait";
+            if (percent == 100) {
+                clearInterval(interval);
+                _("status_" + type_suffix).innerHTML = "";
+                _("progressBar_" + type_suffix).value = 0;
+                show_message();
+            }
+        }, 100);
     } else if (data.status === 'mismatch') {
         cuteAlert({
             type: 'question',

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -257,7 +257,7 @@ function progressHandler(event) {
 }
 
 function completeHandler(event) {
-    _("status").innerHTML = "";
+    _("status").innerHTML = "Processing...";
     _("progressBar").value = 0;
     var data = JSON.parse(event.target.responseText);
     if (data.status === 'ok') {


### PR DESCRIPTION
# Existing behavior (2.0.0-RC3):
You know, people just press OK and don't read a message.

[![IMAGE_ALT](https://i9.ytimg.com/vi_webp/ahnWBLOhnyw/mqdefault.webp?sqp=CPSZoY0G&rs=AOn4CLDl0uDc_prZP_27-poh6EU8CCmz5w)](https://youtu.be/ahnWBLOhnyw)

As seen in the video, the module stays in a *risky* state about 3-4s after pressing OK. 
Even though the message says "wait for LED to resume blinking", many will just pull out the power straight, which will brick a module.

# Improved behavior by this PR
This PR modifies web updater's  behavior to prevent possible user errors by:
1. Mark 99% at the end of an upload instead of 100%, which was giving a false cue that all the job has been done.
2. Added "Processing..." message to `completeHandler` instead of a blank, indicating a user that some work is in progress under the background.
3. Added 5 seconds delay before displaying "Update Succeeded" alert.

[![IMAGE_ALT](https://i9.ytimg.com/vi_webp/TvWp3ntqK_Q/mqdefault.webp?sqp=CPSZoY0G&rs=AOn4CLDOCQQwrk7A5Z7l-Pu9qH_-sZ3yew)](https://youtu.be/TvWp3ntqK_Q)

As seen in the video, the RX completed rebooting with the "Update Succeeded" alert.