### PR TITLE
Set radio timeout when doing telemetry RX

### DIFF
--- a/src/include/common.h
+++ b/src/include/common.h
@@ -53,9 +53,7 @@ typedef enum
 typedef enum
 {
     ttrpTransmitting,     // Transmitting RC channels as normal
-    ttrpInReceiveMode,    // Has switched to Receive mode for telemetry on the next slot (set on TX done)
-    ttrpWindowInProgress  // Tock has fired while in receive mode, receiving telemetry on this slot
-                          // Next slot will go back to ttrsTransmitting
+    ttrpInReceiveMode     // Has switched to Receive mode for telemetry on the next slot (set on TX done)
 } TxTlmRcvPhase_e;
 
 typedef enum

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -228,7 +228,7 @@ void ICACHE_RAM_ATTR SX127xDriver::SetRxTimeoutUs(uint32_t interval)
   timeoutSymbols = 0; // no timeout i.e. use continuous mode
   if (interval)
   {
-    int spread;
+    int spread = 0;
     switch (currSF)
     {
     case SX127x_SF_6:
@@ -255,8 +255,11 @@ void ICACHE_RAM_ATTR SX127xDriver::SetRxTimeoutUs(uint32_t interval)
     }
     double symbolTimeUs = ((double)(1 << spread)) / GetCurrBandwidth() * 1000000;
     timeoutSymbols = interval / symbolTimeUs;
+    hal.setRegValue(SX127X_REG_SYMB_TIMEOUT_LSB, timeoutSymbols);
+    DBGLN("Interval: %d", interval);
+    DBGLN("symbolTimeUs: %d", (uint32_t)symbolTimeUs);
+    DBGLN("Timeout: %d symbols", timeoutSymbols);
   }
-  hal.setRegValue(SX127X_REG_SYMB_TIMEOUT_LSB, timeoutSymbols);
 }
 
 bool SX127xDriver::DetectChip()

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -376,7 +376,7 @@ void SX127xDriver::Config(SX127x_Bandwidth bw, SX127x_SpreadingFactor sf, SX127x
         spread = 12;
         break;
     }
-    double symbolTimeUs = ((double)(1<<spread)) / GetCurrBandwidth();
+    double symbolTimeUs = ((double)(1<<spread)) / GetCurrBandwidth() * 1000000;
     timeoutSymbols = interval / symbolTimeUs;
   }
   SetRxTimeout(timeoutSymbols);

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -563,8 +563,8 @@ void ICACHE_RAM_ATTR SX127xDriver::IsrCallback()
 {
     uint8_t irqStatus = instance->GetIrqFlags();
     instance->ClearIrqFlags();
-    if ((irqStatus & SX127X_CLEAR_IRQ_FLAG_TX_DONE))
+    if ((irqStatus & SX127X_CLEAR_IRQ_FLAG_TX_DONE) && (instance->currOpmode == SX127x_OPMODE_TX))
         instance->TXnbISR();
-    else if ((irqStatus & SX127X_CLEAR_IRQ_FLAG_RX_DONE))
+    if ((irqStatus & SX127X_CLEAR_IRQ_FLAG_RX_DONE) && ((instance->currOpmode == SX127x_OPMODE_RXSINGLE)) || (instance->currOpmode == SX127x_OPMODE_RXCONTINUOUS))
         instance->RXnbISR();
 }

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -326,6 +326,12 @@ void ICACHE_RAM_ATTR SX127xDriver::TXnb()
 void ICACHE_RAM_ATTR SX127xDriver::RXnbISR()
 {
   hal.readRegisterFIFO(RXdataBuffer, PayloadLength);
+  if (timeoutSymbols)
+  {
+    // From page 42 of the datasheet rev 7
+    // In Rx Single mode, the device will return to Standby mode as soon as the interrupt occurs
+    currOpmode = SX127x_OPMODE_STANDBY;
+  }
   LastPacketRSSI = GetLastPacketRSSI();
   LastPacketSNR = GetLastPacketSNR();
   // https://www.mouser.com/datasheet/2/761/sx1276-1278113.pdf

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -228,7 +228,7 @@ void ICACHE_RAM_ATTR SX127xDriver::SetRxTimeoutUs(uint32_t interval)
   timeoutSymbols = 0; // no timeout i.e. use continuous mode
   if (interval)
   {
-    int spread = 0;
+    unsigned int spread = 0;
     switch (currSF)
     {
     case SX127x_SF_6:
@@ -253,12 +253,10 @@ void ICACHE_RAM_ATTR SX127xDriver::SetRxTimeoutUs(uint32_t interval)
       spread = 12;
       break;
     }
-    double symbolTimeUs = ((double)(1 << spread)) / GetCurrBandwidth() * 1000000;
+    uint32_t symbolTimeUs = ((uint32_t)(1 << spread)) * 1000000 / GetCurrBandwidth();
     timeoutSymbols = interval / symbolTimeUs;
     hal.setRegValue(SX127X_REG_SYMB_TIMEOUT_LSB, timeoutSymbols);
-    DBGLN("Interval: %d", interval);
-    DBGLN("symbolTimeUs: %d", (uint32_t)symbolTimeUs);
-    DBGLN("Timeout: %d symbols", timeoutSymbols);
+    DBGLN("SetRxTimeout(%u), symbolTime=%uus symbols=%u", interval, (uint32_t)symbolTimeUs, timeoutSymbols)
   }
 }
 

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -255,7 +255,8 @@ void ICACHE_RAM_ATTR SX127xDriver::SetRxTimeoutUs(uint32_t interval)
     }
     uint32_t symbolTimeUs = ((uint32_t)(1 << spread)) * 1000000 / GetCurrBandwidth();
     timeoutSymbols = interval / symbolTimeUs;
