### PR TITLE
Pin library dependency versions

### DIFF
--- a/src/targets/HGLRC_2400.ini
+++ b/src/targets/HGLRC_2400.ini
@@ -13,8 +13,6 @@ build_flags =
 	-D VTABLES_IN_FLASH=1
 	-O2
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
-lib_deps = 
-	${env_common_esp32.lib_deps}
 
 [env:HGLRC_Hermes_2400_TX_via_WIFI]
 extends = env:HGLRC_Hermes_2400_TX_via_UART

--- a/src/targets/Jumper_2400.ini
+++ b/src/targets/Jumper_2400.ini
@@ -15,8 +15,6 @@ build_flags =
 	-O2
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 upload_speed = 460800
-lib_deps =
-	${env_common_esp32.lib_deps}
 
 [env:Jumper_AION_NANO_2400_TX_via_UART]
 extends = env_common_esp32, radio_2400
@@ -30,8 +28,7 @@ build_flags =
 	-O2
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 lib_deps =
-	${env_common_esp32.lib_deps}
-	olikraus/U8g2@^2.28.8
+	${env_common_esp32.oled_lib_deps}
 
 [env:Jumper_AION_NANO_2400_TX_via_WIFI]
 extends = env:Jumper_AION_NANO_2400_TX_via_UART

--- a/src/targets/axis_2400.ini
+++ b/src/targets/axis_2400.ini
@@ -15,8 +15,7 @@ build_flags =
 monitor_speed = 420000
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 lib_deps =
-    ${env_common_esp32.lib_deps}
-    Bodmer/TFT_eSPI @ 2.4.11
+    ${env_common_esp32.tft_lib_deps}
 
 [env:AXIS_THOR_2400_TX_via_WIFI]
 extends = env:AXIS_THOR_2400_TX_via_UART

--- a/src/targets/betafpv_2400.ini
+++ b/src/targets/betafpv_2400.ini
@@ -19,7 +19,7 @@ extends = env:BETAFPV_2400_TX_via_UART
 
 [env:BETAFPV_2400_TX_MICRO_via_UART]
 extends = env_common_esp32
-build_flags = 
+build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
 	-include target/BETAFPV_2400_TX_MICRO.h
@@ -27,16 +27,15 @@ build_flags =
 	-O2
 upload_speed = 460800
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
-lib_deps = 
-	${env_common_esp32.lib_deps}
-	olikraus/U8g2@^2.28.8
+lib_deps =
+    ${env_common_esp32.oled_lib_deps}
 
 [env:BETAFPV_2400_TX_MICRO_via_WIFI]
 extends = env:BETAFPV_2400_TX_MICRO_via_UART
 
 [env:BETAFPV_2400_TX_MICRO_1000mw_via_UART]
 extends = env:BETAFPV_2400_TX_MICRO_via_UART
-build_flags = 
+build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
 	-include target/BETAFPV_2400_TX_MICRO.h

--- a/src/targets/betafpv_900.ini
+++ b/src/targets/betafpv_900.ini
@@ -17,15 +17,14 @@ extends = env:BETAFPV_900_TX_via_UART
 
 [env:BETAFPV_900_TX_MICRO_via_UART]
 extends = env_common_esp32
-build_flags = 
+build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
 	-include target/BETAFPV_900_TX_MICRO.h
 upload_speed = 460800
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
-lib_deps = 
-	${env_common_esp32.lib_deps}
-	olikraus/U8g2@^2.28.8
+lib_deps =
+    ${env_common_esp32.oled_lib_deps}
 
 [env:BETAFPV_900_TX_MICRO_via_WIFI]
 extends = env:BETAFPV_900_TX_MICRO_via_UART

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -44,10 +44,16 @@ build_flags =
 	-I ${PROJECTSRC_DIR}/hal
 src_filter = ${common_env_data.src_filter} -<ESP8266*.*> -<STM32*.*>
 lib_deps =
-	makuna/NeoPixelBus @ ^2.6.7
-	ottowinter/ESPAsyncWebServer-esphome @ ^2.1.0
-	lemmingdev/ESP32-BLE-Gamepad @ ^0.3.3
-	h2zero/NimBLE-Arduino @ ^1.3.6
+	makuna/NeoPixelBus @ 2.6.7
+	ottowinter/ESPAsyncWebServer-esphome @ 2.1.0
+	lemmingdev/ESP32-BLE-Gamepad @ 0.3.4
+	h2zero/NimBLE-Arduino @ 1.3.6
+oled_lib_deps =
+	${env_common_esp32.lib_deps}
+	olikraus/U8g2 @ 2.28.8
+tft_lib_deps =
+	${env_common_esp32.lib_deps}
+    Bodmer/TFT_eSPI @ 2.4.11
 
 # ------------------------- COMMON ESP82xx DEFINITIONS -----------------
 [env_common_esp82xx]
@@ -68,7 +74,7 @@ extra_scripts =
 	${env.extra_scripts}
 	pre:python/build_html.py
 lib_deps =
