### PR TITLE
FIFO protection

### DIFF
--- a/src/include/native.h
+++ b/src/include/native.h
@@ -5,6 +5,8 @@
 #include <cstdint>
 #include <cstring>
 #include <cctype>
+#include <algorithm>
+
 #include <stdio.h>
 #include <unistd.h>
 #include <math.h>
@@ -42,6 +44,7 @@ public:
     void end() {}
     void begin(int baud) {}
     void enableHalfDuplexRx() {}
+    int availableForWrite() {return 256;}
 
     // Print methods
     size_t write(uint8_t c) {return 1;}

--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -662,7 +662,7 @@ void ICACHE_RAM_ATTR CRSF::handleUARTout()
     if (packageLengthRemaining > 0 || SerialOutFIFO.size() > 0) {
         duplex_set_TX();
 
-        uint32_t periodBytesRemaining = maxPeriodBytes;
+        uint32_t periodBytesRemaining = std::min((int)maxPeriodBytes, CRSF::Port.availableForWrite());
         while (periodBytesRemaining)
         {
 #ifdef PLATFORM_ESP32

--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -87,7 +87,7 @@ uint32_t CRSF::UARTwdtLastChecked;
 
 uint8_t CRSF::CRSFoutBuffer[CRSF_MAX_PACKET_LEN] = {0};
 uint8_t CRSF::maxPacketBytes = CRSF_MAX_PACKET_LEN;
-uint32_t CRSF::maxPeriodBytes = CRSF_MAX_PACKET_LEN;
+uint8_t CRSF::maxPeriodBytes = CRSF_MAX_PACKET_LEN;
 uint32_t CRSF::TxToHandsetBauds[] = {400000, 115200, 5250000, 3750000, 1870000, 921600};
 uint8_t CRSF::UARTcurrentBaudIdx = 0;
 
@@ -278,7 +278,7 @@ void ICACHE_RAM_ATTR CRSF::sendTelemetryToTX(uint8_t *data)
         if (SerialOutFIFO.ensure(size + 1))
         {
             SerialOutFIFO.push(size); // length
-            SerialOutFIFO.pushBytes(data, (int)size);
+            SerialOutFIFO.pushBytes(data, size);
         }
 #ifdef PLATFORM_ESP32
         portEXIT_CRITICAL(&FIFOmux);
@@ -542,7 +542,7 @@ void ICACHE_RAM_ATTR CRSF::AddMspMessage(const uint8_t length, volatile uint8_t*
         if (MspWriteFIFO.ensure(length + 1))
         {
             MspWriteFIFO.push(length);
-            MspWriteFIFO.pushBytes((const uint8_t *)data, (int)length);
+            MspWriteFIFO.pushBytes((const uint8_t *)data, length);
         }
     }
 }
@@ -662,7 +662,7 @@ void ICACHE_RAM_ATTR CRSF::handleUARTout()
     if (packageLengthRemaining > 0 || SerialOutFIFO.size() > 0) {
         duplex_set_TX();
 
-        uint32_t periodBytesRemaining = std::min((int)maxPeriodBytes, CRSF::Port.availableForWrite());
+        uint8_t periodBytesRemaining = std::min((int)maxPeriodBytes, CRSF::Port.availableForWrite());
         while (periodBytesRemaining)
         {
 #ifdef PLATFORM_ESP32

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -143,7 +143,7 @@ private:
     static uint32_t BadPktsCount;
     static uint32_t UARTwdtLastChecked;
     static uint8_t maxPacketBytes;
-    static uint32_t maxPeriodBytes;
+    static uint8_t maxPeriodBytes;
     static uint32_t TxToHandsetBauds[6];
     static uint8_t UARTcurrentBaudIdx;
     static bool CRSFstate;

--- a/src/lib/FIFO/FIFO.cpp
+++ b/src/lib/FIFO/FIFO.cpp
@@ -132,3 +132,15 @@ void ICACHE_RAM_ATTR FIFO::flush()
     tail = 0;
     numElements = 0;
 }
+
+bool ICACHE_RAM_ATTR FIFO::ensure(int requiredSize)
+{
+    if(requiredSize > FIFO_SIZE)
+        return false;
+    while(!available(requiredSize)) {
+        uint8_t len = pop();
+        head = (head + len) % FIFO_SIZE;
+        numElements -= len;
+    }
+    return true;
+}

--- a/src/lib/FIFO/FIFO.cpp
+++ b/src/lib/FIFO/FIFO.cpp
@@ -57,7 +57,7 @@ void ICACHE_RAM_ATTR FIFO::push(const uint8_t data)
     }
 }
 
