### PR TITLE
Add missing wifi targets for some DIY modules

### DIFF
--- a/src/targets/diy_2400.ini
+++ b/src/targets/diy_2400.ini
@@ -14,6 +14,9 @@ build_flags =
 	-O2
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 
+[env:DIY_2400_TX_ESP32_SX1280_Mini_via_WIFI]
+extends = env:DIY_2400_TX_ESP32_SX1280_Mini_via_UART
+
 [env:DIY_2400_TX_ESP32_SX1280_E28_via_UART]
 extends = env_common_esp32, radio_2400
 build_flags =

--- a/src/targets/diy_2400.ini
+++ b/src/targets/diy_2400.ini
@@ -48,6 +48,9 @@ lib_deps =
 	${env_common_esp32.lib_deps}
 	olikraus/U8g2@^2.28.8
 
+[env:DIY_2400_TX_ESP32_SX1280_LORA1280F27_via_WIFI]
+extends = env:DIY_2400_TX_ESP32_SX1280_LORA1280F27_via_UART
+
 [env:DIY_2400_TX_ESP8285_SX1280_via_UART]
 # Status: These TXes work as free-running transmitters, but do not have working halfduplex inverted UART
 # to let them work in handsets so if someone could fix that for CapnBry, he'd love you with mouth

--- a/src/targets/diy_900.ini
+++ b/src/targets/diy_900.ini
@@ -14,6 +14,9 @@ src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 lib_deps = 	${env_common_esp32.lib_deps}
 		olikraus/U8g2@^2.28.8
 
+[env:DIY_900_TX_TTGO_V1_SX127x_via_WIFI]
+extends = env:DIY_900_TX_TTGO_V1_SX127x_via_UART
+
 [env:DIY_900_TX_TTGO_V2_SX127x_via_UART]
 extends = env_common_esp32, radio_900
 build_flags =
@@ -25,6 +28,9 @@ src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 lib_deps = 	${env_common_esp32.lib_deps}
 		olikraus/U8g2@^2.28.8
 
+[env:DIY_900_TX_TTGO_V2_SX127x_via_WIFI]
+extends = env:DIY_900_TX_TTGO_V2_SX127x_via_UART
+
 [env:DIY_900_TX_ESP32_SX127x_E19_via_UART]
 extends = env_common_esp32, radio_900
 build_flags =
@@ -34,6 +40,9 @@ build_flags =
 	-include target/DIY_900_TX_ESP32_SX127x_E19.h
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 
+[env:DIY_900_TX_ESP32_SX127x_E19_via_WIFI]
+extends = env:DIY_900_TX_ESP32_SX127x_E19_via_UART
+
 [env:DIY_900_TX_ESP32_SX127x_RFM95_via_UART]
 extends = env_common_esp32, radio_900
 build_flags =
@@ -42,6 +51,9 @@ build_flags =
 	${radio_900.build_flags}
 	-include target/DIY_900_TX_ESP32_SX127x_RFM95.h
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+
+[env:DIY_900_TX_ESP32_SX127x_RFM95_via_WIFI]
+extends = env:DIY_900_TX_ESP32_SX127x_RFM95_via_UART
 
 
 # ********************************


### PR DESCRIPTION
Adds missing WIFI targets for
- DIY_2400_TX_ESP32_SX1280_Mini_via_WIFI
- DIY_900_TX_TTGO_V1_SX127x_via_WIFI
- DIY_900_TX_TTGO_V2_SX127x_via_WIFI
- DIY_900_TX_ESP32_SX127x_E19_via_WIFI
- DIY_900_TX_ESP32_SX127x_RFM95_via_WIFI

Fixes #1207 