-    hal.setRegValue(SX127X_REG_SYMB_TIMEOUT_LSB, timeoutSymbols);
+    hal.setRegValue(SX127X_REG_MODEM_CONFIG_2, timeoutSymbols >> 8, 1, 0);  // set the timeout MSB
+    hal.setRegValue(SX127X_REG_SYMB_TIMEOUT_LSB, timeoutSymbols & 0xFF);
     DBGLN("SetRxTimeout(%u), symbolTime=%uus symbols=%u", interval, (uint32_t)symbolTimeUs, timeoutSymbols)
   }
 }

--- a/src/lib/SX127xDriver/SX127x.h
+++ b/src/lib/SX127xDriver/SX127x.h
@@ -45,6 +45,7 @@ public:
     uint8_t currPWR = 0b0000;
     SX127x_ModulationModes ModFSKorLoRa = SX127x_OPMODE_LORA;
     bool IQinverted = false;
+    uint16_t timeoutSymbols = 0;
     ///////////////////////////////////
 
     /////////////Packet Stats//////////
@@ -62,8 +63,8 @@ public:
     bool Begin();
     void End();
     bool DetectChip();
-    void Config(SX127x_Bandwidth bw, SX127x_SpreadingFactor sf, SX127x_CodingRate cr, uint32_t freq, uint8_t preambleLen, uint8_t syncWord, bool InvertIQ, uint8_t PayloadLength);
-    void Config(SX127x_Bandwidth bw, SX127x_SpreadingFactor sf, SX127x_CodingRate cr, uint32_t freq, uint8_t preambleLen, bool InvertIQ, uint8_t PayloadLength);
+    void Config(SX127x_Bandwidth bw, SX127x_SpreadingFactor sf, SX127x_CodingRate cr, uint32_t freq, uint8_t preambleLen, uint8_t syncWord, bool InvertIQ, uint8_t PayloadLength, uint32_t interval);
+    void Config(SX127x_Bandwidth bw, SX127x_SpreadingFactor sf, SX127x_CodingRate cr, uint32_t freq, uint8_t preambleLen, bool InvertIQ, uint8_t PayloadLength, uint32_t interval);
     void SetMode(SX127x_RadioOPmodes mode);
     void SetTxIdleMode() { SetMode(SX127x_OPMODE_STANDBY); } // set Idle mode used when switching from RX to TX
     void ConfigLoraDefaults();
