### PR TITLE
Display error message if wrong Lua is used

### DIFF
--- a/src/lua/ELRS.lua
+++ b/src/lua/ELRS.lua
@@ -268,6 +268,10 @@ local function refreshLCD()
         end
         lcd.drawText(lOffset, (radio_data.yOffset*4), "LUA v0."..version..", TX "..tx_lua_version.list[tx_lua_version.selected], INVERS)
         lcd.drawText(lOffset, (radio_data.yOffset*5), "[force use]", INVERS + BLINK)
+    elseif version == -1 then
+        lcd.drawText(lOffset, (radio_data.yOffset*2), "!!! VERSION MISMATCH !!!", INVERS)
+        lcd.drawText(lOffset, (radio_data.yOffset*3), "Module is not ELRS v1", INVERS)
+        lcd.drawText(lOffset, (radio_data.yOffset*5), "Use the elrsV2.lua", INVERS)
     else
         lcd.drawText(lOffset, (radio_data.yOffset*5), "Connecting...", INVERS + BLINK)
     end
@@ -341,6 +345,12 @@ local function loadViewFunctions()
     TLMinterval.view = viewTlmInterval
 end
 
+local function processElrsV2(data)
+    UartBadPkts = data[3]
+    UartGoodPkts = (data[4]*256) + data[5]
+    version = -1 -- Indicate this is ELRS a 2.0 system, wrong script
+end
+
 local function processResp()
     local command, data = crossfireTelemetryPop()
     if (data == nil) then return end
@@ -384,6 +394,8 @@ local function processResp()
         end
 
         needResp = false
+    elseif (command == 0x2E) and (data[1] == 0xEA) and (data[2] == 0xEE) then
+        processElrsV2(data)
     end
 end
 

--- a/src/lua/elrsV2.lua
+++ b/src/lua/elrsV2.lua
@@ -588,7 +588,7 @@ local function parseElrsV1Message(data)
   -- local badPkt = data[9]
   -- local goodPkt = (data[10]*256) + data[11]
   -- goodBadPkt = string.format("%u/%u   X", badPkt, goodPkt)
-  fieldPopup = {id = 0, status = 2, timeout = 0xFF, info = "ERROR: V1.0 module"}
+  fieldPopup = {id = 0, status = 2, timeout = 0xFF, info = "ERROR: 1.x firmware"}
   fieldTimeout = getTime() + 0xFFFF
 end
 

--- a/src/lua/elrsV2.lua
+++ b/src/lua/elrsV2.lua
@@ -580,6 +580,18 @@ local function parseElrsInfoMessage(data)
   goodBadPkt = string.format("%u/%u   %s", badPkt, goodPkt, state)
 end
 
+local function parseElrsV1Message(data)
+  if (data[1] ~= 0xEA) or (data[2] ~= 0xEE) then
+    return
+  end
+
+  -- local badPkt = data[9]
+  -- local goodPkt = (data[10]*256) + data[11]
+  -- goodBadPkt = string.format("%u/%u   X", badPkt, goodPkt)
+  fieldPopup = {id = 0, status = 2, timeout = 0xFF, info = "ERROR: V1.0 module"}
+  fieldTimeout = getTime() + 0xFFFF
+end
+
 local function refreshNext()
   local command, data = crossfireTelemetryPop()
   if command == 0x29 then
@@ -589,6 +601,8 @@ local function refreshNext()
     if allParamsLoaded < 1 or statusComplete == 0 then
       fieldTimeout = 0 -- go fast until we have complete status record
     end
+  elseif command == 0x2D then
+    parseElrsV1Message(data)
   elseif command == 0x2E then
     parseElrsInfoMessage(data)
   end


### PR DESCRIPTION
If a V2 module is used with ELRS.lua (V1 Lua), have it display
```
!!! VERSION MISMATCH !!!
Module is not ELRS v1
Use the elrsV2.lua
```

If a V1 module is used with elrsV2.lua (V2 Lua) have it display the popup
```
ERROR: 1.x firmware
```

The short message in the V2 Lua is that short so that it fits into the existing popup warning code without adding a lot of bloat to support showing the message.