### PR TITLE
Fix RSSI calculation when SNR <0

### DIFF
--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -291,6 +291,10 @@ void ICACHE_RAM_ATTR SX127xDriver::RXnbISR()
   hal.readRegisterFIFO(RXdataBuffer, PayloadLength);
   LastPacketRSSI = GetLastPacketRSSI();
   LastPacketSNR = GetLastPacketSNR();
+  // https://www.mouser.com/datasheet/2/761/sx1276-1278113.pdf
+  // page 87 (note we already do /4 in GetLastPacketSNR())
+  int8_t negOffset = (LastPacketSNR < 0) ? LastPacketSNR : 0;
+  LastPacketRSSI += negOffset;
   RXdoneCallback();
 }
 

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -371,6 +371,10 @@ void ICACHE_RAM_ATTR SX1280Driver::GetLastPacketStats()
     hal.ReadCommand(SX1280_RADIO_GET_PACKETSTATUS, status, 2);
     LastPacketRSSI = -(int8_t)(status[0] / 2);
     LastPacketSNR = (int8_t)status[1] / 4;
+    // https://www.mouser.com/datasheet/2/761/DS_SX1280-1_V2.2-1511144.pdf
+    // need to subtract SNR from RSSI when SNR <= 0;
+    int8_t negOffset = (LastPacketSNR < 0) ? LastPacketSNR : 0; 
+    LastPacketRSSI += negOffset;
 }
 
 void ICACHE_RAM_ATTR SX1280Driver::IsrCallback()


### PR DESCRIPTION
The SNR reading needs to be subtracted from the RSSIdbm raw value when the SNR <0. Otherwise the RSSIdbm is just reading the noise floor instead of the actual signal strength. 

References:
SX1280 : https://www.mouser.com/datasheet/2/761/DS_SX1280-1_V2.2-1511144.pdf table 11-64
SX127x: https://www.mouser.com/datasheet/2/761/sx1276-1278113.pdf page 87