### PR TITLE
Fix FrSky LUA

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -662,7 +662,7 @@ void ICACHE_RAM_ATTR CRSF::handleUARTout()
     if (packageLengthRemaining > 0 || SerialOutFIFO.size() > 0) {
         duplex_set_TX();
 
-        uint8_t periodBytesRemaining = std::min((int)maxPeriodBytes, CRSF::Port.availableForWrite());
+        uint8_t periodBytesRemaining = maxPeriodBytes;
         while (periodBytesRemaining)
         {
 #ifdef PLATFORM_ESP32


### PR DESCRIPTION
In PR #1285 where I introduced a check so that we didn't push more bytes than was available on the serial port this caused the problem on the R9M TX module.

Apparently availableForWrite does not work as expected and seems to always return
And upon thinking about it, it's not really necessary.