### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/include/common.h
+++ b/src/include/common.h
@@ -177,3 +177,7 @@ uint32_t uidMacSeedGet(void);
 //Koopman formatting https://users.ece.cmu.edu/~koopman/crc/
 #define ELRS_CRC_POLY 0x07 // 0x83
 #define ELRS_CRC14_POLY 0x2E57 // 0x372B
+
+#ifndef UNUSED
+#define UNUSED(x) (void)(x)
+#endif

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -1,3 +1,4 @@
+#include "common.h"
 #include "POWERMGNT.h"
 #include "DAC.h"
 

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -106,6 +106,8 @@ void POWERMGNT::SetPowerCaliValues(int8_t *values, size_t size)
         nvs_set_blob(handle, "powercali", &powerCaliValues, sizeof(powerCaliValues));
     }
     nvs_commit(handle);
+#else
+    UNUSED(isUpdate);
 #endif
 }
 

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -784,6 +784,7 @@ void OnTLMRatePacket(mspPacket_t *packet)
 void OnPowerGetCalibration(mspPacket_t *packet)
 {
   uint8_t index = packet->readByte();
+  UNUSED(index);
   int8_t values[PWR_COUNT] = {0};
   POWERMGNT.GetPowerCaliValues(values, PWR_COUNT);
   DBGLN("power get calibration value %d",  values[index]);


### PR DESCRIPTION
Adds a UNUSED define to suppress unused warnings related to variables used for debug output. STM32 already has that macro so it's added if not defined.