### PR TITLE
Send opentx sync packets first

### DIFF
--- a/src/lib/FIFO/FIFO.cpp
+++ b/src/lib/FIFO/FIFO.cpp
@@ -73,6 +73,22 @@ void ICACHE_RAM_ATTR FIFO::pushBytes(const uint8_t *data, uint8_t len)
     numElements += len;
 }
 
+void ICACHE_RAM_ATTR FIFO::pushBytesFront(const uint8_t *data, uint8_t len)
+{
+    if (numElements + len > FIFO_SIZE)
+    {
+        ERRLN("Buffer full, will flush");
+        flush();
+        return;
+    }
+    head -= len;
+    numElements += len;
+    for (int i = 0; i < len; i++)
+    {
+        buffer[(head+i) % FIFO_SIZE] = data[i];
+    }
+}
+
 uint8_t ICACHE_RAM_ATTR FIFO::pop()
 {
     if (numElements == 0)

--- a/src/lib/FIFO/FIFO.h
+++ b/src/lib/FIFO/FIFO.h
@@ -54,6 +54,9 @@ public:
     // Push all bytes to FIFO, if all the bytes will not fit then the FIFO is flushed and no bytes are pushed
     void ICACHE_RAM_ATTR pushBytes(const uint8_t *data, uint8_t len);
 
+    // Push all bytes to the head of the FIFO, if all the bytes will not fit then the FIFO is flushed and no bytes are pushed
+    void ICACHE_RAM_ATTR pushBytesFront(const uint8_t *data, uint8_t len);
+
     // Pop a single byte (returns 0 if no bytes left)
     uint8_t ICACHE_RAM_ATTR pop();
 
@@ -69,7 +72,7 @@ public:
 
     // reset the FIFO back to empty
     void ICACHE_RAM_ATTR flush();
-    
+
     // returns true if the number of bytes requested is available in the FIFO
     bool ICACHE_RAM_ATTR available(uint8_t requiredSize) { return (numElements + requiredSize) < FIFO_SIZE; }
 


### PR DESCRIPTION
If we need an opentx sync packet then it is pushed to the head of the FIFO.
I think this also addresses the sometime seen 0/250 when running 500Hz.