### PR TITLE
LUA not updated when changing receiver number in model

### DIFF
--- a/src/lib/CONFIG/config.h
+++ b/src/lib/CONFIG/config.h
@@ -96,7 +96,7 @@ private:
     tx_config_t m_config;
     ELRS_EEPROM *m_eeprom;
     uint8_t     m_modified;
-    model_config_t *m_model;
+    volatile model_config_t *m_model;
     uint8_t     m_modelId;
 #if defined(PLATFORM_ESP32)
     nvs_handle  handle;


### PR DESCRIPTION
# Problem
On an ESP32 based TX module, when changing the receiver number in the model and going back into LUA it looks like it has overwritten the config with the previous config. What has actually happened is that the `m_config` variable in `TxConfig` has been changed in core 0 (the UART handling core) via callbacks to `tx_main` and the LUA device is running in core 1 but the pointer is stale, so it's showing the old data!

# Solution
Put a `volatile` on it!