-void ICACHE_RAM_ATTR FIFO::pushBytes(const uint8_t *data, int len)
+void ICACHE_RAM_ATTR FIFO::pushBytes(const uint8_t *data, uint8_t len)
 {
     if (numElements + len > FIFO_SIZE)
     {
@@ -89,7 +89,7 @@ uint8_t ICACHE_RAM_ATTR FIFO::pop()
     }
 }
 
-void ICACHE_RAM_ATTR FIFO::popBytes(uint8_t *data, int len)
+void ICACHE_RAM_ATTR FIFO::popBytes(uint8_t *data, uint8_t len)
 {
     if (numElements < len)
     {
@@ -133,7 +133,7 @@ void ICACHE_RAM_ATTR FIFO::flush()
     numElements = 0;
 }
 
-bool ICACHE_RAM_ATTR FIFO::ensure(int requiredSize)
+bool ICACHE_RAM_ATTR FIFO::ensure(uint8_t requiredSize)
 {
     if(requiredSize > FIFO_SIZE)
         return false;

--- a/src/lib/FIFO/FIFO.h
+++ b/src/lib/FIFO/FIFO.h
@@ -54,4 +54,5 @@ public:
     uint8_t ICACHE_RAM_ATTR peek();
     uint16_t ICACHE_RAM_ATTR size();
     void ICACHE_RAM_ATTR flush();
+    bool ICACHE_RAM_ATTR ensure(int requiredSize) { return (numElements + requiredSize) < FIFO_SIZE; }
 };

--- a/src/lib/FIFO/FIFO.h
+++ b/src/lib/FIFO/FIFO.h
@@ -47,12 +47,34 @@ private:
 public:
     FIFO();
     ~FIFO();
+
+    // Push a single byte to the FIFO, FIFO is flushed if this byte will not fit and the byte is not pushed
     void ICACHE_RAM_ATTR push(const uint8_t data);
+
+    // Push all bytes to FIFO, if all the bytes will not fit then the FIFO is flushed and no bytes are pushed
     void ICACHE_RAM_ATTR pushBytes(const uint8_t *data, int len);
+
+    // Pop a single byte (returns 0 if no bytes left)
     uint8_t ICACHE_RAM_ATTR pop();
+
+    // Pops 'len' bytes into the buffer pointed to by 'data'. If there are not enough bytes in the FIFO
+    // then the FIFO is flush and the bytes are not read
     void ICACHE_RAM_ATTR popBytes(uint8_t *data, int len);
+
+    // return the first byte in the FIFO without removing it
     uint8_t ICACHE_RAM_ATTR peek();
+
+    // return the number of bytes in the FIFO
     uint16_t ICACHE_RAM_ATTR size();
+
+    // reset the FIFO back to empty
     void ICACHE_RAM_ATTR flush();
-    bool ICACHE_RAM_ATTR ensure(int requiredSize) { return (numElements + requiredSize) < FIFO_SIZE; }
+    
+    // returns true if the number of bytes requested is available in the FIFO
+    bool ICACHE_RAM_ATTR available(int requiredSize) { return (numElements + requiredSize) < FIFO_SIZE; }
+    
+    // Ensure that there is enough room in the FIFO for the requestedSize in bytes.
+    // "packets" are popped from the head of the FIFO until there is enough room available.
+    // This method assumes that on the FIFO contains length-prefixed data packets.
+    bool ICACHE_RAM_ATTR ensure(int requiredSize);
 };

--- a/src/lib/FIFO/FIFO.h
+++ b/src/lib/FIFO/FIFO.h
@@ -52,14 +52,14 @@ public:
     void ICACHE_RAM_ATTR push(const uint8_t data);
 
     // Push all bytes to FIFO, if all the bytes will not fit then the FIFO is flushed and no bytes are pushed
