### PR TITLE
Add hysteresis to TX fan

### DIFF
--- a/src/lib/LUA/devLUA.cpp
+++ b/src/lib/LUA/devLUA.cpp
@@ -304,7 +304,6 @@ static void registerLuaParameters()
 #if defined(GPIO_PIN_FAN_EN)
   registerLUAParameter(&luaFanThreshold, [](uint8_t id, uint8_t arg){
       config.SetPowerFanThreshold(arg);
-      POWERMGNT::setFanEnableTheshold((PowerLevels_e)arg);
   }, luaPowerFolder.common.id);
 #endif
   // VTX folder

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -37,7 +37,6 @@ extern SX1280Driver Radio;
 #endif
 
 PowerLevels_e POWERMGNT::CurrentPower = PWR_COUNT; // default "undefined" initial value
-PowerLevels_e POWERMGNT::FanEnableThreshold = PWR_250mW;
 #if defined(POWER_OUTPUT_VALUES)
 static int16_t powerValues[] = POWER_OUTPUT_VALUES;
 #endif
@@ -193,21 +192,6 @@ void POWERMGNT::setDefaultPower()
     setPower(getDefaultPower());
 }
 
-void POWERMGNT::updateFan()
-{
-#if defined(GPIO_PIN_FAN_EN)
-    digitalWrite(GPIO_PIN_FAN_EN, (CurrentPower >= FanEnableThreshold) ? HIGH : LOW);
-#endif
-}
-
-void POWERMGNT::setFanEnableTheshold(PowerLevels_e Power)
-{
-#if defined(GPIO_PIN_FAN_EN)
-    FanEnableThreshold = Power;
-    updateFan();
-#endif
-}
-
 void POWERMGNT::setPower(PowerLevels_e Power)
 {
     if (Power == CurrentPower)
@@ -246,5 +230,4 @@ void POWERMGNT::setPower(PowerLevels_e Power)
 #endif
     CurrentPower = Power;
     devicesTriggerEvent();
-    updateFan();
 }

--- a/src/lib/POWERMGNT/POWERMGNT.h
+++ b/src/lib/POWERMGNT/POWERMGNT.h
@@ -48,7 +48,6 @@ class POWERMGNT
 
 private:
     static PowerLevels_e CurrentPower;
-    static PowerLevels_e FanEnableThreshold;
     static void updateFan();
 #if defined(PLATFORM_ESP32)
     static nvs_handle  handle;
@@ -63,7 +62,6 @@ public:
     static uint8_t powerToCrsfPower(PowerLevels_e Power);
     static PowerLevels_e getDefaultPower();
     static void setDefaultPower();
-    static void setFanEnableTheshold(PowerLevels_e Power);
     static void init();
     static void SetPowerCaliValues(int8_t *values, size_t size);
     static void GetPowerCaliValues(int8_t *values, size_t size);

--- a/src/lib/THERMAL/devThermal.cpp
+++ b/src/lib/THERMAL/devThermal.cpp
@@ -1,54 +1,52 @@
-#include "targets.h"
-#include "common.h"
-#include "device.h"
+#include "devThermal.h"
 
-#ifdef HAS_THERMAL
+#if defined(HAS_THERMAL) || defined(HAS_FAN)
 
-#include "thermal.h"
-#include "config.h"
-
-#if defined(TARGET_TX)
-extern TxConfig config;
-#else
-extern RxConfig config;
+#if defined(TARGET_RX)
+    #error "devThermal not supported on RX"
 #endif
+
+#include "config.h"
+extern TxConfig config;
+
+#define THERMAL_DURATION 1000
+
+#if defined(HAS_THERMAL)
+//#include "targets.h"
+//#include "common.h"
+extern bool IsArmed();
 
 Thermal thermal;
 
-#define THERMAL_DURATION    1000
-
-extern bool ICACHE_RAM_ATTR IsArmed();
-
-#ifdef HAS_SMART_FAN
+#if defined(HAS_SMART_FAN)
 bool is_smart_fan_control = false;
 bool is_smart_fan_working = false;
 #endif
 
