### PR TITLE
Give Device Type-specific Popup Success message

### DIFF
--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -343,7 +343,7 @@ static void WebUploadResponseHandler(AsyncWebServerRequest *request) {
       #ifdef PLATFORM_ESP8266
         success += "Please wait for LED to resume blinking before disconnecting power.\"}";
       #else
-        success += "Please wait for the Lua script to terminate WiFi mode.\"}";
+        success += "Please wait for the module to terminate WiFi mode.\"}";
       #endif
       AsyncWebServerResponse *response = request->beginResponse(200, "application/json", success);
       response->addHeader("Connection", "close");

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -340,7 +340,7 @@ static void WebUploadResponseHandler(AsyncWebServerRequest *request) {
     if (target_seen) {
       DBGLN("Update complete, rebooting");
       String success = String("{\"status\": \"ok\", \"msg\": \"Update complete. ");
-      #ifdef PLATFORM_ESP8266
+      #if defined(TARGET_RX)
         success += "Please wait for LED to resume blinking before disconnecting power.\"}";
       #else
         success += "Please wait for the module to terminate WiFi mode.\"}";

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -341,9 +341,9 @@ static void WebUploadResponseHandler(AsyncWebServerRequest *request) {
       DBGLN("Update complete, rebooting");
       String success = String("{\"status\": \"ok\", \"msg\": \"Update complete. ");
       #if defined(TARGET_RX)
-        success += "Please wait for LED to resume blinking before disconnecting power.\"}";
+        success += "Please wait for the LED to resume blinking before disconnecting power.\"}";
       #else
-        success += "Please wait for the module to terminate WiFi mode.\"}";
+        success += "Please wait for a few seconds while the device reboots.\"}";
       #endif
       AsyncWebServerResponse *response = request->beginResponse(200, "application/json", success);
       response->addHeader("Connection", "close");

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -339,7 +339,13 @@ static void WebUploadResponseHandler(AsyncWebServerRequest *request) {
   } else {
     if (target_seen) {
       DBGLN("Update complete, rebooting");
-      AsyncWebServerResponse *response = request->beginResponse(200, "application/json", "{\"status\": \"ok\", \"msg\": \"Update complete. Please wait for LED to resume blinking before disconnecting power.\"}");
+      String success = String("{\"status\": \"ok\", \"msg\": \"Update complete. ");
+      #ifdef PLATFORM_ESP8266
+        success += "Please wait for LED to resume blinking before disconnecting power.\"}";
+      #else
+        success += "Please wait for the Lua script to terminate WiFi mode.\"}";
+      #endif
+      AsyncWebServerResponse *response = request->beginResponse(200, "application/json", success);
       response->addHeader("Connection", "close");
       request->send(response);
       request->client()->close();
@@ -422,7 +428,7 @@ static void WebUploadForceUpdateHandler(AsyncWebServerRequest *request) {
   target_seen = true;
   if (request->arg("action").equals("confirm")) {
     if (Update.end(true)) { //true to set the size to the current progress
-      DBGLN("Upload Success: %ubytes\nPlease wait for LED to turn resume blinking before disconnecting power", totalSize);
+      DBGLN("Upload Success: %ubytes\nPlease wait for LED to resume blinking before disconnecting power", totalSize);
     } else {
       Update.printError(LOGGING_UART);
     }


### PR DESCRIPTION
Some TX Modules doesn't have RGB LEDs that shows its current status.

This PR aims to give the Web Update Success Popup some clearer and Device-type specific message.
This also affects the Build and Flash in STA Mode.

Feel free to improve the PR and push your commits into it.

(resubmitted, rebased to 2.2.x-maintenance)