### PR TITLE
Screen updates

### DIFF
--- a/src/lib/SCREEN/OLED/oledscreen.cpp
+++ b/src/lib/SCREEN/OLED/oledscreen.cpp
@@ -215,15 +215,15 @@ void OLEDScreen::displayMainScreen(){
     #ifdef USE_OLED_SPI_SMALL
         u8g2.setFont(u8g2_font_t0_15_mr);
         u8g2.drawStr(0,15, &(rate_string[current_rate_index])[0]);
-        u8g2.drawStr(70,15 ,&(ratio_string[current_ratio_index])[0]);
-        u8g2.drawStr(0,32, &(power_string[current_power_index])[0]);
+        u8g2.drawStr(70,15, &(ratio_string[current_ratio_index])[0]);
+        u8g2.drawStr(0,32, &(power_string[last_power_index])[0]);
         u8g2.drawStr(70,32, "Test");
     #else
         u8g2.setFont(u8g2_font_t0_15_mr);
         u8g2.drawStr(0,13, "ExpressLRS");
         u8g2.drawStr(0,45, &(rate_string[current_rate_index])[0]);
-        u8g2.drawStr(70,45 , &(ratio_string[current_ratio_index])[0]);
-        u8g2.drawStr(0,60, &(power_string[current_power_index])[0]);
+        u8g2.drawStr(70,45, &(ratio_string[current_ratio_index])[0]);
+        u8g2.drawStr(0,60, &(power_string[last_power_index])[0]);
         u8g2.setFont(u8g2_font_profont10_mr);
         u8g2.drawStr(70,56, "TLM");
         u8g2.drawStr(0,27, "Ver: ");
@@ -346,13 +346,13 @@ void OLEDScreen::doRateValueSelect(int action)
     u8g2.clearBuffer();
     #ifdef USE_OLED_SPI_SMALL
         u8g2.setFont(u8g2_font_t0_16_mr);
-        u8g2.drawStr(0,15, &(rate_string[current_rate_index])[0]);
+        u8g2.drawStr(0,15, &(rate_string[current_index])[0]);
         u8g2.setFont(u8g2_font_profont10_mr);
         u8g2.drawStr(0,60, "PRESS TO CONFIRM");
         helperDrawImage32(IMAGE_RATE);
     #else
         u8g2.setFont(u8g2_font_t0_16_mr);
-        u8g2.drawStr(0,20, &(rate_string[current_rate_index])[0]);
+        u8g2.drawStr(0,20, &(rate_string[current_index])[0]);
         u8g2.setFont(u8g2_font_profont10_mr);
         u8g2.drawStr(0,44, "PRESS TO");
         u8g2.drawStr(0,56, "CONFIRM");
@@ -368,13 +368,13 @@ void OLEDScreen::doPowerValueSelect(int action)
     u8g2.clearBuffer();
     #ifdef USE_OLED_SPI_SMALL
         u8g2.setFont(u8g2_font_t0_16_mr);
-        u8g2.drawStr(0,15, &(power_string[current_power_index])[0]);
+        u8g2.drawStr(0,15, &(power_string[current_index])[0]);
         u8g2.setFont(u8g2_font_courR08_tr);
         u8g2.drawStr(0,60, "PRESS TO CONFIRM");
         helperDrawImage32(IMAGE_POWER);
     #else
         u8g2.setFont(u8g2_font_t0_16_mr);
-        u8g2.drawStr(0,20, &(power_string[current_power_index])[0]);
+        u8g2.drawStr(0,20, &(power_string[current_index])[0]);
         u8g2.setFont(u8g2_font_profont10_mr);
         u8g2.drawStr(0,44, "PRESS TO");
         u8g2.drawStr(0,56, "CONFIRM");
@@ -385,19 +385,18 @@ void OLEDScreen::doPowerValueSelect(int action)
 
 void OLEDScreen::doRatioValueSelect(int action)
 {
-
     nextIndex(current_ratio_index, action, RATIO_MAX_NUMBER);
 
     u8g2.clearBuffer();
     #ifdef USE_OLED_SPI_SMALL
         u8g2.setFont(u8g2_font_t0_16_mr);
-        u8g2.drawStr(0,15, &(ratio_string[current_ratio_index])[0]);
+        u8g2.drawStr(0,15, &(ratio_string[current_index])[0]);
         u8g2.setFont(u8g2_font_profont10_mr);
         u8g2.drawStr(0,60, "PRESS TO CONFIRM");
         helperDrawImage32(IMAGE_RATIO);
     #else
         u8g2.setFont(u8g2_font_t0_16_mr);
-        u8g2.drawStr(0,20, &(ratio_string[current_ratio_index])[0]);
+        u8g2.drawStr(0,20, &(ratio_string[current_index])[0]);
         u8g2.setFont(u8g2_font_profont10_mr);
         u8g2.drawStr(0,44, "PRESS TO");
         u8g2.drawStr(0,56, "CONFIRM");
@@ -418,7 +417,7 @@ void OLEDScreen::doSmartFanValueSelect(int action)
     // TODO display the value
 }
 
-void OLEDScreen::doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t ratio_index, uint8_t motion_index, uint8_t fan_index)
+void OLEDScreen::doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t ratio_index, uint8_t motion_index, uint8_t fan_index, uint8_t running_power_index)
 {
     if(current_screen_status == SCREEN_STATUS_IDLE)
     {
@@ -428,9 +427,9 @@ void OLEDScreen::doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t 
             displayMainScreen();
         }
 
-        if(power_index != current_power_index)
+        if(last_power_index != running_power_index)
         {
-            current_power_index = power_index;
+            last_power_index = running_power_index;
             displayMainScreen();
         }
 
@@ -443,10 +442,10 @@ void OLEDScreen::doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t 
     else
     {
         current_rate_index = rate_index;
-        current_power_index = power_index;
         current_ratio_index = ratio_index;
     }
 
+    current_power_index = power_index;
     current_powersaving_index = motion_index;
     current_smartfan_index = fan_index;
 }

