### PR TITLE
Add define USE_TX_BACKPACK to BETAFPV_2400_TX

### DIFF
--- a/src/include/target/BETAFPV_2400_TX_MICRO.h
+++ b/src/include/target/BETAFPV_2400_TX_MICRO.h
@@ -3,6 +3,7 @@
 #endif
 
 // Any device features
+#define USE_TX_BACKPACK
 #define USE_OLED_I2C
 #define OLED_REVERSED
 #define HAS_FIVE_WAY_BUTTON


### PR DESCRIPTION
The new v2 betafpv modules have the backpack feature, We should have this on by default I think.
Or should we have 2 separate targets to prevent confusion?