@@ -74,6 +75,7 @@ public:
     void SetOutputPowerMax() { SetOutputPower(0b1111); };
     void SetPreambleLength(uint8_t PreambleLen);
     void SetSpreadingFactor(SX127x_SpreadingFactor sf);
+    void SetRxTimeout(uint16_t timeout);
 
     uint32_t GetCurrBandwidth();
     uint32_t GetCurrBandwidthNormalisedShifted();

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -351,10 +351,10 @@ void ICACHE_RAM_ATTR SX1280Driver::RXnbISR()
     {
         // From table 11-28, pg 81 datasheet rev 3.2
         // upon successsful receipt, when the timer is active or in single mode, it returns to STDBY_RC
-        currOpmode = SX1280_MODE_STDBY_RC;
+        // but because we have AUTO_FS enabled we automatically transition to state SX1280_MODE_FS
+        currOpmode = SX1280_MODE_FS;
     }
-    uint8_t FIFOaddr = GetRxBufferAddr();
-    hal.ReadBuffer(FIFOaddr, RXdataBuffer, PayloadLength);
+    hal.ReadBuffer(0x00, RXdataBuffer, PayloadLength);
     GetLastPacketStats();
     RXdoneCallback();
 }
@@ -409,8 +409,8 @@ void ICACHE_RAM_ATTR SX1280Driver::IsrCallback()
 {
     uint16_t irqStatus = instance->GetIrqStatus();
     instance->ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
-    if ((irqStatus & SX1280_IRQ_TX_DONE) && (instance->currOpmode == SX1280_MODE_TX))
+    if (irqStatus & SX1280_IRQ_TX_DONE)
         instance->TXnbISR();
-    if ((irqStatus & SX1280_IRQ_RX_DONE) && (instance->currOpmode == SX1280_MODE_RX))
+    if (irqStatus & SX1280_IRQ_RX_DONE)
         instance->RXnbISR();
 }

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -386,8 +386,8 @@ void ICACHE_RAM_ATTR SX1280Driver::IsrCallback()
 {
     uint16_t irqStatus = instance->GetIrqStatus();
     instance->ClearIrqStatus(SX1280_IRQ_RADIO_ALL);
-    if ((irqStatus & SX1280_IRQ_TX_DONE))
+    if ((irqStatus & SX1280_IRQ_TX_DONE) && (instance->currOpmode == SX1280_MODE_TX))
         instance->TXnbISR();
-    else if ((irqStatus & SX1280_IRQ_RX_DONE))
+    if ((irqStatus & SX1280_IRQ_RX_DONE) && (instance->currOpmode == SX1280_MODE_RX))
         instance->RXnbISR();
 }

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -347,7 +347,12 @@ void ICACHE_RAM_ATTR SX1280Driver::TXnb()
 void ICACHE_RAM_ATTR SX1280Driver::RXnbISR()
 {
     // In continuous receive mode, the device stays in Rx mode
-    //currOpmode = SX1280_MODE_FS;
+    if (timeout != 0xFFFF)
+    {
+        // From table 11-28, pg 81 datasheet rev 3.2
+        // upon successsful receipt, when the timer is active or in single mode, it returns to STDBY_RC
+        currOpmode = SX1280_MODE_STDBY_RC;
+    }
     uint8_t FIFOaddr = GetRxBufferAddr();
     hal.ReadBuffer(FIFOaddr, RXdataBuffer, PayloadLength);
     GetLastPacketStats();

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -354,7 +354,8 @@ void ICACHE_RAM_ATTR SX1280Driver::RXnbISR()
         // but because we have AUTO_FS enabled we automatically transition to state SX1280_MODE_FS
         currOpmode = SX1280_MODE_FS;
     }