--- a/src/lib/SCREEN/OLED/oledscreen.cpp
+++ b/src/lib/SCREEN/OLED/oledscreen.cpp
@@ -211,10 +211,10 @@ void helperDrawImage32(int menu)
 
 void OLEDScreen::displayMainScreen(){
     u8g2.clearBuffer();
-    String power = power_string[last_power_index];
+    String power = power_string[current_power_index];
     if (current_dynamic)
     {
-        power += " *";
+        power = String(power_string[last_power_index]) + " *";
     }
 
     #ifdef USE_OLED_SPI_SMALL
@@ -453,7 +453,7 @@ void OLEDScreen::doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t 
         current_rate_index = rate_index;
         current_ratio_index = ratio_index;
     }
-    
+
     current_power_index = power_index;
     current_powersaving_index = motion_index;
     current_smartfan_index = fan_index;

--- a/src/lib/SCREEN/OLED/oledscreen.cpp
+++ b/src/lib/SCREEN/OLED/oledscreen.cpp
@@ -211,19 +211,24 @@ void helperDrawImage32(int menu)
 
 void OLEDScreen::displayMainScreen(){
     u8g2.clearBuffer();
+    String power = power_string[last_power_index];
+    if (current_dynamic)
+    {
+        power += " *";
+    }
 
     #ifdef USE_OLED_SPI_SMALL
         u8g2.setFont(u8g2_font_t0_15_mr);
         u8g2.drawStr(0,15, &(rate_string[current_rate_index])[0]);
         u8g2.drawStr(70,15, &(ratio_string[current_ratio_index])[0]);
-        u8g2.drawStr(0,32, &(power_string[last_power_index])[0]);
+        u8g2.drawStr(0,32, power.c_str());
         u8g2.drawStr(70,32, "Test");
     #else
         u8g2.setFont(u8g2_font_t0_15_mr);
         u8g2.drawStr(0,13, "ExpressLRS");
         u8g2.drawStr(0,45, &(rate_string[current_rate_index])[0]);
         u8g2.drawStr(70,45, &(ratio_string[current_ratio_index])[0]);
-        u8g2.drawStr(0,60, &(power_string[last_power_index])[0]);
+        u8g2.drawStr(0,60, power.c_str());
         u8g2.setFont(u8g2_font_profont10_mr);
         u8g2.drawStr(70,56, "TLM");
         u8g2.drawStr(0,27, "Ver: ");
@@ -417,8 +422,13 @@ void OLEDScreen::doSmartFanValueSelect(int action)
     // TODO display the value
 }
 
