### PR TITLE
Adding dual sx1280 radio support for recievers (Ghost Atto Duo)

### DIFF
--- a/src/include/target/GHOST_ATTO_DUO_2400_RX.h
+++ b/src/include/target/GHOST_ATTO_DUO_2400_RX.h
@@ -1,0 +1,31 @@
+#define DEVICE_NAME "GHOST ATTO DUO"
+// There is some special handling for this target
+#define TARGET_RX_GHOST_ATTO_DUO_V1
+
+#define HAS_DUAL_SX1280 // Use this for anything related to the duo. 
+                        // We do not want to use names like ghost in the code 
+                        // because someone might want to make a dual sx1280 rx. 
+
+// GPIO pin definitions
+// First SX1280 Radio
+#define GPIO_PIN_NSS            PA15
+#define GPIO_PIN_BUSY           PA3
+#define GPIO_PIN_DIO1           PA1
+// Second SX1280 Radio
+#define GPIO_PIN_NSS_2            PA11
+#define GPIO_PIN_BUSY_2           PA4
+#define GPIO_PIN_DIO1_2           PB7
+
+#define GPIO_PIN_MOSI           PB5
+#define GPIO_PIN_MISO           PB4
+#define GPIO_PIN_SCK            PB3
+#define GPIO_PIN_RST            PB0
+#define GPIO_PIN_RCSIGNAL_RX    PB6 // USART1, half duplex
+#define GPIO_PIN_RCSIGNAL_TX    PA2 // USART2, half duplex
+#define GPIO_PIN_LED_WS2812      PA7
+#define GPIO_PIN_LED_WS2812_FAST PA_7
+// #define GPIO_PIN_BUTTON         PA12 // We do not use the button
+
+// Output Power - use default SX1280
+
+#define Regulatory_Domain_ISM_2400 1

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -92,7 +92,7 @@ static bool newChannelsAvailable;
 CRSF crsf(CRSF_TX_SERIAL);
 
 /* CRSF_RX_SERIAL is used by telemetry receiver and can be on a different peripheral */
-#if defined(TARGET_RX_GHOST_ATTO_V1) /* !TARGET_RX_GHOST_ATTO_V1 */
+#if defined(TARGET_RX_GHOST_ATTO_V1) || defined(TARGET_RX_GHOST_ATTO_DUO_V1) /* !TARGET_RX_GHOST_ATTO_V1 OR TARGET_RX_GHOST_ATTO_DUO_V1 */
     #define CRSF_RX_SERIAL CrsfRxSerial
     HardwareSerial CrsfRxSerial(USART1, HALF_DUPLEX_ENABLED);
 #elif defined(TARGET_R9SLIMPLUS_RX) /* !TARGET_R9SLIMPLUS_RX */

--- a/src/targets/imrc.ini
+++ b/src/targets/imrc.ini
@@ -56,7 +56,6 @@ extends = env:GHOST_ATTO_2400_RX_via_STLINK
 
 [env:GHOST_ATTO_DUO_2400_RX_via_STLINK]
 extends = env_common_stm32, radio_2400
-platform = ststm32@11.0.0
 board = GHOST_ATTO
 build_flags =
 	${env_common_stm32.build_flags}
@@ -70,7 +69,7 @@ src_filter = ${env_common_stm32.src_filter} -<tx_*.cpp>
 lib_deps =
 lib_ignore = Servo
 upload_flags =
-	BOOTLOADER=bootloader/ghost/ghost_atto_v1.2_bootloader.bin
+	BOOTLOADER=bootloader/ghost/ghost_atto_bootloader.bin
 	VECT_OFFSET=0x4000
 
 [env:GHOST_ATTO_DUO_2400_RX_via_BetaflightPassthrough]

--- a/src/targets/imrc.ini
+++ b/src/targets/imrc.ini
@@ -53,3 +53,25 @@ upload_flags =
 
 [env:GHOST_ATTO_2400_RX_via_BetaflightPassthrough]
 extends = env:GHOST_ATTO_2400_RX_via_STLINK
+
+[env:GHOST_ATTO_DUO_2400_RX_via_STLINK]
+extends = env_common_stm32, radio_2400
+platform = ststm32@11.0.0
+board = GHOST_ATTO
+build_flags =
+	${env_common_stm32.build_flags}
+	${common_env_data.build_flags_rx}
+	${radio_2400.build_flags}
+ 	-include target/GHOST_ATTO_DUO_2400_RX.h
+ 	-D HSE_VALUE=32000000U
+	-DVECT_TAB_OFFSET=0x08004000U
+	-Wl,--defsym=FLASH_APP_OFFSET=0x4000
+src_filter = ${env_common_stm32.src_filter} -<tx_*.cpp>
+lib_deps =
+lib_ignore = Servo
+upload_flags =
+	BOOTLOADER=bootloader/ghost/ghost_atto_v1.2_bootloader.bin
+	VECT_OFFSET=0x4000
+
+[env:GHOST_ATTO_DUO_2400_RX_via_BetaflightPassthrough]
+extends = env:GHOST_DUO_ATTO_2400_RX_via_STLINK


### PR DESCRIPTION
- [x] Check pins

- [x] add `has_dual_sx1280` to rx_main.c

- [x] Test one 1280 at a time (Hard code which one to use)

## Work on logic for true diversity on RX's
- [ ] Add option for two 1280's in the driver so you can create two radios and change pins for the second 1280.
- [ ] Test two radio's 
- [ ] Add logic for switching based on bad packets.. and telemetry based on rssi values 

## Field test
- [ ] Field test