### PR TITLE
Take TX out of RX mode when doing config commit

### DIFF
--- a/src/include/common.h
+++ b/src/include/common.h
@@ -53,7 +53,8 @@ typedef enum
 typedef enum
 {
     ttrpTransmitting,     // Transmitting RC channels as normal
-    ttrpInReceiveMode     // Has switched to Receive mode for telemetry on the next slot (set on TX done)
+    ttrpPreReceiveGap,    // Has switched to Receive mode for telemetry, but in the gap between TX done and Tock
+    ttrpExpectingTelem    // Still in Receive mode, Tock has fired, receiving telem as far as we know
 } TxTlmRcvPhase_e;
 
 typedef enum

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -574,7 +574,6 @@ static void ConfigChangeCommit()
   devicesTriggerEvent();
 }
 
-
 static void CheckConfigChangePending()
 {
   if (config.IsModified() || ModelUpdatePending)
@@ -603,9 +602,11 @@ static void CheckConfigChangePending()
     while (pauseCycles--)
       timerCallbackIdle();
 #endif
+    // Prevent any other RF SPI traffic during the commit from RX or scheduled TX
+    Radio.SetTxIdleMode();
     hwTimer.callbackTock = &timerCallbackIdle;
-    // If telemetry expected in the next interval, the radio is in RX mode
-    // and will skip sending the next packet when the tiemr resumes.
+    // If telemetry expected in the next interval, the radio was in RX mode
+    // and will skip sending the next packet when the timer resumes.
     // Return to normal send mode because if the skipped packet happened
     // to be on the last slot of the FHSS the skip will prevent FHSS
     if (TelemetryRcvPhase == ttrpInReceiveMode)

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -603,7 +603,6 @@ static void CheckConfigChangePending()
       timerCallbackIdle();
 #endif
     // Prevent any other RF SPI traffic during the commit from RX or scheduled TX
-    Radio.SetTxIdleMode();
     hwTimer.callbackTock = &timerCallbackIdle;
     // If telemetry expected in the next interval, the radio was in RX mode
     // and will skip sending the next packet when the timer resumes.
@@ -611,6 +610,7 @@ static void CheckConfigChangePending()
     // to be on the last slot of the FHSS the skip will prevent FHSS
     if (TelemetryRcvPhase == ttrpInReceiveMode)
     {
+      Radio.SetTxIdleMode();
       TelemetryRcvPhase = ttrpTransmitting;
     }
     ConfigChangeCommit();


### PR DESCRIPTION
Before doing a `config.commit()` on the TX, take the RF out of receive mode. If a packet comes in while we're spinning on the nvs commit, it will cause a crash as we try to process the ISR.

Ref #1394 

I believe the order needs to be
* switch callbackTock
* disable RX

This is because we could start disabling the RX, then instantly get the tock ISR before the handler changes, which would put the RF back into RX mode if it was supposed to happen next and then the problem would still occur.

I also had to go back to tracking all three phases of the telem receiver: 
1. TX mode
2. After TX done, before Tock (switched to receive mode but still before the actual expected receive slot)
3. During the RX slot. Tock has fired and we're in RX mode, expecting that the RF is actually doing a receive or has recently finished it.

In the first version of this using the existing code where it only tracked Phase 1 and Phase 2, the module is in RX mode which needs to be disabled (the reason for this PR) but it only can tell to make the switch if it is in Phase 2, which only lasts ~400us of the 2400us period. If we don't track Phase 3 as well, the alternative is to always call `Radio.SetTxIdleMode()` to force it out. I feel like tracking all 3 phases is better long term so we can actually tell which we're in. 

### Testing
For anyone who wants to confirm this bug on ESP32 TX, connect with telemetry running at 1:2 500Hz to get the most data coming back to the TX. For me it takes 3-12 tries on master before the module reboots itself, it doesn't matter if it is a change from the OLED+Joystick or the Lua, any config change will do it.

Tested on BetaFPV 1W TX for all development, then tested on FM30 for compatibility.