### PR TITLE
Upgrade STM32 Arduino platform to 15.1 and support -flto flag

### DIFF
--- a/src/targets/frsky.ini
+++ b/src/targets/frsky.ini
@@ -6,11 +6,13 @@
 ## TODO: R9M STLINK/stock and R9M Lite targets can be merged
 [env:Frsky_TX_R9M_via_STLINK]
 extends = env_common_stm32, radio_900
+platform = ststm32@15.1.0
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_tx}
 	${radio_900.build_flags}
 	-include target/Frsky_TX_R9M.h
+	-flto
 	-D HSE_VALUE=12000000U
 	-DVECT_TAB_OFFSET=0x4000U
 board_build.ldscript = variants/R9M_ldscript.ld
@@ -34,6 +36,7 @@ build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_tx}
 	-include target/Frsky_TX_R9M_LITE.h
+	-flto
 	-D HSE_VALUE=12000000U
 	-DVECT_TAB_OFFSET=0x4000U
 


### PR DESCRIPTION
## Problem
Cock all space on FrSky R9M

## Solution
After talking to PeHo some time ago, and some further investigation, we can upgrade the base platform to at least version 14.0 which fully supports the -flto flag.
This flag performs "link time optimisations" such as method inlining across compilation units and reduces the size of the binary for STM32 targets.

### Size Before (without debug log)
```
RAM:   [==        ]  24.8% (used 5076 bytes from 20480 bytes)
Flash: [=======   ]  73.5% (used 48196 bytes from 65536 bytes)
```
### Size After (without debug log)
```
RAM:   [==        ]  25.0% (used 5112 bytes from 20480 bytes)
Flash: [======    ]  63.9% (used 41904 bytes from 65536 bytes)
```
### Size After (with debug log)
```
RAM:   [==        ]  24.9% (used 5108 bytes from 20480 bytes)
Flash: [=======   ]  66.7% (used 43736 bytes from 65536 bytes)
```
That would equate to a metric f-ton of space!