### PR TITLE
Fix OLED power updates when using LUA

### DIFF
--- a/src/lib/SCREEN/OLED/oledscreen.cpp
+++ b/src/lib/SCREEN/OLED/oledscreen.cpp
@@ -428,6 +428,9 @@ void OLEDScreen::doSmartFanValueSelect(int action)
 void OLEDScreen::doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t ratio_index, uint8_t motion_index, uint8_t fan_index, bool dynamic, uint8_t running_power_index)
 {
 
+    current_power_index = power_index;
+    current_powersaving_index = motion_index;
+    current_smartfan_index = fan_index;
     if(current_screen_status == SCREEN_STATUS_IDLE)
     {
         if(rate_index != current_rate_index)
@@ -456,10 +459,6 @@ void OLEDScreen::doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t 
         current_rate_index = rate_index;
         current_ratio_index = ratio_index;
     }
-
-    current_power_index = power_index;
-    current_powersaving_index = motion_index;
-    current_smartfan_index = fan_index;
 }
 
 void OLEDScreen::doTemperatureUpdate(uint8_t temperature)

--- a/src/lib/SCREEN/TFT/tftscreen.cpp
+++ b/src/lib/SCREEN/TFT/tftscreen.cpp
@@ -288,6 +288,9 @@ void TFTScreen::doSmartFanValueSelect(int action)
 
 void TFTScreen::doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t ratio_index, uint8_t motion_index, uint8_t fan_index, bool dynamic, uint8_t running_power_index)
 {
+    current_power_index = power_index;
+    current_powersaving_index = motion_index;
+    current_smartfan_index = fan_index;
     if (current_screen_status == SCREEN_STATUS_IDLE)
     {
         if(rate_index != current_rate_index)
@@ -324,10 +327,6 @@ void TFTScreen::doParamUpdate(uint8_t rate_index, uint8_t power_index, uint8_t r
         current_rate_index = rate_index;
         current_ratio_index = ratio_index;
     }
-
-    current_power_index = power_index;
-    current_powersaving_index = motion_index;
-    current_smartfan_index = fan_index;
 }
 
 void TFTScreen::doTemperatureUpdate(uint8_t temperature)


### PR DESCRIPTION
The OLED/TFT was not being updated with the new power setting when dynamic power was off and the value changed in the LUA script.

Partially fixes #1356, not sure about the BLE part so I've asked for feedback. Once I get feedback, if there is an issue then I'll do another PR for that part.