### PR TITLE
Using clang microsoft format for this project

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: Microsoft
+ColumnLimit: 0
+IndentWidth: 4


### PR DESCRIPTION
This is open for discussion. I wanted to add this file so we can all be on the same sheet of music when it comes to formatting. I know I am guilty of changing formatting styles on the fly and being able to use short cuts for formatting might help. So no matter who is developing, you can just auto format and everything should be kind of ok? 
```
    On Windows Shift + Alt + F
    On Mac Shift + Option + F
    On Linux Ctrl + Shift + I
```

@pkendall64 and I choose Microsoft because it seemed to be the least aggressive change when running the format tool.

I really do not have an opinion on which is the best so feedback is welcome :) 
