### PR TITLE
update web server to resolve deprecation, limit version of nimble lib

### DIFF
--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -44,8 +44,9 @@ build_flags =
 src_filter = ${common_env_data.src_filter} -<ESP8266*.*> -<STM32*.*>
 lib_deps =
 	makuna/NeoPixelBus @ ^2.6.7
-	ottowinter/ESPAsyncWebServer-esphome @ ^1.3.0
+	ottowinter/ESPAsyncWebServer-esphome @ ^2.1.0
 	lemmingdev/ESP32-BLE-Gamepad @ ^0.3.3
+	h2zero/NimBLE-Arduino @ ^1.3.6
 
 # ------------------------- COMMON ESP82xx DEFINITIONS -----------------
 [env_common_esp82xx]
@@ -66,7 +67,7 @@ extra_scripts =
 	${env.extra_scripts}
 	pre:python/build_html.py
 lib_deps =
-	ottowinter/ESPAsyncWebServer-esphome @ ^1.3.0
+	ottowinter/ESPAsyncWebServer-esphome @ ^2.1.0
 upload_speed = 460800
 monitor_speed = 420000
 monitor_filters = esp8266_exception_decoder


### PR DESCRIPTION
ESPAsyncWebServer-esphome did trigger the warning:

```warning: 'SPIFFS' is deprecated: SPIFFS has been deprecated. Please consider moving to LittleFS or other filesystems.``` 

That is solved with a newer version.

ESP32-BLE-Gamepad pulls in NimBLE-Arduino without version constraint. To limit the version I added it to the lib_deps