### PR TITLE
Serial pin checking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,9 +100,9 @@ jobs:
             ;;
         esac
         # All the features
-        PLATFORMIO_BUILD_FLAGS="$REG -DUSE_DIVERSITY" pio run -e ${{ matrix.target }}
+        PLATFORMIO_BUILD_FLAGS="$REG -DUSE_DIVERSITY -DDEBUG_LOG" pio run -e ${{ matrix.target }}
         # Minimal/default features
-        PLATFORMIO_BUILD_FLAGS="$REG !-DUSE_DIVERSITY" pio run -e ${{ matrix.target }}
+        PLATFORMIO_BUILD_FLAGS="$REG" pio run -e ${{ matrix.target }}
         mv .pio/build ~/artifacts/AU_915
 
     - name: Store Artifacts

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -175,7 +175,3 @@ uint32_t uidMacSeedGet(void);
 //Koopman formatting https://users.ece.cmu.edu/~koopman/crc/
 #define ELRS_CRC_POLY 0x07 // 0x83
 #define ELRS_CRC14_POLY 0x2E57 // 0x372B
-
-#ifndef UNUSED
-#define UNUSED(x) (void)(x)
-#endif

--- a/src/include/target/NamimnoRC_FLASH_2400_OLED_TX.h
+++ b/src/include/target/NamimnoRC_FLASH_2400_OLED_TX.h
@@ -36,10 +36,6 @@
 #define GPIO_PIN_RCSIGNAL_TX    13
 #define GPIO_PIN_FAN_EN         2
 
-/* Backpack logger connection */
-#define GPIO_PIN_DEBUG_RX       3
-#define GPIO_PIN_DEBUG_TX       1
-
 /* WS2812 led */
 #define GPIO_PIN_LED_WS2812     4
 

--- a/src/include/target/NamimnoRC_VOYAGER_900_OLED_TX.h
+++ b/src/include/target/NamimnoRC_VOYAGER_900_OLED_TX.h
@@ -34,10 +34,6 @@
 #define GPIO_PIN_RCSIGNAL_TX    13
 #define GPIO_PIN_FAN_EN         2
 
-/* Backpack logger connection */
-#define GPIO_PIN_DEBUG_RX       3
-#define GPIO_PIN_DEBUG_TX       1
-
 /* WS2812 led */
 #define GPIO_PIN_LED_WS2812     4
 

--- a/src/include/targets.h
+++ b/src/include/targets.h
@@ -88,11 +88,32 @@
 #define BACKPACK_LOGGING_BAUD 460800
 #endif
 
+#if defined(TARGET_TX)
+#if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
 #ifndef GPIO_PIN_DEBUG_RX
-#define GPIO_PIN_DEBUG_RX       UNDEF_PIN // use default
+#define GPIO_PIN_DEBUG_RX       3
 #endif
 #ifndef GPIO_PIN_DEBUG_TX
-#define GPIO_PIN_DEBUG_TX       UNDEF_PIN // use default
+#define GPIO_PIN_DEBUG_TX       1
+#endif
+#endif
+#if defined(DEBUG_LOG) || defined(DEBUG_LOG_VERBOSE) || defined(USE_TX_BACKPACK)
+#if GPIO_PIN_RCSIGNAL_TX == GPIO_PIN_DEBUG_TX || GPIO_PIN_RCSIGNAL_TX == GPIO_PIN_DEBUG_RX
+#error "Cannot debug out the RC signal port!"
+#endif
+#if !defined(GPIO_PIN_DEBUG_RX) || !defined(GPIO_PIN_DEBUG_TX) || GPIO_PIN_DEBUG_RX == UNDEF_PIN || GPIO_PIN_DEBUG_TX == UNDEF_PIN
+#error "When using DEBUG_LOG, DEBUG_LOG_VERBOSE or USE_TX_BACKPACK you must define both GPIO_PIN_DEBUG_RX and GPIO_PIN_DEBUG_TX"
+#endif
+#endif
+#else // TARGET_RX
+#if defined(PLATFORM_ESP8266)
+#ifndef GPIO_PIN_DEBUG_RX
+#define GPIO_PIN_DEBUG_RX       3
+#endif
+#ifndef GPIO_PIN_DEBUG_TX
+#define GPIO_PIN_DEBUG_TX       1
+#endif
+#endif
 #endif
 
 #if defined(Regulatory_Domain_ISM_2400)

