### PR TITLE
Bugfix - index was not compared to the provided min

### DIFF
--- a/src/lib/SCREEN/screen.cpp
+++ b/src/lib/SCREEN/screen.cpp
@@ -280,7 +280,7 @@ void Screen::nextIndex(int &index, int action, int min, int max)
         index++;
     }
 
-    if(index < 0)
+    if(index < min)
     {
         index = max - 1;
     }


### PR DESCRIPTION
The nextIndex() function should compare the value against the provided "min" parameter, not 0.