### PR TITLE
Prepare radio drivers for FLRC mode and clean up the code

### DIFF
--- a/src/include/targets.h
+++ b/src/include/targets.h
@@ -43,6 +43,10 @@
 #endif
 #endif
 
+#ifndef DMA_ATTR
+#define DMA_ATTR
+#endif
+
 /* Set red led to default */
 #ifndef GPIO_PIN_LED
 #ifdef GPIO_PIN_LED_RED

--- a/src/lib/LUA/devLUA.cpp
+++ b/src/lib/LUA/devLUA.cpp
@@ -11,15 +11,6 @@
 #include "OTA.h"
 #include "hwTimer.h"
 
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
-#include "SX127xDriver.h"
-extern SX127xDriver Radio;
-#elif defined(Regulatory_Domain_ISM_2400)
-#include "SX1280Driver.h"
-extern SX1280Driver Radio;
-#else
-#error "Radio configuration is not valid!"
-#endif
 
 static const char emptySpace[1] = {0};
 static char strPowerLevels[] = "10;25;50;100;250;500;1000;2000";

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -2,6 +2,7 @@
 #include "POWERMGNT.h"
 #include "DAC.h"
 #include "helpers.h"
+#include "common.h"
 
 /*
  * Moves the power management values and special cases out of the main code and into `targets.h`.
@@ -31,12 +32,6 @@
  * If nothing is defined then the default method `Radio.SetOutputPowerMax` will be used, which sets the value to
  * 13 on SX1280 (~12.5dBm) or 15 on SX127x (~17dBm)
  */
-
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
-extern SX127xDriver Radio;
-#elif Regulatory_Domain_ISM_2400
-extern SX1280Driver Radio;
-#endif
 
 PowerLevels_e POWERMGNT::CurrentPower = PWR_COUNT; // default "undefined" initial value
 PowerLevels_e POWERMGNT::FanEnableThreshold = PWR_250mW;

--- a/src/lib/POWERMGNT/POWERMGNT.h
+++ b/src/lib/POWERMGNT/POWERMGNT.h
@@ -4,12 +4,6 @@
 #include "DAC.h"
 #include "device.h"
 
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
-#include "SX127xDriver.h"
-#elif Regulatory_Domain_ISM_2400
-#include "SX1280Driver.h"
-#endif
-
 #if defined(PLATFORM_ESP32)
 #include <nvs_flash.h>
 #include <nvs.h>

--- a/src/lib/SCREEN/screen.h
+++ b/src/lib/SCREEN/screen.h
@@ -2,8 +2,9 @@
 #pragma once
 
 #include "targets.h"
+#include "common.h"
 
-#define RATE_MAX_NUMBER 4
+#define RATE_MAX_NUMBER RATE_MAX
 #define POWER_MAX_NUMBER 8
 #define RATIO_MAX_NUMBER 8
 #define POWERSAVING_MAX_NUMBER 2

--- a/src/lib/SX127xDriver/SX127x.h
+++ b/src/lib/SX127xDriver/SX127x.h
@@ -12,59 +12,38 @@ class SX127xDriver
 
 public:
     static SX127xDriver *instance;
-    SX127xDriver();
+
     ///////Callback Function Pointers/////
-    static void inline nullCallback(void);
+    void (*RXdoneCallback)(); //function pointer for callback
+    void (*TXdoneCallback)(); //function pointer for callback
 
-    static void (*RXdoneCallback)(); //function pointer for callback
-    static void (*TXdoneCallback)(); //function pointer for callback
-
-    static void (*TXtimeout)(); //function pointer for callback
-    static void (*RXtimeout)(); //function pointer for callback
-
-///////////Radio Variables////////
+    ///////////Radio Variables////////
     #define TXRXBuffSize 16
-    const uint8_t TXbuffLen = TXRXBuffSize;
-    const uint8_t RXbuffLen = TXRXBuffSize;
-
-    static volatile WORD_ALIGNED_ATTR uint8_t TXdataBuffer[TXRXBuffSize];
-    static volatile WORD_ALIGNED_ATTR uint8_t RXdataBuffer[TXRXBuffSize];
+    volatile WORD_ALIGNED_ATTR uint8_t TXdataBuffer[TXRXBuffSize];
+    volatile WORD_ALIGNED_ATTR uint8_t RXdataBuffer[TXRXBuffSize];
 
     bool headerExplMode = false;
     bool crcEnabled = false;
 
     //// Parameters ////
-    uint8_t PayloadLength = 8; // Dummy default value which is overwritten during setup.
-    uint32_t currFreq = 0; // leave as 0 to ensure that it gets set
-    uint8_t currSyncWord = SX127X_SYNC_WORD;
-    uint8_t currPreambleLen = 0;
-    SX127x_Bandwidth currBW = SX127x_BW_125_00_KHZ; //default values from datasheet
-    SX127x_SpreadingFactor currSF = SX127x_SF_7;
-    SX127x_CodingRate currCR = SX127x_CR_4_5;
-    SX127x_RadioOPmodes currOpmode = SX127x_OPMODE_SLEEP;
-    uint8_t currPWR = 0b0000;
-    SX127x_ModulationModes ModFSKorLoRa = SX127x_OPMODE_LORA;
-    bool IQinverted = false;
-    uint16_t timeoutSymbols = 0;
+    uint32_t currFreq;
+    uint8_t PayloadLength;
+    bool IQinverted;
+    uint16_t timeoutSymbols;
     ///////////////////////////////////
 
     /////////////Packet Stats//////////
     int8_t LastPacketRSSI;
     int8_t LastPacketSNR;
