### PR TITLE
Add FLRC support for #team2400

### DIFF
--- a/src/include/common.h
+++ b/src/include/common.h
@@ -76,15 +76,16 @@ typedef enum
 
 typedef enum
 {
-    RATE_4HZ = 0,
-    RATE_25HZ,
-    RATE_50HZ,
-    RATE_100HZ,
-    RATE_150HZ,
-    RATE_200HZ,
-    RATE_250HZ,
-    RATE_500HZ,
-    RATE_1000HZ,
+    RATE_LORA_4HZ = 0,
+    RATE_LORA_25HZ,
+    RATE_LORA_50HZ,
+    RATE_LORA_100HZ,
+    RATE_LORA_150HZ,
+    RATE_LORA_200HZ,
+    RATE_LORA_250HZ,
+    RATE_LORA_500HZ,
+    RATE_FLRC_500HZ,
+    RATE_FLRC_1000HZ,
 } expresslrs_RFrates_e; // Max value of 16 since only 4 bits have been assigned in the sync package.
 
 enum {
@@ -130,17 +131,17 @@ typedef struct expresslrs_mod_settings_s
 extern SX127xDriver Radio;
 
 #elif defined(RADIO_SX128X)
-#define RATE_MAX 4
-#define RATE_DEFAULT 0
-#define RATE_BINDING 3  // 50Hz bind mode
+#define RATE_MAX 6      // 2xFLRC + 4xLoRa
+#define RATE_DEFAULT 0  // Default to FLRC 1000Hz
+#define RATE_BINDING 5  // 50Hz bind mode
 
 extern SX1280Driver Radio;
 #endif
 
 
-#define SYNC_PACKET_SWITCH_OFFSET   1   // Switch encoding mode
-#define SYNC_PACKET_TLM_OFFSET      3   // Telemetry ratio
-#define SYNC_PACKET_RATE_OFFSET     6   // Rate index
+#define SYNC_PACKET_SWITCH_OFFSET   0   // Switch encoding mode
+#define SYNC_PACKET_TLM_OFFSET      2   // Telemetry ratio
+#define SYNC_PACKET_RATE_OFFSET     5   // Rate index
 #define SYNC_PACKET_SWITCH_MASK     0b11
 #define SYNC_PACKET_TLM_MASK        0b111
 #define SYNC_PACKET_RATE_MASK       0b11

--- a/src/lib/LED/devRGB.cpp
+++ b/src/lib/LED/devRGB.cpp
@@ -13,9 +13,9 @@
 #endif
 
 #if defined(PLATFORM_ESP32)
-    #define METHOD Neo800KbpsMethod 
+    #define METHOD Neo800KbpsMethod
 #elif defined(PLATFORM_ESP8266)
-    #define METHOD NeoEsp8266Uart1800KbpsMethod 
+    #define METHOD NeoEsp8266Uart1800KbpsMethod
 #endif
 
 #ifdef WS2812_IS_GRB
@@ -209,10 +209,14 @@ constexpr uint8_t LEDSEQ_MODEL_MISMATCH[] = { 10, 10, 10, 10, 10, 100 };   // 3x
 
 constexpr uint8_t rate_hue[RATE_MAX] =
 {
-    170,     // 500/200 hz  blue
-    85,      // 250/100 hz  green
-    21,      // 150/50 hz   orange
-    0        // 50/25 hz    red
+#if defined(RADIO_SX128X)
+    208,     // FLRC 1000 Hz - purple
+    64,      // FLRC  500 Hz - yellow
+#endif
+    170,     // LoRa 500/200 Hz - blue
+    85,      // LoRa 250/100 Hz - green
+    21,      // LoRa 150/ 50 Hz - orange
+    0        // LoRa  50/ 25 Hz - red
 };
 
 static blinkyColor_t blinkyColor;

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -21,7 +21,7 @@ static struct luaItem_selection luaAirRate = {
 #if defined(RADIO_SX127X)
     "25(-123dbm);50(-120dbm);100(-117dbm);200(-112dbm)",
 #elif defined(RADIO_SX128X)
-    "50(-117dbm);150(-112dbm);250(-108dbm);500(-105dbm)",
+    "50(-117dbm);150(-112dbm);250(-108dbm);500(-105dbm);F500(-104dbm);F1000(-104dbm)",
 #else
     #error Invalid radio configuration!
 #endif

--- a/src/lib/SCREEN/screen.cpp
+++ b/src/lib/SCREEN/screen.cpp
@@ -8,6 +8,8 @@ void (*Screen::updatecallback)(int updateType) = &nullCallback;
 
 #if defined(RADIO_SX128X)
 const char *Screen::rate_string[RATE_MAX_NUMBER] = {
+    "F1000Hz",
+    "F500Hz",
     "500Hz",
     "250Hz",
     "150Hz",

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -2,10 +2,6 @@
 #include "logging.h"
 
 SX127xHal hal;
-
-void ICACHE_RAM_ATTR nullCallbackTx() {}
-void ICACHE_RAM_ATTR nullCallbackRx(uint8_t) {}
-
 SX127xDriver *SX127xDriver::instance = NULL;
 
 
@@ -26,11 +22,9 @@ const uint8_t SX127x_AllowedSyncwords[105] =
 
 //////////////////////////////////////////////
 
-SX127xDriver::SX127xDriver()
+SX127xDriver::SX127xDriver(): SX12xxDriverCommon()
 {
   instance = this;
-  TXdoneCallback = &nullCallbackTx; // remove callbacks
-  RXdoneCallback = &nullCallbackRx;
   PayloadLength = 8; // Dummy default value which is overwritten during setup.
   currFreq = 0; // leave as 0 to ensure that it gets set
 }
@@ -56,8 +50,7 @@ void SX127xDriver::End()
 {
   SetMode(SX127x_OPMODE_SLEEP);
   hal.end();
-  TXdoneCallback = &nullCallbackTx; // remove callbacks
-  RXdoneCallback = &nullCallbackRx;
+  RemoveCallbacks();
 }
 
 void SX127xDriver::ConfigLoraDefaults()
@@ -334,7 +327,7 @@ void ICACHE_RAM_ATTR SX127xDriver::RXnbISR()
   // page 87 (note we already do /4 in GetLastPacketSNR())
   int8_t negOffset = (LastPacketSNR < 0) ? LastPacketSNR : 0;
   LastPacketRSSI += negOffset;
-  RXdoneCallback(0);
+  RXdoneCallback(SX12XX_RX_OK);
 }
 
 void ICACHE_RAM_ATTR SX127xDriver::RXnb()

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -3,7 +3,8 @@
 
 SX127xHal hal;
 
-void ICACHE_RAM_ATTR nullCallback(void) {}
+void ICACHE_RAM_ATTR nullCallbackTx() {}
+void ICACHE_RAM_ATTR nullCallbackRx(uint8_t) {}
 
 SX127xDriver *SX127xDriver::instance = NULL;
 
@@ -28,8 +29,8 @@ const uint8_t SX127x_AllowedSyncwords[105] =
 SX127xDriver::SX127xDriver()
 {
   instance = this;
-  TXdoneCallback = &nullCallback; // remove callbacks
-  RXdoneCallback = &nullCallback;
+  TXdoneCallback = &nullCallbackTx; // remove callbacks
+  RXdoneCallback = &nullCallbackRx;
   PayloadLength = 8; // Dummy default value which is overwritten during setup.
   currFreq = 0; // leave as 0 to ensure that it gets set
 }
@@ -55,8 +56,8 @@ void SX127xDriver::End()
 {
   SetMode(SX127x_OPMODE_SLEEP);
   hal.end();
-  TXdoneCallback = &nullCallback; // remove callbacks
-  RXdoneCallback = &nullCallback;
+  TXdoneCallback = &nullCallbackTx; // remove callbacks
+  RXdoneCallback = &nullCallbackRx;
 }
 
 void SX127xDriver::ConfigLoraDefaults()
@@ -333,7 +334,7 @@ void ICACHE_RAM_ATTR SX127xDriver::RXnbISR()
   // page 87 (note we already do /4 in GetLastPacketSNR())
   int8_t negOffset = (LastPacketSNR < 0) ? LastPacketSNR : 0;
   LastPacketRSSI += negOffset;
-  RXdoneCallback();
+  RXdoneCallback(0);
 }
 
 void ICACHE_RAM_ATTR SX127xDriver::RXnb()

--- a/src/lib/SX127xDriver/SX127x.h
+++ b/src/lib/SX127xDriver/SX127x.h
@@ -2,40 +2,25 @@
 
 #include "SX127xRegs.h"
 #include "SX127xHal.h"
+#include "SX12xxDriverCommon.h"
 
 #ifdef PLATFORM_ESP8266
 #include <cstdint>
 #endif
 
-class SX127xDriver
+class SX127xDriver: public SX12xxDriverCommon
 {
 
 public:
     static SX127xDriver *instance;
 
-    ///////Callback Function Pointers/////
-    void (*RXdoneCallback)(uint8_t crcFail); //function pointer for callback
-    void (*TXdoneCallback)(); //function pointer for callback
-
     ///////////Radio Variables////////
-    #define TXRXBuffSize 16
-    volatile WORD_ALIGNED_ATTR uint8_t TXdataBuffer[TXRXBuffSize];
-    volatile WORD_ALIGNED_ATTR uint8_t RXdataBuffer[TXRXBuffSize];
-
     bool headerExplMode = false;
     bool crcEnabled = false;
 
     //// Parameters ////
-    uint32_t currFreq;
-    uint8_t PayloadLength;
-    bool IQinverted;
     uint16_t timeoutSymbols;
     ///////////////////////////////////
-
-    /////////////Packet Stats//////////
-    int8_t LastPacketRSSI;
-    int8_t LastPacketSNR;
-    /////////////////////////////////
 
     ////////////////Configuration Functions/////////////
     SX127xDriver();

--- a/src/lib/SX127xDriver/SX127x.h
+++ b/src/lib/SX127xDriver/SX127x.h
@@ -14,7 +14,7 @@ public:
     static SX127xDriver *instance;
 
     ///////Callback Function Pointers/////
-    void (*RXdoneCallback)(); //function pointer for callback
+    void (*RXdoneCallback)(uint8_t crcFail); //function pointer for callback
     void (*TXdoneCallback)(); //function pointer for callback
 
     ///////////Radio Variables////////

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -44,7 +44,8 @@ static uint32_t endTX;
 #define RX_TIMEOUT_PERIOD_BASE SX1280_RADIO_TICK_SIZE_0015_US
 #define RX_TIMEOUT_PERIOD_BASE_NANOS 15625
 
-void ICACHE_RAM_ATTR nullCallback(void) {}
+void ICACHE_RAM_ATTR nullCallbackTx() {}
+void ICACHE_RAM_ATTR nullCallbackRx(uint8_t) {}
 
 SX1280Driver::SX1280Driver()
 {
@@ -55,8 +56,8 @@ void SX1280Driver::End()
 {
     SetMode(SX1280_MODE_SLEEP);
     hal.end();
-    TXdoneCallback = &nullCallback; // remove callbacks
-    RXdoneCallback = &nullCallback;
+    TXdoneCallback = &nullCallbackTx; // remove callbacks
+    RXdoneCallback = &nullCallbackRx;
     currFreq = 2400000000;
     PayloadLength = 8; // Dummy default value which is overwritten during setup.
 }
@@ -101,6 +102,7 @@ void SX1280Driver::Config(uint8_t bw, uint8_t sf, uint8_t cr, uint32_t freq,
 
     PayloadLength = _PayloadLength;
     IQinverted = InvertIQ;
+    packet_mode = mode;
     SetMode(SX1280_MODE_STDBY_XOSC);
     hal.WriteCommand(SX1280_RADIO_SET_PACKETTYPE, mode);
     if (mode == SX1280_PACKET_TYPE_FLRC)
@@ -262,8 +264,9 @@ void SX1280Driver::SetPacketParamsFLRC(uint8_t HeaderType,
                                        uint32_t syncWord,
                                        uint16_t crcSeed)
 {
-    if (PreambleLength < 8) PreambleLength = 8;
-        PreambleLength = ((PreambleLength / 4) - 1) << 4;
+    if (PreambleLength < 8)
+        PreambleLength = 8;
+    PreambleLength = ((PreambleLength / 4) - 1) << 4;
     crc = (crc) ? SX1280_FLRC_CRC_2_BYTE : SX1280_FLRC_CRC_OFF;
 
     uint8_t buf[7];
@@ -408,8 +411,9 @@ void ICACHE_RAM_ATTR SX1280Driver::TXnb()
 #endif
 }
 
-void ICACHE_RAM_ATTR SX1280Driver::RXnbISR()
+void ICACHE_RAM_ATTR SX1280Driver::RXnbISR(uint16_t const irqStatus)
 {
+    uint8_t const fail = !!(irqStatus & (SX1280_IRQ_CRC_ERROR | SX1280_IRQ_RX_TX_TIMEOUT));
     // In continuous receive mode, the device stays in Rx mode
     if (timeout != 0xFFFF)
     {
@@ -418,10 +422,13 @@ void ICACHE_RAM_ATTR SX1280Driver::RXnbISR()
         // but because we have AUTO_FS enabled we automatically transition to state SX1280_MODE_FS
         currOpmode = SX1280_MODE_FS;
     }
-    uint8_t FIFOaddr = GetRxBufferAddr();
-    hal.ReadBuffer(FIFOaddr, RXdataBuffer, PayloadLength);
-    GetLastPacketStats();
-    RXdoneCallback();
+    if (!fail)
+    {
+        uint8_t const FIFOaddr = GetRxBufferAddr();
+        hal.ReadBuffer(FIFOaddr, RXdataBuffer, PayloadLength);
+        GetLastPacketStats();
+    }
+    RXdoneCallback(fail);
 }
 
 void ICACHE_RAM_ATTR SX1280Driver::RXnb()
@@ -468,8 +475,14 @@ int8_t ICACHE_RAM_ATTR SX1280Driver::GetRssiInst()
 void ICACHE_RAM_ATTR SX1280Driver::GetLastPacketStats()
 {
     uint8_t status[2];
-
     hal.ReadCommand(SX1280_RADIO_GET_PACKETSTATUS, status, 2);
+    if (packet_mode == SX1280_PACKET_TYPE_FLRC) {
+        // No SNR in FLRC mode
+        LastPacketRSSI = -(int8_t)(status[1] / 2);
+        LastPacketSNR = 0;
+        return;
+    }
+    // LoRa mode has both RSSI and SNR
     LastPacketRSSI = -(int8_t)(status[0] / 2);
     LastPacketSNR = (int8_t)status[1] / 4;
     // https://www.mouser.com/datasheet/2/761/DS_SX1280-1_V2.2-1511144.pdf
@@ -487,6 +500,6 @@ void ICACHE_RAM_ATTR SX1280Driver::IsrCallback()
         hal.TXRXdisable();
         instance->TXnbISR();
     }
-    if (irqStatus & SX1280_IRQ_RX_DONE)
-        instance->RXnbISR();
+    else if (irqStatus & (SX1280_IRQ_RX_DONE | SX1280_IRQ_CRC_ERROR | SX1280_IRQ_RX_TX_TIMEOUT))
+        instance->RXnbISR(irqStatus);
 }

--- a/src/lib/SX1280Driver/SX1280.h
+++ b/src/lib/SX1280Driver/SX1280.h
@@ -3,33 +3,19 @@
 #include "targets.h"
 #include "SX1280_Regs.h"
 #include "SX1280_hal.h"
+#include "SX12xxDriverCommon.h"
 
 
-
-class SX1280Driver
+class SX1280Driver: public SX12xxDriverCommon
 {
 public:
     static SX1280Driver *instance;
 
-    ///////Callback Function Pointers/////
-    void (*RXdoneCallback)(uint8_t crcFail); //function pointer for callback
-    void (*TXdoneCallback)(); //function pointer for callback
 
     ///////////Radio Variables////////
-    #define TXRXBuffSize 16
-    volatile WORD_ALIGNED_ATTR uint8_t TXdataBuffer[TXRXBuffSize];
-    volatile WORD_ALIGNED_ATTR uint8_t RXdataBuffer[TXRXBuffSize];
-
     uint16_t timeout = 0xFFFF;
 
-    uint32_t currFreq;
-    uint8_t PayloadLength;
-    bool IQinverted;
     ///////////////////////////////////
-
-    /////////////Packet Stats//////////
-    int8_t LastPacketRSSI;
-    int8_t LastPacketSNR;
 
     ////////////////Configuration Functions/////////////
     SX1280Driver();

--- a/src/lib/SX1280Driver/SX1280.h
+++ b/src/lib/SX1280Driver/SX1280.h
@@ -12,7 +12,7 @@ public:
     static SX1280Driver *instance;
 
     ///////Callback Function Pointers/////
-    void (*RXdoneCallback)(); //function pointer for callback
+    void (*RXdoneCallback)(uint8_t crcFail); //function pointer for callback
     void (*TXdoneCallback)(); //function pointer for callback
 
     ///////////Radio Variables////////
@@ -62,6 +62,7 @@ public:
 
 private:
     SX1280_RadioOperatingModes_t currOpmode = SX1280_MODE_SLEEP;
+    uint8_t packet_mode;
 
     void SetMode(SX1280_RadioOperatingModes_t OPmode);
     void SetFIFOaddr(uint8_t txBaseAddr, uint8_t rxBaseAddr);
@@ -87,6 +88,6 @@ private:
 
 
     static void IsrCallback();
-    void RXnbISR(); // ISR for non-blocking RX routine
+    void RXnbISR(uint16_t irqStatus); // ISR for non-blocking RX routine
     void TXnbISR(); // ISR for non-blocking TX routine
 };

--- a/src/lib/SX12xxDriverCommon/SX12xxDriverCommon.h
+++ b/src/lib/SX12xxDriverCommon/SX12xxDriverCommon.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <targets.h>
+
+
+class SX12xxDriverCommon
+{
+public:
+    typedef uint8_t rx_status;
+    enum
+    {
+        SX12XX_RX_OK        = 0,
+        SX12XX_RX_CRC_FAIL  = 1 << 0,
+        SX12XX_RX_TIMEOUT   = 1 << 1,
+    };
+
+    SX12xxDriverCommon():
+        RXdoneCallback(nullCallbackRx),
+        TXdoneCallback(nullCallbackTx) {}
+
+    static void ICACHE_RAM_ATTR nullCallbackRx(rx_status) {}
+    static void ICACHE_RAM_ATTR nullCallbackTx() {}
+
+    ///////Callback Function Pointers/////
+    void (*RXdoneCallback)(rx_status crcFail); //function pointer for callback
+    void (*TXdoneCallback)(); //function pointer for callback
+
+    #define TXRXBuffSize 16
+    volatile WORD_ALIGNED_ATTR uint8_t TXdataBuffer[TXRXBuffSize];
+    volatile WORD_ALIGNED_ATTR uint8_t RXdataBuffer[TXRXBuffSize];
+
+    ///////////Radio Variables////////
+    uint32_t currFreq;
+    uint8_t PayloadLength;
+    bool IQinverted;
+
+    /////////////Packet Stats//////////
+    int8_t LastPacketRSSI;
+    int8_t LastPacketSNR;
+
+protected:
+    void RemoveCallbacks(void)
+    {
+        RXdoneCallback = nullCallbackRx;
+        TXdoneCallback = nullCallbackTx;
+    }
+};

--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -11,16 +11,16 @@ static_assert(RATE_BINDING < RATE_MAX, "Binding rate must be below RATE_MAX");
 SX127xDriver DMA_ATTR Radio;
 
 expresslrs_mod_settings_s ExpressLRS_AirRateConfig[RATE_MAX] = {
-    {0, RADIO_TYPE_SX127x_LORA, RATE_200HZ, SX127x_BW_500_00_KHZ, SX127x_SF_6, SX127x_CR_4_7, 5000, TLM_RATIO_1_64, 4, 8, 8},
-    {1, RADIO_TYPE_SX127x_LORA, RATE_100HZ, SX127x_BW_500_00_KHZ, SX127x_SF_7, SX127x_CR_4_7, 10000, TLM_RATIO_1_64, 4, 8, 8},
-    {2, RADIO_TYPE_SX127x_LORA, RATE_50HZ, SX127x_BW_500_00_KHZ, SX127x_SF_8, SX127x_CR_4_7, 20000, TLM_RATIO_NO_TLM, 4, 10, 8},
-    {3, RADIO_TYPE_SX127x_LORA, RATE_25HZ, SX127x_BW_500_00_KHZ, SX127x_SF_9, SX127x_CR_4_7, 40000, TLM_RATIO_NO_TLM, 2, 10, 8}};
+    {0, RADIO_TYPE_SX127x_LORA, RATE_LORA_200HZ, SX127x_BW_500_00_KHZ, SX127x_SF_6, SX127x_CR_4_7, 5000, TLM_RATIO_1_64, 4, 8, 8},
+    {1, RADIO_TYPE_SX127x_LORA, RATE_LORA_100HZ, SX127x_BW_500_00_KHZ, SX127x_SF_7, SX127x_CR_4_7, 10000, TLM_RATIO_1_64, 4, 8, 8},
+    {2, RADIO_TYPE_SX127x_LORA, RATE_LORA_50HZ, SX127x_BW_500_00_KHZ, SX127x_SF_8, SX127x_CR_4_7, 20000, TLM_RATIO_NO_TLM, 4, 10, 8},
+    {3, RADIO_TYPE_SX127x_LORA, RATE_LORA_25HZ, SX127x_BW_500_00_KHZ, SX127x_SF_9, SX127x_CR_4_7, 40000, TLM_RATIO_NO_TLM, 2, 10, 8}};
 
 expresslrs_rf_pref_params_s ExpressLRS_AirRateRFperf[RATE_MAX] = {
-    {0, RATE_200HZ, -112, 4380, 3000, 2500, 600, 5000},
-    {1, RATE_100HZ, -117, 8770, 3500, 2500, 600, 5000},
-    {2, RATE_50HZ, -120, 18560, 4000, 2500, 600, 5000},
-    {3, RATE_25HZ, -123, 29950, 6000, 4000, 0, 5000}};
+    {0, RATE_LORA_200HZ, -112,  4380, 3000, 2500, 600, 5000},
+    {1, RATE_LORA_100HZ, -117,  8770, 3500, 2500, 600, 5000},
+    {2, RATE_LORA_50HZ,  -120, 18560, 4000, 2500, 600, 5000},
+    {3, RATE_LORA_25HZ,  -123, 29950, 6000, 4000,   0, 5000}};
 #endif
 
 #if defined(RADIO_SX128X)
@@ -29,16 +29,20 @@ expresslrs_rf_pref_params_s ExpressLRS_AirRateRFperf[RATE_MAX] = {
 SX1280Driver DMA_ATTR Radio;
 
 expresslrs_mod_settings_s ExpressLRS_AirRateConfig[RATE_MAX] = {
-    {0, RADIO_TYPE_SX128x_LORA, RATE_500HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF5, SX1280_LORA_CR_LI_4_6,  2000, TLM_RATIO_1_128,  4, 12, 8},
-    {1, RADIO_TYPE_SX128x_LORA, RATE_250HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF6, SX1280_LORA_CR_LI_4_7,  4000, TLM_RATIO_1_64,   4, 14, 8},
-    {2, RADIO_TYPE_SX128x_LORA, RATE_150HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF7, SX1280_LORA_CR_LI_4_7,  6666, TLM_RATIO_1_32,   4, 12, 8},
-    {3, RADIO_TYPE_SX128x_LORA, RATE_50HZ,  SX1280_LORA_BW_0800, SX1280_LORA_SF9, SX1280_LORA_CR_LI_4_6, 20000, TLM_RATIO_NO_TLM, 2, 12, 8}};
+    {0, RADIO_TYPE_SX128x_FLRC, RATE_FLRC_1000HZ, SX1280_FLRC_BR_0_650_BW_0_6, SX1280_FLRC_BT_1, SX1280_FLRC_CR_1_2,     1000, TLM_RATIO_1_128,  8, 32, 8},
+    {1, RADIO_TYPE_SX128x_FLRC, RATE_FLRC_500HZ,  SX1280_FLRC_BR_0_650_BW_0_6, SX1280_FLRC_BT_1, SX1280_FLRC_CR_1_2,     2000, TLM_RATIO_1_128,  4, 32, 8},
+    {2, RADIO_TYPE_SX128x_LORA, RATE_LORA_500HZ,  SX1280_LORA_BW_0800,         SX1280_LORA_SF5,  SX1280_LORA_CR_LI_4_6,  2000, TLM_RATIO_1_128,  4, 12, 8},
+    {3, RADIO_TYPE_SX128x_LORA, RATE_LORA_250HZ,  SX1280_LORA_BW_0800,         SX1280_LORA_SF6,  SX1280_LORA_CR_LI_4_7,  4000, TLM_RATIO_1_64,   4, 14, 8},
+    {4, RADIO_TYPE_SX128x_LORA, RATE_LORA_150HZ,  SX1280_LORA_BW_0800,         SX1280_LORA_SF7,  SX1280_LORA_CR_LI_4_7,  6666, TLM_RATIO_1_32,   4, 12, 8},
+    {5, RADIO_TYPE_SX128x_LORA, RATE_LORA_50HZ,   SX1280_LORA_BW_0800,         SX1280_LORA_SF9,  SX1280_LORA_CR_LI_4_6, 20000, TLM_RATIO_NO_TLM, 2, 12, 8}};
 
 expresslrs_rf_pref_params_s ExpressLRS_AirRateRFperf[RATE_MAX] = {
-    {0, RATE_500HZ, -105, 1665, 2500, 2500, 3, 5000},
-    {1, RATE_250HZ, -108, 3300, 3000, 2500, 6, 5000},
-    {2, RATE_150HZ, -112, 5871, 3500, 2500, 10, 5000},
-    {3, RATE_50HZ, -117, 18443, 4000, 2500, 0, 5000}};
+    {0, RATE_FLRC_1000HZ, -104,   389, 2500, 2500,  3, 5000},
+    {1, RATE_FLRC_500HZ,  -104,   389, 2500, 2500,  3, 5000},
+    {2, RATE_LORA_500HZ,  -105,  1665, 2500, 2500,  3, 5000},
+    {3, RATE_LORA_250HZ,  -108,  3300, 3000, 2500,  6, 5000},
+    {4, RATE_LORA_150HZ,  -112,  5871, 3500, 2500, 10, 5000},
+    {5, RATE_LORA_50HZ,   -117, 18443, 4000, 2500,  0, 5000}};
 #endif
 
 expresslrs_mod_settings_s *get_elrs_airRateConfig(uint8_t index)