--- a/src/lib/MSP/msp.h
+++ b/src/lib/MSP/msp.h
@@ -91,7 +91,7 @@ public:
     bool            processReceivedByte(uint8_t c);
     mspPacket_t*    getReceivedPacket();
     void            markPacketReceived();
-    bool            sendPacket(mspPacket_t* packet, Stream* port);
+    static bool     sendPacket(mspPacket_t* packet, Stream* port);
 
 private:
     mspState_e  m_inputState;

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -1,6 +1,7 @@
 #include "common.h"
 #include "POWERMGNT.h"
 #include "DAC.h"
+#include "helpers.h"
 
 /*
  * Moves the power management values and special cases out of the main code and into `targets.h`.

--- a/src/lib/VTX/devVTX.cpp
+++ b/src/lib/VTX/devVTX.cpp
@@ -9,7 +9,6 @@
 
 extern bool ICACHE_RAM_ATTR IsArmed();
 extern CRSF crsf;
-extern MSP msp;
 extern Stream *LoggingBackpack;
 
 static enum VtxSendState_e
@@ -52,7 +51,7 @@ static void VtxConfigToMSPOut()
     }
 
     crsf.AddMspMessage(&packet);
-    msp.sendPacket(&packet, LoggingBackpack); // send to tx-backpack as MSP
+    MSP::sendPacket(&packet, LoggingBackpack); // send to tx-backpack as MSP
 }
 
 static int event()

--- a/src/lib/VTX/devVTX.cpp
+++ b/src/lib/VTX/devVTX.cpp
@@ -10,7 +10,7 @@
 extern bool ICACHE_RAM_ATTR IsArmed();
 extern CRSF crsf;
 extern MSP msp;
-extern HardwareSerial LoggingBackpack;
+extern Stream *LoggingBackpack;
 
 static enum VtxSendState_e
 {
@@ -52,7 +52,7 @@ static void VtxConfigToMSPOut()
     }
 
     crsf.AddMspMessage(&packet);
-    msp.sendPacket(&packet, &LoggingBackpack); // send to tx-backpack as MSP
+    msp.sendPacket(&packet, LoggingBackpack); // send to tx-backpack as MSP
 }
 
 static int event()

--- a/src/lib/helpers/helpers.h
+++ b/src/lib/helpers/helpers.h
@@ -1,3 +1,43 @@
 #pragma once
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
+
+#ifndef UNUSED
+#define UNUSED(x) (void)(x)
+#endif
+
+class NullSerial : public HardwareSerial
+{
+  public:
+    int available(void)
+    {
+        return 0;
+    }
+
+    void flush(void)
+    {
+        return;
+    }
+
+    int peek(void)
+    {
+        return -1;
+    }
+
+    int read(void)
+    {
+        return -1;
+    }
+
+    size_t write(uint8_t u_Data)
+    {
+        UNUSED(u_Data);
+        return 0x01;
+    }
+
+    size_t write(const uint8_t *buffer, size_t size)
+    {
+        UNUSED(buffer);
+        return size;
+    }
+};

--- a/src/lib/helpers/helpers.h
+++ b/src/lib/helpers/helpers.h
@@ -6,7 +6,7 @@
 #define UNUSED(x) (void)(x)
 #endif
 
-class NullSerial : public HardwareSerial
+class NullStream : public Stream
 {
   public:
     int available(void)

--- a/src/lib/logging/logging.h
+++ b/src/lib/logging/logging.h
@@ -22,8 +22,8 @@
 #endif
 
 #if defined(TARGET_TX)
-extern HardwareSerial LoggingBackpack;
-#define LOGGING_UART LoggingBackpack
+extern Stream *LoggingBackpack;
+#define LOGGING_UART (*LoggingBackpack)
 #else
 #define LOGGING_UART Serial
 #endif

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -913,30 +913,26 @@ static void setupTarget()
    * Setup the logging/backpack serial port.
    * This is done here because we need it even if there is no backpack!
    */