-    uint32_t TimeOnAir;
-    uint32_t TXstartMicros;
-    uint32_t TXspiTime;
-    uint32_t HeadRoom;
-    uint32_t LastTXdoneMicros;
-    uint32_t TXdoneMicros;
     /////////////////////////////////
 
     ////////////////Configuration Functions/////////////
+    SX127xDriver();
     bool Begin();
     void End();
     bool DetectChip();
-    void Config(SX127x_Bandwidth bw, SX127x_SpreadingFactor sf, SX127x_CodingRate cr, uint32_t freq, uint8_t preambleLen, uint8_t syncWord, bool InvertIQ, uint8_t PayloadLength, uint32_t interval);
-    void Config(SX127x_Bandwidth bw, SX127x_SpreadingFactor sf, SX127x_CodingRate cr, uint32_t freq, uint8_t preambleLen, bool InvertIQ, uint8_t PayloadLength, uint32_t interval);
+    void Config(uint8_t bw, uint8_t sf, uint8_t cr, uint32_t freq, uint8_t preambleLen, uint8_t syncWord, bool InvertIQ, uint8_t PayloadLength, uint32_t interval);
+    void Config(uint8_t bw, uint8_t sf, uint8_t cr, uint32_t freq, uint8_t preambleLen, bool InvertIQ, uint8_t PayloadLength, uint32_t interval);
     void SetMode(SX127x_RadioOPmodes mode);
     void SetTxIdleMode() { SetMode(SX127x_OPMODE_STANDBY); } // set Idle mode used when switching from RX to TX
     void ConfigLoraDefaults();
@@ -108,7 +87,16 @@ public:
     void RXnb();
 
 private:
-    static void ICACHE_RAM_ATTR IsrCallback();
+    uint8_t currSyncWord = SX127X_SYNC_WORD;
+    uint8_t currPreambleLen = 0;
+    SX127x_Bandwidth currBW = SX127x_BW_125_00_KHZ; //default values from datasheet
+    SX127x_SpreadingFactor currSF = SX127x_SF_7;
+    SX127x_CodingRate currCR = SX127x_CR_4_5;
+    SX127x_RadioOPmodes currOpmode = SX127x_OPMODE_SLEEP;
+    uint8_t currPWR = 0b0000;
+    SX127x_ModulationModes ModFSKorLoRa = SX127x_OPMODE_LORA;
+
+    static void IsrCallback();
     void RXnbISR(); // ISR for non-blocking RX routine
     void TXnbISR(); // ISR for non-blocking TX routine
 };

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -44,7 +44,7 @@ static uint32_t endTX;
 #define RX_TIMEOUT_PERIOD_BASE SX1280_RADIO_TICK_SIZE_0015_US
 #define RX_TIMEOUT_PERIOD_BASE_NANOS 15625
 
-void ICACHE_RAM_ATTR SX1280Driver::nullCallback(void) {}
+void ICACHE_RAM_ATTR nullCallback(void) {}
 
 SX1280Driver::SX1280Driver()
 {
@@ -57,6 +57,8 @@ void SX1280Driver::End()
     hal.end();
     TXdoneCallback = &nullCallback; // remove callbacks
     RXdoneCallback = &nullCallback;
+    currFreq = 2400000000;
+    PayloadLength = 8; // Dummy default value which is overwritten during setup.
 }
 
 bool SX1280Driver::Begin()
@@ -77,27 +79,47 @@ bool SX1280Driver::Begin()
 
     SetMode(SX1280_MODE_STDBY_RC);                                                                                                //Put in STDBY_RC mode
     hal.WriteCommand(SX1280_RADIO_SET_PACKETTYPE, SX1280_PACKET_TYPE_LORA);                                                       //Set packet type to LoRa
-    ConfigLoRaModParams(currBW, currSF, currCR);                                                                                  //Configure Modulation Params
+    ConfigModParamsLoRa(SX1280_LORA_BW_0800, SX1280_LORA_SF6, SX1280_LORA_CR_4_7);                                                //Configure Modulation Params
     hal.WriteCommand(SX1280_RADIO_SET_AUTOFS, 0x01);                                                                              //Enable auto FS
     hal.WriteRegister(0x0891, (hal.ReadRegister(0x0891) | 0xC0));                                                                 //default is low power mode, switch to high sensitivity instead
-    SetPacketParams(12, SX1280_LORA_PACKET_IMPLICIT, 8, SX1280_LORA_CRC_OFF, SX1280_LORA_IQ_NORMAL);                              //default params
+    SetPacketParamsLoRa(12, SX1280_LORA_PACKET_IMPLICIT, 8, SX1280_LORA_CRC_OFF, SX1280_LORA_IQ_NORMAL);                          //default params
     SetFrequencyReg(currFreq);                                                                                                    //Set Freq
     SetFIFOaddr(0x00, 0x00);                                                                                                      //Config FIFO addr