@@ -74,7 +78,7 @@ ICACHE_RAM_ATTR uint8_t enumRatetoIndex(uint8_t const rate)
     }
     // If 25Hz selected and not available, return the slowest rate available
     // else return the fastest rate available (500Hz selected but not available)
-    return (rate == RATE_25HZ) ? RATE_MAX - 1 : 0;
+    return (rate == RATE_LORA_25HZ) ? RATE_MAX - 1 : 0;
 }
 
 expresslrs_mod_settings_s *ExpressLRS_currAirRate_Modparams;
@@ -132,15 +136,16 @@ uint16_t RateEnumToHz(uint8_t const eRate)
 {
     switch(eRate)
     {
-    case RATE_1000HZ: return 1000;
-    case RATE_500HZ: return 500;
-    case RATE_250HZ: return 250;
-    case RATE_200HZ: return 200;
-    case RATE_150HZ: return 150;
-    case RATE_100HZ: return 100;
-    case RATE_50HZ: return 50;
-    case RATE_25HZ: return 25;
-    case RATE_4HZ: return 4;
+    case RATE_FLRC_1000HZ: return 1000;
+    case RATE_FLRC_500HZ: return 500;
+    case RATE_LORA_500HZ: return 500;
+    case RATE_LORA_250HZ: return 250;
+    case RATE_LORA_200HZ: return 200;
+    case RATE_LORA_150HZ: return 150;
+    case RATE_LORA_100HZ: return 100;
+    case RATE_LORA_50HZ: return 50;
+    case RATE_LORA_25HZ: return 25;
+    case RATE_LORA_4HZ: return 4;
     default: return 1;
     }
 }

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -781,9 +781,9 @@ static bool ICACHE_RAM_ATTR ProcessRfPacket_SYNC(uint32_t now)
     return false;
 }
 
