### PR TITLE
update zorro output power calibration

### DIFF
--- a/src/include/target/DIY_2400_TX_DUPLETX_TX.h
+++ b/src/include/target/DIY_2400_TX_DUPLETX_TX.h
@@ -6,8 +6,8 @@
 #define USE_TX_BACKPACK
 #define USE_SX1280_DCDC
 #define USE_SKY85321
-#define SKY85321_PDET_SLOPE     0.032
-#define SKY85321_PDET_INTERCEPT 1.5
+#define SKY85321_PDET_SLOPE     0.035
+#define SKY85321_PDET_INTERCEPT 2.4
 
 // GPIO pin definitions
 #define GPIO_PIN_NSS            5


### PR DESCRIPTION
The SKY85321 RF amp allows for feedback of the output power via the Pdet (Power Detect) pin.  Pdet (mV) can be calibrated and used to monitor and adjust the output power.  Power output can now be measured real time and corrected.

![image](https://user-images.githubusercontent.com/14170229/151275544-f0e23e1e-e1c1-435d-b679-4512486d183f.png)