-    hal.ReadBuffer(0x00, RXdataBuffer, PayloadLength);
+    uint8_t FIFOaddr = GetRxBufferAddr();
+    hal.ReadBuffer(FIFOaddr, RXdataBuffer, PayloadLength);
     GetLastPacketStats();
     RXdoneCallback();
 }

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -158,7 +158,7 @@ void SX1280Driver::SetMode(SX1280_RadioOperatingModes_t OPmode)
 
     case SX1280_MODE_RX:
         buf[0] = 0x00; // periodBase = 15.625us, page 71 datasheet
-        buf[1] = timeout >> 0xFF;
+        buf[1] = timeout >> 8;
         buf[2] = timeout & 0xFF;
         hal.WriteCommand(SX1280_RADIO_SET_RX, buf, sizeof(buf));
         switchDelay = 100;

--- a/src/lib/SX1280Driver/SX1280.h
+++ b/src/lib/SX1280Driver/SX1280.h
@@ -31,6 +31,7 @@ public:
     uint32_t currFreq = 2400000000;
     SX1280_RadioOperatingModes_t currOpmode = SX1280_MODE_SLEEP;
     bool IQinverted = false;
+    uint16_t timeout = 0xFFFF;
 
     // static uint8_t currPWR;
     // static uint8_t maxPWR;
@@ -62,7 +63,7 @@ public:
     void End();
     void SetMode(SX1280_RadioOperatingModes_t OPmode);
     void SetTxIdleMode() { SetMode(SX1280_MODE_FS); }; // set Idle mode used when switching from RX to TX
-    void Config(SX1280_RadioLoRaBandwidths_t bw, SX1280_RadioLoRaSpreadingFactors_t sf, SX1280_RadioLoRaCodingRates_t cr, uint32_t freq, uint8_t PreambleLength, bool InvertIQ, uint8_t PayloadLength);
+    void Config(SX1280_RadioLoRaBandwidths_t bw, SX1280_RadioLoRaSpreadingFactors_t sf, SX1280_RadioLoRaCodingRates_t cr, uint32_t freq, uint8_t PreambleLength, bool InvertIQ, uint8_t PayloadLength, uint32_t interval);
     void ConfigLoRaModParams(SX1280_RadioLoRaBandwidths_t bw, SX1280_RadioLoRaSpreadingFactors_t sf, SX1280_RadioLoRaCodingRates_t cr);
     void SetPacketParams(uint8_t PreambleLength, SX1280_RadioLoRaPacketLengthsModes_t HeaderType, uint8_t PayloadLength, SX1280_RadioLoRaCrcModes_t crc, SX1280_RadioLoRaIQModes_t InvertIQ);
     void ICACHE_RAM_ATTR SetFrequencyHz(uint32_t freq);

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -254,7 +254,7 @@ void SetRFLinkRate(uint8_t index) // Set speed of RF link
     bool invertIQ = UID[5] & 0x01;
 
     hwTimer.updateInterval(ModParams->interval);
-    Radio.Config(ModParams->bw, ModParams->sf, ModParams->cr, GetInitialFreq(), ModParams->PreambleLen, invertIQ, ModParams->PayloadLength);
+    Radio.Config(ModParams->bw, ModParams->sf, ModParams->cr, GetInitialFreq(), ModParams->PreambleLen, invertIQ, ModParams->PayloadLength, 0);
 
     // Wait for (11/10) 110% of time it takes to cycle through all freqs in FHSS table (in ms)
     cycleInterval = ((uint32_t)11U * FHSSgetChannelCount() * ModParams->FHSShopInterval * ModParams->interval) / (10U * 1000U);
@@ -1241,8 +1241,8 @@ void loop()
 
     if (connectionState == tentative && (now - LastSyncPacket > ExpressLRS_currAirRate_RFperfParams->RxLockTimeoutMs))
     {
-        LostConnection();
         DBGLN("Bad sync, aborting");
+        LostConnection();
         RFmodeLastCycled = now;
         LastSyncPacket = now;
     }

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -357,7 +357,7 @@ void ICACHE_RAM_ATTR SetRFLinkRate(uint8_t index) // Set speed of RF link (hz)
 
   DBGLN("set rate %u", index);
   hwTimer.updateInterval(ModParams->interval);