+#endif // HAS_THERMAL
+
+#if defined(HAS_FAN)
+#include "POWERMGNT.h"
+
+#if !defined(FAN_MIN_RUNTIME)
+    #define FAN_MIN_RUNTIME 60U // seconds
+#endif
+
+#endif
+
 static void initialize()
 {
+#if defined(HAS_THERMAL)
     thermal.init();
-}
-
-static int start()
-{
-    return DURATION_IMMEDIATELY;
-}
-
-static int event()
-{
-#ifdef HAS_SMART_FAN
-    if(!is_smart_fan_control)
-    {
 #endif
-        thermal.update_threshold(config.GetFanMode());
-#ifdef HAS_SMART_FAN
-    }
+#if defined(HAS_FAN)
+    pinMode(GPIO_PIN_FAN_EN, OUTPUT);
 #endif
-    return DURATION_IGNORE;
 }
 
-static int timeout()
+static void timeoutThermal()
 {
+#if defined(HAS_THERMAL)
     if(!IsArmed() && connectionState != wifiUpdate)
     {
         thermal.handle();
@@ -65,14 +63,60 @@ static int timeout()
         }
 #endif
     }
+#endif // HAS_THERMAL
+}
+
+static void timeoutFan()
+{
+#if defined(HAS_FAN)
+    static uint8_t fanOnDuration;
+
+    // Enable the fan if at or above the threshold
+    if (POWERMGNT::currPower() >= (PowerLevels_e)config.GetPowerFanThreshold())
+    {
+        digitalWrite(GPIO_PIN_FAN_EN, HIGH);
+        fanOnDuration = 0;
+    }
+    // Disable the fan if it has been below the threshold for long enough
+    else
+    {
+        if (fanOnDuration < FAN_MIN_RUNTIME)
+            ++fanOnDuration;
+        else
+            digitalWrite(GPIO_PIN_FAN_EN, LOW);
+    }
+#endif // HAS_FAN
+}
+
+static int event()
+{
+#if defined(HAS_THERMAL)
+#ifdef HAS_SMART_FAN
+    if(!is_smart_fan_control)
+    {
+#endif
+        thermal.update_threshold(config.GetFanMode());
+#ifdef HAS_SMART_FAN
+    }
+#endif
+#endif // HAS_THERMAL
+
+    return THERMAL_DURATION;
+}
+
+static int timeout()
+{
+    timeoutThermal();
+    timeoutFan();
+
     return THERMAL_DURATION;
 }
 
 device_t Thermal_device = {
     .initialize = initialize,
-    .start = start,
+    .start = NULL,
     .event = event,
     .timeout = timeout
 };
 
-#endif
+#endif // HAS_THERMAL || HAS_FAN

--- a/src/lib/THERMAL/devThermal.cpp
+++ b/src/lib/THERMAL/devThermal.cpp
@@ -96,7 +96,7 @@ static void timeoutFan()
             fanIsOn = false;
         }
     }