-    SetDioIrqParams(SX1280_IRQ_RADIO_ALL, SX1280_IRQ_TX_DONE | SX1280_IRQ_RX_DONE, SX1280_IRQ_RADIO_NONE, SX1280_IRQ_RADIO_NONE); //set IRQ to both RXdone/TXdone on DIO1
+    SetDioIrqParams(SX1280_IRQ_RADIO_ALL, SX1280_IRQ_TX_DONE | SX1280_IRQ_RX_DONE);                                               //set IRQ to both RXdone/TXdone on DIO1
 #if defined(USE_SX1280_DCDC)
     hal.WriteCommand(SX1280_RADIO_SET_REGULATORMODE, SX1280_USE_DCDC);     // Enable DCDC converter instead of LDO
 #endif
     return true;
 }
 
-void SX1280Driver::Config(SX1280_RadioLoRaBandwidths_t bw, SX1280_RadioLoRaSpreadingFactors_t sf, SX1280_RadioLoRaCodingRates_t cr, uint32_t freq, uint8_t PreambleLength, bool InvertIQ, uint8_t PayloadLength, uint32_t interval)
+void SX1280Driver::Config(uint8_t bw, uint8_t sf, uint8_t cr, uint32_t freq,
+                          uint8_t PreambleLength, bool InvertIQ, uint8_t _PayloadLength, uint32_t interval,
+                          uint32_t flrcSyncWord, uint16_t flrcCrcSeed, uint8_t flrc)
 {
-    PayloadLength = PayloadLength;
+    uint8_t irqs = SX1280_IRQ_TX_DONE | SX1280_IRQ_RX_DONE;
+    uint8_t const mode = (flrc) ? SX1280_PACKET_TYPE_FLRC : SX1280_PACKET_TYPE_LORA;
+
+    PayloadLength = _PayloadLength;
     IQinverted = InvertIQ;
     SetMode(SX1280_MODE_STDBY_XOSC);
-    ConfigLoRaModParams(bw, sf, cr);
-    SetPacketParams(PreambleLength, SX1280_LORA_PACKET_IMPLICIT, PayloadLength, SX1280_LORA_CRC_OFF, (SX1280_RadioLoRaIQModes_t)((uint8_t)!IQinverted << 6)); // TODO don't make static etc. LORA_IQ_STD = 0x40, LORA_IQ_INVERTED = 0x00
+    hal.WriteCommand(SX1280_RADIO_SET_PACKETTYPE, mode);
+    if (mode == SX1280_PACKET_TYPE_FLRC)
+    {
+        DBGLN("Config FLRC");
+        ConfigModParamsFLRC(bw, cr, sf);
+        SetPacketParamsFLRC(SX1280_FLRC_PACKET_FIXED_LENGTH, /*crc=*/1,
+                            PreambleLength, _PayloadLength, flrcSyncWord, flrcCrcSeed);
+        irqs |= SX1280_IRQ_CRC_ERROR;
+    }
+    else
+    {
+        DBGLN("Config LoRa");
+        ConfigModParamsLoRa(bw, sf, cr);
+        SetPacketParamsLoRa(PreambleLength, SX1280_LORA_PACKET_IMPLICIT,
+                            _PayloadLength, SX1280_LORA_CRC_OFF, InvertIQ);
+    }
     SetFrequencyReg(freq);
+    SetDioIrqParams(SX1280_IRQ_RADIO_ALL, irqs);
     SetRxTimeoutUs(interval);
 }
 
@@ -123,24 +145,8 @@ void SX1280Driver::SetOutputPower(int8_t power)
     return;
 }
 
