### PR TITLE
Ghost tx lite patch

### DIFF
--- a/src/include/target/GHOST_2400_TX.h
+++ b/src/include/target/GHOST_2400_TX.h
@@ -34,7 +34,7 @@
 #define GPIO_PIN_OLED_DC            PC15
 #define GPIO_PIN_OLED_MOSI          PB5
 #define GPIO_PIN_OLED_SCK           PB3
-#define GPIO_PIN_JOYSTICK           PA0
+#define GPIO_PIN_JOYSTICK           A0
 
 // Output Power
 #define MinPower                    PWR_10mW

--- a/src/lib/SCREEN/OLED/oledscreen.cpp
+++ b/src/lib/SCREEN/OLED/oledscreen.cpp
@@ -222,7 +222,10 @@ void OLEDScreen::displayMainScreen(){
         u8g2.drawStr(0,15, &(rate_string[current_rate_index])[0]);
         u8g2.drawStr(70,15, &(ratio_string[current_ratio_index])[0]);
         u8g2.drawStr(0,32, power.c_str());
-        u8g2.drawStr(70,32, "Test");
+        char buffer[7];
+        strncpy(buffer, version, 6);
+        buffer[6] = 0;
+        u8g2.drawStr(70,32, buffer);
     #else
         u8g2.setFont(u8g2_font_t0_15_mr);
         u8g2.drawStr(0,13, "ExpressLRS");


### PR DESCRIPTION
Fixed the `analogRead` for ghost modules. 

New STM arduino library uses analog arrays you have to use `A0,A1,A2...Ax` when using analog pins and not the `PA0`