-	ottowinter/ESPAsyncWebServer-esphome @ ^2.1.0
+	ottowinter/ESPAsyncWebServer-esphome @ 2.1.0
 upload_speed = 460800
 monitor_speed = 420000
 monitor_filters = esp8266_exception_decoder
@@ -89,5 +95,8 @@ build_flags =
 	-I ${PROJECTSRC_DIR}/hal
 src_filter = ${common_env_data.src_filter} -<ESP32*.*> -<ESP8266*.*> -<WS281B*.*>
 lib_deps =
-	paolop74/extEEPROM @ ^3.4.1
+	paolop74/extEEPROM @ 3.4.1
+oled_lib_deps =
+	${env_common_stm32.lib_deps}
+	olikraus/U8g2 @ 2.28.8
 monitor_speed = 420000

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -26,7 +26,7 @@ lib_ignore = SX127xDriver
 
 # ------------------------- COMMON ESP32 DEFINITIONS -----------------
 [env_common_esp32]
-platform = espressif32@3.3.2
+platform = espressif32@3.4.0
 board = esp32dev
 board_build.partitions = min_spiffs.csv
 upload_speed = 460800

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -44,16 +44,16 @@ build_flags =
 	-I ${PROJECTSRC_DIR}/hal
 src_filter = ${common_env_data.src_filter} -<ESP8266*.*> -<STM32*.*>
 lib_deps =
-	makuna/NeoPixelBus @ 2.6.7
+	makuna/NeoPixelBus @ 2.6.9
 	ottowinter/ESPAsyncWebServer-esphome @ 2.1.0
 	lemmingdev/ESP32-BLE-Gamepad @ 0.3.4
 	h2zero/NimBLE-Arduino @ 1.3.6
 oled_lib_deps =
 	${env_common_esp32.lib_deps}
-	olikraus/U8g2 @ 2.28.8
+	olikraus/U8g2 @ 2.32.10
 tft_lib_deps =
 	${env_common_esp32.lib_deps}
-    Bodmer/TFT_eSPI @ 2.4.11
+    Bodmer/TFT_eSPI @ 2.4.30
 
 # ------------------------- COMMON ESP82xx DEFINITIONS -----------------
 [env_common_esp82xx]
@@ -98,5 +98,5 @@ lib_deps =
 	paolop74/extEEPROM @ 3.4.1
 oled_lib_deps =
 	${env_common_stm32.lib_deps}
-	olikraus/U8g2 @ 2.28.8
+	olikraus/U8g2 @ 2.32.10
 monitor_speed = 420000

--- a/src/targets/diy_2400.ini
+++ b/src/targets/diy_2400.ini
@@ -28,8 +28,7 @@ build_flags =
 	-O2
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 lib_deps =
-	${env_common_esp32.lib_deps}
-	olikraus/U8g2@^2.28.8
+    ${env_common_esp32.oled_lib_deps}
 
 [env:DIY_2400_TX_ESP32_SX1280_E28_via_WIFI]
 extends = env:DIY_2400_TX_ESP32_SX1280_E28_via_UART
@@ -45,8 +44,7 @@ build_flags =
 	-O2
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 lib_deps =
-	${env_common_esp32.lib_deps}
-	olikraus/U8g2@^2.28.8
+    ${env_common_esp32.oled_lib_deps}
 
 [env:DIY_2400_TX_ESP32_SX1280_LORA1280F27_via_WIFI]
 extends = env:DIY_2400_TX_ESP32_SX1280_LORA1280F27_via_UART
@@ -74,8 +72,6 @@ build_flags =
 	-O2
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 upload_speed = 460800
-lib_deps =
-	${env_common_esp32.lib_deps}
 
 [env:DIY_2400_TX_DUPLETX_via_UART]
 extends = env:DIY_2400_TX_DUPLETX_via_ETX

--- a/src/targets/diy_900.ini
+++ b/src/targets/diy_900.ini
@@ -11,8 +11,8 @@ build_flags =
 	${radio_900.build_flags}
 	-include target/DIY_900_TX_TTGO_V1_SX127x.h
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
-lib_deps = 	${env_common_esp32.lib_deps}
-		olikraus/U8g2@^2.28.8
+lib_deps =
+    ${env_common_esp32.oled_lib_deps}
 
 [env:DIY_900_TX_TTGO_V1_SX127x_via_WIFI]
 extends = env:DIY_900_TX_TTGO_V1_SX127x_via_UART
@@ -25,8 +25,8 @@ build_flags =
 	${radio_900.build_flags}
 	-include target/DIY_900_TX_TTGO_V2_SX127x.h
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
-lib_deps = 	${env_common_esp32.lib_deps}
-		olikraus/U8g2@^2.28.8
+lib_deps =
+    ${env_common_esp32.oled_lib_deps}
 
 [env:DIY_900_TX_TTGO_V2_SX127x_via_WIFI]
 extends = env:DIY_900_TX_TTGO_V2_SX127x_via_UART

