### PR TITLE
GPIO_PIN_RST must not be UNDEF_PIN if used

### DIFF
--- a/src/lib/SX127xDriver/SX127xHal.cpp
+++ b/src/lib/SX127xDriver/SX127xHal.cpp
@@ -69,11 +69,11 @@ void SX127xHal::init()
 
   digitalWrite(GPIO_PIN_NSS, HIGH);
 
-#if defined(GPIO_PIN_RST)
+#if defined(GPIO_PIN_RST) && (GPIO_PIN_RST != UNDEF_PIN)
   pinMode(GPIO_PIN_RST, OUTPUT);
 
   delay(100);
-  digitalWrite(GPIO_PIN_RST, 0);
+  digitalWrite(GPIO_PIN_RST, LOW);
   delay(100);
   pinMode(GPIO_PIN_RST, INPUT); // leave floating
 #endif

--- a/src/lib/SX1280Driver/SX1280_hal.cpp
+++ b/src/lib/SX1280Driver/SX1280_hal.cpp
@@ -114,9 +114,9 @@ void SX1280Hal::reset(void)
 {
     DBGLN("SX1280 Reset");
 
-#if defined(GPIO_PIN_RST)
+#if defined(GPIO_PIN_RST) && (GPIO_PIN_RST != UNDEF_PIN)
     pinMode(GPIO_PIN_RST, OUTPUT);
-    
+
     delay(50);
     digitalWrite(GPIO_PIN_RST, LOW);
     delay(50);


### PR DESCRIPTION
Following up with makes GPIO_PIN_RST optional for the sx1280/sx127x #1226 and #1220, the code was still executing even when GPIO_PIN_RST wasn't defined for the target. This is because `targets.h` has this:
```
#ifndef GPIO_PIN_RST
#define GPIO_PIN_RST UNDEF_PIN
#endif
```

This PR just completes those 2 PRs so the code is fully compiled out. It was calling digitalXXX with -1 for the pin number, so theoretically it was already not asserting it.