-
+    // vv else fan is off currently vv
     else if (fanShouldBeOn)
     {
         // Delay turning the fan on for 4 cycles to be sure it really should be on

--- a/src/lib/THERMAL/devThermal.cpp
+++ b/src/lib/THERMAL/devThermal.cpp
@@ -29,7 +29,7 @@ bool is_smart_fan_working = false;
 #include "POWERMGNT.h"
 
 #if !defined(FAN_MIN_RUNTIME)
-    #define FAN_MIN_RUNTIME 60U // seconds
+    #define FAN_MIN_RUNTIME 30U // seconds
 #endif
 
 #endif

--- a/src/lib/THERMAL/devThermal.cpp
+++ b/src/lib/THERMAL/devThermal.cpp
@@ -12,8 +12,8 @@ extern TxConfig config;
 #define THERMAL_DURATION 1000
 
 #if defined(HAS_THERMAL)
-//#include "targets.h"
-//#include "common.h"
+#include "common.h"
+#include "thermal.h"
 extern bool IsArmed();
 
 Thermal thermal;
@@ -32,7 +32,7 @@ bool is_smart_fan_working = false;
     #define FAN_MIN_RUNTIME 30U // seconds
 #endif
 
-#endif
+#endif // HAS_FAN
 
 static void initialize()
 {

--- a/src/lib/THERMAL/devThermal.h
+++ b/src/lib/THERMAL/devThermal.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#if defined(GPIO_PIN_FAN_EN)
+#define HAS_FAN
+#endif
+
+#if defined(HAS_THERMAL) || defined(HAS_FAN)
 #include "device.h"
 
 extern device_t Thermal_device;
+#endif

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -115,13 +115,13 @@ device_affinity_t ui_devices[] = {
 #ifdef HAS_BUTTON
   {&Button_device, 1},
 #endif
-#if defined HAS_TFT_SCREEN || defined(USE_OLED_SPI) || defined(USE_OLED_SPI_SMALL) || defined(USE_OLED_I2C)
+#if defined(HAS_TFT_SCREEN) || defined(USE_OLED_SPI) || defined(USE_OLED_SPI_SMALL) || defined(USE_OLED_I2C)
   {&Screen_device, 0},
 #endif
 #ifdef HAS_GSENSOR
   {&Gsensor_device, 0},
 #endif
-#ifdef HAS_THERMAL
+#if defined(HAS_THERMAL) || defined(HAS_FAN)
   {&Thermal_device, 0},
 #endif
   {&VTX_device, 1}
@@ -1002,7 +1002,6 @@ void setup()
     TelemetryReceiver.SetDataToReceive(sizeof(CRSFinBuffer), CRSFinBuffer, ELRS_TELEMETRY_BYTES_PER_CALL);
 
     POWERMGNT.init();
-    POWERMGNT.setFanEnableTheshold((PowerLevels_e)config.GetPowerFanThreshold());
 
     // Set the pkt rate, TLM ratio, and power from the stored eeprom values
     ChangeRadioParams();

--- a/src/user_defines.txt
+++ b/src/user_defines.txt
@@ -36,6 +36,12 @@
 
 -DLOCK_ON_FIRST_CONNECTION
 
+# For TX devices with fans, FAN_MIN_RUNTIME keeps the fan running even after the power level has
+# dropped below the configured Fan Threshold. This prevents the fan from turning on and off every
+# few seconds if the power level is constantly changing.
+# Default is 60 seconds if not defined, value can be 0-254.
+#-DFAN_MIN_RUNTIME=60
+
 ### COMPATIBILITY OPTIONS: ###
 
 # Invert the TX/RX half-duplex pin in the transmitter code. Handset external

--- a/src/user_defines.txt
+++ b/src/user_defines.txt
@@ -39,8 +39,8 @@
 # For TX devices with fans, FAN_MIN_RUNTIME keeps the fan running even after the power level has
 # dropped below the configured Fan Threshold. This prevents the fan from turning on and off every
 # few seconds if the power level is constantly changing.
-# Default is 60 seconds if not defined, value can be 0-254.
-#-DFAN_MIN_RUNTIME=60
+# Default is 30 seconds if not defined, value can be 0-254.
+#-DFAN_MIN_RUNTIME=30
 
 ### COMPATIBILITY OPTIONS: ###
 


### PR DESCRIPTION
Adds `FAN_MIN_RUNTIME`, which keeps the transmitter fan on for a duration after the power level has dropped back below the Fan Threshold. The enabling of the fan is also delayed by 5 seconds.

### Details
On dynamic power, there are many times where the power level is bumped up to max configured power. It can be annoying to hear the fan turn on and off just for the short duration. The suggestion was to keep the fan on even after the power level has dropped, so it will already be on the next time the power blips high.

I've implemented a hysteresis to both the turn on and turn off of the fan. I've added this to the devThermal device because if we kept it in POWERMGMT, it would rely on being called every second to be able to turn have the fan change state NOT directly in response to the power changing, so devices are made just for that.

* The power level must meet or exceed the threshold for a minimum of 4 seconds before the fan is enabled. This prevents it from turning on if the power is only at the threshold for a short time. The duration was chosen assuming dynamic power will lower the power before this if a single event caused the momentary power spike.
* The power level must be below the threshold for at least `FAN_MIN_RUNTIME` seconds before the fan is disabled. This keeps the fan on, anticipating it will go back to the threshold before the timeout. This can be overriden with a user_define if people don't like it, from 0s to 254s

### For Discussion
How long should the default be? schugabe suggested 60s and that's what I used at first, but it might be a little long, causing the fan to always be on just because the power went above the threshold. Is 30s too short? I pushed a change to lower it to 30s, since it is configurable and all.