### PR TITLE
Optimise CRSF output on TX

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -37,6 +37,8 @@ inBuffer_U CRSF::inBuffer;
 volatile crsfPayloadLinkstatistics_s CRSF::LinkStatistics;
 
 #if CRSF_TX_MODULE
+#define HANDSET_TELEMETRY_FIFO_SIZE 128 // this is the smallest telemetry FIFO size in ETX with CRSF defined
+
 static FIFO MspWriteFIFO;
 
 void inline CRSF::nullCallback(void) {}
@@ -750,7 +752,7 @@ void ICACHE_RAM_ATTR CRSF::adjustMaxPacketSize()
     uint32_t UARTrequestedBaud = TxToHandsetBauds[UARTcurrentBaudIdx];
     // baud / 10bits-per-byte / 2 windows (1RX, 1TX) / rate * 0.80 (leeway)
     int maxSize = UARTrequestedBaud / 10 / 2 / (1000000/RequestedRCpacketInterval) * 80 / 100;
-    maxSize = maxSize > 255 ? 255 : maxSize;
+    maxSize = maxSize > HANDSET_TELEMETRY_FIFO_SIZE ? HANDSET_TELEMETRY_FIFO_SIZE : maxSize;
     // we need a minimum of 10 bytes otherwise our LUA will not make progress and at 8 we'd get a divide by 0!
     maxSendBytes = maxSize < 10 ? 10 : maxSize;
     DBGLN("Adjusted max sending size %u", maxSendBytes);

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -100,7 +100,7 @@ public:
     static void AddMspMessage(mspPacket_t* packet);
     static void ResetMspQueue();
     static volatile uint32_t OpenTXsyncLastSent;
-    static uint8_t GetMaxPacketBytes() { return maxPacketBytes; }
+    static uint8_t GetMaxPacketBytes() { return maxSendBytes > CRSF_MAX_PACKET_LEN ? CRSF_MAX_PACKET_LEN : maxSendBytes; }
     static uint32_t GetCurrentBaudRate() { return TxToHandsetBauds[UARTcurrentBaudIdx]; }
 
     static uint32_t ICACHE_RAM_ATTR GetRCdataLastRecv();
@@ -142,7 +142,7 @@ private:
     static uint32_t GoodPktsCount;
     static uint32_t BadPktsCount;
     static uint32_t UARTwdtLastChecked;
-    static uint8_t maxPacketBytes;
+    static uint8_t maxSendBytes;
     static uint32_t TxToHandsetBauds[6];
     static uint8_t UARTcurrentBaudIdx;
     static bool CRSFstate;

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -100,7 +100,7 @@ public:
     static void AddMspMessage(mspPacket_t* packet);
     static void ResetMspQueue();
     static volatile uint32_t OpenTXsyncLastSent;
-    static uint8_t GetMaxPacketBytes() { return maxSendBytes > CRSF_MAX_PACKET_LEN ? CRSF_MAX_PACKET_LEN : maxSendBytes; }
+    static uint8_t GetMaxPacketBytes() { return maxPacketBytes; }
     static uint32_t GetCurrentBaudRate() { return TxToHandsetBauds[UARTcurrentBaudIdx]; }
 
     static uint32_t ICACHE_RAM_ATTR GetRCdataLastRecv();
@@ -142,7 +142,8 @@ private:
     static uint32_t GoodPktsCount;
     static uint32_t BadPktsCount;
     static uint32_t UARTwdtLastChecked;
-    static uint8_t maxSendBytes;
+    static uint8_t maxPacketBytes;
+    static uint32_t maxPeriodBytes;
     static uint32_t TxToHandsetBauds[6];
     static uint8_t UARTcurrentBaudIdx;
     static bool CRSFstate;


### PR DESCRIPTION
Send out the maximum number of "packets" that we can in our allotted time-slice.

The calculation for the `maxSendBytes` is now limited to 255 bytes rather than the previous 64 (`CRSF_MAX_PACKET_LEN`) as we were using the value for two different purposes. Now it's `maxSendBytes` and the max packet size is calculated as the minimum of `CRSF_MAX_PACKET_LEN` or `maxSendBytes`.
