### PR TITLE
Fix for too early VTX MSP commands

### DIFF
--- a/src/lib/VTX/devVTX.cpp
+++ b/src/lib/VTX/devVTX.cpp
@@ -62,7 +62,7 @@ static int event()
         (VtxSendState == VTXSS_UNKNOWN && connectionState == connected))
     {
         VtxSendState = VTXSS_SENDING1;
-        return DURATION_IMMEDIATELY;
+        return 1000;
     }
 
     if (connectionState == disconnected)


### PR DESCRIPTION
## Problem
Some FCs are way too slow starting up and miss the MSP command on startup because ELRS connection is just so damn good!

## Solution
Rather than sending the MSP immediately after connection established, add a 1 second timeout.