### PR TITLE
Add guard around DEVICE_NAME for common headers

### DIFF
--- a/src/include/native.h
+++ b/src/include/native.h
@@ -75,6 +75,9 @@ inline void delay(int32_t time) {
 inline unsigned long millis() { return 0; }
 inline void delayMicroseconds(int delay) { }
 
+const char device_name[] = "testing";
+const uint8_t device_name_size = sizeof(device_name);
+
 #ifdef _WIN32
 #define random rand
 #define srandom srand

--- a/src/include/options.h
+++ b/src/include/options.h
@@ -1,5 +1,7 @@
-#pragma once 
+#pragma once
 
 extern const unsigned char target_name[];
 extern const uint8_t target_name_size;
+extern const char device_name[];
+extern const uint8_t device_name_size;
 extern const char PROGMEM compile_options[];

--- a/src/include/target/BETAFPV_2400_RX.h
+++ b/src/include/target/BETAFPV_2400_RX.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "BETAFPV 2400RX"
+#endif
 
 #define USE_SX1280_DCDC
 

--- a/src/include/target/BETAFPV_2400_TX.h
+++ b/src/include/target/BETAFPV_2400_TX.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME          "BETAFPV 2400TX"
+#endif
 
 // There is some special handling for this target
 #define TARGET_TX_BETAFPV_2400_V1

--- a/src/include/target/BETAFPV_2400_TX_MICRO.h
+++ b/src/include/target/BETAFPV_2400_TX_MICRO.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME              "BETAFPV 2400TX Micro"
+#endif
 
 // Any device features
 #define USE_OLED_I2C

--- a/src/include/target/BETAFPV_900_TX.h
+++ b/src/include/target/BETAFPV_900_TX.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME          "BETAFPV 900TX"
+#endif
 
 // There is some special handling for this target
 #define TARGET_TX_BETAFPV_900_V1

--- a/src/include/target/BETAFPV_900_TX_MICRO.h
+++ b/src/include/target/BETAFPV_900_TX_MICRO.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME              "BETAFPV 900TX Micro"
+#endif
 
 // There is some special handling for this target
 #define TARGET_TX_BETAFPV_900_MICRO_V1
@@ -6,7 +8,7 @@
 // Any device features
 #define USE_OLED_I2C
 #define OLED_REVERSED
-  
+
 // GPIO pin definitions
 #define GPIO_PIN_NSS            5
 #define GPIO_PIN_DIO0           4

--- a/src/include/target/DIY_2400_RX_ESP8285_SX1280.h
+++ b/src/include/target/DIY_2400_RX_ESP8285_SX1280.h
@@ -1,4 +1,7 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "ELRS 2400RX"
+#endif
+
 // GPIO pin definitions
 #define GPIO_PIN_NSS            15
 #define GPIO_PIN_BUSY           5

--- a/src/include/target/DIY_2400_RX_PWMP.h
+++ b/src/include/target/DIY_2400_RX_PWMP.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "DIY2400 PWMP"
+#endif
 
 #define CRSF_RCVR_NO_SERIAL
 

--- a/src/include/target/DIY_2400_RX_STM32_CCG_Nano_v0_5.h
+++ b/src/include/target/DIY_2400_RX_STM32_CCG_Nano_v0_5.h
@@ -1,4 +1,7 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "ELRS 2400RX"
+#endif
+
 // GPIO pin definitions
 #define GPIO_PIN_NSS         PA4
 #define GPIO_PIN_MOSI        PA7

--- a/src/include/target/DIY_2400_TX_ESP32_SX1280_E28.h
+++ b/src/include/target/DIY_2400_TX_ESP32_SX1280_E28.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "DIY2400 E28"
+#endif
 
 // Any device features
 #define USE_OLED_SPI

--- a/src/include/target/DIY_2400_TX_ESP32_SX1280_LORA1280F27.h
+++ b/src/include/target/DIY_2400_TX_ESP32_SX1280_LORA1280F27.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "DIY2400 F27"
+#endif
 
 // Output Power
 #define MinPower PWR_10mW

--- a/src/include/target/DIY_2400_TX_ESP32_SX1280_Mini.h
+++ b/src/include/target/DIY_2400_TX_ESP32_SX1280_Mini.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "DIY2400 Mini"
+#endif
 
 // GPIO pin definitions
 #define GPIO_PIN_NSS          5

--- a/src/include/target/DIY_2400_TX_ESP8285_SX1280.h
+++ b/src/include/target/DIY_2400_TX_ESP8285_SX1280.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "DIY2400 ESP8266"
+#endif
 
 // GPIO pin definitions
 #define GPIO_PIN_NSS            15

--- a/src/include/target/DIY_900_RX_ESP8285_SX127x.h
+++ b/src/include/target/DIY_900_RX_ESP8285_SX127x.h
@@ -1,4 +1,7 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "ELRS 900RX"
+#endif
+
 // GPIO pin definitions
 #define GPIO_PIN_NSS 15
 #define GPIO_PIN_DIO0 4

--- a/src/include/target/DIY_900_RX_HUZZAH_RFM95W.h
+++ b/src/include/target/DIY_900_RX_HUZZAH_RFM95W.h
@@ -1,4 +1,7 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "ELRS 900RX"
+#endif
+
 // GPIO pin definitions
 #define GPIO_PIN_NSS 15
 #define GPIO_PIN_DIO0 5

--- a/src/include/target/DIY_900_RX_PWMP.h
+++ b/src/include/target/DIY_900_RX_PWMP.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "DIY900 PWMP"
+#endif
 
 #define CRSF_RCVR_NO_SERIAL
 

--- a/src/include/target/DIY_900_TX_ESP32_SX127x_E19.h
+++ b/src/include/target/DIY_900_TX_ESP32_SX127x_E19.h
@@ -1,5 +1,7 @@
 // The name of the device in the LUA module
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "DIY900 E19"
+#endif
 
 // GPIO pin definitions
 #define GPIO_PIN_NSS 5

--- a/src/include/target/DIY_900_TX_ESP32_SX127x_RFM95.h
+++ b/src/include/target/DIY_900_TX_ESP32_SX127x_RFM95.h
@@ -1,5 +1,7 @@
 // The name of the device in the LUA module
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "DIY900 RFM95"
+#endif
 
 // GPIO pin definitions
 #define GPIO_PIN_NSS 5

--- a/src/include/target/DIY_900_TX_TTGO_V1_SX127x.h
+++ b/src/include/target/DIY_900_TX_TTGO_V1_SX127x.h
@@ -1,5 +1,7 @@
 // The name of the device in the LUA module
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "DIY900 TTGO V1"
+#endif
 
 // Any device features
 #define USE_OLED_I2C

--- a/src/include/target/DIY_900_TX_TTGO_V2_SX127x.h
+++ b/src/include/target/DIY_900_TX_TTGO_V2_SX127x.h
@@ -1,5 +1,7 @@
 // The name of the device in the LUA module
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "DIY900 TTGO V2"
+#endif
 
 // Any device features
 #define USE_OLED_I2C

--- a/src/include/target/FM30_RX_MINI.h
+++ b/src/include/target/FM30_RX_MINI.h
@@ -1,11 +1,15 @@
 #if defined(RX_AS_TX)
-    #define DEVICE_NAME          "SIYI FR Mini"
+    #ifndef DEVICE_NAME
+        #define DEVICE_NAME          "SIYI FR Mini"
+    #endif
     // There is some special handling for this target
     #define TARGET_TX_FM30_MINI
 #else
     // There is some special handling for this target
     #define TARGET_RX_FM30_MINI
-    #define DEVICE_NAME "FM30 MINI"
+    #ifndef DEVICE_NAME
+        #define DEVICE_NAME "FM30 MINI"
+    #endif
 #endif
 
 #define USE_SX1280_DCDC

--- a/src/include/target/FM30_TX.h
+++ b/src/include/target/FM30_TX.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME          "SIYI FM30"
+#endif
 
 // There is some special handling for this target
 #define TARGET_TX_FM30

--- a/src/include/target/Frsky_RX_R9M.h
+++ b/src/include/target/Frsky_RX_R9M.h
@@ -37,7 +37,9 @@ https://github.com/jaxxzer
 #else
     #define GPIO_PIN_RCSIGNAL_RX    PA10
     #define GPIO_PIN_RCSIGNAL_TX    PA9
-    #define DEVICE_NAME "R9MM"
+    #ifndef DEVICE_NAME
+        #define DEVICE_NAME "R9MM"
+    #endif
 #endif
 
 #if defined(TARGET_R9MX_RX)

--- a/src/include/target/Frsky_TX_R9M_LITE.h
+++ b/src/include/target/Frsky_TX_R9M_LITE.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "FrSky R9M Lite"
+#endif
 
 #define TARGET_USE_EEPROM           1
 #define TARGET_EEPROM_ADDR          0x51

--- a/src/include/target/Frsky_TX_R9M_LITE_PRO.h
+++ b/src/include/target/Frsky_TX_R9M_LITE_PRO.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "R9M Lite Pro"
+#endif
 
 #define TARGET_USE_EEPROM           1
 #define TARGET_EEPROM_ADDR          0x51

--- a/src/include/target/GHOST_2400_TX_LITE.h
+++ b/src/include/target/GHOST_2400_TX_LITE.h
@@ -1,5 +1,7 @@
 // This target extends the GHOST_2400_TX target
+#ifndef DEVICE_NAME
 #define DEVICE_NAME              "Ghost 24TX Lite"
+#endif
 
 // There is some special handling for this target
 #define TARGET_TX_GHOST_LITE

--- a/src/include/target/GHOST_ATTO_2400_RX.h
+++ b/src/include/target/GHOST_ATTO_2400_RX.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "GHOST ATTO"
+#endif
 // There is some special handling for this target
 #define TARGET_RX_GHOST_ATTO_V1
 

--- a/src/include/target/HGLRC_Hermes_2400_TX.h
+++ b/src/include/target/HGLRC_Hermes_2400_TX.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "HGLRC Hermes 24"
+#endif
 
 // Any device features
 #define USE_SX1280_DCDC

--- a/src/include/target/HappyModel_ES24TX_2400_TX.h
+++ b/src/include/target/HappyModel_ES24TX_2400_TX.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "HM ES24TX"
+#endif
 
 // Any device features
 #define USE_TX_BACKPACK

--- a/src/include/target/HappyModel_ES24TX_Pro_Series_2400_TX.h
+++ b/src/include/target/HappyModel_ES24TX_Pro_Series_2400_TX.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "ES24TX Pro Ser"
+#endif
 
 // Any device features
 #define USE_TX_BACKPACK

--- a/src/include/target/HappyModel_TX_ES900TX.h
+++ b/src/include/target/HappyModel_TX_ES900TX.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME          "HM ES900TX"
+#endif
 
 #define USE_TX_BACKPACK
 

--- a/src/include/target/HappyModel_TX_ES915TX.h
+++ b/src/include/target/HappyModel_TX_ES915TX.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "HM ES915TX"
+#endif
 
 #if defined(Regulatory_Domain_EU_868)
     #define POWER_OUTPUT_VALUES {375,850,1200,1400,1700,2000,2400,2600}

--- a/src/include/target/MATEK_2400_RX.h
+++ b/src/include/target/MATEK_2400_RX.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "MATEK 2400RX"
+#endif
 // GPIO pin definitions
 #define GPIO_PIN_NSS                15
 #define GPIO_PIN_BUSY               5

--- a/src/include/target/NamimnoRC_FLASH_2400_OLED_TX.h
+++ b/src/include/target/NamimnoRC_FLASH_2400_OLED_TX.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "Nm.Flash OLED"
+#endif
 
 // Features
 #define USE_TX_BACKPACK

--- a/src/include/target/NamimnoRC_FLASH_2400_RX.h
+++ b/src/include/target/NamimnoRC_FLASH_2400_RX.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "Namimno 2400RX"
+#endif
 // GPIO pin definitions
 #define GPIO_PIN_RST            PB4
 #define GPIO_PIN_BUSY           PB5

--- a/src/include/target/NamimnoRC_FLASH_2400_TX.h
+++ b/src/include/target/NamimnoRC_FLASH_2400_TX.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "Namimno Flash"
+#endif
 
 #define USE_TX_BACKPACK
 

--- a/src/include/target/NamimnoRC_VOYAGER_900_ESP_RX.h
+++ b/src/include/target/NamimnoRC_VOYAGER_900_ESP_RX.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "Namimno 900RX"
+#endif
 // GPIO pin definitions
 #define GPIO_PIN_NSS          15
 #define GPIO_PIN_DIO0         5

--- a/src/include/target/NamimnoRC_VOYAGER_900_OLED_TX.h
+++ b/src/include/target/NamimnoRC_VOYAGER_900_OLED_TX.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "Nm.Voyager OLED"
+#endif
 
 // Features
 #define USE_TX_BACKPACK

--- a/src/include/target/NamimnoRC_VOYAGER_900_RX.h
+++ b/src/include/target/NamimnoRC_VOYAGER_900_RX.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "Namimno 900RX"
+#endif
 // GPIO pin definitions
 #define GPIO_PIN_RST            PC14
 #define GPIO_PIN_DIO0           PA15

--- a/src/include/target/NamimnoRC_VOYAGER_900_TX.h
+++ b/src/include/target/NamimnoRC_VOYAGER_900_TX.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "Namimno Voyager"
+#endif
 
 #define USE_TX_BACKPACK
 

--- a/src/include/target/QuadKopters_JR_2400_TX.h
+++ b/src/include/target/QuadKopters_JR_2400_TX.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "QuadKopters 24"
+#endif
 
 // Any device features
 #define USE_TX_BACKPACK

--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -25,7 +25,6 @@ HardwareSerial CRSF::Port = Serial;
 Stream *CRSF::PortSecondary;
 
 GENERIC_CRC8 crsf_crc(CRSF_CRC_POLY);
-const char deviceName[] = DEVICE_NAME;
 
 ///Out FIFO to buffer messages///
 static FIFO SerialOutFIFO;
@@ -938,9 +937,9 @@ uint16_t CRSF::GetChannelOutput(uint8_t ch)
 
 void CRSF::GetDeviceInformation(uint8_t *frame, uint8_t fieldCount)
 {
-    deviceInformationPacket_t *device = (deviceInformationPacket_t *)(frame + sizeof(crsf_ext_header_t) + sizeof(deviceName));
+    deviceInformationPacket_t *device = (deviceInformationPacket_t *)(frame + sizeof(crsf_ext_header_t) + device_name_size);
     // Packet starts with device name
-    memcpy(frame + sizeof(crsf_ext_header_t), deviceName, sizeof(deviceName));
+    memcpy(frame + sizeof(crsf_ext_header_t), device_name, device_name_size);
     // Followed by the device
     device->serialNo = htobe32(0x454C5253); // ['E', 'L', 'R', 'S'], seen [0x00, 0x0a, 0xe7, 0xc6] // "Serial 177-714694" (value is 714694)
     device->hardwareVer = 0; // unused currently by us, seen [ 0x00, 0x0b, 0x10, 0x01 ] // "Hardware: V 1.01" / "Bootloader: V 3.06"

--- a/src/lib/CrsfProtocol/crsf_protocol.h
+++ b/src/lib/CrsfProtocol/crsf_protocol.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <cmath>
 #include "crc.h"
+#include "options.h"
 
 #if TARGET_TX && PLATFORM_STM32
 #define CRSF_TX_MODULE_STM32 1
@@ -244,7 +245,7 @@ typedef struct deviceInformationPacket_s
     uint8_t parameterVersion;
 } PACKED deviceInformationPacket_t;
 
-#define DEVICE_INFORMATION_PAYLOAD_LENGTH (sizeof(deviceInformationPacket_t) + sizeof(DEVICE_NAME))
+#define DEVICE_INFORMATION_PAYLOAD_LENGTH (sizeof(deviceInformationPacket_t) + device_name_size)
 #define DEVICE_INFORMATION_LENGTH (sizeof(crsf_ext_header_t) + DEVICE_INFORMATION_PAYLOAD_LENGTH + CRSF_FRAME_CRC_SIZE)
 #define DEVICE_INFORMATION_FRAME_SIZE (DEVICE_INFORMATION_PAYLOAD_LENGTH + CRSF_FRAME_LENGTH_EXT_TYPE_CRC)
 

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -543,6 +543,7 @@ static void startMDNS()
     MDNS.addService("http", "tcp", 80);
     MDNS.addServiceTxt("http", "tcp", "vendor", "elrs");
     MDNS.addServiceTxt("http", "tcp", "target", (const char *)&target_name[4]);
+    MDNS.addServiceTxt("http", "tcp", "device", device_name);
     MDNS.addServiceTxt("http", "tcp", "version", VERSION);
     MDNS.addServiceTxt("http", "tcp", "options", String(FPSTR(compile_options)).c_str());
     MDNS.addServiceTxt("http", "tcp", "type", "tx");

--- a/src/src/options.cpp
+++ b/src/src/options.cpp
@@ -7,6 +7,7 @@ const unsigned char target_name[] = "\xBE\xEF\xCA\xFE" STR(TARGET_NAME);
 const uint8_t target_name_size = sizeof(target_name);
 
 const char PROGMEM compile_options[] = {
+    "-DDEVICE_NAME=\"" STR(DEVICE_NAME) "\" "
 #ifdef MY_BINDING_PHRASE
     "-DMY_BINDING_PHRASE=\"" STR(MY_BINDING_PHRASE) "\" "
 #endif
@@ -27,6 +28,9 @@ const char PROGMEM compile_options[] = {
     #ifdef UART_INVERTED
         "-DUART_INVERTED "
     #endif
+    #ifdef DISABLE_ALL_BEEPS
+        "-DDISABLE_ALL_BEEPS "
+    #endif
     #ifdef JUST_BEEP_ONCE
         "-DJUST_BEEP_ONCE "
     #endif
@@ -42,6 +46,9 @@ const char PROGMEM compile_options[] = {
     #ifdef TLM_REPORT_INTERVAL_MS
         "-DTLM_REPORT_INTERVAL_MS=" STR(TLM_REPORT_INTERVAL_MS) " "
     #endif
+    #ifdef USE_TX_BACKPACK
+        "-DUSE_TX_BACKPACK "
+    #endif
 #endif
 
 #ifdef TARGET_RX
@@ -56,6 +63,15 @@ const char PROGMEM compile_options[] = {
     #endif
     #ifdef USE_DIVERSITY
         "-DUSE_DIVERSITY "
+    #endif
+    #ifdef RCVR_UART_BAUD
+        "-DRCVR_UART_BAUD=" STR(RCVR_UART_BAUD) " "
+    #endif
+    #ifdef RCVR_INVERT_TX
+        "-DRCVR_INVERT_TX "
+    #endif
+    #ifdef USE_R9MM_R9MINI_SBUS
+        "-DUSE_R9MM_R9MINI_SBUS "
     #endif
 #endif
 };

--- a/src/src/options.cpp
+++ b/src/src/options.cpp
@@ -5,9 +5,10 @@
 #define STR(macro) QUOTE(macro)
 const unsigned char target_name[] = "\xBE\xEF\xCA\xFE" STR(TARGET_NAME);
 const uint8_t target_name_size = sizeof(target_name);
+const char device_name[] = STR(DEVICE_NAME);
+const uint8_t device_name_size = sizeof(device_name);
 
 const char PROGMEM compile_options[] = {
-    "-DDEVICE_NAME=\"" STR(DEVICE_NAME) "\" "
 #ifdef MY_BINDING_PHRASE
     "-DMY_BINDING_PHRASE=\"" STR(MY_BINDING_PHRASE) "\" "
 #endif


### PR DESCRIPTION
Add `DEVICE_NAME` to mDNS options string so configurator can use this to match alias for a target.
Also, adds other missing options to mDNS options string.