-void SX1280Driver::SetPacketParams(uint8_t PreambleLength, SX1280_RadioLoRaPacketLengthsModes_t HeaderType, uint8_t PayloadLength, SX1280_RadioLoRaCrcModes_t crc, SX1280_RadioLoRaIQModes_t InvertIQ)
-{
-    uint8_t buf[7];
-
-    buf[0] = PreambleLength;
-    buf[1] = HeaderType;
-    buf[2] = PayloadLength;
-    buf[3] = crc;
-    buf[4] = InvertIQ;
-    buf[5] = 0x00;
-    buf[6] = 0x00;
-
-    hal.WriteCommand(SX1280_RADIO_SET_PACKETPARAMS, buf, sizeof(buf));
-}
-
 void SX1280Driver::SetMode(SX1280_RadioOperatingModes_t OPmode)
 {
-
     if (OPmode == currOpmode)
     {
        return;
@@ -202,16 +208,12 @@ void SX1280Driver::SetMode(SX1280_RadioOperatingModes_t OPmode)
     currOpmode = OPmode;
 }
 
-void SX1280Driver::ConfigLoRaModParams(SX1280_RadioLoRaBandwidths_t bw, SX1280_RadioLoRaSpreadingFactors_t sf, SX1280_RadioLoRaCodingRates_t cr)
+void SX1280Driver::ConfigModParamsLoRa(uint8_t bw, uint8_t sf, uint8_t cr)
 {
     // Care must therefore be taken to ensure that modulation parameters are set using the command
     // SetModulationParam() only after defining the packet type SetPacketType() to be used
 
-    WORD_ALIGNED_ATTR uint8_t rfparams[3] = {0};
-
-    rfparams[0] = (uint8_t)sf;
-    rfparams[1] = (uint8_t)bw;
-    rfparams[2] = (uint8_t)cr;
+    WORD_ALIGNED_ATTR uint8_t rfparams[3] = {sf, bw, cr};
 
     hal.WriteCommand(SX1280_RADIO_SET_MODULATIONPARAMS, rfparams, sizeof(rfparams));
 
@@ -228,6 +230,68 @@ void SX1280Driver::ConfigLoRaModParams(SX1280_RadioLoRaBandwidths_t bw, SX1280_R
     default:
         hal.WriteRegister(0x925, 0x32); // for SF9, SF10, SF11, SF12
     }
+}
+
+void SX1280Driver::SetPacketParamsLoRa(uint8_t PreambleLength, SX1280_RadioLoRaPacketLengthsModes_t HeaderType,
+                                       uint8_t PayloadLength, SX1280_RadioLoRaCrcModes_t crc,
+                                       uint8_t InvertIQ)
+{
+    uint8_t buf[7];
+
+    buf[0] = PreambleLength;
+    buf[1] = HeaderType;
+    buf[2] = PayloadLength;
+    buf[3] = crc;
+    buf[4] = InvertIQ ? SX1280_LORA_IQ_INVERTED : SX1280_LORA_IQ_NORMAL;
+    buf[5] = 0x00;
+    buf[6] = 0x00;
+
+    hal.WriteCommand(SX1280_RADIO_SET_PACKETPARAMS, buf, sizeof(buf));
+}
+
+void SX1280Driver::ConfigModParamsFLRC(uint8_t bw, uint8_t cr, uint8_t bt)
+{
+    WORD_ALIGNED_ATTR uint8_t rfparams[3] = {bw, cr, bt};
+    hal.WriteCommand(SX1280_RADIO_SET_MODULATIONPARAMS, rfparams, sizeof(rfparams));
+}
+
+void SX1280Driver::SetPacketParamsFLRC(uint8_t HeaderType,
+                                       uint8_t crc,
+                                       uint8_t PreambleLength,
+                                       uint8_t PayloadLength,
+                                       uint32_t syncWord,
+                                       uint16_t crcSeed)
+{
+    if (PreambleLength < 8) PreambleLength = 8;
+        PreambleLength = ((PreambleLength / 4) - 1) << 4;
+    crc = (crc) ? SX1280_FLRC_CRC_2_BYTE : SX1280_FLRC_CRC_OFF;
+
+    uint8_t buf[7];
+    buf[0] = PreambleLength;                    // AGCPreambleLength
+    buf[1] = SX1280_FLRC_SYNC_WORD_LEN_P32S;    // SyncWordLength
+    buf[2] = SX1280_FLRC_RX_MATCH_SYNC_WORD_1;  // SyncWordMatch
+    buf[3] = HeaderType;                        // PacketType
+    buf[4] = PayloadLength;                     // PayloadLength
+    buf[5] = (crc << 4);                        // CrcLength
+    buf[6] = 0x08;                              // Must be whitening disabled
+    hal.WriteCommand(SX1280_RADIO_SET_PACKETPARAMS, buf, sizeof(buf));
+
+    // CRC seed (use dedicated cipher)
+    buf[0] = (uint8_t)(crcSeed >> 8);
+    buf[1] = (uint8_t)crcSeed;
+    hal.WriteRegister(SX1280_REG_FLRC_CRC_SEED, buf, 2);
+
+    // CRC POLY 0x3D65
+    buf[0] = 0x3D;
+    buf[1] = 0x65;
+    hal.WriteRegister(SX1280_REG_FLRC_CRC_POLY, buf, 2);
+
+    // Set SyncWord1
+    buf[0] = (uint8_t)(syncWord >> 24);
+    buf[1] = (uint8_t)(syncWord >> 16);
+    buf[2] = (uint8_t)(syncWord >> 8);
+    buf[3] = (uint8_t)syncWord;
+    hal.WriteRegister(SX1280_REG_FLRC_SYNC_WORD, buf, 4);
 }
 
 void ICACHE_RAM_ATTR SX1280Driver::SetFrequencyHz(uint32_t Reqfreq)

--- a/src/lib/SX1280Driver/SX1280.h
+++ b/src/lib/SX1280Driver/SX1280.h
@@ -7,73 +7,43 @@
 class SX1280Driver
 {
 public:
+    static SX1280Driver *instance;
+
     ///////Callback Function Pointers/////
-    static void ICACHE_RAM_ATTR nullCallback(void);
-
-    void (*RXdoneCallback)() = &nullCallback; //function pointer for callback
-    void (*TXdoneCallback)() = &nullCallback; //function pointer for callback
-
-    static void (*TXtimeout)(); //function pointer for callback
-    static void (*RXtimeout)(); //function pointer for callback
+    void (*RXdoneCallback)(); //function pointer for callback
+    void (*TXdoneCallback)(); //function pointer for callback
 
     ///////////Radio Variables////////
     #define TXRXBuffSize 16
-    volatile uint8_t TXdataBuffer[TXRXBuffSize];
-    volatile uint8_t RXdataBuffer[TXRXBuffSize];
+    volatile WORD_ALIGNED_ATTR uint8_t TXdataBuffer[TXRXBuffSize];
+    volatile WORD_ALIGNED_ATTR uint8_t RXdataBuffer[TXRXBuffSize];
 
-    uint8_t PayloadLength = 8; // Dummy default value which is overwritten during setup.
-
-    static uint8_t _syncWord;
-
-    SX1280_RadioLoRaBandwidths_t currBW = SX1280_LORA_BW_0800;
-    SX1280_RadioLoRaSpreadingFactors_t currSF = SX1280_LORA_SF6;
-    SX1280_RadioLoRaCodingRates_t currCR = SX1280_LORA_CR_4_7;
-    uint32_t currFreq = 2400000000;
-    SX1280_RadioOperatingModes_t currOpmode = SX1280_MODE_SLEEP;
-    bool IQinverted = false;
     uint16_t timeout = 0xFFFF;
 
-    // static uint8_t currPWR;
-    // static uint8_t maxPWR;
-
+    uint32_t currFreq;
+    uint8_t PayloadLength;
+    bool IQinverted;
     ///////////////////////////////////
 
     /////////////Packet Stats//////////
-    int8_t LastPacketRSSI = 0;
-    int8_t LastPacketSNR = 0;
-    volatile uint8_t NonceTX = 0;
-    volatile uint8_t NonceRX = 0;
-    static uint32_t TotalTime;
-    static uint32_t TimeOnAir;
-    static uint32_t TXstartMicros;
-    static uint32_t TXspiTime;
-    static uint32_t HeadRoom;
-    static uint32_t TXdoneMicros;
-    /////////////////////////////////
-
-    //// Local Variables //// Copy of values for SPI speed optimisation
-    static uint8_t CURR_REG_PAYLOAD_LENGTH;
-    static uint8_t CURR_REG_DIO_MAPPING_1;
-    static uint8_t CURR_REG_FIFO_ADDR_PTR;
+    int8_t LastPacketRSSI;
+    int8_t LastPacketSNR;
 
     ////////////////Configuration Functions/////////////
     SX1280Driver();
-    static SX1280Driver *instance;
     bool Begin();
     void End();
-    void SetMode(SX1280_RadioOperatingModes_t OPmode);
     void SetTxIdleMode() { SetMode(SX1280_MODE_FS); }; // set Idle mode used when switching from RX to TX
-    void Config(SX1280_RadioLoRaBandwidths_t bw, SX1280_RadioLoRaSpreadingFactors_t sf, SX1280_RadioLoRaCodingRates_t cr, uint32_t freq, uint8_t PreambleLength, bool InvertIQ, uint8_t PayloadLength, uint32_t interval);
-    void ConfigLoRaModParams(SX1280_RadioLoRaBandwidths_t bw, SX1280_RadioLoRaSpreadingFactors_t sf, SX1280_RadioLoRaCodingRates_t cr);
-    void SetPacketParams(uint8_t PreambleLength, SX1280_RadioLoRaPacketLengthsModes_t HeaderType, uint8_t PayloadLength, SX1280_RadioLoRaCrcModes_t crc, SX1280_RadioLoRaIQModes_t InvertIQ);
-    void ICACHE_RAM_ATTR SetFrequencyHz(uint32_t freq);
-    void ICACHE_RAM_ATTR SetFrequencyReg(uint32_t freq);
-    void ICACHE_RAM_ATTR SetFIFOaddr(uint8_t txBaseAddr, uint8_t rxBaseAddr);
+    void Config(uint8_t bw, uint8_t sf, uint8_t cr, uint32_t freq,
+                uint8_t PreambleLength, bool InvertIQ, uint8_t PayloadLength, uint32_t interval,
+                uint32_t flrcSyncWord=0, uint16_t flrcCrcSeed=0, uint8_t flrc=0);
+    void SetFrequencyHz(uint32_t freq);
+    void SetFrequencyReg(uint32_t freq);
     void SetRxTimeoutUs(uint32_t interval);
     void SetOutputPower(int8_t power);
     void SetOutputPowerMax() { SetOutputPower(13); };
 
-    int32_t ICACHE_RAM_ATTR GetFrequencyError();
+    int32_t GetFrequencyError();
 
     void TXnb();
     void RXnb();
@@ -83,14 +53,37 @@ public:
 
     void GetStatus();
 
-    void SetDioIrqParams(uint16_t irqMask, uint16_t dio1Mask, uint16_t dio2Mask, uint16_t dio3Mask);
-    
     bool GetFrequencyErrorbool();
     uint8_t GetRxBufferAddr();
     void GetLastPacketStats();
 
 private:
-    static void ICACHE_RAM_ATTR IsrCallback();
+    SX1280_RadioOperatingModes_t currOpmode = SX1280_MODE_SLEEP;
+
+    void SetMode(SX1280_RadioOperatingModes_t OPmode);
+    void SetFIFOaddr(uint8_t txBaseAddr, uint8_t rxBaseAddr);
+
+    // LoRa functions
+    void ConfigModParamsLoRa(uint8_t bw, uint8_t sf, uint8_t cr);
+    void SetPacketParamsLoRa(uint8_t PreambleLength, SX1280_RadioLoRaPacketLengthsModes_t HeaderType,
+                             uint8_t PayloadLength, SX1280_RadioLoRaCrcModes_t crc,
+                             uint8_t InvertIQ);
+    // FLRC functions
+    void ConfigModParamsFLRC(uint8_t bw, uint8_t cr, uint8_t bt=SX1280_FLRC_BT_0_5);
+    void SetPacketParamsFLRC(uint8_t HeaderType,
+                             uint8_t crc,
+                             uint8_t PreambleLength,
+                             uint8_t PayloadLength,
+                             uint32_t syncWord,
+                             uint16_t crcSeed);
+
+    void SetDioIrqParams(uint16_t irqMask,
+                         uint16_t dio1Mask=SX1280_IRQ_RADIO_NONE,
+                         uint16_t dio2Mask=SX1280_IRQ_RADIO_NONE,
+                         uint16_t dio3Mask=SX1280_IRQ_RADIO_NONE);
+
+
+    static void IsrCallback();
     void RXnbISR(); // ISR for non-blocking RX routine
     void TXnbISR(); // ISR for non-blocking TX routine
 };

--- a/src/lib/SX1280Driver/SX1280_Regs.h
+++ b/src/lib/SX1280Driver/SX1280_Regs.h
@@ -4,6 +4,10 @@
 #define SX1280_REG_LR_ESTIMATED_FREQUENCY_ERROR_MSB 0x0954
 #define SX1280_REG_LR_ESTIMATED_FREQUENCY_ERROR_MASK 0x0FFFFF
 
+#define SX1280_REG_FLRC_CRC_POLY    0x9C6
+#define SX1280_REG_FLRC_CRC_SEED    0x9C8
+#define SX1280_REG_FLRC_SYNC_WORD   0x9CF
+
 #define SX1280_XTAL_FREQ 52000000
 #define FREQ_STEP ((double)(SX1280_XTAL_FREQ / pow(2.0, 18.0)))
 
@@ -179,6 +183,83 @@ typedef enum
     SX1280_LORA_CRC_ON = 0x20,  //!< CRC activated
     SX1280_LORA_CRC_OFF = 0x00, //!< CRC not used
 } SX1280_RadioLoRaCrcModes_t;
