### PR TITLE
Setting TFT lib version requirement

### DIFF
--- a/src/targets/axis_2400.ini
+++ b/src/targets/axis_2400.ini
@@ -16,7 +16,7 @@ monitor_speed = 420000
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 lib_deps =
     ${env_common_esp32.lib_deps}
-    https://github.com/Bodmer/TFT_eSPI#40cd5bfe7b62bfc1606df930e0f0d540d8f20618
+    Bodmer/TFT_eSPI @ 2.4.11
 
 [env:AXIS_THOR_2400_TX_via_WIFI]
 extends = env:AXIS_THOR_2400_TX_via_UART

--- a/src/targets/axis_2400.ini
+++ b/src/targets/axis_2400.ini
@@ -16,7 +16,7 @@ monitor_speed = 420000
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 lib_deps =
     ${env_common_esp32.lib_deps}
-    bodmer/TFT_eSPI
+    https://github.com/Bodmer/TFT_eSPI#40cd5bfe7b62bfc1606df930e0f0d540d8f20618
 
 [env:AXIS_THOR_2400_TX_via_WIFI]
 extends = env:AXIS_THOR_2400_TX_via_UART


### PR DESCRIPTION
This sets the TFT library to v2.4.01. 

There was a bug in v2.4.0 that broke platformio builds. 