-void ICACHE_RAM_ATTR ProcessRFPacket(uint8_t const crcFail)
+void ICACHE_RAM_ATTR ProcessRFPacket(SX12xxDriverCommon::rx_status const status)
 {
-    if (crcFail)
+    if (status != SX12xxDriverCommon::SX12XX_RX_OK)
     {
         DBGVLN("HW CRC error");
         #if defined(DEBUG_RX_SCOREBOARD)
@@ -861,9 +861,9 @@ void ICACHE_RAM_ATTR ProcessRFPacket(uint8_t const crcFail)
         hwTimer.resume(); // will throw an interrupt immediately
 }
 
-void ICACHE_RAM_ATTR RXdoneISR(uint8_t const crcFail)
+void ICACHE_RAM_ATTR RXdoneISR(SX12xxDriverCommon::rx_status const status)
 {
-    ProcessRFPacket(crcFail);
+    ProcessRFPacket(status);
 }
 
 void ICACHE_RAM_ATTR TXdoneISR()

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -136,9 +136,6 @@ volatile uint8_t NonceRX = 0; // nonce that we THINK we are up to.
 bool alreadyFHSS = false;
 bool alreadyTLMresp = false;
 
-uint32_t beginProcessing;
-uint32_t doneProcessing;
-
 //////////////////////////////////////////////////////////////
 
 ///////Variables for Telemetry and Link Quality///////////////
@@ -249,7 +246,11 @@ void SetRFLinkRate(uint8_t index) // Set speed of RF link
 
     hwTimer.updateInterval(ModParams->interval);
     Radio.Config(ModParams->bw, ModParams->sf, ModParams->cr, GetInitialFreq(),
-                 ModParams->PreambleLen, invertIQ, ModParams->PayloadLength, 0);
+                 ModParams->PreambleLen, invertIQ, ModParams->PayloadLength, 0
+#if defined(RADIO_SX128X)
+                 , uidMacSeedGet(), CRCInitializer, (ModParams->radio_type == RADIO_TYPE_SX128x_FLRC)
+#endif
+                 );
 
     // Wait for (11/10) 110% of time it takes to cycle through all freqs in FHSS table (in ms)
     cycleInterval = ((uint32_t)11U * FHSSgetChannelCount() * ModParams->FHSShopInterval * ModParams->interval) / (10U * 1000U);
