### PR TITLE
Add Backpack to betafpv 1W, and device_name

### DIFF
--- a/src/include/target/BETAFPV_2400_TX_MICRO.h
+++ b/src/include/target/BETAFPV_2400_TX_MICRO.h
@@ -1,5 +1,9 @@
 #ifndef DEVICE_NAME
-#define DEVICE_NAME              "BETAFPV 2G4Micro"
+#ifdef BETAFPV_MICRO_1000MW
+#define DEVICE_NAME              "BFPV 2G4Micro1W"
+#else
+#define DEVICE_NAME              "BETAFPV2G4Micro"
+#endif
 #endif
 
 // Any device features
@@ -37,6 +41,8 @@
     #define MinPower PWR_25mW
     #define MaxPower PWR_1000mW
     #define POWER_OUTPUT_VALUES {-18,-15,-12,-7,-4,2}
+    // Backpack on standard pins 1/3
+    #define USE_TX_BACKPACK
 #else
     #define MinPower PWR_10mW
     #define MaxPower PWR_500mW

--- a/src/include/target/BETAFPV_2400_TX_MICRO.h
+++ b/src/include/target/BETAFPV_2400_TX_MICRO.h
@@ -7,6 +7,7 @@
 #endif
 
 // Any device features
+#define USE_TX_BACKPACK
 #define USE_OLED_I2C
 #define OLED_REVERSED
 #define HAS_FIVE_WAY_BUTTON
@@ -41,8 +42,6 @@
     #define MinPower PWR_25mW
     #define MaxPower PWR_1000mW
     #define POWER_OUTPUT_VALUES {-18,-15,-12,-7,-4,2}
-    // Backpack on standard pins 1/3
-    #define USE_TX_BACKPACK
 #else
     #define MinPower PWR_10mW
     #define MaxPower PWR_500mW


### PR DESCRIPTION
The BetaFPV 1000mW target has a backpack but it is not included in the target definition.

* Added USE_TX_BACKPACK
* Added DEVICE_NAME "BFPV 2G4Micro1W" (15 chars)
* Shorten DEVICE_NAME "BETAFPV 2G4Micro" to "BETAFPV2G4Micro" (16 to 15 chars)