--- a/src/targets/diy_ble_joystick.ini
+++ b/src/targets/diy_ble_joystick.ini
@@ -14,6 +14,5 @@ build_flags =
 	-D VTABLES_IN_FLASH=1
 	-O2
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
-lib_deps = 
-	${env_common_esp32.lib_deps}
-	olikraus/U8g2@^2.28.8
+lib_deps =
+    ${env_common_esp32.oled_lib_deps}

--- a/src/targets/frsky.ini
+++ b/src/targets/frsky.ini
@@ -20,8 +20,6 @@ src_filter = ${env_common_stm32.src_filter} -<rx_*.cpp>
 upload_flags =
 	BOOTLOADER=bootloader/r9m_bootloader.bin
 	VECT_OFFSET=0x4000
-lib_deps =
-	https://github.com/PaoloP74/extEEPROM.git
 
 [env:Frsky_TX_R9M_via_stock_BL]
 extends = env:Frsky_TX_R9M_via_STLINK
@@ -59,8 +57,6 @@ upload_flags =
 	BOOTLOADER=bootloader/r9m_lite_pro_bootloader.bin
 	VECT_OFFSET=0x8000
 src_filter = ${env_common_stm32.src_filter} -<rx_*.cpp>
-lib_deps =
-	https://github.com/PaoloP74/extEEPROM.git
 
 
 # ********************************
@@ -103,9 +99,6 @@ build_flags =
 	-DVECT_TAB_OFFSET=0x08008000U
 board_build.ldscript = variants/R9MM/R9MM_ldscript.ld
 src_filter = ${common_env_data.src_filter} -<ESP32*.*> -<ESP8266*.*> -<WS281B*.*> -<tx_*.cpp>
-lib_deps =
-	https://github.com/PaoloP74/extEEPROM.git
-	Wire
 
 [env:Frsky_RX_R9SLIMPLUS_via_STLINK]
 extends = env:Frsky_RX_R9SLIMPLUS_via_BetaflightPassthrough

--- a/src/targets/happymodel_2400.ini
+++ b/src/targets/happymodel_2400.ini
@@ -13,8 +13,6 @@ build_flags =
 	-D VTABLES_IN_FLASH=1
 	-O2
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
-lib_deps = 
-	${env_common_esp32.lib_deps}
 
 [env:HappyModel_ES24TX_2400_TX_via_WIFI]
 extends = env:HappyModel_ES24TX_2400_TX_via_UART
@@ -29,8 +27,6 @@ build_flags =
 	-D VTABLES_IN_FLASH=1
 	-O2
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
-lib_deps = 
-	${env_common_esp32.lib_deps}
 
 [env:HappyModel_ES24TX_Pro_Series_2400_TX_via_WIFI]
 extends = env:HappyModel_ES24TX_Pro_Series_2400_TX_via_UART

--- a/src/targets/iFlight_2400.ini
+++ b/src/targets/iFlight_2400.ini
@@ -13,8 +13,6 @@ build_flags =
 	-D VTABLES_IN_FLASH=1
 	-O2
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
-lib_deps = 
-	${env_common_esp32.lib_deps}
 
 [env:iFlight_2400_TX_via_WIFI]
 extends = env:iFlight_2400_TX_via_UART

--- a/src/targets/imrc.ini
+++ b/src/targets/imrc.ini
@@ -20,8 +20,7 @@ upload_flags =
 	BOOTLOADER=bootloader/ghost/ghost_tx_bootloader.bin
 	VECT_OFFSET=0x4000
 lib_deps =
-	${env_common_stm32.lib_deps}
-	olikraus/U8g2@^2.28.8
+	${env_common_stm32.oled_lib_deps}
 
 [env:GHOST_2400_TX_LITE_via_STLINK]
 extends = env:GHOST_2400_TX_via_STLINK

--- a/src/targets/namimnorc_2400.ini
+++ b/src/targets/namimnorc_2400.ini
@@ -31,8 +31,7 @@ build_flags =
 	-O2
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 lib_deps =
-	${env_common_esp32.lib_deps}
-	olikraus/U8g2@^2.28.8
+	${env_common_esp32.oled_lib_deps}
 
 [env:NamimnoRC_FLASH_2400_OLED_TX_via_WIFI]
 extends = env:NamimnoRC_FLASH_2400_OLED_TX_via_UART

--- a/src/targets/namimnorc_900.ini
+++ b/src/targets/namimnorc_900.ini
@@ -33,8 +33,7 @@ build_flags =
 	-O2
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 lib_deps =
-	${env_common_esp32.lib_deps}
-	olikraus/U8g2@^2.28.8
+	${env_common_esp32.oled_lib_deps}
 
 [env:NamimnoRC_VOYAGER_900_OLED_TX_via_WIFI]
 extends = env:NamimnoRC_VOYAGER_900_OLED_TX_via_UART


### PR DESCRIPTION
Pin the version of libraries to the exact version and do not allow then to float up to "compatible" versions because sometimes they aren't!