### PR TITLE
Adds msp<->crsf  encap and decap libs

### DIFF
--- a/src/lib/CRC/crc.cpp
+++ b/src/lib/CRC/crc.cpp
@@ -20,7 +20,7 @@ uint8_t ICACHE_RAM_ATTR GENERIC_CRC8::calc(const uint8_t data)
     return crc8tab[data];
 }
 
-uint8_t ICACHE_RAM_ATTR GENERIC_CRC8::calc(const uint8_t *data, uint8_t len, uint8_t crc)
+uint8_t ICACHE_RAM_ATTR GENERIC_CRC8::calc(const uint8_t *data, uint16_t len, uint8_t crc)
 {
     while (len--)
     {

--- a/src/lib/CRC/crc.h
+++ b/src/lib/CRC/crc.h
@@ -13,7 +13,7 @@ private:
 public:
     GENERIC_CRC8(uint8_t poly);
     uint8_t calc(const uint8_t data);
-    uint8_t calc(const uint8_t *data, uint8_t len, uint8_t crc = 0);
+    uint8_t calc(const uint8_t *data, uint16_t len, uint8_t crc = 0);
 };
 
 class GENERIC_CRC14

--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -850,7 +850,7 @@ bool CRSF::RXhandleUARTout()
         retVal = true;
     }
     