-#if defined(PLATFORM_ESP8266)
-  HardwareSerial *serialPort = new HardwareSerial(0);
-#elif defined(GPIO_PIN_DEBUG_TX)
+#if defined(PLATFORM_ESP32) && defined(GPIO_PIN_DEBUG_RX) && GPIO_PIN_DEBUG_RX != UNDEF_PIN && defined(GPIO_PIN_DEBUG_TX) && GPIO_PIN_DEBUG_TX != UNDEF_PIN
   HardwareSerial *serialPort = new HardwareSerial(2);
+  serialPort->begin(BACKPACK_LOGGING_BAUD, SERIAL_8N1, GPIO_PIN_DEBUG_RX, GPIO_PIN_DEBUG_TX);
+#elif defined(PLATFORM_ESP8266) && defined(GPIO_PIN_DEBUG_TX) && GPIO_PIN_DEBUG_TX != UNDEF_PIN
+  HardwareSerial *serialPort = new HardwareSerial(0);
+  serialPort->begin(BACKPACK_LOGGING_BAUD, SERIAL_8N1, SERIAL_TX_ONLY, GPIO_PIN_DEBUG_TX);
+#elif defined(TARGET_TX_FM30)
+  USBSerial *serialPort = new USBSerial;
+  serialPort->begin();
+#elif (defined(GPIO_PIN_DEBUG_RX) && GPIO_PIN_DEBUG_RX != UNDEF_PIN) || (defined(GPIO_PIN_DEBUG_TX) && GPIO_PIN_DEBUG_TX != UNDEF_PIN)
+  HardwareSerial *serialPort = new HardwareSerial(2);
+  #if defined(GPIO_PIN_DEBUG_RX) && GPIO_PIN_DEBUG_RX != UNDEF_PIN
+    serialPort->setRx(GPIO_PIN_DEBUG_RX);
+  #endif
+  #if defined(GPIO_PIN_DEBUG_TX) && GPIO_PIN_DEBUG_TX != UNDEF_PIN
+    serialPort->setTx(GPIO_PIN_DEBUG_TX);
+  #endif
+  serialPort->begin(BACKPACK_LOGGING_BAUD);
 #else
   Stream *serialPort = new NullStream();
-#endif
-
-#if defined(PLATFORM_ESP32)
-#if defined(GPIO_PIN_DEBUG_RX) && GPIO_PIN_DEBUG_RX != UNDEF_PIN && defined(GPIO_PIN_DEBUG_TX) && GPIO_PIN_DEBUG_TX != UNDEF_PIN
-  serialPort->begin(BACKPACK_LOGGING_BAUD, SERIAL_8N1, GPIO_PIN_DEBUG_RX, GPIO_PIN_DEBUG_TX);
-#endif
-#elif defined(PLATFORM_ESP8266)
-#if defined(GPIO_PIN_DEBUG_TX) && GPIO_PIN_DEBUG_TX != UNDEF_PIN
-  serialPort->begin(BACKPACK_LOGGING_BAUD, SERIAL_8N1, SERIAL_TX_ONLY, GPIO_PIN_DEBUG_TX);
-#endif
-#else
-#if defined(GPIO_PIN_DEBUG_RX) && GPIO_PIN_DEBUG_RX != UNDEF_PIN
-  serialPort->setRx(GPIO_PIN_DEBUG_RX);
-#endif
-#if defined(GPIO_PIN_DEBUG_TX) && GPIO_PIN_DEBUG_TX != UNDEF_PIN
-  serialPort->setTx(GPIO_PIN_DEBUG_TX);
-#endif
-  serialPort->begin(BACKPACK_LOGGING_BAUD);
 #endif
   LoggingBackpack = serialPort;
 }

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -880,6 +880,35 @@ void ProcessMSPPacket(mspPacket_t *packet)
   }
 }
 
