### PR TITLE
Target E28 Internal

### DIFF
--- a/src/include/target/DIY_2400_TX_ESP32_E28_INTERNAL.h
+++ b/src/include/target/DIY_2400_TX_ESP32_E28_INTERNAL.h
@@ -1,0 +1,26 @@
+#ifndef DEVICE_NAME
+#define DEVICE_NAME "E28 INTERNAL"
+#endif
+
+// Any device features
+#define USE_SX1280_DCDC
+
+// GPIO pin definitions
+#define GPIO_PIN_NSS            5
+#define GPIO_PIN_BUSY           21
+#define GPIO_PIN_DIO1           4
+#define GPIO_PIN_DIO2           22
+#define GPIO_PIN_MOSI           23
+#define GPIO_PIN_MISO           19
+#define GPIO_PIN_SCK            18
+#define GPIO_PIN_RST            14
+#define GPIO_PIN_RX_ENABLE      27
+#define GPIO_PIN_TX_ENABLE      26
+#define GPIO_PIN_RCSIGNAL_RX    3
+#define GPIO_PIN_RCSIGNAL_TX    1
+
+// Output Power
+#define MinPower PWR_10mW
+#define MaxPower PWR_250mW
+#define POWER_OUTPUT_VALUES {-17,-13,-9,-6,-2}
+#define Regulatory_Domain_ISM_2400 1

--- a/src/targets/diy_2400.ini
+++ b/src/targets/diy_2400.ini
@@ -79,6 +79,23 @@ extends = env:DIY_2400_TX_DUPLETX_via_ETX
 [env:DIY_2400_TX_DUPLETX_via_WIFI]
 extends = env:DIY_2400_TX_DUPLETX_via_ETX
 
+[env:DIY_2400_TX_ESP32_E28_INTERNAL_via_ETX]
+extends = env_common_esp32, radio_2400
+build_flags =
+	${env_common_esp32.build_flags}
+	${common_env_data.build_flags_tx}
+	${radio_2400.build_flags}
+	-include target/DIY_2400_TX_ESP32_E28_INTERNAL.h
+	-D VTABLES_IN_FLASH=1
+	-O2
+src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+upload_speed = 460800
+
+[env:DIY_2400_TX_ESP32_E28_INTERNAL_via_UART]
+extends = env:DIY_2400_TX_ESP32_E28_INTERNAL_via_ETX
+
+[env:DIY_2400_TX_ESP32_E28_INTERNAL_via_WIFI]
+extends = env:DIY_2400_TX_ESP32_E28_INTERNAL_via_ETX
 
 # ********************************
 # Receiver targets


### PR DESCRIPTION
Simple DIY target based on ESP32 and E28-2G4M27S transceiver with support EdgeTX passthrough
![t-lite_internal](https://user-images.githubusercontent.com/1244228/152670771-a0c5e154-f4e3-4aeb-b537-557e4ec837bb.jpg)