-void OLEDScreen::doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t ratio_index, uint8_t motion_index, uint8_t fan_index, uint8_t running_power_index)
+void OLEDScreen::doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t ratio_index, uint8_t motion_index, uint8_t fan_index, bool dynamic, uint8_t running_power_index)
 {
+    current_dynamic = dynamic;
+    current_power_index = power_index;
+    current_powersaving_index = motion_index;
+    current_smartfan_index = fan_index;
+
     if(current_screen_status == SCREEN_STATUS_IDLE)
     {
         if(rate_index != current_rate_index)
@@ -444,10 +454,6 @@ void OLEDScreen::doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t 
         current_rate_index = rate_index;
         current_ratio_index = ratio_index;
     }
-
-    current_power_index = power_index;
-    current_powersaving_index = motion_index;
-    current_smartfan_index = fan_index;
 }
 
 void OLEDScreen::doTemperatureUpdate(uint8_t temperature)

--- a/src/lib/SCREEN/OLED/oledscreen.cpp
+++ b/src/lib/SCREEN/OLED/oledscreen.cpp
@@ -424,10 +424,6 @@ void OLEDScreen::doSmartFanValueSelect(int action)
 
 void OLEDScreen::doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t ratio_index, uint8_t motion_index, uint8_t fan_index, bool dynamic, uint8_t running_power_index)
 {
-    current_dynamic = dynamic;
-    current_power_index = power_index;
-    current_powersaving_index = motion_index;
-    current_smartfan_index = fan_index;
 
     if(current_screen_status == SCREEN_STATUS_IDLE)
     {
@@ -437,8 +433,9 @@ void OLEDScreen::doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t 
             displayMainScreen();
         }
 
-        if(last_power_index != running_power_index)
+        if(last_power_index != running_power_index || current_dynamic != dynamic)
         {
+            current_dynamic = dynamic;
             last_power_index = running_power_index;
             displayMainScreen();
         }
@@ -451,9 +448,15 @@ void OLEDScreen::doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t 
     }
     else
     {
+        last_power_index = running_power_index;
+        current_dynamic = dynamic;
         current_rate_index = rate_index;
         current_ratio_index = ratio_index;
     }
+    
+    current_power_index = power_index;
+    current_powersaving_index = motion_index;
+    current_smartfan_index = fan_index;
 }
 
 void OLEDScreen::doTemperatureUpdate(uint8_t temperature)

--- a/src/lib/SCREEN/OLED/oledscreen.h
+++ b/src/lib/SCREEN/OLED/oledscreen.h
@@ -43,7 +43,7 @@ public:
 
     void init(bool reboot);
     void idleScreen();
-    void doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t ratio_index, uint8_t motion_index, uint8_t fan_index, uint8_t running_power_index);
+    void doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t ratio_index, uint8_t motion_index, uint8_t fan_index, bool dynamic, uint8_t running_power_index);
     void doTemperatureUpdate(uint8_t temperature);
     void doScreenBackLight(int state);
 };

--- a/src/lib/SCREEN/OLED/oledscreen.h
+++ b/src/lib/SCREEN/OLED/oledscreen.h
@@ -43,7 +43,7 @@ public:
 
     void init(bool reboot);
     void idleScreen();
-    void doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t ratio_index, uint8_t motion_index, uint8_t fan_index);
+    void doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t ratio_index, uint8_t motion_index, uint8_t fan_index, uint8_t running_power_index);
     void doTemperatureUpdate(uint8_t temperature);
     void doScreenBackLight(int state);
 };