@@ -780,12 +781,19 @@ static bool ICACHE_RAM_ATTR ProcessRfPacket_SYNC(uint32_t now)
     return false;
 }
 
-void ICACHE_RAM_ATTR ProcessRFPacket()
+void ICACHE_RAM_ATTR ProcessRFPacket(uint8_t const crcFail)
 {
-    beginProcessing = micros();
-
-    uint8_t type = Radio.RXdataBuffer[0] & 0b11;
-    uint16_t inCRC = (((uint16_t)(Radio.RXdataBuffer[0] & 0b11111100)) << 6) | Radio.RXdataBuffer[7];
+    if (crcFail)
+    {
+        DBGVLN("HW CRC error");
+        #if defined(DEBUG_RX_SCOREBOARD)
+            lastPacketCrcError = true;
+        #endif
+        return;
+    }
+    uint32_t const beginProcessing = micros();
+    uint16_t const inCRC = (((uint16_t)(Radio.RXdataBuffer[0] & 0b11111100)) << 6) | Radio.RXdataBuffer[7];
+    uint8_t const type = Radio.RXdataBuffer[0] & 0b11;
 
     // For smHybrid the CRC only has the packet type in byte 0
     // For smHybridWide the FHSS slot is added to the CRC in byte 0 on RC_DATA_PACKETs
@@ -846,7 +854,6 @@ void ICACHE_RAM_ATTR ProcessRFPacket()
     // but do not extend it indefinitely
     RFmodeCycleMultiplier = RFmodeCycleMultiplierSlow;
 
-    doneProcessing = micros();
 #if defined(DEBUG_RX_SCOREBOARD)
     if (type != SYNC_PACKET) DBGW(connectionHasModelMatch ? 'R' : 'r');
 #endif
@@ -854,9 +861,9 @@ void ICACHE_RAM_ATTR ProcessRFPacket()
         hwTimer.resume(); // will throw an interrupt immediately
 }
 
