### PR TITLE
adds ifndef to duplex device name

### DIFF
--- a/src/include/target/DIY_2400_TX_DUPLETX_TX.h
+++ b/src/include/target/DIY_2400_TX_DUPLETX_TX.h
@@ -1,4 +1,6 @@
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "DupleTX"
+#endif
 
 // Any device features
 #define USE_TX_BACKPACK


### PR DESCRIPTION
As required for the configurator to make alias targets.