--- a/src/lib/SCREEN/TFT/tftscreen.cpp
+++ b/src/lib/SCREEN/TFT/tftscreen.cpp
@@ -157,7 +157,7 @@ void TFTScreen::idleScreen()
                         rate_string[current_rate_index], TFT_BLACK, TFT_WHITE);
 
     displayFontCenter(IDLE_PAGE_STAT_START_X, SCREEN_X, IDLE_PAGE_POWER_START_Y,  SCREEN_NORMAL_FONT_SIZE, SCREEN_NORMAL_FONT,
-                        power_string[current_power_index], TFT_BLACK, TFT_WHITE);
+                        power_string[last_power_index], TFT_BLACK, TFT_WHITE);
 
     displayFontCenter(IDLE_PAGE_STAT_START_X, SCREEN_X, IDLE_PAGE_RATIO_START_Y,  SCREEN_NORMAL_FONT_SIZE, SCREEN_NORMAL_FONT,
                         ratio_string[current_ratio_index], TFT_BLACK, TFT_WHITE);
@@ -249,21 +249,21 @@ void TFTScreen::doRateValueSelect(int action)
 {
     nextIndex(current_rate_index, action, RATE_MAX_NUMBER);
     displayFontCenter(SUB_PAGE_VALUE_START_X, SCREEN_X, SUB_PAGE_VALUE_START_Y,  SCREEN_LARGE_FONT_SIZE, SCREEN_LARGE_FONT,
-                        rate_string[current_rate_index], TFT_BLACK, TFT_WHITE);
+                        rate_string[current_index], TFT_BLACK, TFT_WHITE);
 }
 
 void TFTScreen::doPowerValueSelect(int action)
 {
     nextIndex(current_power_index, action, MinPower, MaxPower+1);
     displayFontCenter(SUB_PAGE_VALUE_START_X, SCREEN_X, SUB_PAGE_VALUE_START_Y,  SCREEN_LARGE_FONT_SIZE, SCREEN_LARGE_FONT,
-                        power_string[current_power_index], TFT_BLACK, TFT_WHITE);
+                        power_string[current_index], TFT_BLACK, TFT_WHITE);
 }
 
 void TFTScreen::doRatioValueSelect(int action)
 {
     nextIndex(current_ratio_index, action, RATIO_MAX_NUMBER);
     displayFontCenter(SUB_PAGE_VALUE_START_X, SCREEN_X, SUB_PAGE_VALUE_START_Y,  SCREEN_LARGE_FONT_SIZE, SCREEN_LARGE_FONT,
-                        ratio_string[current_ratio_index], TFT_BLACK, TFT_WHITE);
+                        ratio_string[current_index], TFT_BLACK, TFT_WHITE);
 }
 
 
@@ -271,32 +271,32 @@ void TFTScreen::doPowerSavingValueSelect(int action)
 {
     nextIndex(current_powersaving_index, action, POWERSAVING_MAX_NUMBER);
     displayFontCenter(SUB_PAGE_VALUE_START_X, SCREEN_X, SUB_PAGE_VALUE_START_Y,  SCREEN_LARGE_FONT_SIZE, SCREEN_LARGE_FONT,
-                        powersaving_string[current_powersaving_index], TFT_BLACK, TFT_WHITE);
+                        powersaving_string[current_index], TFT_BLACK, TFT_WHITE);
 }
 
 void TFTScreen::doSmartFanValueSelect(int action)
 {
     nextIndex(current_smartfan_index, action, SMARTFAN_MAX_NUMBER);
     displayFontCenter(SUB_PAGE_VALUE_START_X, SCREEN_X, SUB_PAGE_VALUE_START_Y,  SCREEN_LARGE_FONT_SIZE, SCREEN_LARGE_FONT,
-                        smartfan_string[current_smartfan_index], TFT_BLACK, TFT_WHITE);
+                        smartfan_string[current_index], TFT_BLACK, TFT_WHITE);
 }
 