-void ICACHE_RAM_ATTR RXdoneISR()
+void ICACHE_RAM_ATTR RXdoneISR(uint8_t const crcFail)
 {
-    ProcessRFPacket();
+    ProcessRFPacket(crcFail);
 }
 
 void ICACHE_RAM_ATTR TXdoneISR()

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -231,11 +231,11 @@ void DynamicPower_Update()
   dynamic_power_rssi_n = 0;
 }
 
-void ICACHE_RAM_ATTR ProcessTLMpacket(uint8_t const crcFail)
+void ICACHE_RAM_ATTR ProcessTLMpacket(SX12xxDriverCommon::rx_status const status)
 {
-  if (crcFail)
+  if (status != SX12xxDriverCommon::SX12XX_RX_OK)
   {
-    DBGLN("TLM crc error");
+    DBGLN("TLM HW CRC error");
     return;
   }
   uint16_t const inCRC = (((uint16_t)Radio.RXdataBuffer[0] & 0b11111100) << 6) | Radio.RXdataBuffer[7];
@@ -634,9 +634,9 @@ static void CheckConfigChangePending()
   }
 }
 
-void ICACHE_RAM_ATTR RXdoneISR(uint8_t const crcFail)
+void ICACHE_RAM_ATTR RXdoneISR(SX12xxDriverCommon::rx_status const status)
 {
-  ProcessTLMpacket(crcFail);
+  ProcessTLMpacket(status);
   busyTransmitting = false;
 }
 