-    if (SerialOutFIFO.peek() > 0 && bytesWritten < maxBytesPerCall)
+    while (SerialOutFIFO.peek() > 0 && bytesWritten < maxBytesPerCall)
     {
         if (SerialOutFIFO.size() > SerialOutFIFO.peek())
         {

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -3,6 +3,10 @@
 
 #include "targets.h"
 #include "crsf_protocol.h"
+#if defined(PLATFORM_ESP8266) && defined(CRSF_RX_MODULE)
+#include "crsf2msp.h"
+#include "msp2crsf.h"
+#endif
 #ifndef TARGET_NATIVE
 #include "HardwareSerial.h"
 #endif
@@ -31,7 +35,13 @@ public:
     }
 
     CRSF(Stream &dev) : _dev(&dev) {}
+
+    #if defined(PLATFORM_ESP8266)
+    static CROSSFIRE2MSP crsf2msp;
+    static MSP2CROSSFIRE msp2crsf;
     #endif
+    #endif
+
 
     static HardwareSerial Port;
     static Stream *PortSecondary; // A second UART used to mirror telemetry out on the TX, not read from

--- a/src/lib/CRSF2MSP/crsf2msp.cpp
+++ b/src/lib/CRSF2MSP/crsf2msp.cpp
@@ -1,0 +1,217 @@
+#include "crsf2msp.h"
+
+extern GENERIC_CRC8 crsf_crc; // defined in crsf.cpp reused here
+
+CROSSFIRE2MSP::CROSSFIRE2MSP()
+{
+    reset();
+}
+
+void CROSSFIRE2MSP::reset()
+{
+    pktLen = 0;
+    idx = 0;
+    frameComplete = false;
+    MSPvers = MSP_FRAME_UNKNOWN;
+}
+
+void CROSSFIRE2MSP::parse(const uint8_t *data)
+{
+    uint8_t CRSFpayloadLen = data[CRSF_FRAME_PAYLOAD_LEN_IDX] - CRSF_EXT_FRAME_PAYLOAD_LEN_SIZE_OFFSET;
+    bool error = isError(data);
+    bool newFrame = isNewFrame(data);
+
+    bool seqError;
+    uint8_t seqNumber = getSeqNumber(data);
+    uint8_t SeqNumberNext;
+
+    SeqNumberNext = (seqNumberPrev + 1) & 0b1111;
+    SeqNumberNext == seqNumber ? seqError = false : seqError = true;
+    seqNumberPrev = seqNumber;
+
+    if ((!newFrame && seqError) || error)
+    {
+        reset();
+        return;
+    }
+
+    if (newFrame) // single packet or first chunk of series of packets
+    {
+        idx = 3; // skip the header start wiring at offset 3.
+        MSPvers = getVersion(data);
+        src = data[CRSF_MSP_SRC_OFFSET];
+        dest = data[CRSF_MSP_DEST_OFFSET];
+        uint8_t header[3];
+        header[0] = '$';
+        header[1] = (MSPvers == MSP_FRAME_V1 || MSPvers == MSP_FRAME_V1_JUMBO) ? 'M' : 'X';
+        header[2] = error ? '!' : getHeaderDir(data);
+        memcpy(&outBuffer[0], header, sizeof(header));
+        pktLen = getFrameLen(data, MSPvers);
+
+        memcpy(&outBuffer[idx], &data[CRSF_MSP_FRAME_OFFSET], CRSFpayloadLen);
+        idx += CRSFpayloadLen;
+    }
+    else
+    { // process the next chunk of MSP frame
+        // if the last CRSF frame is zero padded we can't use the CRSF payload length
+        // but if this isn't the last chunk we can't use the MSP payload length
+        // the solution is to use the minimum of the two lengths
+        uint32_t a = (uint32_t)CRSFpayloadLen;
+        uint32_t b = pktLen - (idx - 3);
+        uint32_t minLen = !(b < a) ? a : b;
+        memcpy(&outBuffer[idx], &data[CRSF_MSP_FRAME_OFFSET], minLen); // next chunk of data
+        idx += minLen;
+    }
+
+    const uint16_t idxSansHeader = idx - 3;
+    if (idxSansHeader == pktLen) // we have a complete MSP frame, -3 because the header isn't counted
+    {
+        // we need to overwrite the CRSF checksum with the MSP checksum
+        uint8_t crc = getChecksum(outBuffer, pktLen, MSPvers);
+        outBuffer[idx] = crc;
+        frameComplete = true;
+
+        FIFOout.pushSize(idx + 1);
+        FIFOout.pushBytes(outBuffer, idx + 1);
+    }
+}
+
+bool CROSSFIRE2MSP::isNewFrame(const uint8_t *data)
+{
+    const uint8_t statusByte = data[CRSF_MSP_STATUS_BYTE_OFFSET];
+    return (bool)((statusByte & 0b10000) >> 4); // bit active if there is a new frame
+}
+
+bool CROSSFIRE2MSP::isError(const uint8_t *data)
+{
+    const uint8_t statusByte = data[CRSF_MSP_STATUS_BYTE_OFFSET];
+    return (bool)((statusByte & 0b10000000) >> 7);
+}
+
+uint8_t CROSSFIRE2MSP::getSeqNumber(const uint8_t *data)
+{
+    const uint8_t statusByte = data[CRSF_MSP_STATUS_BYTE_OFFSET];
+    return statusByte & 0b1111; // first four bits is seq number
+}
+
+MSPframeType_e CROSSFIRE2MSP::getVersion(const uint8_t *data)
+{
+    const uint8_t statusByte = data[CRSF_MSP_STATUS_BYTE_OFFSET];
+    const uint8_t payloadLen = data[CRSF_MSP_FRAME_OFFSET]; // first element is the payload length
+    uint8_t headerVersion = ((statusByte & 0b01100000) >> 5);
+    MSPframeType_e MSPvers;
+
+    if (headerVersion == 1)
+    {
+        if (payloadLen == 0xFF)
+        {
+            MSPvers = MSP_FRAME_V1_JUMBO;
+        }
+        else
+        {
+            MSPvers = MSP_FRAME_V1;
+        }
+    }
+    else if (headerVersion == 2)
+    {
+        MSPvers = MSP_FRAME_V2;
+    }
+    else
+    {
+        MSPvers = MSP_FRAME_UNKNOWN;
+    }
+    return MSPvers;
+}
+
+uint8_t CROSSFIRE2MSP::getChecksum(const uint8_t *data, const uint32_t len, MSPframeType_e mspVersion)
+{
+    const uint8_t startIdx = 3; // skip the $M</> header  in both cases
+    uint8_t checkSum = 0;
+
+    if (mspVersion == MSP_FRAME_V1 || mspVersion == MSP_FRAME_V1_JUMBO)
+    {
+        for (uint32_t i = 0; i < len; i++)
+        {
+            checkSum ^= data[i + startIdx];
+        }
+        return checkSum;
+    }
+    else if (mspVersion == MSP_FRAME_V2)
+    {
+        checkSum = crsf_crc.calc(&data[startIdx], len);
+    }
+    else
+    {
+        checkSum = 0;
+    }
+    return checkSum;
+}
+
+uint32_t CROSSFIRE2MSP::getFrameLen(const uint8_t *data, MSPframeType_e mspVersion)
+{
+    uint8_t lowByte;
+    uint8_t highByte;
+
+    if (mspVersion == MSP_FRAME_V1)
+    {
+        return (MSP_V1_FRAME_LEN_FROM_PAYLOAD_LEN(data[CRSF_MSP_FRAME_OFFSET]));
+    }
+    else if (mspVersion == MSP_FRAME_V1_JUMBO)
+    {
+        lowByte = data[CRSF_MSP_FRAME_OFFSET + 2];
+        highByte = data[CRSF_MSP_FRAME_OFFSET + 3];
+        return MSP_V1_JUMBO_FRAME_LEN_FROM_PAYLOAD_LEN((highByte << 8) | lowByte);
+    }
+    else if (mspVersion == MSP_FRAME_V2)
+    {
+        lowByte = data[CRSF_MSP_FRAME_OFFSET + 3];
+        highByte = data[CRSF_MSP_FRAME_OFFSET + 4];
+        return MSP_V2_FRAME_LEN_FROM_PAYLOAD_LEN((highByte << 8) | lowByte);
+    }
+    else
+    {
+        return 0;
+    }
+}
+
+uint8_t CROSSFIRE2MSP::getHeaderDir(const uint8_t *data)
+{
+    const uint8_t statusByte = data[CRSF_MSP_TYPE_IDX];
+    if (statusByte == 0x7A)
+    {
+        return '<';
+    }
+    else if (statusByte == 0x7B)
+    {
+        return '>';
+    }
+    else
+    {
+        return '!';
+    }
+}
+
+bool CROSSFIRE2MSP::isFrameReady()
+{
+    return frameComplete;
+}
+
+const uint8_t *CROSSFIRE2MSP::getFrame()
+{
+    return outBuffer;
+}
+
+uint32_t CROSSFIRE2MSP::getFrameLen()
+{
+    return idx + 1; // include the last byte (crc)
+}
+
+uint8_t CROSSFIRE2MSP::getSrc()
+{
+    return src;
+}
+
+uint8_t CROSSFIRE2MSP::getDest()
+{
+    return dest;
+}

--- a/src/lib/CRSF2MSP/crsf2msp.h
+++ b/src/lib/CRSF2MSP/crsf2msp.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include "FIFO_GENERIC.h"
+#include "crsfmsp_common.h"
+#include "crc.h"
+#include "logging.h"
+
+/*  Takes a CRSF(MSP) frame and converts it to raw MSP frame
+    adding the MSP header and checksum. Handles chunked MSP messages.
+*/
+
+class CROSSFIRE2MSP
+{
+private:
+    uint8_t outBuffer[MSP_FRAME_MAX_LEN];
+    uint32_t pktLen; // packet length of the incomming msp frame
+    uint32_t idx;    // number of bytes received in the current msp frame
+    uint8_t seqNumberPrev;
+    bool frameComplete;
+    uint8_t src;            // source of the msp frame (from CRSF ext header)
+    uint8_t dest;           // destination of the msp frame (from CRSF ext header)
+    MSPframeType_e MSPvers; // need to store the MSP version since it can only be inferred from the first frame
+
+    bool isNewFrame(const uint8_t *data);
+    bool isError(const uint8_t *data);
+
+    uint8_t getSeqNumber(const uint8_t *data);
+    MSPframeType_e getVersion(const uint8_t *data);
+    uint8_t getHeaderDir(const uint8_t *data);
+    uint8_t getChecksum(const uint8_t *data, const uint32_t packetLen, MSPframeType_e mspVersion);
+    uint32_t getFrameLen(const uint8_t *data, MSPframeType_e mspVersion);
+
+public:
+    CROSSFIRE2MSP();
+    FIFO_GENERIC<MSP_FRAME_MAX_LEN> FIFOout;
+    void parse(const uint8_t *data); // accept crsf frame input
+    bool isFrameReady();
+    const uint8_t *getFrame();
+    uint32_t getFrameLen();
+    void reset();
+    uint8_t getSrc();
+    uint8_t getDest();
+};

--- a/src/lib/CRSF2MSP/crsf2msp.h
+++ b/src/lib/CRSF2MSP/crsf2msp.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <cstring>
 #include "FIFO_GENERIC.h"
 #include "crsfmsp_common.h"
 #include "crc.h"

--- a/src/lib/CRSF2MSP/crsfmsp_common.h
+++ b/src/lib/CRSF2MSP/crsfmsp_common.h
@@ -1,0 +1,28 @@
+
+#pragma once
+
+#define CRSF_MSP_FRAME_OFFSET 6                                             // Start of MSP frame in CRSF packet
+#define CRSF_MSP_STATUS_BYTE_OFFSET 5                                       // Status byte index in CRSF packet
+#define CRSF_MSP_SRC_OFFSET 4                                               // Source ID index in CRSF packet
+#define CRSF_MSP_DEST_OFFSET 3                                              // MSP type index in CRSF packet
+#define CRSF_FRAME_PAYLOAD_LEN_IDX 1                                        // Extended frame payload length index in CRSF packet
+#define CRSF_EXT_FRAME_PAYLOAD_LEN_SIZE_OFFSET 5                            // For Ext Frame, playload is this much bigger than it says in the crsf frame
+#define CRSF_MSP_MAX_BYTES_PER_CHUNK 57                                     // Max bytes per MSP chunk in CRSF packet
+#define CRSF_MSP_TYPE_IDX 2                                                 // MSP type index in CRSF packet
+#define MSP_FRAME_MAX_LEN 512                                               // Max MSP frame length (increase as needed)
+#define CRSF_MSP_OUT_BUFFER_DEPTH (MSP_FRAME_MAX_LEN / CRSF_MAX_PACKET_LEN) // Max number of CRSF frames to buffer
+
+#define CRSF_MSP_LEN_TO_ENCAP_FRAME_OFFSET (CRSF_MAX_PACKET_LEN - CRSF_MSP_MAX_BYTES_PER_CHUNK) // equals 7
+// <sync><crsf_len><crsf_cmd><dst><source><header><msp_len><msp_cmd>
+
+#define MSP_V1_FRAME_LEN_FROM_PAYLOAD_LEN(payload_len) ((payload_len) + 2)       // doesn't include $M< header
+#define MSP_V1_JUMBO_FRAME_LEN_FROM_PAYLOAD_LEN(payload_len) ((payload_len) + 4) // extra 2 bytes for jumbo frame
+#define MSP_V2_FRAME_LEN_FROM_PAYLOAD_LEN(payload_len) ((payload_len) + 5)       // doesn't include $X< header
+
+typedef enum
+{
+    MSP_FRAME_V1 = 1,
+    MSP_FRAME_V2 = 2,
+    MSP_FRAME_V1_JUMBO = 3,
+    MSP_FRAME_UNKNOWN = 4,
+} MSPframeType_e;

--- a/src/lib/CRSF2MSP/msp2crsf.cpp
+++ b/src/lib/CRSF2MSP/msp2crsf.cpp
@@ -1,5 +1,4 @@
 #include "msp2crsf.h"
-#include <iostream>
 
 extern GENERIC_CRC8 crsf_crc;
 

--- a/src/lib/CRSF2MSP/msp2crsf.cpp
+++ b/src/lib/CRSF2MSP/msp2crsf.cpp
@@ -1,0 +1,207 @@
+#include "msp2crsf.h"
+#include <iostream>
+
+extern GENERIC_CRC8 crsf_crc;
+
+MSP2CROSSFIRE::MSP2CROSSFIRE() {} // empty constructor
+
+void MSP2CROSSFIRE::setSeqNumber(uint8_t &data, uint8_t seqNumber)
+{
+    uint8_t seqNumberContrained = seqNumber & 0b1111; // constrain to bounds
+    data &= ~(0b1111);                                // clear seq number
+    data |= seqNumberContrained;                      // set seq number
+}
+
+void MSP2CROSSFIRE::setNewFrame(uint8_t &data, bool isNewFrame)
+{
+    if (isNewFrame)
+    {
+        data |= 0b10000; // set bit 4
+    }
+    else
+    {
+        data &= ~(0b10000); // clear bit 4
+    }
+}
+
+void MSP2CROSSFIRE::setVersion(uint8_t &data, MSPframeType_e version)
+{
+    uint8_t val;
+
+    if (version == MSP_FRAME_V1 || version == MSP_FRAME_V1_JUMBO)
+    {
+        val = 1;
+    }
+    else if (version == MSP_FRAME_V2)
+    {
+        val = 2;
+    }
+    else
+    {
+        setError(data, true);
+        return;
+    }
+    data &= ~(0b11 << 5); // clear version
+    data |= (val << 5);   // set version
+}
+
+uint8_t MSP2CROSSFIRE::getHeaderDir(uint8_t headerDir)
+{
+    if (headerDir == '<')
+    {
+        return 0x7A;
+    }
+    else if (headerDir == '>')
+    {
+        return 0x7B;
+    }
+    else
+    {
+        return 0;
+    }
+}
+
+void MSP2CROSSFIRE::setError(uint8_t &data, bool isError)
+{
+    if (isError)
+    {
+        data |= 0b10000000; // set bit 7
+    }
+    else
+    {
+        data &= ~(0b10000000); // clear bit 7
+    }
+}
+
+uint32_t MSP2CROSSFIRE::getFrameLen(uint32_t payloadLen, uint8_t mspVersion)
+{
+    uint32_t frameLen = 0;
+    switch (mspVersion)
+    {
+        {
+        case MSP_FRAME_V1:
+            frameLen = MSP_V1_FRAME_LEN_FROM_PAYLOAD_LEN(payloadLen);
+            break;
+
+        case MSP_FRAME_V2:
+            frameLen = MSP_V2_FRAME_LEN_FROM_PAYLOAD_LEN(payloadLen);
+            break;
+
+        case MSP_FRAME_V1_JUMBO:
+            frameLen = MSP_V1_JUMBO_FRAME_LEN_FROM_PAYLOAD_LEN(payloadLen);
+            break;
+
+        default:
+            break;
+        }
+    }
+    return frameLen;
+}
+
+uint32_t MSP2CROSSFIRE::getPayloadLen(const uint8_t *data, MSPframeType_e mspVersion)
+{
+    uint32_t packetLen = 0;
+    uint8_t lowByte;
+    uint8_t highByte;
+
+    switch (mspVersion)
+    {
+        {
+        case MSP_FRAME_V1:
+            packetLen = data[3];
+            break;
+
+        case MSP_FRAME_V2:
+            lowByte = data[6];
+            highByte = data[7];
+            packetLen = (highByte << 8) | lowByte;
+            break;
+
+        case MSP_FRAME_V1_JUMBO:
+            lowByte = data[5];
+            highByte = data[6];
+            packetLen = (highByte << 8) | lowByte;
+            break;
+
+        default:
+            break;
+        }
+    }
+    return packetLen;
+}
+
+MSPframeType_e MSP2CROSSFIRE::getVersion(const uint8_t *data)
+{
+    MSPframeType_e frameType;
+
+    if (data[1] == 'M') // detect if V1 or V2
+    {
+        if (data[3] == 0xFF)
+        {
+            frameType = MSP_FRAME_V1_JUMBO;
+        }
+        else
+        {
+            frameType = MSP_FRAME_V1;
+        }
+    }
+    else if (data[1] == 'X')
+    {
+        frameType = MSP_FRAME_V2;
+    }
+    else
+    {
+        frameType = MSP_FRAME_UNKNOWN;
+    }
+    return frameType;
+}
+
+void MSP2CROSSFIRE::parse(const uint8_t *data, uint32_t frameLen, uint8_t src, uint8_t dest)
+{
+    MSPframeType_e mspVersion = getVersion(data);
+    uint32_t MSPpayloadLen = getPayloadLen(data, mspVersion);
+    uint32_t MSPframeLen = getFrameLen(MSPpayloadLen, mspVersion);
+    uint8_t numChunks = (MSPframeLen / CRSF_MSP_MAX_BYTES_PER_CHUNK) + 1; // gotta count the first chunk!
+    uint8_t chunkRemainder = MSPframeLen % CRSF_MSP_MAX_BYTES_PER_CHUNK;
+
+    uint8_t header[7];
+    // first element has to be size of the fifo chunk (can't be bigger than CRSF_MAX_PACKET_LEN)
+    header[0] = 0; // CRSFpktLen; will be set later
+    header[1] = CRSF_ADDRESS_FLIGHT_CONTROLLER;
+    header[2] = 0;                     // CRSFpktLen - CRSF_EXT_FRAME_PAYLOAD_LEN_SIZE_OFFSET;
+    header[3] = getHeaderDir(data[2]); // 3rd byte is the header direction < or >
+    header[4] = dest;
+    header[5] = src;
+    header[6] = 0;
+
+    setVersion(header[6], mspVersion);
+
+    for (uint8_t i = 0; i < numChunks; i++)
+    {
+        setSeqNumber(header[6], (seqNum++ & 0b1111));
+        setNewFrame(header[6], (i == 0 ? true : false)); // if first chunk then set to true, else false
+        setError(header[6], false);
+
+        uint32_t startIdx = (i * CRSF_MSP_MAX_BYTES_PER_CHUNK) + 3; // we don't xmit the MSP header
+        uint8_t CRSFpktLen;                                         // TOTAL length of the CRSF packet, (what the FIFO cares about)
+
+        CRSFpktLen = (i == (numChunks - 1)) ? chunkRemainder : (CRSF_MSP_MAX_BYTES_PER_CHUNK);
+
+        header[0] = CRSFpktLen + CRSF_EXT_FRAME_PAYLOAD_LEN_SIZE_OFFSET + 2;
+        header[2] = CRSFpktLen + CRSF_EXT_FRAME_PAYLOAD_LEN_SIZE_OFFSET;
+        uint8_t crc = crsf_crc.calc(&header[3], 4, 0x00); // don't include the MSP header
+        crc = crsf_crc.calc(&data[startIdx], CRSFpktLen, crc);
+
+        FIFOout.pushBytes(header, sizeof(header));
+        FIFOout.pushBytes(&data[startIdx], CRSFpktLen);
+        FIFOout.push(crc);
+    }
+}
+
+bool MSP2CROSSFIRE::validate(const uint8_t *data, uint32_t expectLen)
+{
+    MSPframeType_e version = getVersion(data);
+    uint32_t FrameLen = getFrameLen(getPayloadLen(data, version), version);
+    FrameLen += 4; // +3 header, +1 crc;
+    return (expectLen == FrameLen) ? true : false;
+}

--- a/src/lib/CRSF2MSP/msp2crsf.h
+++ b/src/lib/CRSF2MSP/msp2crsf.h
@@ -1,12 +1,10 @@
 #pragma once
 
 #include <cstdint>
-#include <cstring>
-#include "crsfmsp_common.h"
-#include "crsf_protocol.h"
-#include "crc.h"
 #include "FIFO_GENERIC.h"
-//#include "logging.h"
+#include "crsfmsp_common.h"
+#include "crc.h"
+#include "logging.h"
 
 /* Takes a MSP frame and converts it to raw CRSF frame
    adding the CRSF header and checksum. Handles chunking of messages

--- a/src/lib/CRSF2MSP/msp2crsf.h
+++ b/src/lib/CRSF2MSP/msp2crsf.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include "crsfmsp_common.h"
+#include "crsf_protocol.h"
+#include "crc.h"
+#include "FIFO_GENERIC.h"
+//#include "logging.h"
+
+/* Takes a MSP frame and converts it to raw CRSF frame
+   adding the CRSF header and checksum. Handles chunking of messages
+*/
+
+class MSP2CROSSFIRE
+{
+private:
+    // bool isBusy;
+    void setNewFrame(uint8_t &data, bool isNewFrame);
+    void setSeqNumber(uint8_t &data, uint8_t seqNumber);
+    void setVersion(uint8_t &data, MSPframeType_e version);
+    uint8_t getHeaderDir(uint8_t headerDir);
+    void setError(uint8_t &data, bool isError);
+    uint8_t seqNum; 
+
+    uint32_t getFrameLen(uint32_t payloadLen, uint8_t mspVersion);
+    MSPframeType_e getVersion(const uint8_t *data);
+    uint32_t getPayloadLen(const uint8_t *data, MSPframeType_e mspVersion);
+
+public:
+    MSP2CROSSFIRE();
+    FIFO_GENERIC<MSP_FRAME_MAX_LEN> FIFOout;
+    void parse(const uint8_t *data, uint32_t frameLen, uint8_t src = CRSF_ADDRESS_CRSF_RECEIVER, uint8_t dest = CRSF_ADDRESS_FLIGHT_CONTROLLER);
+    bool validate(const uint8_t *data, uint32_t expectLen);
+};

--- a/src/lib/FIFO_GENERIC/FIFO_GENERIC.h
+++ b/src/lib/FIFO_GENERIC/FIFO_GENERIC.h
@@ -1,0 +1,153 @@
+/*
+ * FIFO Buffer
+ * Implementation uses arrays to conserve memory
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Daniel Eisterhold
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *
+ *
+ * Modified/Ammended by Alessandro Carcione 2020
+ */
+
+#pragma once
+#include "targets.h"
+#include "logging.h"
+
+template <uint32_t FIFO_SIZE>
+class FIFO_GENERIC
+{
+private:
+    uint32_t head;
+    uint32_t tail;
+    uint32_t numElements;
+    uint8_t buffer[FIFO_SIZE] = {0};
+
+public:
+    FIFO_GENERIC()
+    {
+        head = 0;
+        tail = 0;
+        numElements = 0;
+        memset(buffer, 0, FIFO_SIZE);
+    }
+
+    void push(const uint8_t data)
+    {
+        if (numElements == FIFO_SIZE)
+        {
+            ERRLN("Buffer full, will flush");
+            flush();
+            return;
+        }
+        else
+        {
+            numElements++;
+            buffer[tail] = data;
+            tail = (tail + 1) % FIFO_SIZE;
+        }
+    }
+
+    void pushBytes(const uint8_t *data, uint32_t len)
+    {
+        {
+            if (numElements + len > FIFO_SIZE)
+            {
+                ERRLN("Buffer full, will flush");
+                flush();
+                return;
+            }
+            for (uint32_t i = 0; i < len; i++)
+            {
+                buffer[tail] = data[i];
+                tail = (tail + 1) % FIFO_SIZE;
+            }
+            numElements += len;
+        }
+    }
+
+    uint8_t pop()
+    {
+        {
+            if (numElements == 0)
+            {
+                // DBGLN(F("Buffer empty"));
+                return 0;
+            }
+            else
+            {
+                numElements--;
+                uint8_t data = buffer[head];
+                head = (head + 1) % FIFO_SIZE;
+                return data;
+            }
+        }
+    }
+
+    void popBytes(uint8_t *data, uint32_t len)
+    {
+        {
+            if (numElements < len)
+            {
+                // DBGLN(F("Buffer underrun"));
+                flush();
+            }
+            else
+            {
+                numElements -= len;
+                for (uint32_t i = 0; i < len; i++)
+                {
+                    data[i] = buffer[head];
+                    head = (head + 1) % FIFO_SIZE;
+                }
+            }
+        }
+    }
+
+    uint8_t peek()
+    {
+        {
+            if (numElements == 0)
+            {
+                // DBGLN(F("Buffer empty"));
+                return 0;
+            }
+            else
+            {
+                uint8_t data = buffer[head];
+                return data;
+            }
+        }
+    }
+
+    uint32_t size()
+    {
+        return numElements;
+    }
+
+    void flush()
+    {
+        head = 0;
+        tail = 0;
+        numElements = 0;
+    }
+};

--- a/src/test/msp2crsf2msp_native/test_msp2crsf2msp.cpp
+++ b/src/test/msp2crsf2msp_native/test_msp2crsf2msp.cpp
@@ -152,10 +152,7 @@ void MSPV2_SERIAL_SETTINGS_TEST()
     // cout << endl;
 }
 
