### PR TITLE
fix #1134: don't require python git module

### DIFF
--- a/src/python/build_flags.py
+++ b/src/python/build_flags.py
@@ -87,7 +87,7 @@ def condense_flags():
     build_flags = [escapeChars(x) for x in build_flags] # perform escaping of flags with values
 
 def version_to_env():
-    ver = elrs_helpers.get_git_version(env)
+    ver = elrs_helpers.get_git_version()
     env.Append(GIT_SHA = ver['sha'], GIT_VERSION= ver['version'])
 
 def regulatory_domain_to_env():

--- a/src/python/elrs_helpers.py
+++ b/src/python/elrs_helpers.py
@@ -1,42 +1,13 @@
 import os
 import re
+import subprocess
 
-def get_git(env):
-    """
-    Returns a git.Repo class for a git repo in the current directory
-    installing GitPython if neeeded
-    """
-    try:
-        import git
-    except ImportError:
-        import sys
-        import subprocess
-        sys.stdout.write("Installing GitPython")
-        subprocess.check_call([sys.executable, "-m", "pip", "install", "GitPython"])
-        try:
-            import git
-        except ImportError:
-            env.Execute("$PYTHONEXE -m pip install GitPython")
-            try:
-                import git
-            except ImportError:
-                return None
 
-    try:
-        # Check one directory up for a git repo
-        orig_dir = os.path.abspath(os.path.join(os.getcwd(), os.pardir))
-        git_repo = git.Repo(orig_dir, search_parent_directories=False)
-        # If that succeeded then find out where the top level is and open that
-        git_root = git_repo.git.rev_parse("--show-toplevel")
-        if orig_dir != git_root:
-            git_repo = git.Repo(git_root, search_parent_directories=False)
-        return git_repo
-    except git.InvalidGitRepositoryError:
-        pass
+def git_cmd(*args):
+    return subprocess.check_output(["git"] + list(args)).decode("utf-8").rstrip('\r\n')
 
-    return None
 
-def get_git_version(env):
+def get_git_version():
     """
     Return a dict with keys
     version: The version tag if HEAD is a version, or branch otherwise
@@ -46,21 +17,21 @@ def get_git_version(env):
     ver = "ver.unknown"
     sha = "000000"
 
-    git_repo = get_git(env)
-    if git_repo:
-        import git
-        sha = git_repo.head.object.hexsha
+    try:
+        sha = git_cmd("rev-parse", "HEAD")
+        ver = git_cmd("rev-parse", "--abbrev-ref", "HEAD")
+        # failure here is acceptable, unnamed commits might not have a branch
+        # associated
         try:
-            ver = re.sub(r".*/", "", git_repo.git.describe("--all", "--exact-match"))
-        except git.exc.GitCommandError:
-            try:
-                ver = git_repo.git.symbolic_ref("-q", "--short", "HEAD")
-            except git.exc.GitCommandError:
-                pass
-    elif os.path.exists("VERSION"):
-        with open("VERSION") as _f:
-            data = _f.readline()
-            _f.close()
-        sha = data.split()[1].strip()
+            ver = re.sub(r".*/", "", git_cmd("describe",
+                         "--all", "--exact-match"))
+        except:
+            pass
+    except:
+        if os.path.exists("VERSION"):
+            with open("VERSION") as _f:
+                data = _f.readline()
+                _f.close()
+            sha = data.split()[1].strip()
 
     return dict(version=ver, sha=sha[:6])


### PR DESCRIPTION
Fixes https://github.com/ExpressLRS/ExpressLRS/issues/1134.

I"m still pretty much in favor removing any code which calls python pip, it's creepy if a build-script modifies my system state and its a wrong assumption that every user uses pip to manage their python packages.