### PR TITLE
Enable WS2812_IS_GRB for ES24TX Pro

### DIFF
--- a/src/include/target/HappyModel_ES24TX_Pro_Series_2400_TX.h
+++ b/src/include/target/HappyModel_ES24TX_Pro_Series_2400_TX.h
@@ -3,6 +3,7 @@
 // Any device features
 #define USE_TX_BACKPACK
 #define USE_SX1280_DCDC
+#define WS2812_IS_GRB
 
 // GPIO pin definitions
 #define GPIO_PIN_NSS            5


### PR DESCRIPTION
This adds `WS2812_IS_GRB` to the HappyModel ES24TX Pro Series ExpressLRS TX JR Module(tm), because it is inverted.

You can imagine my surprise this morning when I checked the mail and there was a package in there from HappyModel with a ES24TX Pro Series. I really like the RGB LED lighting up our logo, but the colors are swapped. Earning my free pay, I have fixed all the bugs with this monumental change to flip the colors around the right way.

### Testing
Enable Wifi Mode on the TX and it heartbeats RED to ORANGE, when it should be GREEN to YELLOW.