### PR TITLE
Python Build Compatibility issue.

### DIFF
--- a/src/python/build_html.py
+++ b/src/python/build_html.py
@@ -22,7 +22,7 @@ def compress(data):
     Optional argument is the compression level, in range of 0-9.
     """
     buf = io.BytesIO()
-    with gzip.GzipFile(fileobj=buf, mode='wb', compresslevel=gzip._COMPRESS_LEVEL_BEST, mtime=0.0) as f:
+    with gzip.GzipFile(fileobj=buf, mode='wb', compresslevel=9, mtime=0.0) as f:
         f.write(data)
     return buf.getvalue()
 


### PR DESCRIPTION
Changed `compresslevel=gzip._COMPRESS_LEVEL_BEST` to `compresslevel=9` . They are the same values but in older version of python, gzip does not have that _COMPRESS_LEVEL_BEST define which causes build errors for anyone using python37 or older. 