+static void setupLoggingBackpack()
+{  /*
+   * Setup the logging/backpack serial port.
+   * This is always done because we need a place to send data even if there is no backpack!
+   */
+#if defined(PLATFORM_ESP32) && defined(GPIO_PIN_DEBUG_RX) && GPIO_PIN_DEBUG_RX != UNDEF_PIN && defined(GPIO_PIN_DEBUG_TX) && GPIO_PIN_DEBUG_TX != UNDEF_PIN
+  HardwareSerial *serialPort = new HardwareSerial(2);
+  serialPort->begin(BACKPACK_LOGGING_BAUD, SERIAL_8N1, GPIO_PIN_DEBUG_RX, GPIO_PIN_DEBUG_TX);
+#elif defined(PLATFORM_ESP8266) && defined(GPIO_PIN_DEBUG_TX) && GPIO_PIN_DEBUG_TX != UNDEF_PIN
+  HardwareSerial *serialPort = new HardwareSerial(0);
+  serialPort->begin(BACKPACK_LOGGING_BAUD, SERIAL_8N1, SERIAL_TX_ONLY, GPIO_PIN_DEBUG_TX);
+#elif defined(TARGET_TX_FM30)
+  USBSerial *serialPort = &SerialUSB; // No way to disable creating SerialUSB global, so use it
+  serialPort->begin();
+#elif (defined(GPIO_PIN_DEBUG_RX) && GPIO_PIN_DEBUG_RX != UNDEF_PIN) || (defined(GPIO_PIN_DEBUG_TX) && GPIO_PIN_DEBUG_TX != UNDEF_PIN)
+  HardwareSerial *serialPort = new HardwareSerial(2);
+  #if defined(GPIO_PIN_DEBUG_RX) && GPIO_PIN_DEBUG_RX != UNDEF_PIN
+    serialPort->setRx(GPIO_PIN_DEBUG_RX);
+  #endif
+  #if defined(GPIO_PIN_DEBUG_TX) && GPIO_PIN_DEBUG_TX != UNDEF_PIN
+    serialPort->setTx(GPIO_PIN_DEBUG_TX);
+  #endif
+  serialPort->begin(BACKPACK_LOGGING_BAUD);
+#else
+  Stream *serialPort = new NullStream();
+#endif
+  LoggingBackpack = serialPort;
+}
+
 /**
  * Target-specific initialization code called early in setup()
  * Setup GPIOs or other hardware, config not yet loaded
@@ -909,32 +938,7 @@ static void setupTarget()
   Wire.begin(GPIO_PIN_SDA, GPIO_PIN_SCL);
 #endif
 
-  /*
-   * Setup the logging/backpack serial port.
-   * This is done here because we need it even if there is no backpack!
-   */
-#if defined(PLATFORM_ESP32) && defined(GPIO_PIN_DEBUG_RX) && GPIO_PIN_DEBUG_RX != UNDEF_PIN && defined(GPIO_PIN_DEBUG_TX) && GPIO_PIN_DEBUG_TX != UNDEF_PIN
-  HardwareSerial *serialPort = new HardwareSerial(2);
-  serialPort->begin(BACKPACK_LOGGING_BAUD, SERIAL_8N1, GPIO_PIN_DEBUG_RX, GPIO_PIN_DEBUG_TX);
-#elif defined(PLATFORM_ESP8266) && defined(GPIO_PIN_DEBUG_TX) && GPIO_PIN_DEBUG_TX != UNDEF_PIN
-  HardwareSerial *serialPort = new HardwareSerial(0);
-  serialPort->begin(BACKPACK_LOGGING_BAUD, SERIAL_8N1, SERIAL_TX_ONLY, GPIO_PIN_DEBUG_TX);
-#elif defined(TARGET_TX_FM30)
-  USBSerial *serialPort = new USBSerial;
-  serialPort->begin();
-#elif (defined(GPIO_PIN_DEBUG_RX) && GPIO_PIN_DEBUG_RX != UNDEF_PIN) || (defined(GPIO_PIN_DEBUG_TX) && GPIO_PIN_DEBUG_TX != UNDEF_PIN)
-  HardwareSerial *serialPort = new HardwareSerial(2);
-  #if defined(GPIO_PIN_DEBUG_RX) && GPIO_PIN_DEBUG_RX != UNDEF_PIN
-    serialPort->setRx(GPIO_PIN_DEBUG_RX);
-  #endif
-  #if defined(GPIO_PIN_DEBUG_TX) && GPIO_PIN_DEBUG_TX != UNDEF_PIN
-    serialPort->setTx(GPIO_PIN_DEBUG_TX);
-  #endif
-  serialPort->begin(BACKPACK_LOGGING_BAUD);
-#else
-  Stream *serialPort = new NullStream();
-#endif
-  LoggingBackpack = serialPort;
+  setupLoggingBackpack();
 }
 
 void setup()

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -54,7 +54,13 @@ POWERMGNT POWERMGNT;
 MSP msp;
 ELRS_EEPROM eeprom;
 TxConfig config;
