### PR TITLE
Revert PR #1292

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -236,7 +236,7 @@ void DynamicPower_Update()
     POWERMGNT.incPower();
   }
   if (avg_rssi > rssi_dec_threshold && lq_avg > DYNPOWER_THRESH_LQ_DN) {
-    DBGLN("Power decrease");
+    DBGVLN("Power decrease"); // Note: Verbose debug only - to prevent spamming when on a high telemetry ratio.
     dynamic_power_avg_lq = (DYNPOWER_THRESH_LQ_DN-5)<<16;    // preventing power down too fast due to the averaged LQ calculated from higher power.
     POWERMGNT.decPower();
   }


### PR DESCRIPTION
@CapnBry commented why power down debug logging was set verbose.
Revert my previous PR #1292, and added a comment of the reason of the verbose mode.