--- a/src/test/test_embedded/rx_sx1280_test.cpp
+++ b/src/test/test_embedded/rx_sx1280_test.cpp
@@ -15,7 +15,7 @@ void ICACHE_RAM_ATTR TXdoneCallback()
     //Radio.TXnb(testdata, sizeof(testdata));
 }
 
-void ICACHE_RAM_ATTR RXdoneCallback1()
+void ICACHE_RAM_ATTR RXdoneCallback(uint8_t const /*crcFail*/)
 {
     Serial.println("RXdoneCallback");
 }

--- a/src/test/test_embedded/rx_sx1280_test.cpp
+++ b/src/test/test_embedded/rx_sx1280_test.cpp
@@ -15,7 +15,7 @@ void ICACHE_RAM_ATTR TXdoneCallback()
     //Radio.TXnb(testdata, sizeof(testdata));
 }
 
-void ICACHE_RAM_ATTR RXdoneCallback(uint8_t const /*crcFail*/)
+void ICACHE_RAM_ATTR RXdoneCallback(SX12xxDriverCommon::rx_status const /*status*/)
 {
     Serial.println("RXdoneCallback");
 }

--- a/src/test/test_embedded/tx_sx1280_test.cpp
+++ b/src/test/test_embedded/tx_sx1280_test.cpp
@@ -15,7 +15,7 @@ void ICACHE_RAM_ATTR TXdoneCallback()
     Radio.TXnb(testdata, sizeof(testdata));
 }
 