-    void ICACHE_RAM_ATTR pushBytes(const uint8_t *data, int len);
+    void ICACHE_RAM_ATTR pushBytes(const uint8_t *data, uint8_t len);
 
     // Pop a single byte (returns 0 if no bytes left)
     uint8_t ICACHE_RAM_ATTR pop();
 
     // Pops 'len' bytes into the buffer pointed to by 'data'. If there are not enough bytes in the FIFO
     // then the FIFO is flush and the bytes are not read
-    void ICACHE_RAM_ATTR popBytes(uint8_t *data, int len);
+    void ICACHE_RAM_ATTR popBytes(uint8_t *data, uint8_t len);
 
     // return the first byte in the FIFO without removing it
     uint8_t ICACHE_RAM_ATTR peek();
@@ -71,10 +71,10 @@ public:
     void ICACHE_RAM_ATTR flush();
     
     // returns true if the number of bytes requested is available in the FIFO
-    bool ICACHE_RAM_ATTR available(int requiredSize) { return (numElements + requiredSize) < FIFO_SIZE; }
-    
+    bool ICACHE_RAM_ATTR available(uint8_t requiredSize) { return (numElements + requiredSize) < FIFO_SIZE; }
+
     // Ensure that there is enough room in the FIFO for the requestedSize in bytes.
     // "packets" are popped from the head of the FIFO until there is enough room available.
     // This method assumes that on the FIFO contains length-prefixed data packets.
-    bool ICACHE_RAM_ATTR ensure(int requiredSize);
+    bool ICACHE_RAM_ATTR ensure(uint8_t requiredSize);
 };

--- a/src/test/fifo_native/test_fifo.cpp
+++ b/src/test/fifo_native/test_fifo.cpp
@@ -36,11 +36,32 @@ void test_fifo_popBytes_wrap(void)
     }
 }
 
+void test_fifo_ensure()
+{
+    f.flush();
+    // Push 25 9-byte packets with a 1 byte length header
+    for (int i = 0; i < 25; i++)
+    {
+        f.push(9); // 9 bytes;
+        for(int x = 0 ; x<9 ; x++)
+            f.push(i);
+    }
+    TEST_ASSERT_EQUAL(250, f.size());
+
+    // Ensure we can push a 99 byte packet with a prefix (i.e. 100 bytes)
+    f.ensure(100);
+    TEST_ASSERT_EQUAL(150, f.size());   // make sure that we've popped the right amount to fit our jumbo packet
+    TEST_ASSERT_EQUAL(9, f.pop());      // check that we have a header len
+    for (int x = 0; x < 9; x++)
+        TEST_ASSERT_EQUAL(10, f.pop()); // and that all the bytes in the head packet are what we expect
+}
+
 int main(int argc, char **argv)
 {
     UNITY_BEGIN();
     RUN_TEST(test_fifo_pop_wrap);
     RUN_TEST(test_fifo_popBytes_wrap);
+    RUN_TEST(test_fifo_ensure);
     UNITY_END();
 
     return 0;


### PR DESCRIPTION
## Problem
There are 2 FIFOs in `CRSF.cpp`, SerialOutFIFO and MspWriteFIFO, and their usage has some problems.

When we push data onto the FIFO, as we are pushing data we check the size of the FIFO and if it would overflow with the bytes being added, it blindly flushes the FIFO.

The code in CRSP.cpp actually pushes data in parcels for a full "message" to avoid buffer copying. So we may push the beginning of a message and the second part would overflow and flushes the FIFO and so we only have the second part of the message and generally we push the CRC byte at the end as a seperate call too.

The problem is that the way the FIFO is used is that the messages are prefixed with the length, so if a flush happens partway through a message push we've lost the length header and who know what happens 😢 . Well, is the first byte of the second part of the message starts with a zero, then you can get a lock-up because we assume that is we peek and get a zero then there's no data to read from the FIFO, and we get stuck never popping anything off the FIFO, until eventually a flush happens at the start of a message!

## Solution
This PR adds a function to the FIFO, `ensure`, that checks that there is at least the number of bytes available for the entire message. If there is not then we drop messages from the front of the FIFO until there is enough room.