-void TFTScreen::doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t ratio_index, uint8_t motion_index, uint8_t fan_index)
+void TFTScreen::doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t ratio_index, uint8_t motion_index, uint8_t fan_index, uint8_t running_power_index)
 {
     if(current_screen_status == SCREEN_STATUS_IDLE)
     {
         if(rate_index != current_rate_index)
         {
             current_rate_index = rate_index;
-            displayFontCenter(IDLE_PAGE_STAT_START_X, SCREEN_X, IDLE_PAGE_RATE_START_Y,  SCREEN_NORMAL_FONT_SIZE, SCREEN_NORMAL_FONT,
+            displayFontCenter(IDLE_PAGE_STAT_START_X, SCREEN_X, IDLE_PAGE_RATE_START_Y, SCREEN_NORMAL_FONT_SIZE, SCREEN_NORMAL_FONT,
                                 rate_string[current_rate_index], TFT_BLACK, TFT_WHITE);
         }
 
-        if(power_index != current_power_index)
+        if(last_power_index != running_power_index)
         {
-            current_power_index = power_index;
+            last_power_index = running_power_index;
             displayFontCenter(IDLE_PAGE_STAT_START_X, SCREEN_X, IDLE_PAGE_POWER_START_Y,  SCREEN_NORMAL_FONT_SIZE, SCREEN_NORMAL_FONT,
-                                power_string[current_power_index], TFT_BLACK, TFT_WHITE);
+                                power_string[last_power_index], TFT_BLACK, TFT_WHITE);
         }
 
         if(ratio_index != current_ratio_index)
@@ -309,10 +309,10 @@ void TFTScreen::doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t r
     else
     {
         current_rate_index = rate_index;
-        current_power_index = power_index;
         current_ratio_index = ratio_index;
     }
 
+    current_power_index = power_index;
     current_powersaving_index = motion_index;
     current_smartfan_index = fan_index;
 }

--- a/src/lib/SCREEN/TFT/tftscreen.cpp
+++ b/src/lib/SCREEN/TFT/tftscreen.cpp
@@ -156,8 +156,13 @@ void TFTScreen::idleScreen()
     displayFontCenter(IDLE_PAGE_STAT_START_X, SCREEN_X, IDLE_PAGE_RATE_START_Y,  SCREEN_NORMAL_FONT_SIZE, SCREEN_NORMAL_FONT,
                         rate_string[current_rate_index], TFT_BLACK, TFT_WHITE);
 
-    displayFontCenter(IDLE_PAGE_STAT_START_X, SCREEN_X, IDLE_PAGE_POWER_START_Y,  SCREEN_NORMAL_FONT_SIZE, SCREEN_NORMAL_FONT,
-                        power_string[last_power_index], TFT_BLACK, TFT_WHITE);
+    String power = power_string[last_power_index];
+    if (current_dynamic)
+    {
+        power += " *";
+    }
+    displayFontCenter(IDLE_PAGE_STAT_START_X, SCREEN_X, IDLE_PAGE_POWER_START_Y, SCREEN_NORMAL_FONT_SIZE, SCREEN_NORMAL_FONT,
+                        power, TFT_BLACK, TFT_WHITE);
 
     displayFontCenter(IDLE_PAGE_STAT_START_X, SCREEN_X, IDLE_PAGE_RATIO_START_Y,  SCREEN_NORMAL_FONT_SIZE, SCREEN_NORMAL_FONT,
                         ratio_string[current_ratio_index], TFT_BLACK, TFT_WHITE);
@@ -281,9 +286,14 @@ void TFTScreen::doSmartFanValueSelect(int action)
                         smartfan_string[current_index], TFT_BLACK, TFT_WHITE);
 }
 
