### PR TITLE
makes GPIO_PIN_RST optional for the sx1276

### DIFF
--- a/src/lib/SX127xDriver/SX127xHal.cpp
+++ b/src/lib/SX127xDriver/SX127xHal.cpp
@@ -65,15 +65,18 @@ void SX127xHal::init()
 #endif
 
   pinMode(GPIO_PIN_NSS, OUTPUT);
-  pinMode(GPIO_PIN_RST, OUTPUT);
   pinMode(GPIO_PIN_DIO0, INPUT);
 
   digitalWrite(GPIO_PIN_NSS, HIGH);
+
+#if defined(GPIO_PIN_RST)
+  pinMode(GPIO_PIN_RST, OUTPUT);
 
   delay(100);
   digitalWrite(GPIO_PIN_RST, 0);
   delay(100);
   pinMode(GPIO_PIN_RST, INPUT); // leave floating
+#endif
 
   attachInterrupt(digitalPinToInterrupt(GPIO_PIN_DIO0), dioISR, RISING);
 }


### PR DESCRIPTION
The 900M DIY schematic leave RST floating and GPIO2 unused.  This PR frees GPIO2 for other uses e.g. a possible 7th PWM output (testing required).

https://github.com/ExpressLRS/ExpressLRS/issues/1219