+#if defined(PLATFORM_ESP8266)
+HardwareSerial LoggingBackpack(0);
+#elif defined(GPIO_PIN_DEBUG_TX)
 HardwareSerial LoggingBackpack(2);
+#else
+HardwareSerial LoggingBackpack = NullSerial();
+#endif
 
 volatile uint8_t NonceTX;
 
@@ -912,9 +918,15 @@ static void setupTarget()
   /*
    * Setup the logging/backpack serial port.
    * This is done here because we need it even if there is no backpack!
-   */ 
+   */
 #if defined(PLATFORM_ESP32)
+#if defined(GPIO_PIN_DEBUG_RX) && GPIO_PIN_DEBUG_RX != UNDEF_PIN && defined(GPIO_PIN_DEBUG_TX) && GPIO_PIN_DEBUG_TX != UNDEF_PIN
   LoggingBackpack.begin(BACKPACK_LOGGING_BAUD, SERIAL_8N1, GPIO_PIN_DEBUG_RX, GPIO_PIN_DEBUG_TX);
+#endif
+#elif defined(PLATFORM_ESP8266)
+#if defined(GPIO_PIN_DEBUG_TX) && GPIO_PIN_DEBUG_TX != UNDEF_PIN
+  LoggingBackpack.begin(BACKPACK_LOGGING_BAUD, SERIAL_8N1, SERIAL_TX_ONLY, GPIO_PIN_DEBUG_TX);
+#endif
 #else
 #if defined(GPIO_PIN_DEBUG_RX) && GPIO_PIN_DEBUG_RX != UNDEF_PIN
   LoggingBackpack.setRx(GPIO_PIN_DEBUG_RX);

--- a/src/targets/Jumper_2400.ini
+++ b/src/targets/Jumper_2400.ini
@@ -11,7 +11,6 @@ build_flags =
 	${common_env_data.build_flags_tx}
 	${radio_2400.build_flags}
 	-include target/Jumper_AION_2400_T-Pro_TX.h
-	-DNO_GLOBAL_SERIAL
 	-D VTABLES_IN_FLASH=1
 	-O2
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -40,6 +40,7 @@ build_flags =
 	-D PLATFORM_ESP32=1
 	-D CONFIG_TCPIP_LWIP=1
 	-D BEARSSL_SSL_BASIC
+	-D NO_GLOBAL_SERIAL
 	-I ${PROJECTSRC_DIR}/hal
 src_filter = ${common_env_data.src_filter} -<ESP8266*.*> -<STM32*.*>
 lib_deps =

--- a/src/targets/diy_2400.ini
+++ b/src/targets/diy_2400.ini
@@ -70,7 +70,6 @@ build_flags =
 	${common_env_data.build_flags_tx}
 	${radio_2400.build_flags}
 	-include target/DIY_2400_TX_DUPLETX_TX.h
-	-DNO_GLOBAL_SERIAL
 	-D VTABLES_IN_FLASH=1
 	-O2
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>

--- a/src/test/stubborn_native/test_stubborn.cpp
+++ b/src/test/stubborn_native/test_stubborn.cpp
@@ -5,6 +5,7 @@
 #include <unity.h>
 #include <iostream>
 #include <bitset>
+#include "targets.h"
 #include "helpers.h"
 
 StubbornSender sender(ELRS_TELEMETRY_MAX_PACKAGES);


### PR DESCRIPTION
# Problem
My AION Nano was failing with the latest code.
It seems that using `HardwareSerial LoggingBackpack(2);` is a problem with the default UART0 pins if we've not also defined `NO_GLOBAL_SERIAL` in the PICO-D4!

# Symptom
When flashed my AION Nano looked completely dead, no lights, OLED and even nothing on the serial other than the standard ESP boot message.

# Solution
- Always define `NO_GLOBAL_SERIAL` on ESP32 devices, so we have to be explicit in the pins we use
- Add some extra checks to ensure we do not have conflicts or try to use features that are not supported because of undefined pins