-void TFTScreen::doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t ratio_index, uint8_t motion_index, uint8_t fan_index, uint8_t running_power_index)
+void TFTScreen::doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t ratio_index, uint8_t motion_index, uint8_t fan_index, bool dynamic, uint8_t running_power_index)
 {
-    if(current_screen_status == SCREEN_STATUS_IDLE)
+    current_dynamic = dynamic;
+    current_power_index = power_index;
+    current_powersaving_index = motion_index;
+    current_smartfan_index = fan_index;
+
+    if (current_screen_status == SCREEN_STATUS_IDLE)
     {
         if(rate_index != current_rate_index)
         {
@@ -295,8 +305,13 @@ void TFTScreen::doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t r
         if(last_power_index != running_power_index)
         {
             last_power_index = running_power_index;
-            displayFontCenter(IDLE_PAGE_STAT_START_X, SCREEN_X, IDLE_PAGE_POWER_START_Y,  SCREEN_NORMAL_FONT_SIZE, SCREEN_NORMAL_FONT,
-                                power_string[last_power_index], TFT_BLACK, TFT_WHITE);
+            String power = power_string[last_power_index];
+            if (current_dynamic)
+            {
+                power += " *";
+            }
+            displayFontCenter(IDLE_PAGE_STAT_START_X, SCREEN_X, IDLE_PAGE_POWER_START_Y, SCREEN_NORMAL_FONT_SIZE, SCREEN_NORMAL_FONT,
+                                power, TFT_BLACK, TFT_WHITE);
         }
 
         if(ratio_index != current_ratio_index)
@@ -311,10 +326,6 @@ void TFTScreen::doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t r
         current_rate_index = rate_index;
         current_ratio_index = ratio_index;
     }
-
-    current_power_index = power_index;
-    current_powersaving_index = motion_index;
-    current_smartfan_index = fan_index;
 }
 
 void TFTScreen::doTemperatureUpdate(uint8_t temperature)

--- a/src/lib/SCREEN/TFT/tftscreen.cpp
+++ b/src/lib/SCREEN/TFT/tftscreen.cpp
@@ -288,11 +288,6 @@ void TFTScreen::doSmartFanValueSelect(int action)
 
 void TFTScreen::doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t ratio_index, uint8_t motion_index, uint8_t fan_index, bool dynamic, uint8_t running_power_index)
 {
-    current_dynamic = dynamic;
-    current_power_index = power_index;
-    current_powersaving_index = motion_index;
-    current_smartfan_index = fan_index;
-
     if (current_screen_status == SCREEN_STATUS_IDLE)
     {
         if(rate_index != current_rate_index)
@@ -302,9 +297,10 @@ void TFTScreen::doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t r
                                 rate_string[current_rate_index], TFT_BLACK, TFT_WHITE);
         }
 
-        if(last_power_index != running_power_index)
+        if(last_power_index != running_power_index || current_dynamic != dynamic)
         {
             last_power_index = running_power_index;
+            current_dynamic = dynamic;
             String power = power_string[last_power_index];
             if (current_dynamic)
             {
@@ -323,9 +319,15 @@ void TFTScreen::doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t r
     }
     else
     {
+        last_power_index = running_power_index;
+        current_dynamic = dynamic;
         current_rate_index = rate_index;
         current_ratio_index = ratio_index;
     }
+
+    current_power_index = power_index;
+    current_powersaving_index = motion_index;
+    current_smartfan_index = fan_index;
 }
 
 void TFTScreen::doTemperatureUpdate(uint8_t temperature)

--- a/src/lib/SCREEN/TFT/tftscreen.cpp
+++ b/src/lib/SCREEN/TFT/tftscreen.cpp
@@ -156,10 +156,10 @@ void TFTScreen::idleScreen()
     displayFontCenter(IDLE_PAGE_STAT_START_X, SCREEN_X, IDLE_PAGE_RATE_START_Y,  SCREEN_NORMAL_FONT_SIZE, SCREEN_NORMAL_FONT,
                         rate_string[current_rate_index], TFT_BLACK, TFT_WHITE);
 
-    String power = power_string[last_power_index];
+    String power = power_string[current_power_index];
     if (current_dynamic)
     {
-        power += " *";
+        power = String(power_string[last_power_index]) + " *";
     }
     displayFontCenter(IDLE_PAGE_STAT_START_X, SCREEN_X, IDLE_PAGE_POWER_START_Y, SCREEN_NORMAL_FONT_SIZE, SCREEN_NORMAL_FONT,
                         power, TFT_BLACK, TFT_WHITE);
