### PR TITLE
SX1280 E28 target as really internal module

### DIFF
--- a/src/include/target/DIY_2400_TX_ESP32_SX1280_E28_INTERNAL.h
+++ b/src/include/target/DIY_2400_TX_ESP32_SX1280_E28_INTERNAL.h
@@ -1,0 +1,42 @@
+#ifndef DEVICE_NAME
+#define DEVICE_NAME "DIY2400 E28"
+#endif
+
+// Any device features
+#if !defined(USE_OLED_I2C)
+#define USE_OLED_SPI
+#endif
+#define USE_SX1280_DCDC
+
+// GPIO pin definitions
+#define GPIO_PIN_NSS            5
+#define GPIO_PIN_BUSY           21
+#define GPIO_PIN_DIO1           4
+#define GPIO_PIN_MOSI           23
+#define GPIO_PIN_MISO           19
+#define GPIO_PIN_SCK            18
+#define GPIO_PIN_RST            14
+#define GPIO_PIN_RX_ENABLE      27
+#define GPIO_PIN_TX_ENABLE      26
+#ifdef USE_OLED_SPI
+#define GPIO_PIN_OLED_CS        2
+#define GPIO_PIN_OLED_RST       16
+#define GPIO_PIN_OLED_DC        22
+#define GPIO_PIN_OLED_MOSI      32
+#define GPIO_PIN_OLED_SCK       33
+#elif defined(USE_OLED_I2C)
+#define GPIO_PIN_OLED_SDA       32
+#define GPIO_PIN_OLED_SCK       33
+#define GPIO_PIN_OLED_RST       U8X8_PIN_NONE
+#endif
+#define GPIO_PIN_RCSIGNAL_RX    12
+#define GPIO_PIN_RCSIGNAL_TX    13
+#define GPIO_PIN_LED_WS2812     15
+#define GPIO_PIN_FAN_EN         17
+
+// Output Power
+#define MinPower            PWR_10mW
+#define MaxPower            PWR_250mW
+#define POWER_OUTPUT_VALUES {-15,-11,-8,-5,-1}
+
+#define Regulatory_Domain_ISM_2400 1

--- a/src/targets/diy_2400.ini
+++ b/src/targets/diy_2400.ini
@@ -34,6 +34,23 @@ lib_deps =
 [env:DIY_2400_TX_ESP32_SX1280_E28_via_WIFI]
 extends = env:DIY_2400_TX_ESP32_SX1280_E28_via_UART
 
+[env:DIY_2400_TX_ESP32_SX1280_E28_INTERNAL_via_UART]
+extends = env_common_esp32, radio_2400
+build_flags =
+	${env_common_esp32.build_flags}
+	${common_env_data.build_flags_tx}
+	${radio_2400.build_flags}
+	-include target/DIY_2400_TX_ESP32_SX1280_E28_INTERNAL.h
+	-D VTABLES_IN_FLASH=1
+	-O2
+src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+lib_deps =
+	${env_common_esp32.lib_deps}
+	olikraus/U8g2@^2.28.8
+
+[env:DIY_2400_TX_ESP32_SX1280_E28_INTERNAL_via_WIFI]
+extends = env:DIY_2400_TX_ESP32_SX1280_E28_via_UART
+
 [env:DIY_2400_TX_ESP32_SX1280_LORA1280F27_via_UART]
 extends = env_common_esp32, radio_2400
 build_flags =


### PR DESCRIPTION
ExpressLRS instead of the default multiprotocol as internal module.
It is necessary to use a 2-wire non-inverted uart to connect to the device. Support in hardware is introduced with the release of EdgeTX 2.6.