### PR TITLE
Add support for chunked msp responses

### DIFF
--- a/src/lib/Telemetry/telemetry.cpp
+++ b/src/lib/Telemetry/telemetry.cpp
@@ -245,6 +245,23 @@ bool Telemetry::AppendTelemetryPackage(uint8_t *package)
         {
             targetIndex = payloadTypesCount - 2;
             targetFound = true;
+
+            // larger msp resonses are sent in two chunks so special handling is needed so both get sent
+            if (header->type == CRSF_FRAMETYPE_MSP_RESP)
+            {
+                // there is already another response stored
+                if (payloadTypes[targetIndex].updated)
+                {
+                    // use other slot
+                    targetIndex = payloadTypesCount - 1;
+                }
+
+                // if both slots are taked do not overwrite other data since the first chunk would be lost
+                if (payloadTypes[targetIndex].updated)
+                {
+                    targetFound = false;
+                }
+            }
         }
         else
         {


### PR DESCRIPTION
Betaflight 4.3 adds support for MSP responses that are larger than the crsf frame size. Currently up to two response messages are generated within a short period and the current elrs implementation does only buffer one. The bf 4.3 lua script fails to load because one part of the the chunked response is always lost.

This PR updates the telemetry class to use a (already existing) second buffer slot if MSP response frames are received and restores compability with the bf lua script.