@@ -301,10 +301,10 @@ void TFTScreen::doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t r
         {
             last_power_index = running_power_index;
             current_dynamic = dynamic;
-            String power = power_string[last_power_index];
+            String power = power_string[current_power_index];
             if (current_dynamic)
             {
-                power += " *";
+                power = String(power_string[last_power_index]) + " *";
             }
             displayFontCenter(IDLE_PAGE_STAT_START_X, SCREEN_X, IDLE_PAGE_POWER_START_Y, SCREEN_NORMAL_FONT_SIZE, SCREEN_NORMAL_FONT,
                                 power, TFT_BLACK, TFT_WHITE);

--- a/src/lib/SCREEN/TFT/tftscreen.h
+++ b/src/lib/SCREEN/TFT/tftscreen.h
@@ -50,7 +50,7 @@ public:
 
     void init(bool reboot);
     void idleScreen();
-    void doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t ratio_index, uint8_t motion_index, uint8_t fan_index, uint8_t running_power_index);
+    void doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t ratio_index, uint8_t motion_index, uint8_t fan_index, bool dynamic, uint8_t running_power_index);
     void doTemperatureUpdate(uint8_t temperature);
     void doScreenBackLight(int state);
 

--- a/src/lib/SCREEN/TFT/tftscreen.h
+++ b/src/lib/SCREEN/TFT/tftscreen.h
@@ -50,7 +50,7 @@ public:
 
     void init(bool reboot);
     void idleScreen();
-    void doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t ratio_index, uint8_t motion_index, uint8_t fan_index);
+    void doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t ratio_index, uint8_t motion_index, uint8_t fan_index, uint8_t running_power_index);
     void doTemperatureUpdate(uint8_t temperature);
     void doScreenBackLight(int state);
 

--- a/src/lib/SCREEN/devScreen.cpp
+++ b/src/lib/SCREEN/devScreen.cpp
@@ -243,7 +243,7 @@ static int start()
 {
   if (screen.getScreenStatus() == SCREEN_STATUS_INIT)
   {
-    screen.doParamUpdate(config.GetRate(), (uint8_t)(POWERMGNT::currPower()), config.GetTlm(), config.GetMotionMode(), config.GetFanMode());
+    screen.doParamUpdate(config.GetRate(), config.GetPower(), config.GetTlm(), config.GetMotionMode(), config.GetFanMode(), (uint8_t)(POWERMGNT::currPower()));
     return LOGO_DISPLAY_TIMEOUT;
   }
   return DURATION_IMMEDIATELY;
@@ -257,7 +257,7 @@ static int event()
   }
   else
   {
-    screen.doParamUpdate(config.GetRate(), (uint8_t)(POWERMGNT::currPower()), config.GetTlm(), config.GetMotionMode(), config.GetFanMode());
+    screen.doParamUpdate(config.GetRate(), config.GetPower(), config.GetTlm(), config.GetMotionMode(), config.GetFanMode(), (uint8_t)(POWERMGNT::currPower()));
   }
 
   return DURATION_IGNORE;

--- a/src/lib/SCREEN/devScreen.cpp
+++ b/src/lib/SCREEN/devScreen.cpp
@@ -243,7 +243,7 @@ static int start()
 {
   if (screen.getScreenStatus() == SCREEN_STATUS_INIT)
   {
-    screen.doParamUpdate(config.GetRate(), config.GetPower(), config.GetTlm(), config.GetMotionMode(), config.GetFanMode(), (uint8_t)(POWERMGNT::currPower()));
+    screen.doParamUpdate(config.GetRate(), config.GetPower(), config.GetTlm(), config.GetMotionMode(), config.GetFanMode(), config.GetDynamicPower(), (uint8_t)(POWERMGNT::currPower()));
     return LOGO_DISPLAY_TIMEOUT;
   }
   return DURATION_IMMEDIATELY;
@@ -257,7 +257,7 @@ static int event()
   }
   else
   {
-    screen.doParamUpdate(config.GetRate(), config.GetPower(), config.GetTlm(), config.GetMotionMode(), config.GetFanMode(), (uint8_t)(POWERMGNT::currPower()));
+    screen.doParamUpdate(config.GetRate(), config.GetPower(), config.GetTlm(), config.GetMotionMode(), config.GetFanMode(), config.GetDynamicPower(), (uint8_t)(POWERMGNT::currPower()));
   }
 
   return DURATION_IGNORE;