-void ICACHE_RAM_ATTR RXdoneCallback(uint8_t const /*crcFail*/)
+void ICACHE_RAM_ATTR RXdoneCallback(SX12xxDriverCommon::rx_status const /*status*/)
 {
     Serial.println("RXdoneCallback");
     for (int i = 0; i < 8; i++)

--- a/src/test/test_embedded/tx_sx1280_test.cpp
+++ b/src/test/test_embedded/tx_sx1280_test.cpp
@@ -15,7 +15,7 @@ void ICACHE_RAM_ATTR TXdoneCallback()
     Radio.TXnb(testdata, sizeof(testdata));
 }
 
-void ICACHE_RAM_ATTR RXdoneCallback()
+void ICACHE_RAM_ATTR RXdoneCallback(uint8_t const /*crcFail*/)
 {
     Serial.println("RXdoneCallback");
     for (int i = 0; i < 8; i++)
@@ -44,7 +44,7 @@ void setup()
 void loop()
 {
     // Serial.println("about to TX");
-    
+
     //delay(1000);
 
     // Serial.println("about to RX");


### PR DESCRIPTION
FLRC has faster OTA time (365us including 32b syncword and 16b HW CRC) compared to LoRa so this will be nice update for racers to minimize latency.
Also the link budget will be better for fastest link rates (LoRa -99dBm vs FLRC -104dBm).

Two new rates on top of existing LoRa rates: 
* FLRC 500Hz
* FLRC 1000Hz (needs much more testing!)


~~Note! Merged after #1391 which contains radio driver library preparation for FLRC mode!!~~
