### PR TITLE
Prevent dynamic power incrementing on first TX connection

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -152,7 +152,7 @@ device_affinity_t ui_devices[] = {
 #define DYNAMIC_POWER_MOVING_AVG_K         8 // Number of previous values for calculating moving average. Best with power of 2.
 static int32_t dynamic_power_rssi_sum;
 static int32_t dynamic_power_rssi_n;
-static int32_t dynamic_power_avg_lq;
+static int32_t dynamic_power_avg_lq = DYNPOWER_THRESH_LQ_DN << 16;
 static bool dynamic_power_updated;
 
 #ifdef TARGET_TX_GHOST
@@ -224,6 +224,7 @@ void DynamicPower_Update()
   dynamic_power_rssi_sum += rssi;
   dynamic_power_rssi_n++;
 
+  //DBGLN("LQ=%d LQA=%d RSSI=%d", lq_current, lq_avg, rssi);
   // Dynamic power needs at least DYNAMIC_POWER_MIN_RECORD_NUM amount of telemetry records to update.
   if(dynamic_power_rssi_n < DYNAMIC_POWER_MIN_RECORD_NUM)
     return;


### PR DESCRIPTION
Initializes the dynamic power average LQ variable on the TX to prevent an artificial handful of power increases on the first connection after power up.

### Details
Referenced in the discussion on #1309, on the first connection after power up, dynamic power increments several times from minimum despite high LQ from the RX.
```
got downlink conn
LQ=100 LQA=0 RSSI=-14
LQ=100 LQA=12 RSSI=-13
LQ=100 LQA=23 RSSI=-13
LQ=100 LQA=33 RSSI=-13
Power increase
SetPower: 7
LQ=100 LQA=48 RSSI=-12
LQ=100 LQA=55 RSSI=-12
LQ=100 LQA=60 RSSI=-12
LQ=100 LQA=65 RSSI=-12
LQ=100 LQA=69 RSSI=-12
Power increase
SetPower: 11
LQ=100 LQA=73 RSSI=-12
LQ=100 LQA=76 RSSI=-12
LQ=100 LQA=79 RSSI=-11
LQ=100 LQA=82 RSSI=-11
LQ=100 LQA=84 RSSI=-11
Power increase
SetPower: 17
```

This is because the LQ average starts at 0 on power up and takes a while before it approaches the actual incoming LQ. This PR just initializes the avg LQ to the highwater mark `DYNPOWER_THRESH_LQ_DN`. I considered setting it to 100, but if we're going to use 4 bytes of flash to store an initialized value, might as well make it an optimistic guess instead of 🎖 the best?
