### PR TITLE
Adding via UART and via ETX Flashing Methods for the T-Pro

### DIFF
--- a/src/targets/Jumper_2400.ini
+++ b/src/targets/Jumper_2400.ini
@@ -18,6 +18,9 @@ upload_speed = 460800
 lib_deps =
 	${env_common_esp32.lib_deps}
 
+[env:Jumper_AION_2400_T-Pro_TX_via_UART]
+extends = env:Jumper_AION_2400_T-Pro_TX_via_WIFI
+
 [env:Jumper_AION_NANO_2400_TX_via_UART]
 extends = env_common_esp32, radio_2400
 board = pico32

--- a/src/targets/Jumper_2400.ini
+++ b/src/targets/Jumper_2400.ini
@@ -21,6 +21,9 @@ lib_deps =
 [env:Jumper_AION_2400_T-Pro_TX_via_UART]
 extends = env:Jumper_AION_2400_T-Pro_TX_via_WIFI
 
+[env:Jumper_AION_2400_T-Pro_TX_via_ETX]
+extends = env:Jumper_AION_2400_T-Pro_TX_via_WIFI
+
 [env:Jumper_AION_NANO_2400_TX_via_UART]
 extends = env_common_esp32, radio_2400
 board = pico32


### PR DESCRIPTION
To give users some more options and fighting chance to recover a "bricked" TPro Internal ExpressLRS module, this PR adds a via UART flashing method.

Users, however, still needs to take apart the radio, just like the other "unbricking" method, and use an FTDI dongle/USB to Serial adapter and wire it up correctly for this to work.

Based off TweetFPV's TPro recovery video here:
https://www.youtube.com/watch?v=wrrERX_liCU