-  Radio.Config(ModParams->bw, ModParams->sf, ModParams->cr, GetInitialFreq(), ModParams->PreambleLen, invertIQ, ModParams->PayloadLength, ModParams->interval * 95 / 100);
+  Radio.Config(ModParams->bw, ModParams->sf, ModParams->cr, GetInitialFreq(), ModParams->PreambleLen, invertIQ, ModParams->PayloadLength, ModParams->interval);
 
   ExpressLRS_currAirRate_Modparams = ModParams;
   ExpressLRS_currAirRate_RFperfParams = RFperf;

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -357,7 +357,7 @@ void ICACHE_RAM_ATTR SetRFLinkRate(uint8_t index) // Set speed of RF link (hz)
 
   DBGLN("set rate %u", index);
   hwTimer.updateInterval(ModParams->interval);
-  Radio.Config(ModParams->bw, ModParams->sf, ModParams->cr, GetInitialFreq(), ModParams->PreambleLen, invertIQ, ModParams->PayloadLength);
+  Radio.Config(ModParams->bw, ModParams->sf, ModParams->cr, GetInitialFreq(), ModParams->PreambleLen, invertIQ, ModParams->PayloadLength, ModParams->interval);
 
   ExpressLRS_currAirRate_Modparams = ModParams;
   ExpressLRS_currAirRate_RFperfParams = RFperf;

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -489,7 +489,6 @@ void ICACHE_RAM_ATTR timerCallbackNormal()
   if (TelemetryRcvPhase == ttrpWindowInProgress)
   {
     // Stop Receive mode if it is still active
-    Radio.SetTxIdleMode();
     TelemetryRcvPhase = ttrpTransmitting;
   }
 
@@ -604,7 +603,6 @@ static void CheckConfigChangePending()
     // to be on the last slot of the FHSS the skip will prevent FHSS
     if (TelemetryRcvPhase == ttrpInReceiveMode)
     {
-      Radio.SetTxIdleMode();
       TelemetryRcvPhase = ttrpTransmitting;
     }
     ConfigChangeCommit();
@@ -613,9 +611,6 @@ static void CheckConfigChangePending()
 
 void ICACHE_RAM_ATTR RXdoneISR()
 {
-  // There isn't enough time to receive two packets during one telemetry slot
-  // Stop receiving to prevent a second packet preamble from starting a second receive
-  Radio.SetTxIdleMode();
   ProcessTLMpacket();
   busyTransmitting = false;
 }

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -480,16 +480,10 @@ void ICACHE_RAM_ATTR timerCallbackNormal()
   // Skip transmitting on this slot
   if (TelemetryRcvPhase == ttrpInReceiveMode)
   {
-    TelemetryRcvPhase = ttrpWindowInProgress;
+    TelemetryRcvPhase = ttrpTransmitting;
     crsf.LinkStatistics.downlink_Link_quality = LQCalc.getLQ();
     LQCalc.inc();
     return;
-  }
-  // TLM packet reception was the previous slot, transmit this slot (below)
-  if (TelemetryRcvPhase == ttrpWindowInProgress)
-  {
-    // Stop Receive mode if it is still active
-    TelemetryRcvPhase = ttrpTransmitting;
   }
 
   // Do not send a stale channels packet to the RX if one has not been received from the handset


### PR DESCRIPTION
# Problem
Quote from @AlessandroAU 
> at the very start of the TXnb call, it's possible to get a spurious RXdone! (From the other transmitter) 
approx 300 us late after the packet interval, but JUST before we switch modes to TX 
and it fucks the whole thing up

# Effect
Telemetry Lost/Recovered callouts and sometimes immediate failsafe

# Solution
Use the RX timeout feature of the radio chip to not fire an interrupt if a packets is received after the specified time, which we set to 95% of the allocated send/receive time-slot.