-
-
-
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
     UNITY_BEGIN();
 

--- a/src/test/msp2crsf2msp_native/test_msp2crsf2msp.cpp
+++ b/src/test/msp2crsf2msp_native/test_msp2crsf2msp.cpp
@@ -1,0 +1,175 @@
+#include <cstdint>
+#include <iostream>
+#include <unity.h>
+#include "common.h"
+#include "msp2crsf.h"
+#include "crsf2msp.h"
+
+using namespace std;
+
+GENERIC_CRC8 crsf_crc(CRSF_CRC_POLY);
+
+MSP2CROSSFIRE msp2crsf;
+CROSSFIRE2MSP crsf2msp;
+
+// MSP V2 (function id: 100, payload size: 0)
+const uint8_t MSP_IDENT[] = {0x24, 0x58, 0x3c, 0x00, 0x64, 0x00, 0x00, 0x00, 0x8f};
+const uint8_t MSPV2_HELLO_WORLD[] = {0x24, 0x58, 0x3e, 0xa5, 0x42, 0x42, 0x12, 0x00, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x66, 0x6c, 0x79, 0x69, 0x6e, 0x67, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x82};
+const uint8_t MSPV2_IN_V1_HELLOWORLD[] = {0x24, 0x4d, 0x3e, 0x18, 0xff, 0xa5, 0x42, 0x42, 0x12, 0x00, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x66, 0x6c, 0x79, 0x69, 0x6e, 0x67, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x82, 0xe1};
+const uint8_t MSP_2CHUNKS_LONG[] = {36, 77, 62, 75, 4, 83, 52, 48, 53, 0, 0, 2, 55, 9, 83, 84, 77, 51, 50, 70, 52, 48, 53, 9, 79, 77, 78, 73, 66, 85, 83, 70, 52, 4, 65, 73, 82, 66, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 2, 64, 31, 3, 0, 0, 0, 1, 0, 87};
+const uint8_t MSPV1_JUMBO[] = {36, 77, 62, 255, 116, 25, 1, 65, 82, 77, 59, 65, 78, 71, 76, 69, 59, 72, 79, 82, 73, 90, 79, 78, 59, 72, 69, 65, 68, 70, 82, 69, 69, 59, 70, 65, 73, 76, 83, 65, 70, 69, 59, 72, 69, 65, 68, 65, 68, 74, 59, 66, 69, 69, 80, 69, 82, 59, 79, 83, 68, 32, 68, 73, 83, 65, 66, 76, 69, 59, 84, 69, 76, 69, 77, 69, 84, 82, 89, 59, 66, 76, 65, 67, 75, 66, 79, 88, 59, 70, 80, 86, 32, 65, 78, 71, 76, 69, 32, 77, 73, 88, 59, 66, 76, 65, 67, 75, 66, 79, 88, 32, 69, 82, 65, 83, 69, 32, 40, 62, 51, 48, 115, 41, 59, 67, 65, 77, 69, 82, 65, 32, 67, 79, 78, 84, 82, 79, 76, 32, 49, 59, 67, 65, 77, 69, 82, 65, 32, 67, 79, 78, 84, 82, 79, 76, 32, 50, 59};
+
+// sendt at near the start of the transaction, got stuck here for abit
+const uint8_t MSPV1_81[] = {36, 77, 62, 75, 4, 83, 52, 48, 53, 0, 0, 2, 55, 9, 83, 84, 77, 51, 50, 70, 52, 48, 53, 9, 79, 77, 78, 73, 66, 85, 83, 70, 52, 4, 65, 73, 82, 66, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 2, 64, 31, 3, 0, 0, 0, 1, 0, 87};
+
+// MSPv1JUMBO
+const uint8_t MSPV1_JUMBO_289[] = {36, 77, 62, 255, 116, 25, 1, 65, 82, 77, 59, 65, 78, 71, 76, 69, 59, 72, 79, 82, 73, 90, 79, 78, 59, 72, 69, 65, 68, 70, 82, 69, 69, 59, 70, 65, 73, 76, 83, 65, 70, 69, 59, 72, 69, 65, 68, 65, 68, 74, 59, 66, 69, 69, 80, 69, 82, 59, 79, 83, 68, 32, 68, 73, 83, 65, 66, 76, 69, 59, 84, 69, 76, 69, 77, 69, 84, 82, 89, 59, 66, 76, 65, 67, 75, 66, 79, 88, 59, 70, 80, 86, 32, 65, 78, 71, 76, 69, 32, 77, 73, 88, 59, 66, 76, 65, 67, 75, 66, 79, 88, 32, 69, 82, 65, 83, 69, 32, 40, 62, 51, 48, 115, 41, 59, 67, 65, 77, 69, 82, 65, 32, 67, 79, 78, 84, 82, 79, 76, 32, 49, 59, 67, 65, 77, 69, 82, 65, 32, 67, 79, 78, 84, 82, 79, 76, 32, 50, 59, 67, 65, 77, 69, 82, 65, 32, 67, 79, 78, 84, 82, 79, 76, 32, 51, 59, 80, 82, 69, 65, 82, 77, 59, 86, 84, 88, 32, 80, 73, 84, 32, 77, 79, 68, 69, 59, 80, 65, 82, 65, 76, 89, 90, 69, 59, 65, 67, 82, 79, 32, 84, 82, 65, 73, 78, 69, 82, 59, 86, 84, 88, 32, 67, 79, 78, 84, 82, 79, 76, 32, 68, 73, 83, 65, 66, 76, 69, 59, 76, 65, 85, 78, 67, 72, 32, 67, 79, 78, 84, 82, 79, 76, 59, 83, 84, 73, 67, 75, 32, 67, 79, 77, 77, 65, 78, 68, 83, 32, 68, 73, 83, 65, 66, 76, 69, 59, 66, 69, 69, 80, 69, 82, 32, 77, 85, 84, 69, 59, 150};
+
+const uint8_t MSP_BOARD_INFO_81[] = {36, 77, 62, 75, 4, 83, 52, 48, 53, 0, 0, 2, 55, 9, 83, 84, 77, 51, 50, 70, 52, 48, 53, 9, 79, 77, 78, 73, 66, 85, 83, 70, 52, 4, 65, 73, 82, 66, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+// MSPV2 46b
+const uint8_t MSPV2_SERIAL_SETTINGS[] = {0x24, 0x58, 0x3C, 0x00, 0x0A, 0x10, 0x25, 0x00, 0x04, 0x14, 0x01, 0x00, 0x00, 0x00, 0x05, 0x04, 0x00, 0x05, 0x00, 0x40, 0x00, 0x00, 0x00, 0x05, 0x04, 0x00, 0x05, 0x02, 0x00, 0x00, 0x00, 0x00, 0x05, 0x04, 0x00, 0x05, 0x05, 0x00, 0x00, 0x00, 0x00, 0x05, 0x04, 0x00, 0x05, 0x7B};
+
+void printBufferhex(const uint8_t *buf, int len)
+{
+    cout << "len: " << dec << (int)len << " [ ";
+    for (int i = 0; i < len; i++)
+    {
+        cout << "0x" << hex << (int)buf[i] << " ";
+    }
+    cout << "]" << endl;
+}
+
+void printFIFOhex()
+{
+    while (msp2crsf.FIFOout.peek())
+    {
+        uint8_t len = msp2crsf.FIFOout.pop();
+        cout << "len: " << dec << (int)len << " [ ";
+
+        for (int i = 0; i < len; i++)
+        {
+            cout << "0x";
+            cout << hex << (int)msp2crsf.FIFOout.pop() << " ";
+        }
+        cout << "]" << endl;
+    }
+}
+
+void runTest(const uint8_t *frame, int frameLen)
+{
+    cout << "MSP In Len: " << dec << (int)frameLen << endl;
+
+    // cout << "MSP()                ";
+    // printBufferhex(frame, frameLen);
+
+    // msp2crsf.parse(frame, frameLen);
+    // cout << "CRSF(MSP())          ";
+    // printFIFOhex();
+
+    msp2crsf.parse(frame, frameLen); // do again cause we pop'd the buffer
+    while (msp2crsf.FIFOout.peek() > 0)
+    {
+        uint8_t sizeOut = msp2crsf.FIFOout.pop();
+        uint8_t crsfFrame[64];
+        msp2crsf.FIFOout.popBytes(crsfFrame, sizeOut);
+        crsf2msp.parse(crsfFrame);
+    }
+
+    // if (crsf2msp.isFrameReady())
+    // {
+    //     cout << "CRSF^-1(CRSF(MSP())) ";
+    //     printBufferhex(crsf2msp.getFrame(), crsf2msp.getFrameLen());
+    // }
+    // else
+    // {
+    //     cout << "Frame not ready\n";
+    // }
+    cout << "MSP Out Len: " << dec << (int)crsf2msp.getFrameLen() << endl;
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(frame, crsf2msp.getFrame(), frameLen);
+}
+
+void MSP_IDENT_TEST()
+{
+    // cout << "Testing MSP_IDENT (0 len payload)" << endl;
+    runTest(MSP_IDENT, sizeof(MSP_IDENT));
+    // cout << endl;
+}
+
+void MSPV2_HELLO_WORLD_TEST()
+{
+    // cout << "Testing MSPV2 Hello World" << endl;
+    runTest(MSPV2_HELLO_WORLD, sizeof(MSPV2_HELLO_WORLD));
+    // cout << endl;
+}
+
+void MSPV2_IN_V1_HELLOWORLD_TEST()
+{
+    // cout << "Testing MSPV2 within MSPV1 Hello World" << endl;
+    runTest(MSPV2_IN_V1_HELLOWORLD, sizeof(MSPV2_IN_V1_HELLOWORLD));
+    // cout << endl;
+}
+
+void MSPV2_2_CHUNK_MSG()
+{
+    // cout << "Testing MSP LONG" << endl;
+    runTest(MSP_2CHUNKS_LONG, sizeof(MSP_2CHUNKS_LONG));
+    // cout << endl;
+}
+
+void MSPV1_JUMBO_TEST()
+{
+    // cout << "Testing MSPV2 within MSPV1 Hello World" << endl;
+    runTest(MSPV1_JUMBO, sizeof(MSPV1_JUMBO));
+    // cout << endl;
+}
+
+void MSPV1_81_TEST()
+{
+    // cout << "Testing MSPV2 within MSPV1 Hello World" << endl;
+    runTest(MSPV1_81, sizeof(MSPV1_81));
+    // cout << endl;
+}
+
+void MSPV1_JUMBO_289_TEST()
+{
+    // cout << "Testing MSPV2 within MSPV1 Hello World" << endl;
+    runTest(MSPV1_JUMBO_289, sizeof(MSPV1_JUMBO_289));
+    // cout << endl;
+}
+
+void MSP_BOARD_INFO_81_TEST()
+{
+    // cout << "Testing MSPV2 within MSPV1 Hello World" << endl;
+    runTest(MSP_BOARD_INFO_81, sizeof(MSP_BOARD_INFO_81));
+    // cout << endl;
+}
+
+void MSPV2_SERIAL_SETTINGS_TEST()
+{
+    // cout << "Testing MSPV2 within MSPV1 Hello World" << endl;
+    runTest(MSPV2_SERIAL_SETTINGS, sizeof(MSPV2_SERIAL_SETTINGS));
+    // cout << endl;
+}
+
+
+
+
+main(int argc, char **argv)
+{
+    UNITY_BEGIN();
+
+    RUN_TEST(MSP_IDENT_TEST);
+    RUN_TEST(MSPV2_HELLO_WORLD_TEST);
+    RUN_TEST(MSPV2_IN_V1_HELLOWORLD_TEST);
+    RUN_TEST(MSPV2_2_CHUNK_MSG);
+    RUN_TEST(MSPV1_JUMBO_TEST);
+    RUN_TEST(MSPV1_81_TEST);
+    RUN_TEST(MSPV1_JUMBO_289_TEST);
+    RUN_TEST(MSP_BOARD_INFO_81_TEST);
+    RUN_TEST(MSPV2_SERIAL_SETTINGS_TEST);
+
+    UNITY_END();
+
+    return 0;
+}


### PR DESCRIPTION
Here we go!,

These two libraries convert raw MSP() frames between MSP encapsulated CRSF frames and back. The main intent being allowing MSP over WIFI over CRSF encapsulation and hence awesome features like wireless Betaflight Configurator. 

This can also be used to send arb MSP frames down the CRSF pipe, and we should try to migrate some of the CRSF CMD frames to MSP frames in the future. Eg the VTX cmds. 

