### PR TITLE
Display wifi update page when in wifi mode

### DIFF
--- a/src/lib/SCREEN/screen.cpp
+++ b/src/lib/SCREEN/screen.cpp
@@ -290,4 +290,12 @@ void Screen::nextIndex(int &index, int action, int min, int max)
     }
 }
 
+void Screen::setInWifiMode()
+{
+    current_screen_status = SCREEN_STATUS_WORK;
+    main_menu_page_index = MAIN_MENU_UPDATEFW_INDEX;
+    current_page_index = PAGE_SUB_UPDATEFW_INDEX;
+    updateSubWIFIModePage();
+}
+
 #endif

--- a/src/lib/SCREEN/screen.h
+++ b/src/lib/SCREEN/screen.h
@@ -158,6 +158,7 @@ public:
 
     void activeScreen();
     void doUserAction(int action);
+    void setInWifiMode();
 
     int getUserRateIndex() { return current_rate_index; }
     int getUserPowerIndex() { return current_power_index; }


### PR DESCRIPTION
When moving to WiFi mode via LUA or automatically, update the OLED/TFT with the WiFi "status" page.