### PR TITLE
Updating power change to Screen correctly 

### DIFF
--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -245,5 +245,6 @@ void POWERMGNT::setPower(PowerLevels_e Power)
 #error "[ERROR] Unknown power management!"
 #endif
     CurrentPower = Power;
+    devicesTriggerEvent();
     updateFan();
 }

--- a/src/lib/POWERMGNT/POWERMGNT.h
+++ b/src/lib/POWERMGNT/POWERMGNT.h
@@ -2,6 +2,7 @@
 
 #include "targets.h"
 #include "DAC.h"
+#include "device.h"
 
 #if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
 #include "SX127xDriver.h"


### PR DESCRIPTION
# Current behavior:

When a dynamic power is activated, the changed power is not updated to the screen device (OLED and TFT).

# Cause of the issue

When on 2.0.x the OLED displayed the current power directly read from the power management library, but now it's required the values should be updated through the device event loop. When the power is changed through the Lua script, the event is triggered as expected. However on dynamic power, the varying power is not calling the event trigger.

# Resolved code

Now power management library triggers devicesTriggerEvent() whenever power is changed for any reason.