### PR TITLE
HTTP upload result without JSON and uploadforce

### DIFF
--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -356,6 +356,7 @@ static void WebUploadResponseHandler(AsyncWebServerRequest *request) {
 }
 
 static void WebUploadDataHandler(AsyncWebServerRequest *request, const String& filename, size_t index, uint8_t *data, size_t len, bool final) {
+  force_update = force_update || request->hasArg("force");
   if (index == 0) {
     DBGLN("Update: %s", filename.c_str());
     #if defined(PLATFORM_ESP8266)

--- a/src/python/BFinitPassthrough.py
+++ b/src/python/BFinitPassthrough.py
@@ -133,8 +133,11 @@ def reset_to_bootloader(args):
     s.flush()
     rx_target = rl.read_line().strip()
     flash_target = re.sub("_VIA_.*", "", args.target.upper())
+    ignore_incorrect_target = args.action == "uploadforce"
     if rx_target == "":
         dbg_print("Cannot detect RX target, blindly flashing!")
+    elif ignore_incorrect_target:
+        dbg_print(f"Force flashing {flash_target}, detected {rx_target}")
     elif rx_target != flash_target:
         if query_yes_no("\n\n\nWrong target selected! your RX is '%s', trying to flash '%s', continue? Y/N\n" % (rx_target, flash_target)):
             dbg_print("Ok, flashing anyway!")
@@ -161,6 +164,9 @@ if __name__ == '__main__':
         dest="half_duplex", help="Use half duplex mode")
     parser.add_argument("-t", "--type", type=str, default="ESP82",
         help="Defines flash target type which is sent to target in reboot command")
+    parser.add_argument("-a", "--action", type=str, default="upload",
+        help="Upload action: upload (default), or uploadforce to flash even on target mismatch")
+
     args = parser.parse_args()
 
     if (args.port == None):

--- a/src/python/UARTupload.py
+++ b/src/python/UARTupload.py
@@ -18,6 +18,7 @@ def dbg_print(line=''):
     print(line, flush=True)
     return
 
+
 def uart_upload(port, filename, baudrate, ghst=False, ignore_incorrect_target=False, key=None, target="") -> int:
     SCRIPT_DEBUG = False
     half_duplex = False
@@ -211,6 +212,7 @@ def uart_upload(port, filename, baudrate, ghst=False, ignore_incorrect_target=Fa
     dbg_print("[FAILED] Upload failed!\n\n")
     return ElrsUploadResult.ErrorGeneral
 
+
 def on_upload(source, target, env):
     envkey = None
     ghst = False
@@ -239,6 +241,7 @@ def on_upload(source, target, env):
         dbg_print("{0}\n".format(e))
         return ElrsUploadResult.ErrorGeneral
     return returncode
+
 
 if __name__ == '__main__':
     filename = 'firmware.bin'

--- a/src/python/UARTupload.py
+++ b/src/python/UARTupload.py
@@ -21,7 +21,7 @@ def dbg_print(line=''):
     return
 
 
-def uart_upload(port, filename, baudrate, ghst=False, key=None, target=""):
+def uart_upload(port, filename, baudrate, ghst=False, ignore_incorrect_target=False, key=None, target=""):
     half_duplex = False
 
     dbg_print("=================== FIRMWARE UPLOAD ===================\n")
@@ -76,7 +76,6 @@ def uart_upload(port, filename, baudrate, ghst=False, key=None, target=""):
         gotBootloader = 'CCC' in rl.read_line()
 
         # Init bootloader
-        ignore_incorrect_target = False
         if not gotBootloader:
             # legacy bootloader requires a 500ms delay
             delay_seq2 = .5
@@ -218,6 +217,7 @@ def on_upload(source, target, env):
     envkey = None
     ghst = False
     firmware_path = str(source[0])
+    upload_force = target[0].name == 'uploadforce' # 'in' operator doesn't work on Alias list
 
     upload_port = env.get('UPLOAD_PORT', None)
     if upload_port is None:
@@ -236,7 +236,7 @@ def on_upload(source, target, env):
                 envkey = flag.split("=")[1]
 
     try:
-        uart_upload(upload_port, firmware_path, upload_speed, ghst, key=envkey, target=env['PIOENV'])
+        uart_upload(upload_port, firmware_path, upload_speed, ghst, upload_force, key=envkey, target=env['PIOENV'])
     except Exception as e:
         dbg_print("{0}\n".format(e))
         return -1

--- a/src/python/UARTupload.py
+++ b/src/python/UARTupload.py
@@ -10,18 +10,16 @@ import SerialHelper
 import re
 import bootloader
 from query_yes_no import query_yes_no
+from elrs_helpers import ElrsUploadResult
 
-SCRIPT_DEBUG = 0
 BAUDRATE_DEFAULT = 420000
 
-
 def dbg_print(line=''):
-    sys.stdout.write(line)
-    sys.stdout.flush()
+    print(line, flush=True)
     return
 
-
-def uart_upload(port, filename, baudrate, ghst=False, ignore_incorrect_target=False, key=None, target=""):
+def uart_upload(port, filename, baudrate, ghst=False, ignore_incorrect_target=False, key=None, target="") -> int:
+    SCRIPT_DEBUG = False
     half_duplex = False
 
     dbg_print("=================== FIRMWARE UPLOAD ===================\n")
@@ -42,7 +40,7 @@ def uart_upload(port, filename, baudrate, ghst=False, ignore_incorrect_target=Fa
     if not os.path.exists(filename):
         msg = "[FAILED] file '%s' does not exist\n" % filename
         dbg_print(msg)
-        raise Exception(msg)
+        return ElrsUploadResult.ErrorGeneral
 
     s = serial.Serial(port=port, baudrate=baudrate,
         bytesize=8, parity='N', stopbits=1,
@@ -91,11 +89,10 @@ def uart_upload(port, filename, baudrate, ghst=False, ignore_incorrect_target=Fa
                 if 10 < currAttempt:
                     msg = "[FAILED] to get to BL in reasonable time\n"
                     dbg_print(msg)
-                    raise Exception(msg)
+                    return ElrsUploadResult.ErrorGeneral
 
                 if 5 < currAttempt:
                     # Enable debug logs after 5 retries
-                    global SCRIPT_DEBUG
                     SCRIPT_DEBUG = True
 
                 dbg_print("[%1u] retry...\n" % currAttempt)
@@ -147,7 +144,8 @@ def uart_upload(port, filename, baudrate, ghst=False, ignore_incorrect_target=Fa
                                 ignore_incorrect_target = True
                                 continue
                             else:
-                                raise Exception("Wrong target selected your RX is '%s', trying to flash '%s'" % (line, flash_target))
+                                dbg_print("Wrong target selected your RX is '%s', trying to flash '%s'" % (line, flash_target))
+                                return ElrsUploadResult.ErrorMismatch
                         elif flash_target != "":
                             dbg_print("Verified RX target '%s'" % flash_target)
 
@@ -159,7 +157,7 @@ def uart_upload(port, filename, baudrate, ghst=False, ignore_incorrect_target=Fa
             if "CCC" not in rl.read_line(15.):
                 msg = "[FAILED] Unable to communicate with bootloader...\n"
                 dbg_print(msg)
-                raise Exception(msg)
+                return ElrsUploadResult.ErrorGeneral
             dbg_print(" sync OK\n")
         else:
             dbg_print("\nWe were already in bootloader\n")
@@ -208,10 +206,10 @@ def uart_upload(port, filename, baudrate, ghst=False, ignore_incorrect_target=Fa
 
     if (status):
         dbg_print("Success!!!!\n\n")
-    else:
-        dbg_print("[FAILED] Upload failed!\n\n")
-        raise Exception('Failed to Upload')
+        return ElrsUploadResult.Success
 
+    dbg_print("[FAILED] Upload failed!\n\n")
+    return ElrsUploadResult.ErrorGeneral
 
 def on_upload(source, target, env):
     envkey = None
@@ -236,12 +234,11 @@ def on_upload(source, target, env):
                 envkey = flag.split("=")[1]
 
     try:
-        uart_upload(upload_port, firmware_path, upload_speed, ghst, upload_force, key=envkey, target=env['PIOENV'])
+        returncode = uart_upload(upload_port, firmware_path, upload_speed, ghst, upload_force, key=envkey, target=env['PIOENV'])
     except Exception as e:
         dbg_print("{0}\n".format(e))
-        return -1
-    return 0
-
+        return ElrsUploadResult.ErrorGeneral
+    return returncode
 
 if __name__ == '__main__':
     filename = 'firmware.bin'
@@ -259,4 +256,5 @@ if __name__ == '__main__':
     if 3 < len(sys.argv):
         baudrate = sys.argv[3]
 
-    uart_upload(port, filename, baudrate)
+    returncode = uart_upload(port, filename, baudrate)
+    exit(returncode)

--- a/src/python/build_env_setup.py
+++ b/src/python/build_env_setup.py
@@ -6,6 +6,17 @@ import upload_via_esp8266_backpack
 import esp_compress
 import ETXinitPassthrough
 
+def add_target_uploadoption(name: str, desc: str) -> None:
+    # Add an upload target 'uploadforce' that forces update if target mismatch
+    # This must be called after UPLOADCMD is set
+    env.AddCustomTarget(
+        name=name,
+        dependencies="${BUILD_DIR}/${PROGNAME}.bin",
+        title=name,
+        description=desc,
+        actions=env['UPLOADCMD']
+    )
+
 platform = env.get('PIOPLATFORM', '')
 stm = platform in ['ststm32']
 
@@ -72,7 +83,10 @@ elif platform in ['espressif32']:
         env.AddPreAction("upload", ETXinitPassthrough.init_passthrough)
 
 if "_WIFI" in target_name:
+    add_target_uploadoption("uploadconfirm", "Do not upload, just send confirm")
     if "_TX_" in target_name:
         env.SetDefault(UPLOAD_PORT="elrs_tx.local")
     else:
         env.SetDefault(UPLOAD_PORT="elrs_rx.local")
+
+add_target_uploadoption("uploadforce", "Upload even if target mismatch")

--- a/src/python/build_env_setup.py
+++ b/src/python/build_env_setup.py
@@ -17,6 +17,7 @@ def add_target_uploadoption(name: str, desc: str) -> None:
         actions=env['UPLOADCMD']
     )
 
+
 platform = env.get('PIOPLATFORM', '')
 stm = platform in ['ststm32']
 

--- a/src/python/build_env_setup.py
+++ b/src/python/build_env_setup.py
@@ -89,4 +89,5 @@ if "_WIFI" in target_name:
     else:
         env.SetDefault(UPLOAD_PORT="elrs_rx.local")
 
-add_target_uploadoption("uploadforce", "Upload even if target mismatch")
+if platform != 'native':
+    add_target_uploadoption("uploadforce", "Upload even if target mismatch")

--- a/src/python/elrs_helpers.py
+++ b/src/python/elrs_helpers.py
@@ -2,7 +2,6 @@ import os
 import re
 import subprocess
 
-
 def git_cmd(*args):
     return subprocess.check_output(["git"] + list(args)).decode("utf-8").rstrip('\r\n')
 
@@ -35,3 +34,11 @@ def get_git_version():
             sha = data.split()[1].strip()
 
     return dict(version=ver, sha=sha[:6])
+
+class ElrsUploadResult:
+        # SUCCESS
+        Success = 0
+        # ERROR: Unspecified
+        ErrorGeneral = -1
+        # ERROR: target mismatch
+        ErrorMismatch = -2

--- a/src/python/elrs_helpers.py
+++ b/src/python/elrs_helpers.py
@@ -35,6 +35,7 @@ def get_git_version():
 
     return dict(version=ver, sha=sha[:6])
 
+
 class ElrsUploadResult:
         # SUCCESS
         Success = 0

--- a/src/python/query_yes_no.py
+++ b/src/python/query_yes_no.py
@@ -1,11 +1,15 @@
 import sys
 from inputimeout import inputimeout, TimeoutOccurred
 
-def query_yes_no(question=''): #https://code.activestate.com/recipes/577058/
+def query_yes_no(question='') -> bool: #https://code.activestate.com/recipes/577058/
     """Ask a yes/no question via raw_input() and return their answer.
     "question" is a string that is presented to the user.
     The "answer" return value is True for "yes" or False for "no".
     """
+    # Always return false if not in an interactive shell
+    if not sys.stdin.isatty():
+        return False
+
     valid = {"yes": True, "y": True, "ye": True, "no": False, "n": False}
 
     while True:
@@ -13,8 +17,8 @@ def query_yes_no(question=''): #https://code.activestate.com/recipes/577058/
         try:
             choice = inputimeout(prompt=question, timeout=5)
         except TimeoutOccurred:
-            sys.stdout.write("Please respond with 'yes' or 'no' " "(or 'y' or 'n')")
+            sys.stdout.write("Please respond with 'yes' or 'no' (or 'y' or 'n')")
             sys.stdout.flush()
-	
+
         if choice in valid:
             return valid[choice]

--- a/src/python/upload_via_esp8266_backpack.py
+++ b/src/python/upload_via_esp8266_backpack.py
@@ -1,7 +1,7 @@
 import subprocess, os
 import opentx
 
-def process_http_result(output_json_file: str) -> bool:
+def process_http_result(output_json_file: str) -> int:
     import json
     # Print the HTTP result that was saved to the json file
     # Returns: true if the result was OK
@@ -10,21 +10,22 @@ def process_http_result(output_json_file: str) -> bool:
 
     result = output_json['status']
     msg = output_json['msg']
-    retval = False
 
     if result == 'ok':
         # Update complete. Please wait for LED to resume blinking before disconnecting power.
         msg = f'UPLOAD SUCCESS\n\033[32m{msg}\033[0m'  # green
         # 'ok' is the only acceptable result
-        retval = True
+        retval = 0
     elif result == 'mismatch':
         # <b>Current target:</b> LONG_ASS_NAME.<br><b>Uploaded image:</b> OTHER_NAME.<br/><br/>Flashing the wrong firmware may lock or damage your device.
         msg = msg.replace('<br>', '\n').replace('<br/>', '\n') # convert breaks to newline
         msg = msg.replace('<b>', '\033[34m').replace('</b>', '\033[0m') # bold to blue
         msg = '\033[33mTARGET MISMATCH\033[0m\n' + msg # yellow warning
+        retval = -2
     else:
         # Not enough space.
         msg = f'UPLOAD ERROR\n\033[31m{msg}\033[0m' # red
+        retval = -1
 
     print()
     print(msg, flush=True)
@@ -109,8 +110,8 @@ def on_upload(source, target, env):
 
             # Flash main application binary
             subprocess.check_call(cmd + [addr])
-            success = process_http_result(bin_upload_output)
-            if success:
+            returncode = process_http_result(bin_upload_output)
+            if returncode == 0:
                 # process_http_result should have printed whatever message
                 # the target returned if it was successful
                 return 0

--- a/src/python/upload_via_esp8266_backpack.py
+++ b/src/python/upload_via_esp8266_backpack.py
@@ -2,6 +2,7 @@ import subprocess, os
 import opentx
 from elrs_helpers import ElrsUploadResult
 
+
 def process_http_result(output_json_file: str) -> int:
     import json
     # Print the HTTP result that was saved to the json file
@@ -31,6 +32,7 @@ def process_http_result(output_json_file: str) -> int:
     print()
     print(msg, flush=True)
     return retval
+
 
 def on_upload(source, target, env):
     isstm = env.get('PIOPLATFORM', '') in ['ststm32']

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -74,7 +74,7 @@ monitor_speed = 420000
 monitor_filters = esp8266_exception_decoder
 upload_resetmethod = nodemcu
 bf_upload_command =
-	python "$PROJECT_DIR/python/BFinitPassthrough.py" -b $UPLOAD_SPEED ${UPLOAD_PORT and "-p "+UPLOAD_PORT} -r $PIOENV
+	python "$PROJECT_DIR/python/BFinitPassthrough.py" -b $UPLOAD_SPEED ${UPLOAD_PORT and "-p "+UPLOAD_PORT} -r $PIOENV --action $TARGET
 	python "$PROJECT_DIR/python/esptool-3.0/esptool.py" -b $UPLOAD_SPEED ${UPLOAD_PORT and "-p "+UPLOAD_PORT} -c esp8266 --before no_reset --after soft_reset write_flash 0x0000 "$SOURCE"
 
 # ------------------------- COMMON STM32 DEFINITIONS -----------------


### PR DESCRIPTION
Attempts to standardize the build process return codes, allowing target mismatch to be detected and also upload methods that allow forcing even on target mismatch

Holy smokes this turned into a lot of changes.

## Display HTTP message and pass back result
Change the HTTP upload process to parse the JSON returned from the HTTP upload process, and pass the result back up the chain as an error code. This is so the Configurator can determine the process failed, when the upload succeeds but the target reports an error message.

## New "targets" (PIO commands)
This also adds two new upload types
* `uploadforce`: Force update even if target mismatch is detected. For wifi this sets the `force=1` parameter on the upload. For UART and BFPassthrough, this skips the unskippable y/n confirmation as if the user selected YES
* `uploadconfirm`: Send the upload confirm trigger to a wifi target. This skips the file upload entirely and is much faster, since only the confirm is sent.

Use instead of `upload` as the target such as `pio run --environment DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough -t uploadforce`

## No y/n prompts in Configurator
To prevent endless loops, the target mismatch Y/N prompt is always skipped if not running in an interactive shell (stdin is not a TTY)

## Standardize return codes
Added `ElrsUploadResult` to the python upload process that returns some standard codes across the upload process instead of some throwing exceptions, some returning success when they failed, some returning an error code
* ElrsUploadResult.Success = 0 # Success
* ElrsUploadResult.ErrorGeneral = -1 # General error code
* ElrsUploadResult.ErrorMismatch  = - 2 # Target mismatch

## Original Issue
Reference [Configurator#246](https://github.com/ExpressLRS/ExpressLRS-Configurator/issues/246)

The HTTP upload process only returns an error if the upload fails entirely, not if the target returns an error message at the end, The user sees the message "UPLOAD SUCCESS" even if the target returned "Target Mismatch" or any error like "Not enough space", even though the process never actually completed.
```
100 1149k    0     0  100 1149k      0  59599  0:00:19  0:00:19 --:--:-- 49855
100 1149k  100   206  100 1149k     10  59285  0:00:20  0:00:19  0:00:01 45635
{"status": "mismatch", "msg": "<b>Current target:</b> DIY_2400_TX_ESP32_SX1280_E28.<br><b>Uploaded image:</b> JUMPER_AION_NANO_2400_TX.<br/><br/>Flashing the wrong firmware may lock or damage your device."}
** UPLOAD SUCCESS. Flashing in progress.
** Please wait for LED to resume blinking before disconnecting power
======================== [SUCCESS] Took 125.61 seconds ========================

Environment                        Status    Duration
---------------------------------  --------  ------------
Jumper_AION_NANO_2400_TX_via_WIFI  SUCCESS   00:02:05.614
========================= 1 succeeded in 00:02:05.614 =========================
```

This PR tackles this by parsing the returned JSON object and setting an appropriate return code to indicate success or failure at the application layer and not just the protocol layer. To assist further integrations, the returned json is also saved to a file in the firmware directory, as [firmware name without .bin]-output.json, e.g. `firmware-output.json`. The message displayed to the user is also colored to help aid in quickly identifying if it succeeded.

Success (return code of 0 from the process):
![image](https://user-images.githubusercontent.com/677183/151635020-c7d2785f-da04-4663-aac3-03c7f3240a2a.png)

Error (return code -1 from the process):
![image](https://user-images.githubusercontent.com/677183/151635061-7f523e88-4351-4384-83ca-9b6b4cca4e0a.png)

Mismatch (return code -2 from the process, screenshot is old and shows -1, but -2 is now returned):
![image](https://user-images.githubusercontent.com/677183/151635079-e2f1a471-d952-488d-a5a2-8a175de4fbb7.png)

Or the standard error code returned by curl if there is a failure in the curl system, such as 6 for "Could not resolve host".