--- a/src/lib/SCREEN/screen.cpp
+++ b/src/lib/SCREEN/screen.cpp
@@ -191,22 +191,27 @@ void Screen::doValueConfirm()
 {
     if(current_page_index == PAGE_SUB_RATE_INDEX)
     {
+        current_rate_index = current_index;
         updatecallback(USER_UPDATE_TYPE_RATE);
     }
     else if(current_page_index == PAGE_SUB_POWER_INDEX)
     {
+        current_power_index = current_index;
         updatecallback(USER_UPDATE_TYPE_POWER);
     }
     else if(current_page_index == PAGE_SUB_RATIO_INDEX)
     {
+        current_ratio_index = current_index;
         updatecallback(USER_UPDATE_TYPE_RATIO);
     }
     else if(current_page_index == PAGE_SUB_SMARTFAN_INDEX)
     {
+        current_smartfan_index = current_index;
         updatecallback(USER_UPDATE_TYPE_SMARTFAN);
     }
     else if(current_page_index == PAGE_SUB_POWERSAVING_INDEX)
     {
+        current_powersaving_index = current_index;
         updatecallback(USER_UPDATE_TYPE_POWERSAVING);
     }
 
@@ -271,22 +276,26 @@ void Screen::doValueSelection(int action)
 
 void Screen::nextIndex(int &index, int action, int min, int max)
 {
-    if(action == USER_ACTION_UP)
+    if (action == USER_ACTION_NONE) // set current index to the value being processed
     {
-        index--;
+        current_index = index;
     }
-    if(action == USER_ACTION_DOWN)
+    else if (action == USER_ACTION_UP)
     {
-        index++;
+        current_index--;
+    }
+    else if (action == USER_ACTION_DOWN)
+    {
+        current_index++;
     }
 
-    if(index < min)
+    if (current_index < min)
     {
-        index = max - 1;
+        current_index = max - 1;
     }
-    if(index > max - 1)
+    else if (current_index > max - 1)
     {
-        index = min;
+        current_index = min;
     }
 }
 

--- a/src/lib/SCREEN/screen.h
+++ b/src/lib/SCREEN/screen.h
@@ -116,6 +116,9 @@ protected:
     int current_ratio_index;
     int current_powersaving_index;
     int current_smartfan_index;
+    
+    int current_index;
+    int last_power_index;
 
     int current_screen_status;
 
@@ -152,7 +155,7 @@ public:
 
     virtual void init(bool reboot) = 0;
     virtual void idleScreen() = 0;
-    virtual void doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t ratio_index, uint8_t motion_index, uint8_t fan_index) = 0;
+    virtual void doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t ratio_index, uint8_t motion_index, uint8_t fan_index, uint8_t running_power_index) = 0;
     virtual void doTemperatureUpdate(uint8_t temperature) = 0;
     virtual void doScreenBackLight(int state) = 0;
 

--- a/src/lib/SCREEN/screen.h
+++ b/src/lib/SCREEN/screen.h
@@ -116,6 +116,7 @@ protected:
     int current_ratio_index;
     int current_powersaving_index;
     int current_smartfan_index;
+    bool current_dynamic;
     
     int current_index;
     int last_power_index;
@@ -155,7 +156,7 @@ public:
 
     virtual void init(bool reboot) = 0;
     virtual void idleScreen() = 0;
-    virtual void doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t ratio_index, uint8_t motion_index, uint8_t fan_index, uint8_t running_power_index) = 0;
+    virtual void doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t ratio_index, uint8_t motion_index, uint8_t fan_index, bool dynamic, uint8_t running_power_index) = 0;
     virtual void doTemperatureUpdate(uint8_t temperature) = 0;
     virtual void doScreenBackLight(int state) = 0;
 


### PR DESCRIPTION
Fixes some minor niggles with the screens

- when cancelling a value selection screen, the value is reset back to the configured value rather than the previously unselected value
- the power on the idle screen is the current power level, when in dynamic power mode, and the editing screen starts at the configured power level
- mark power level with '*' on idle screen when in dynamic power mode