### PR TITLE
Device core affinity

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -5,6 +5,8 @@
 #include "helpers.h"
 
 #if defined(PLATFORM_ESP32)
+#include "device.h"
+
 HardwareSerial CRSF::Port = HardwareSerial(1);
 portMUX_TYPE FIFOmux = portMUX_INITIALIZER_UNLOCKED;
 TaskHandle_t xESP32uartTask = NULL;
@@ -817,6 +819,7 @@ bool CRSF::UARTwdt()
 void ICACHE_RAM_ATTR CRSF::ESP32uartTask(void *pvParameters)
 {
     DBGLN("ESP32 CRSF UART LISTEN TASK STARTED");
+    devicesInit();
     portDISABLE_INTERRUPTS();
     CRSF::Port.begin(TxToHandsetBauds[UARTcurrentBaudIdx], SERIAL_8N1,
                      GPIO_PIN_RCSIGNAL_RX, GPIO_PIN_RCSIGNAL_TX,
@@ -824,10 +827,12 @@ void ICACHE_RAM_ATTR CRSF::ESP32uartTask(void *pvParameters)
     CRSF::duplex_set_RX();
     portENABLE_INTERRUPTS();
     flush_port_input();
+    devicesStart();
     (void)pvParameters;
     for (;;)
     {
         handleUARTin();
+        devicesUpdate(millis());
     }
 }
 #endif // PLATFORM_ESP32

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -149,11 +149,6 @@ private:
     static uint8_t MspData[ELRS_MSP_BUFFER];
     static uint8_t MspDataLength;
 
-#ifdef PLATFORM_ESP32
-    static void ESP32uartTask(void *pvParameters);
-    static void ESP32syncPacketTask(void *pvParameters);
-#endif
-
     static void ICACHE_RAM_ATTR adjustMaxPacketSize();
     static void duplex_set_RX();
     static void duplex_set_TX();

--- a/src/lib/CRSF/devCRSF.cpp
+++ b/src/lib/CRSF/devCRSF.cpp
@@ -4,6 +4,7 @@
 
 #include "CRSF.h"
 
+#ifdef CRSF_TX_MODULE
 static int start()
 {
     CRSF::Begin();
@@ -22,3 +23,4 @@ device_t CRSF_device = {
     .event = nullptr,
     .timeout = timeout
 };
+#endif

--- a/src/lib/CRSF/devCRSF.cpp
+++ b/src/lib/CRSF/devCRSF.cpp
@@ -1,0 +1,24 @@
+#include "targets.h"
+#include "common.h"
+#include "device.h"
+
+#include "CRSF.h"
+
+static int start()
+{
+    CRSF::Begin();
+    return DURATION_IMMEDIATELY;
+}
+
+static int timeout()
+{
+    CRSF::handleUARTin();
+    return DURATION_IMMEDIATELY;
+}
+
+device_t CRSF_device = {
+    .initialize = nullptr,
+    .start = start,
+    .event = nullptr,
+    .timeout = timeout
+};

--- a/src/lib/CRSF/devCRSF.h
+++ b/src/lib/CRSF/devCRSF.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "device.h"
+
+extern device_t CRSF_device;

--- a/src/lib/DEVICE/device.cpp
+++ b/src/lib/DEVICE/device.cpp
@@ -1,35 +1,57 @@
-#include <stdint.h>
-
-#include "device.h"
+#include "targets.h"
 #include "common.h"
 #include "logging.h"
 #include "helpers.h"
+#include "device.h"
 
+///////////////////////////////////////
 // Even though we aren't using anything this keeps the PIO dependency analyzer happy!
-#include "POWERMGNT.h"
 
-static volatile bool eventFired = false;
+#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868)  || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#include "SX127xDriver.h"
+#endif
+
+#if defined(Regulatory_Domain_ISM_2400)
+#include "SX1280Driver.h"
+#endif
+
+///////////////////////////////////////
+
 static device_affinity_t *uiDevices;
 static uint8_t deviceCount;
+
+static bool eventFired[2] = {false, false};
+static connectionState_e lastConnectionState[2] = {disconnected, disconnected};
+
 static unsigned long deviceTimeout[16] = {0};
 
-static connectionState_e lastConnectionState = disconnected;
-
 #if defined(PLATFORM_ESP32)
-#define LOOP_CORE xPortGetCoreID()
+static TaskHandle_t xDeviceTask = NULL;
+static SemaphoreHandle_t taskSemaphore;
+static SemaphoreHandle_t completeSemaphore;
+static void deviceTask(void *pvArgs);
+#define CURRENT_CORE  xPortGetCoreID()
 #else
-#define LOOP_CORE -1
+#define CURRENT_CORE -1
 #endif
 
 void devicesRegister(device_affinity_t *devices, uint8_t count)
 {
     uiDevices = devices;
     deviceCount = count;
+
+    #if defined(PLATFORM_ESP32)
+        taskSemaphore = xSemaphoreCreateBinary();
+        completeSemaphore = xSemaphoreCreateBinary();
+        disableCore0WDT();
+        xTaskCreatePinnedToCore(deviceTask, "deviceTask", 3000, NULL, 0, &xDeviceTask, 0);
+    #endif
 }
 
 void devicesInit()
 {
-    uint32_t core = LOOP_CORE;
+    int32_t core = CURRENT_CORE;
+
     for(size_t i=0 ; i<deviceCount ; i++) {
         if (uiDevices[i].core == core || core == -1) {
             if (uiDevices[i].device->initialize) {
@@ -37,16 +59,24 @@ void devicesInit()
             }
         }
     }
+    #if defined(PLATFORM_ESP32)
+    if (core == 1)
+    {
+        xSemaphoreGive(taskSemaphore);
+        xSemaphoreTake(completeSemaphore, portMAX_DELAY);
+    }
+    #endif
 }
 
 void devicesStart()
 {
-    uint32_t core = LOOP_CORE;
+    int32_t core = CURRENT_CORE;
     unsigned long now = millis();
+
     for(size_t i=0 ; i<deviceCount ; i++)
     {
-        deviceTimeout[i] = 0xFFFFFFFF;
         if (uiDevices[i].core == core || core == -1) {
+            deviceTimeout[i] = 0xFFFFFFFF;
             if (uiDevices[i].device->start)
             {
                 int delay = (uiDevices[i].device->start)();
@@ -54,22 +84,32 @@ void devicesStart()
             }
         }
     }
+    #if defined(PLATFORM_ESP32)
+    if (core == 1)
+    {
+        xSemaphoreGive(taskSemaphore);
+        xSemaphoreTake(completeSemaphore, portMAX_DELAY);
+    }
+    #endif
 }
 
 void devicesTriggerEvent()
 {
-    eventFired = true;
+    eventFired[0] = true;
+    eventFired[1] = true;
 }
 
 void devicesUpdate(unsigned long now)
 {
-    uint32_t core = LOOP_CORE;
-    bool handleEvents = eventFired;
-    eventFired = false;
+    int32_t core = CURRENT_CORE;
+
+    bool handleEvents = eventFired[core==-1?0:core];
+    eventFired[core==-1?0:core] = false;
+
     for(size_t i=0 ; i<deviceCount ; i++)
     {
         if (uiDevices[i].core == core || core == -1) {
-            if ((handleEvents || lastConnectionState != connectionState) && uiDevices[i].device->event)
+            if ((handleEvents || lastConnectionState[core==-1?0:core] != connectionState) && uiDevices[i].device->event)
             {
                 int delay = (uiDevices[i].device->event)();
                 if (delay != DURATION_IGNORE)
@@ -79,11 +119,12 @@ void devicesUpdate(unsigned long now)
             }
         }
     }
-    lastConnectionState = connectionState;
+    lastConnectionState[core==-1?0:core] = connectionState;
+
     for(size_t i=0 ; i<deviceCount ; i++)
     {
         if (uiDevices[i].core == core || core == -1) {
-            if (now > deviceTimeout[i] && uiDevices[i].device->timeout)
+            if (uiDevices[i].device->timeout && now >= deviceTimeout[i])
             {
                 int delay = (uiDevices[i].device->timeout)();
                 deviceTimeout[i] = delay == DURATION_NEVER ? 0xFFFFFFFF : now + delay;
@@ -91,3 +132,19 @@ void devicesUpdate(unsigned long now)
         }
     }
 }
+
+#if defined(PLATFORM_ESP32)
+static void deviceTask(void *pvArgs)
+{
+    xSemaphoreTake(taskSemaphore, portMAX_DELAY);
+    devicesInit();
+    xSemaphoreGive(completeSemaphore);
+    xSemaphoreTake(taskSemaphore, portMAX_DELAY);
+    devicesStart();
+    xSemaphoreGive(completeSemaphore);
+    for (;;)
+    {
+        devicesUpdate(millis());
+    }
+}
+#endif

--- a/src/lib/DEVICE/device.cpp
+++ b/src/lib/DEVICE/device.cpp
@@ -2,39 +2,56 @@
 
 #include "device.h"
 #include "common.h"
+#include "logging.h"
 #include "helpers.h"
 
 // Even though we aren't using anything this keeps the PIO dependency analyzer happy!
 #include "POWERMGNT.h"
 
-static bool eventFired = false;
-static device_t **uiDevices;
+static volatile bool eventFired = false;
+static device_affinity_t *uiDevices;
 static uint8_t deviceCount;
 static unsigned long deviceTimeout[16] = {0};
 
 static connectionState_e lastConnectionState = disconnected;
 
-void devicesInit(device_t **devices, uint8_t count)
+#if defined(PLATFORM_ESP32)
+#define LOOP_CORE xPortGetCoreID()
+#else
+#define LOOP_CORE -1
+#endif
+
+void devicesRegister(device_affinity_t *devices, uint8_t count)
 {
     uiDevices = devices;
     deviceCount = count;
-    for(size_t i=0 ; i<count ; i++) {
-        if (uiDevices[i]->initialize) {
-            (uiDevices[i]->initialize)();
+}
+
+void devicesInit()
+{
+    uint32_t core = LOOP_CORE;
+    for(size_t i=0 ; i<deviceCount ; i++) {
+        if (uiDevices[i].core == core || core == -1) {
+            if (uiDevices[i].device->initialize) {
+                (uiDevices[i].device->initialize)();
+            }
         }
     }
 }
 
 void devicesStart()
 {
+    uint32_t core = LOOP_CORE;
     unsigned long now = millis();
     for(size_t i=0 ; i<deviceCount ; i++)
     {
         deviceTimeout[i] = 0xFFFFFFFF;
-        if (uiDevices[i]->start)
-        {
-            int delay = (uiDevices[i]->start)();
-            deviceTimeout[i] = delay == DURATION_NEVER ? 0xFFFFFFFF : now + delay;
+        if (uiDevices[i].core == core || core == -1) {
+            if (uiDevices[i].device->start)
+            {
+                int delay = (uiDevices[i].device->start)();
+                deviceTimeout[i] = delay == DURATION_NEVER ? 0xFFFFFFFF : now + delay;
+            }
         }
     }
 }
@@ -46,26 +63,31 @@ void devicesTriggerEvent()
 
 void devicesUpdate(unsigned long now)
 {
+    uint32_t core = LOOP_CORE;
     bool handleEvents = eventFired;
     eventFired = false;
     for(size_t i=0 ; i<deviceCount ; i++)
     {
-        if ((handleEvents || lastConnectionState != connectionState) && uiDevices[i]->event)
-        {
-            int delay = (uiDevices[i]->event)();
-            if (delay != DURATION_IGNORE)
+        if (uiDevices[i].core == core || core == -1) {
+            if ((handleEvents || lastConnectionState != connectionState) && uiDevices[i].device->event)
             {
-                deviceTimeout[i] = delay == DURATION_NEVER ? 0xFFFFFFFF : now + delay;
+                int delay = (uiDevices[i].device->event)();
+                if (delay != DURATION_IGNORE)
+                {
+                    deviceTimeout[i] = delay == DURATION_NEVER ? 0xFFFFFFFF : now + delay;
+                }
             }
         }
     }
     lastConnectionState = connectionState;
     for(size_t i=0 ; i<deviceCount ; i++)
     {
-        if (now > deviceTimeout[i] && uiDevices[i]->timeout)
-        {
-            int delay = (uiDevices[i]->timeout)();
-            deviceTimeout[i] = delay == DURATION_NEVER ? 0xFFFFFFFF : now + delay;
+        if (uiDevices[i].core == core || core == -1) {
+            if (now > deviceTimeout[i] && uiDevices[i].device->timeout)
+            {
+                int delay = (uiDevices[i].device->timeout)();
+                deviceTimeout[i] = delay == DURATION_NEVER ? 0xFFFFFFFF : now + delay;
+            }
         }
     }
 }

--- a/src/lib/DEVICE/device.h
+++ b/src/lib/DEVICE/device.h
@@ -19,7 +19,13 @@ typedef struct {
     int (*timeout)();
 } device_t;
 
-void devicesInit(device_t **devices, uint8_t count);
+typedef struct {
+  device_t *device;
+  int8_t core; // 0 = UART core or 1 = loopcore
+} device_affinity_t;
+
+void devicesRegister(device_affinity_t *devices, uint8_t count);
+void devicesInit();
 void devicesStart();
 void devicesUpdate(unsigned long now);
 void devicesTriggerEvent();

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -45,18 +45,18 @@ SX1280Driver Radio;
 #define PACKET_TO_TOCK_SLACK 200 // Desired buffer time between Packet ISR and Tock ISR
 ///////////////////
 
-device_t *ui_devices[] = {
+device_affinity_t ui_devices[] = {
 #ifdef HAS_LED
-  &LED_device,
+  {&LED_device, 0},
 #endif
 #ifdef HAS_RGB
-  &RGB_device,
+  {&RGB_device, 0},
 #endif
 #ifdef HAS_WIFI
-  &WIFI_device,
+  {&WIFI_device, 0},
 #endif
 #ifdef HAS_BUTTON
-  &Button_device
+  {&Button_device, 0},
 #endif
 };
 
@@ -1164,7 +1164,9 @@ void setup()
 
     INFOLN("ExpressLRS Module Booting...");
 
-    devicesInit(ui_devices, ARRAY_SIZE(ui_devices));
+    devicesRegister(ui_devices, ARRAY_SIZE(ui_devices));
+    devicesInit();
+
     setupBindingFromConfig();
 
     FHSSrandomiseFHSSsequence(uidMacSeedGet());

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -25,6 +25,7 @@ SX1280Driver Radio;
 #include "stubborn_sender.h"
 
 #include "helpers.h"
+#include "devCRSF.h"
 #include "devLED.h"
 #include "devOLED.h"
 #include "devBuzzer.h"
@@ -92,6 +93,7 @@ StubbornSender MspSender(ELRS_MSP_MAX_PACKAGES);
 uint8_t CRSFinBuffer[CRSF_MAX_PACKET_LEN+1];
 
 device_affinity_t ui_devices[] = {
+  {&CRSF_device, 0},
 #ifdef HAS_LED
   {&LED_device, 1},
 #endif
@@ -951,7 +953,6 @@ void setup()
     hwTimer.init();
     //hwTimer.resume();  //uncomment to automatically start the RX timer and leave it running
     connectionState = noCrossfire;
-    crsf.Begin();
   }
 
   devicesStart();
@@ -981,10 +982,6 @@ void loop()
     if (rebootTime != 0 && now > rebootTime) {
       ESP.restart();
     }
-  #endif
-
-  #if defined(PLATFORM_STM32) || defined(PLATFORM_ESP8266)
-    crsf.handleUARTin();
   #endif
 
   if (connectionState > MODE_STATES)

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -91,30 +91,30 @@ StubbornReceiver TelemetryReceiver(ELRS_TELEMETRY_MAX_PACKAGES);
 StubbornSender MspSender(ELRS_MSP_MAX_PACKAGES);
 uint8_t CRSFinBuffer[CRSF_MAX_PACKET_LEN+1];
 
-device_t *ui_devices[] = {
+device_affinity_t ui_devices[] = {
 #ifdef HAS_LED
-  &LED_device,
+  {&LED_device, 1},
 #endif
 #ifdef HAS_RGB
-  &RGB_device,
+  {&RGB_device, 1},
 #endif
-  &LUA_device,
+  {&LUA_device, 1},
 #ifdef HAS_BLE
-  &BLE_device,
+  {&BLE_device, 1},
 #endif
 #if defined(USE_OLED_SPI) || defined(USE_OLED_SPI_SMALL) || defined(USE_OLED_I2C)
-  &OLED_device,
+  {&OLED_device, 0},
 #endif
 #ifdef HAS_BUZZER
-  &Buzzer_device,
+  {&Buzzer_device, 1},
 #endif
 #ifdef HAS_WIFI
-  &WIFI_device,
+  {&WIFI_device, 1},
 #endif
 #ifdef HAS_BUTTON
-  &Button_device,
+  {&Button_device, 1},
 #endif
-  &VTX_device
+  {&VTX_device, 1}
 };
 
 //////////// DYNAMIC TX OUTPUT POWER ////////////
@@ -904,8 +904,10 @@ void setup()
   Serial.begin(460800);
   setupTarget();
 
-  // Initialise the UI devices
-  devicesInit(ui_devices, ARRAY_SIZE(ui_devices));
+  // Register the devices with the framework
+  devicesRegister(ui_devices, ARRAY_SIZE(ui_devices));
+  // Initialise the devices
+  devicesInit();
 
   FHSSrandomiseFHSSsequence(uidMacSeedGet());
 


### PR DESCRIPTION
Fixes #1153 

This PR extracts CRSF into a device on the TX side, and allows devices to be assigned to a particular core.
In the case of the CRSF UART device, this is core 0.
Most other devices are on core 1 (the loop code), which is the core that is handling all the radio SPI and timer interrupts.
The OLEDScreen and I2C devices are also moved to core 0, as they do not play nice interrupts that use the SPI bus.

On STM32 devices (i.e. single core) the core affinity setting is ignored and all devices run on the single core.
