### PR TITLE
Improve rom bootloader upload reliability

### DIFF
--- a/src/python/BFinitPassthrough.py
+++ b/src/python/BFinitPassthrough.py
@@ -128,7 +128,7 @@ def reset_to_bootloader(args):
         dbg_print("  * Using full duplex (CRSF)")
         #this is the training sequ for the ROM bootloader, we send it here so it doesn't auto-neg to the wrong baudrate by the BootloaderInitSeq that we send to reset ELRS
         rl.write(b'\x07\x07\x12\x20' + 32 * b'\x55')
-        time.sleep(0.5)
+        time.sleep(0.2)
     rl.write(BootloaderInitSeq)
     s.flush()
     rx_target = rl.read_line().strip()

--- a/src/python/BFinitPassthrough.py
+++ b/src/python/BFinitPassthrough.py
@@ -126,12 +126,10 @@ def reset_to_bootloader(args):
     else:
         BootloaderInitSeq = bootloader.get_init_seq('CRSF', args.type)
         dbg_print("  * Using full duplex (CRSF)")
-    #this is the training sequ for the ROM bootloader, we send it here so it doesn't auto-neg to the wrong baudrate by the BootloaderInitSeq that we send to reset ELRS
-    rl.write(b'\x07\x07\x12\x20' + 32 * b'\x55')
-    time.sleep(0.5)
+        #this is the training sequ for the ROM bootloader, we send it here so it doesn't auto-neg to the wrong baudrate by the BootloaderInitSeq that we send to reset ELRS
+        rl.write(b'\x07\x07\x12\x20' + 32 * b'\x55')
+        time.sleep(0.5)
     rl.write(BootloaderInitSeq)
-    time.sleep(0.5)
-    rl.write(b'\x07\x07\x12\x20' + 32 * b'\x55')
     s.flush()
     rx_target = rl.read_line().strip()
     flash_target = re.sub("_VIA_.*", "", args.target.upper())

--- a/src/python/BFinitPassthrough.py
+++ b/src/python/BFinitPassthrough.py
@@ -126,7 +126,12 @@ def reset_to_bootloader(args):
     else:
         BootloaderInitSeq = bootloader.get_init_seq('CRSF', args.type)
         dbg_print("  * Using full duplex (CRSF)")
+    #this is the training sequ for the ROM bootloader, we send it here so it doesn't auto-neg to the wrong baudrate by the BootloaderInitSeq that we send to reset ELRS
+    rl.write(b'\x07\x07\x12\x20' + 32 * b'\x55')
+    time.sleep(0.5)
     rl.write(BootloaderInitSeq)
+    time.sleep(0.5)
+    rl.write(b'\x07\x07\x12\x20' + 32 * b'\x55')
     s.flush()
     rx_target = rl.read_line().strip()
     flash_target = re.sub("_VIA_.*", "", args.target.upper())

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -73,7 +73,7 @@ monitor_filters = esp8266_exception_decoder
 upload_resetmethod = nodemcu
 bf_upload_command =
 	python "$PROJECT_DIR/python/BFinitPassthrough.py" -b $UPLOAD_SPEED ${UPLOAD_PORT and "-p "+UPLOAD_PORT} -r $PIOENV
-	python "$PROJECT_DIR/python/esptool-3.0/esptool.py" -b $UPLOAD_SPEED ${UPLOAD_PORT and "-p "+UPLOAD_PORT} -c esp8266 --before no_reset --after soft_reset write_flash 0x0000 "$SOURCE" 
+	python "$PROJECT_DIR/python/esptool-3.0/esptool.py" -b $UPLOAD_SPEED ${UPLOAD_PORT and "-p "+UPLOAD_PORT} -c esp8266 --before no_reset --after soft_reset write_flash 0x0000 "$SOURCE"
 
 # ------------------------- COMMON STM32 DEFINITIONS -----------------
 [env_common_stm32]

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -73,7 +73,8 @@ monitor_filters = esp8266_exception_decoder
 upload_resetmethod = nodemcu
 bf_upload_command =
 	python "$PROJECT_DIR/python/BFinitPassthrough.py" -b $UPLOAD_SPEED ${UPLOAD_PORT and "-p "+UPLOAD_PORT} -r $PIOENV
-	python "$PROJECT_DIR/python/esptool-3.0/esptool.py" -b $UPLOAD_SPEED ${UPLOAD_PORT and "-p "+UPLOAD_PORT} -c esp8266 --before no_reset --after soft_reset write_flash 0x0000 "$SOURCE"
+	python "$PROJECT_DIR/python/esptool-3.0/esptool.py" -b $UPLOAD_SPEED ${UPLOAD_PORT and "-p "+UPLOAD_PORT} -c esp8266 --before no_reset erase_flash 
+	python "$PROJECT_DIR/python/esptool-3.0/esptool.py" -b $UPLOAD_SPEED ${UPLOAD_PORT and "-p "+UPLOAD_PORT} -c esp8266 --before no_reset_no_sync --after soft_reset write_flash 0x0000 "$SOURCE" 
 
 # ------------------------- COMMON STM32 DEFINITIONS -----------------
 [env_common_stm32]

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -73,8 +73,7 @@ monitor_filters = esp8266_exception_decoder
 upload_resetmethod = nodemcu
 bf_upload_command =
 	python "$PROJECT_DIR/python/BFinitPassthrough.py" -b $UPLOAD_SPEED ${UPLOAD_PORT and "-p "+UPLOAD_PORT} -r $PIOENV
-	python "$PROJECT_DIR/python/esptool-3.0/esptool.py" -b $UPLOAD_SPEED ${UPLOAD_PORT and "-p "+UPLOAD_PORT} -c esp8266 --before no_reset erase_flash 
-	python "$PROJECT_DIR/python/esptool-3.0/esptool.py" -b $UPLOAD_SPEED ${UPLOAD_PORT and "-p "+UPLOAD_PORT} -c esp8266 --before no_reset_no_sync --after soft_reset write_flash 0x0000 "$SOURCE" 
+	python "$PROJECT_DIR/python/esptool-3.0/esptool.py" -b $UPLOAD_SPEED ${UPLOAD_PORT and "-p "+UPLOAD_PORT} -c esp8266 --before no_reset --after soft_reset write_flash 0x0000 "$SOURCE" 
 
 # ------------------------- COMMON STM32 DEFINITIONS -----------------
 [env_common_stm32]


### PR DESCRIPTION
I was having issues with flashing my RXs in 'recovery mode' IE, holding the boot button, applying power then flashing via _BetaflightPassthrough. 

Interestingly it worked fine when I would lower the baud rate to 115200, or if I allowed the RX to do the 'hot reboot' where we trigger the reboot from ELRS. I think I tracked down the issue to the rl.write(BootloaderInitSeq) command in the python upload script. When we're in recovery flashing mode this is the first signal the ROM bootloader sees, it tries to lock-on and infer the baud rate from this sequence but gets it horribly wrong!

I found that if I sandwich that command with the real training sequence from esptool.py (b'\x07\x07\x12\x20' + 32 * b'\x55') it now works almost 100% of the time (I still occasionally get the 0x80 command error which is resolved by another attempt).

I tested about a dozen times from recovery mode as well as the normal 'hot reboot' and it seems to work well now.