### PR TITLE
Fix renamed ttrp constant compile error

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -654,11 +654,11 @@ void ICACHE_RAM_ATTR TXdoneISR()
   HandleFHSS();
   HandlePrepareForTLM();
 #if defined(Regulatory_Domain_EU_CE_2400)
-  if(TelemetryRcvPhase != ttrpInReceiveMode)
+  if (TelemetryRcvPhase != ttrpPreReceiveGap)
   {
     // Start RX for Listen Before Talk early because it takes about 100us
     // from RX enable to valid instant RSSI values are returned.
-    // If rx was already started by TLM prepare above, this call will let RX 
+    // If rx was already started by TLM prepare above, this call will let RX
     // continue as normal.
     BeginClearChannelAssessment();
   }


### PR DESCRIPTION
I was wrong about #1395 being ready to go! I'm not sure how all the tests passed, but I thought that there was a `ttrpInReceiveMode` somewhere in the LBT code that needed to be fixed by #1395 and here it is.

This enum item was renamed in that PR to be clearer about when the state was active.