### PR TITLE
Space fix (needed for correct parsing in ETX)

### DIFF
--- a/src/lua/elrsV2.lua
+++ b/src/lua/elrsV2.lua
@@ -846,7 +846,7 @@ local function setLCDvar()
   lcd_title_color = nil
   lcd_title_bw = nil
   -- Determine if popupConfirmation takes 3 arguments or 2
-  --if pcall(popupConfirmation, "", "", EVT_VIRTUAL_EXIT) then
+  -- if pcall(popupConfirmation, "", "", EVT_VIRTUAL_EXIT) then
   -- major 1 is assumed to be FreedomTX
   local ver, radio, major = getVersion()
   if major ~= 1 then


### PR DESCRIPTION
Although a space should not be required for correct parsing after two hyphens comment begin, it is good style according to http://lua-users.org/wiki/LuaStyleGuide
But the LUA parser of EdgeTX was having a hiccup due to it, at least on tested B/W targets.