### PR TITLE
volatile not needed on TX model_config_t

### DIFF
--- a/src/lib/CONFIG/config.h
+++ b/src/lib/CONFIG/config.h
@@ -96,7 +96,7 @@ private:
     tx_config_t m_config;
     ELRS_EEPROM *m_eeprom;
     uint8_t     m_modified;
-    volatile model_config_t *m_model;
+    model_config_t *m_model;
     uint8_t     m_modelId;
 #if defined(PLATFORM_ESP32)
     nvs_handle  handle;


### PR DESCRIPTION
Reverts #1327. See the discussion in the dev thread "Lua model id volatile", but 
* This is not needed, The problem pkendall64 was experiencing was actually the internal module not getting modelid updates [EdgeTX#1508](https://github.com/EdgeTX/edgetx/pull/1508)
* It is actually applying the volatile keyword incorrectly anyway. This code generates a pointer to volatile data when it intended to generate a volatile pointer to data. :)

This shaves ~200 bytes back off the ESP32 binaries since the compiler doesn't have to generate `memw` instructions and re-fetch the members between each access.