### PR TITLE
display "aux1 is HIGH" warning in LUA title bar

### DIFF
--- a/src/lib/LUA/devLUA.cpp
+++ b/src/lib/LUA/devLUA.cpp
@@ -194,6 +194,7 @@ struct luaItem_selection luaBluetoothTelem = {
 
 static char luaBadGoodString[10];
 
+extern bool ICACHE_RAM_ATTR IsArmed();
 extern TxConfig config;
 extern void VtxTriggerSend();
 extern uint8_t adjustPacketRateForBaud(uint8_t rate);
@@ -426,6 +427,7 @@ static int event()
 {
   setLuaWarningFlag(LUA_FLAG_MODEL_MATCH, connectionState == connected && connectionHasModelMatch == false);
   setLuaWarningFlag(LUA_FLAG_CONNECTED, connectionState == connected);
+  setLuaWarningFlag(LUA_FLAG_ISARMED, IsArmed());
   uint8_t rate = adjustPacketRateForBaud(config.GetRate());
   setLuaTextSelectionValue(&luaAirRate, RATE_MAX - 1 - rate);
   setLuaTextSelectionValue(&luaTlmRate, config.GetTlm());

--- a/src/lib/LUA/lua.cpp
+++ b/src/lib/LUA/lua.cpp
@@ -193,7 +193,7 @@ void sendELRSstatus()
     "",                   //status2 = connected status
     "",                   //status1, reserved for future use
     "Model Mismatch",     //warning3, model mismatch
-    "",           //warning2, reserved for future use
+    "Aux1 is HIGH",           //warning2, reserved for future use
     "",           //warning1, reserved for future use
     "",  //critical warning3, reserved for future use
     "",  //critical warning2, reserved for future use

--- a/src/lib/LUA/lua.cpp
+++ b/src/lib/LUA/lua.cpp
@@ -194,7 +194,7 @@ void sendELRSstatus()
     "",                   //status2 = connected status
     "",                   //status1, reserved for future use
     "Model Mismatch",     //warning3, model mismatch
-    "Aux1 is HIGH",           //warning2, reserved for future use
+    "[ ! Armed ! ]",           //warning2, reserved for future use
     "",           //warning1, reserved for future use
     "",  //critical warning3, reserved for future use
     "",  //critical warning2, reserved for future use

--- a/src/lib/LUA/lua.cpp
+++ b/src/lib/LUA/lua.cpp
@@ -5,6 +5,7 @@
 #include "logging.h"
 
 extern CRSF crsf;
+extern void devicesTriggerEvent();
 
 static volatile bool UpdateParamReq = false;
 
@@ -277,6 +278,7 @@ bool luaHandleUpdateParameter()
       {
         // special case for elrs linkstat request
         DBGVLN("ELRS status request");
+        devicesTriggerEvent();
         sendELRSstatus();
       } else if (crsf.ParameterUpdateData[1] == 0x2E) {
         suppressCurrentLuaWarning();

--- a/src/lib/LUA/lua.h
+++ b/src/lib/LUA/lua.h
@@ -9,7 +9,7 @@ enum lua_Flags{
     LUA_FLAG_CONNECTED = 0, //bit 0 and 1 are status flags, show up as the little icon in the lua top right corner
     LUA_FLAG_STATUS1,
     LUA_FLAG_MODEL_MATCH,   //bit 2,3,4 are warning flags, change the tittle bar every 0.5s
-    LUA_FLAG_WARNING2,
+    LUA_FLAG_ISARMED,
     LUA_FLAG_WARNING1,
     LUA_FLAG_CRITICAL_WARNING1, //bit 5,6,7 are critical warning flag, block the lua screen until user confirm to suppress the warning.
     LUA_FLAG_CRITICAL_WARNING2,
@@ -101,11 +101,11 @@ struct tagLuaElrsParams {
     char msg[1]; // null-terminated string
 } PACKED;
 
-extern void sendLuaCommandResponse(struct luaItem_command *cmd, uint8_t step, const char *message);
+void sendLuaCommandResponse(struct luaItem_command *cmd, uint8_t step, const char *message);
 
-extern void suppressCurrentLuaWarning(void);
-extern void setLuaWarningFlag(lua_Flags flag, bool value);
-extern uint8_t getLuaWarningFlags(void);
+void suppressCurrentLuaWarning(void);
+void setLuaWarningFlag(lua_Flags flag, bool value);
+uint8_t getLuaWarningFlags(void);
 extern void ICACHE_RAM_ATTR luaParamUpdateReq();
 extern bool luaHandleUpdateParameter();
 

--- a/src/lua/elrsV2.lua
+++ b/src/lua/elrsV2.lua
@@ -573,7 +573,12 @@ local function parseElrsInfoMessage(data)
 
   local badPkt = data[3]
   local goodPkt = (data[4]*256) + data[5]
-  elrsFlags = data[6]
+  local newFlags = data[6]
+  -- If flags are changing, reset the warning timeout to display/hide message immediately
+  if newFlags ~= elrsFlags then
+    elrsFlags = newFlags
+    titleShowWarnTimeout = 0
+  end
   elrsFlagsInfo = fieldGetString(data, 7)
 
   local state = (bit32.btest(elrsFlags, 1) and "C") or "-"


### PR DESCRIPTION
this PR intend to help user to troubleshoot when "the joystick is not working" because aux1 high = armed, which prevent joystick to work. at least this will blink in the lua title bar and trigger enough curiousity to get more info from the docs/website/discord regarding ELRS Aux1.