### PR TITLE
Add firmware.bin to webui

### DIFF
--- a/src/html/rx_index.html
+++ b/src/html/rx_index.html
@@ -14,7 +14,7 @@
 			<img src="logo.svg" height="250" width="250" style="padding:20px;"></a>
 			<h1>Welcome to your <b>ExpressLRS</b><br /> update page<br />
 			</h1>
-			<p>From here you can update your <b>Transmitter</b> module with <b>@PLATFORM@</b> firmware</p>
+			<p>From here you can update your <b>Receiver</b> module with <b>@PLATFORM@</b> firmware</p>
 			<p>
 				<b>Firmware Rev. </b><a href="firmware.bin" title="Click to download firmware"><var>@VERSION@</var></a>
 			</p>
@@ -35,9 +35,9 @@
 
 			<div align="left">
 				<fieldset>
-					Here you can update module firmware,
-					be careful to upload the correct file otherwise a bad flash may occur. If this happens you will need
-					to reflash via USB/Serial.
+					Choose a file to update module firmware. Select the correct .bin file for @PLATFORM@ otherwise a bad flash may occur.
+					If this happens you will need to recover via USB/Serial. You may also download the
+					<a href="firmware.bin" title="Click to download firmware">currently running firmware</a>.
 					<br><br>
 					<legend>
 						<h2>Firmware Update:</h2>
@@ -58,7 +58,7 @@
 			<div align="left">
 				<fieldset>
 					If you set the 'Model Match' below to a number other than 255, you can specify the 'Receiver' number in OpenTX/EdgeTX
-					model setup page and turn on the 'Model Match' in the ELRS LUA script for that model. 'Model Match' is between 0 and 63 inclusive.
+					model setup page and turn on the 'Model Match' in the ELRS Lua script for that model. 'Model Match' is between 0 and 63 inclusive.
 					<br><br>
 					<legend>
 						<h2>Model Match:</h2>

--- a/src/html/rx_index.html
+++ b/src/html/rx_index.html
@@ -14,10 +14,10 @@
 			<img src="logo.svg" height="250" width="250" style="padding:20px;"></a>
 			<h1>Welcome to your <b>ExpressLRS</b><br /> update page<br />
 			</h1>
-			<p>From here you can update your <b>Receiver</b> module with <b>@PLATFORM@</b> firmware<br />
+			<p>From here you can update your <b>Transmitter</b> module with <b>@PLATFORM@</b> firmware</p>
 			<p>
-				<b>Firmware Rev. </b><var id="FirmVersion">@VERSION@</var>
-			<p>
+				<b>Firmware Rev. </b><a href="firmware.bin" title="Click to download firmware"><var>@VERSION@</var></a>
+			</p>
 		</div>
 	</section>
 	<br>

--- a/src/html/tx_index.html
+++ b/src/html/tx_index.html
@@ -35,9 +35,9 @@
 
 			<div align="left">
 				<fieldset>
-					Here you can update module firmware,
-					be careful to upload the correct file otherwise a bad flash may occur. If this happens you will need
-					to reflash via USB/Serial.
+					Choose a file to update module firmware. Select the correct .bin file for @PLATFORM@ otherwise a bad flash may occur.
+					If this happens you will need to recover via USB/Serial. You may also download the
+					<a href="firmware.bin" title="Click to download firmware">currently running firmware</a>.
 					<br><br>
 					<legend>
 						<h2>Firmware Update:</h2>

--- a/src/html/tx_index.html
+++ b/src/html/tx_index.html
@@ -14,10 +14,10 @@
 			<img src="logo.svg" height="250" width="250" style="padding:20px;"></a>
 			<h1>Welcome to your <b>ExpressLRS</b><br /> update page<br />
 			</h1>
-			<p>From here you can update your <b>Transmitter</b> module with <b>@PLATFORM@</b> firmware<br />
+			<p>From here you can update your <b>Transmitter</b> module with <b>@PLATFORM@</b> firmware</p>
 			<p>
-				<b>Firmware Rev. </b><var>@VERSION@</var>
-			<p>
+				<b>Firmware Rev. </b><a href="firmware.bin" title="Click to download firmware"><var>@VERSION@</var></a>
+			</p>
 		</div>
 	</section>
 	<br>


### PR DESCRIPTION
This adds a new URI to the webui, `/firmware.bin` which pulls the ESP's current firmware as a download which the user can use to flash other devices in the field.

### Why
A lot of people ask about being able to do OTA flashing because they might forget to flash an RX or something and thus leave themselves stranded at the field. The problem is that all our firmware is custom so there's no way to have a generic image that is the receiver firmware.

As a compromise, this adds the ability to download the current firmware from a working device so the user can flash it to another device.
![image](https://user-images.githubusercontent.com/677183/144713944-d8d3e850-940c-4387-88d3-6f72e9a370d0.png)

This PR makes the firmware version at the top of the page a clickable link that downloads the firmware binary with a filename of `targetname_version (hash).bin`.

### Completeness
As I keep telling anyone who will listen, I am going out of the country for the next week so if anyone wants to take this concept PR and do all the testing and make sure it always works, that's fine with me. Otherwise I'll look at it when I get back. I've only tested it and looked at the binary that comes out and it seems to be the same (just looking at the first page and last page in a hex editor). Tag it with pick or 2.1, I have no strong preference!