+
+/*!
+ * \brief Represents the bandwidth values for FLRC packet type
+ */
+typedef enum
+{
+    SX1280_FLRC_BR_1_300_BW_1_2 = 0x45,
+    SX1280_FLRC_BR_1_000_BW_1_2 = 0x69,
+    SX1280_FLRC_BR_0_650_BW_0_6 = 0x86,
+    SX1280_FLRC_BR_0_520_BW_0_6 = 0xAA,
+    SX1280_FLRC_BR_0_325_BW_0_3 = 0xC7,
+    SX1280_FLRC_BR_0_260_BW_0_3 = 0xEB,
+} SX1280_RadioFlrcBandwidths_t;
+
+/*!
+ * \brief Represents the coding rate values for FLRC packet type
+ */
+typedef enum
+{
+    SX1280_FLRC_CR_1_2 = 0x00,
+    SX1280_FLRC_CR_3_4 = 0x02,
+    SX1280_FLRC_CR_1_0 = 0x04,
+} SX1280_RadioFlrcCodingRates_t;
+
+/*!
+ * \brief Represents the Gaussian filter value in FLRC packet types
+ */
+typedef enum
+{
+    SX1280_FLRC_BT_DIS  = 0x00,
+    SX1280_FLRC_BT_1    = 0x10,
+    SX1280_FLRC_BT_0_5  = 0x20,
+} SX1280_RadioFlrcGaussianFilter_t;
+
+typedef enum
+{
+    SX1280_FLRC_SYNC_NOSYNC        = 0x00,
+    SX1280_FLRC_SYNC_WORD_LEN_P32S = 0x04,
+} SX1280_RadioFlrcSyncWordLen_t;
+
+typedef enum
+{
+    SX1280_FLRC_RX_DISABLE_SYNC_WORD     = 0x00,
+    SX1280_FLRC_RX_MATCH_SYNC_WORD_1     = 0x10,
+    SX1280_FLRC_RX_MATCH_SYNC_WORD_2     = 0x20,
+    SX1280_FLRC_RX_MATCH_SYNC_WORD_1_2   = 0x30,
+    SX1280_FLRC_RX_MATCH_SYNC_WORD_3     = 0x40,
+    SX1280_FLRC_RX_MATCH_SYNC_WORD_1_3   = 0x50,
+    SX1280_FLRC_RX_MATCH_SYNC_WORD_2_3   = 0x60,
+    SX1280_FLRC_RX_MATCH_SYNC_WORD_1_2_3 = 0x70,
+} SX1280_RadioFlrcSyncWordCombination_t;
+
+typedef enum
+{
+    SX1280_FLRC_PACKET_FIXED_LENGTH    = 0x00,
+    SX1280_FLRC_PACKET_VARIABLE_LENGTH = 0x20,
+} SX1280_RadioFlrcPacketType_t;
+
+typedef enum
+{
+    SX1280_FLRC_CRC_OFF    = 0x00,
+    SX1280_FLRC_CRC_1_BYTE = 0x10,
+    SX1280_FLRC_CRC_2_BYTE = 0x20,
+    SX1280_FLRC_CRC_3_BYTE = 0x30,
+} SX1280_RadioFlrcCrc_t;
+
+enum
+{
+    // Error Packet Status
+    SX1280_FLRC_PKT_ERROR_BUSY      = 1 << 0,
+    SX1280_FLRC_PKT_ERROR_PKT_RCVD  = 1 << 1,
+    SX1280_FLRC_PKT_ERROR_HDR_RCVD  = 1 << 2,
+    SX1280_FLRC_PKT_ERROR_ABORT     = 1 << 3,
+    SX1280_FLRC_PKT_ERROR_CRC       = 1 << 4,
+    SX1280_FLRC_PKT_ERROR_LENGTH    = 1 << 5,
+    SX1280_FLRC_PKT_ERROR_SYNC      = 1 << 6,
+};
 
 typedef enum RadioCommands_u
 {

--- a/src/lib/SX1280Driver/SX1280_hal.cpp
+++ b/src/lib/SX1280Driver/SX1280_hal.cpp
@@ -48,7 +48,7 @@ void SX1280Hal::init()
     digitalWrite(GPIO_PIN_NSS, HIGH);
 
 #if defined(GPIO_PIN_PA_ENABLE) && (GPIO_PIN_PA_ENABLE != UNDEF_PIN)
-    DBGLN("Use PA ctrl pin: %d", GPIO_PIN_PA_ENABLE);
+    DBGLN("Use PA enable pin: %d", GPIO_PIN_PA_ENABLE);
     pinMode(GPIO_PIN_PA_ENABLE, OUTPUT);
     digitalWrite(GPIO_PIN_PA_ENABLE, LOW);
 #endif
@@ -85,17 +85,13 @@ void SX1280Hal::init()
     SPI.begin(GPIO_PIN_SCK, GPIO_PIN_MISO, GPIO_PIN_MOSI, -1); // sck, miso, mosi, ss (ss can be any GPIO)
     gpio_pullup_en((gpio_num_t)GPIO_PIN_MISO);
     SPI.setFrequency(10000000);
-#endif
-
-#ifdef PLATFORM_ESP8266
+#elif defined(PLATFORM_ESP8266)
     DBGLN("PLATFORM_ESP8266");
     SPI.begin();
     SPI.setBitOrder(MSBFIRST);
     SPI.setDataMode(SPI_MODE0);
     SPI.setFrequency(10000000);
-#endif
-
-#ifdef PLATFORM_STM32
+#elif defined(PLATFORM_STM32)
     DBGLN("Config SPI");
     SPI.setMOSI(GPIO_PIN_MOSI);
     SPI.setMISO(GPIO_PIN_MISO);

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -27,16 +27,6 @@
 
 #include "WebContent.h"
 
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
-#include "SX127xDriver.h"
-extern SX127xDriver Radio;
-#endif
-
-#if defined(Regulatory_Domain_ISM_2400)
-#include "SX1280Driver.h"
-extern SX1280Driver Radio;
-#endif
-
 #include "config.h"
 #if defined(TARGET_TX)
 extern TxConfig config;

--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -3,13 +3,13 @@
 #if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
 
 #include "SX127xDriver.h"
-extern SX127xDriver Radio;
+SX127xDriver DMA_ATTR Radio;
 
 expresslrs_mod_settings_s ExpressLRS_AirRateConfig[RATE_MAX] = {
-    {0, RATE_200HZ, SX127x_BW_500_00_KHZ, SX127x_SF_6, SX127x_CR_4_7, 5000, TLM_RATIO_1_64, 4, 8, 8},
-    {1, RATE_100HZ, SX127x_BW_500_00_KHZ, SX127x_SF_7, SX127x_CR_4_7, 10000, TLM_RATIO_1_64, 4, 8, 8},
-    {2, RATE_50HZ, SX127x_BW_500_00_KHZ, SX127x_SF_8, SX127x_CR_4_7, 20000, TLM_RATIO_NO_TLM, 4, 10, 8},
-    {3, RATE_25HZ, SX127x_BW_500_00_KHZ, SX127x_SF_9, SX127x_CR_4_7, 40000, TLM_RATIO_NO_TLM, 2, 10, 8}};
+    {0, RADIO_TYPE_SX127x_LORA, RATE_200HZ, SX127x_BW_500_00_KHZ, SX127x_SF_6, SX127x_CR_4_7, 5000, TLM_RATIO_1_64, 4, 8, 8},
+    {1, RADIO_TYPE_SX127x_LORA, RATE_100HZ, SX127x_BW_500_00_KHZ, SX127x_SF_7, SX127x_CR_4_7, 10000, TLM_RATIO_1_64, 4, 8, 8},
+    {2, RADIO_TYPE_SX127x_LORA, RATE_50HZ, SX127x_BW_500_00_KHZ, SX127x_SF_8, SX127x_CR_4_7, 20000, TLM_RATIO_NO_TLM, 4, 10, 8},
+    {3, RADIO_TYPE_SX127x_LORA, RATE_25HZ, SX127x_BW_500_00_KHZ, SX127x_SF_9, SX127x_CR_4_7, 40000, TLM_RATIO_NO_TLM, 2, 10, 8}};
 
 expresslrs_rf_pref_params_s ExpressLRS_AirRateRFperf[RATE_MAX] = {
     {0, RATE_200HZ, -112, 4380, 3000, 2500, 600, 5000},
@@ -21,13 +21,13 @@ expresslrs_rf_pref_params_s ExpressLRS_AirRateRFperf[RATE_MAX] = {
 #if defined(Regulatory_Domain_ISM_2400)
 
 #include "SX1280Driver.h"
-extern SX1280Driver Radio;
+SX1280Driver DMA_ATTR Radio;
 
 expresslrs_mod_settings_s ExpressLRS_AirRateConfig[RATE_MAX] = {
-    {0, RATE_500HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF5, SX1280_LORA_CR_LI_4_6, 2000, TLM_RATIO_1_128, 4, 12, 8},
-    {1, RATE_250HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF6, SX1280_LORA_CR_LI_4_7, 4000, TLM_RATIO_1_64, 4, 14, 8},
-    {2, RATE_150HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF7, SX1280_LORA_CR_LI_4_7, 6666, TLM_RATIO_1_32, 4, 12, 8},
-    {3, RATE_50HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF9, SX1280_LORA_CR_LI_4_6, 20000, TLM_RATIO_NO_TLM, 2, 12, 8}};
+    {0, RADIO_TYPE_SX128x_LORA, RATE_500HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF5, SX1280_LORA_CR_LI_4_6,  2000, TLM_RATIO_1_128,  4, 12, 8},
+    {1, RADIO_TYPE_SX128x_LORA, RATE_250HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF6, SX1280_LORA_CR_LI_4_7,  4000, TLM_RATIO_1_64,   4, 14, 8},
+    {2, RADIO_TYPE_SX128x_LORA, RATE_150HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF7, SX1280_LORA_CR_LI_4_7,  6666, TLM_RATIO_1_32,   4, 12, 8},
+    {3, RADIO_TYPE_SX128x_LORA, RATE_50HZ,  SX1280_LORA_BW_0800, SX1280_LORA_SF9, SX1280_LORA_CR_LI_4_6, 20000, TLM_RATIO_NO_TLM, 2, 12, 8}};
 
 expresslrs_rf_pref_params_s ExpressLRS_AirRateRFperf[RATE_MAX] = {
     {0, RATE_500HZ, -105, 1665, 2500, 2500, 3, 5000},
@@ -36,45 +36,32 @@ expresslrs_rf_pref_params_s ExpressLRS_AirRateRFperf[RATE_MAX] = {
     {3, RATE_50HZ, -117, 18443, 4000, 2500, 0, 5000}};
 #endif
 
-expresslrs_mod_settings_s *get_elrs_airRateConfig(int8_t index);
-
-expresslrs_mod_settings_s *get_elrs_airRateConfig(int8_t index)
+expresslrs_mod_settings_s *get_elrs_airRateConfig(uint8_t index)
 {
-    // Protect against out of bounds rate
-    if (index < 0)
-    {
-        // Set to first entry in the array
-        return &ExpressLRS_AirRateConfig[0];
-    }
-    else if (index > (RATE_MAX - 1))
+    if (RATE_MAX <= index)
     {
         // Set to last usable entry in the array
-        return &ExpressLRS_AirRateConfig[RATE_MAX - 1];
+        index = RATE_MAX - 1;
     }
     return &ExpressLRS_AirRateConfig[index];
 }
 
-expresslrs_rf_pref_params_s *get_elrs_RFperfParams(int8_t index)
+expresslrs_rf_pref_params_s *get_elrs_RFperfParams(uint8_t index)
 {
-    // Protect against out of bounds rate
-    if (index < 0)
-    {
-        // Set to first entry in the array
-        return &ExpressLRS_AirRateRFperf[0];
-    }
-    else if (index > (RATE_MAX - 1))
+    if (RATE_MAX <= index)
     {
         // Set to last usable entry in the array
-        return &ExpressLRS_AirRateRFperf[RATE_MAX - 1];
+        index = RATE_MAX - 1;
     }
     return &ExpressLRS_AirRateRFperf[index];
 }
 
 ICACHE_RAM_ATTR uint8_t enumRatetoIndex(expresslrs_RFrates_e rate)
 { // convert enum_rate to index
-    for (int i = 0; i < RATE_MAX; i++)
+    expresslrs_mod_settings_s const * ModParams;
+    for (uint8_t i = 0; i < RATE_MAX; i++)
     {
-        expresslrs_mod_settings_s *const ModParams = get_elrs_airRateConfig(i);
+        ModParams = get_elrs_airRateConfig(i);
         if (ModParams->enum_rate == rate)
         {
             return i;
@@ -87,8 +74,6 @@ ICACHE_RAM_ATTR uint8_t enumRatetoIndex(expresslrs_RFrates_e rate)
 
 expresslrs_mod_settings_s *ExpressLRS_currAirRate_Modparams;
 expresslrs_rf_pref_params_s *ExpressLRS_currAirRate_RFperfParams;
-
-uint8_t ExpressLRS_nextAirRateIndex = 0;
 
 connectionState_e connectionState = disconnected;
 connectionState_e connectionStatePrev = disconnected;
@@ -116,40 +101,32 @@ uint16_t CRCInitializer = (UID[4] << 8) | UID[5];
 #define RSSI_FLOOR_NUM_READS 5 // number of times to sweep the noise foor to get avg. RSSI reading
 #define MEDIAN_SIZE 20
 
-uint8_t ICACHE_RAM_ATTR TLMratioEnumToValue(expresslrs_tlm_ratio_e enumval)
+uint8_t ICACHE_RAM_ATTR TLMratioEnumToValue(uint8_t enumval)
 {
     switch (enumval)
     {
     case TLM_RATIO_NO_TLM:
         return 1;
-        break;
     case TLM_RATIO_1_2:
         return 2;
-        break;
     case TLM_RATIO_1_4:
         return 4;
-        break;
     case TLM_RATIO_1_8:
         return 8;
-        break;
     case TLM_RATIO_1_16:
         return 16;
-        break;
     case TLM_RATIO_1_32:
         return 32;
-        break;
     case TLM_RATIO_1_64:
         return 64;
-        break;
     case TLM_RATIO_1_128:
         return 128;
-        break;
     default:
         return 0;
     }
 }
 
-uint16_t RateEnumToHz(expresslrs_RFrates_e eRate)
+uint16_t RateEnumToHz(uint8_t eRate)
 {
     switch(eRate)
     {


### PR DESCRIPTION
* SX128x radio driver modified to support FLRC mode
* Code cleanups especially radio variable externs and OTA param structs merged
* Sync packing offsets + masks common for RX and TX to minimize errors
