### PR TITLE
Enter WiFi update mode looks bad on 128x64 devices.

### DIFF
--- a/src/lib/LUA/devLUA.cpp
+++ b/src/lib/LUA/devLUA.cpp
@@ -344,7 +344,7 @@ static void registerLuaParameters()
       }
       else if (arg > 0 && arg < 4)
       {
-        sendLuaCommandResponse(&luaWebUpdate, 3, "Enter WiFi Update Mode?");
+        sendLuaCommandResponse(&luaWebUpdate, 3, "Enter WiFi Update?");
       }
       else if (arg == 5)
       {

--- a/src/lib/LUA/devLUA.cpp
+++ b/src/lib/LUA/devLUA.cpp
@@ -339,7 +339,7 @@ static void registerLuaParameters()
         //confirm run on ELRSv2.lua or start command from CRSF configurator,
         //since ELRS LUA can do 2 step confirmation, it needs confirmation to start wifi to prevent stuck on
         //unintentional button press.
-        sendLuaCommandResponse(&luaWebUpdate, 2, "Wifi Running...");
+        sendLuaCommandResponse(&luaWebUpdate, 2, "WiFi Running...");
         connectionState = wifiUpdate;
       }
       else if (arg > 0 && arg < 4)


### PR DESCRIPTION
Current "Enter WiFi Update Mode?" string does not fits on 128x64 displays and leaves part of "o" on screen after switching to "Wifi Running" as seen in https://www.youtube.com/watch?v=BTZUFhBgb8k so maybe truncating it to  "Enter WiFi Update?" will be nicer?

Also "Wifi Running..." is inconsistent with other strings so i renamed it to "WiFi Running..."