### PR TITLE
Use home network SSID in AP mode fallback

### DIFF
--- a/src/lib/CONFIG/config.h
+++ b/src/lib/CONFIG/config.h
@@ -15,6 +15,7 @@
 #define TX_CONFIG_VERSION   5
 #define RX_CONFIG_VERSION   4
 #define UID_LEN             6
+#define CONFIG_SSID_LEN     33 // including trailing null
 
 #if defined(TARGET_TX)
 typedef struct {
@@ -29,8 +30,8 @@ typedef struct {
 
 typedef struct {
     uint32_t        version;
-    char            ssid[33];
-    char            password[33];
+    char            ssid[CONFIG_SSID_LEN];
+    char            password[CONFIG_SSID_LEN];
     uint8_t         vtxBand;
     uint8_t         vtxChannel;
     uint8_t         vtxPower;
@@ -128,8 +129,8 @@ typedef struct {
     uint8_t     uid[UID_LEN];
     uint8_t     powerOnCounter;
     uint8_t     modelId;
-    char        ssid[33];
-    char        password[33];
+    char        ssid[CONFIG_SSID_LEN];
+    char        password[CONFIG_SSID_LEN];
     rx_config_pwm_t pwmChannels[PWM_MAX_CHANNELS];
 } rx_config_t;
 

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -618,6 +618,30 @@ static void startServices()
   DBGLN("HTTPUpdateServer ready! Open http://%s.local in your browser", wifi_hostname);
 }
 
+static void wifiSetApSsidAndPassword()
+{
+  const char *ap_ssid;
+  const char *ap_pass;
+  char ssid[CONFIG_SSID_LEN + 5];
+
+  // If an SSID is set in the config, use that as the AP name, except with TX/RX appended
+  if (config.GetSSID()[0] != 0)
+  {
+    strlcpy(ssid, config.GetSSID(), sizeof(ssid) - 5);
+    strlcat(ssid, " ELRS", sizeof(ssid));
+    ap_ssid = ssid;
+    ap_pass = config.GetPassword();
+  }
+  else
+  {
+    // else use our default "ExpressLRS TX" and such
+    ap_ssid = wifi_ap_ssid;
+    ap_pass = wifi_ap_password;
+  }
+
+  WiFi.softAP(ap_ssid, ap_pass);
+}
+
 static void HandleWebUpdate()
 {
   unsigned long now = millis();
@@ -657,7 +681,7 @@ static void HandleWebUpdate()
         #endif
         changeTime = now;
         WiFi.softAPConfig(ipAddress, ipAddress, netMsk);
-        WiFi.softAP(wifi_ap_ssid, wifi_ap_password);
+        wifiSetApSsidAndPassword();
         WiFi.scanNetworks(true);
         startServices();
         break;


### PR DESCRIPTION
When falling back to AP mode because the home network is not available, this PR uses the home network SSID and password instead of the default "ExpressLRS TX" / "ExpressLRS RX" SSID and password. The home network SSID is appended with " ELRS" to distinguish it from the actual home network if the RX/TX device couldn't connect while at home.

* Allows greater security at events, because anyone can see an ExpressLRS AP and connect to it and ruin your day if they were total jerks. This way uses your home network password so it is as secure as the home network.
* Allows finding your device at an event. Look, ExpressLRS is popular and everyone wants it, but when you go to a race and there are 93 "ExpressLRS RX" wifi networks, how do you find yours? Now everyone will know your home network name instead. So, kinda less secure if you're worried about that, but anyone who thinks hiding an SSID is secure is an idiot.

I made it `[home network name] ELRS` instead of  `[home network name] TX` and `[home network name] RX` because that way only one extra network needs to be save to your phone / laptop / etc because typing in a password is a pain.

Fixes #1230