### PR TITLE
Bring back NamimnoRC Gen1 TX Backpack

### DIFF
--- a/src/include/target/NamimnoRC_FLASH_2400_TX.h
+++ b/src/include/target/NamimnoRC_FLASH_2400_TX.h
@@ -25,13 +25,8 @@
 #define GPIO_PIN_BUFFER_OE_INVERTED 1
 #define GPIO_PIN_FAN_EN             PB1
 /* Backpack logger connection */
-#ifdef USE_ESP8266_BACKPACK
-    #define GPIO_PIN_DEBUG_RX       PA10
-    #define GPIO_PIN_DEBUG_TX       PA9
-#else
-    #define GPIO_PIN_DEBUG_RX       PA3
-    #define GPIO_PIN_DEBUG_TX       PA2
-#endif
+#define GPIO_PIN_DEBUG_RX       PA10
+#define GPIO_PIN_DEBUG_TX       PA9
 /* WS2812 led */
 #define GPIO_PIN_LED_WS2812         PB0
 #define GPIO_PIN_LED_WS2812_FAST    PB_0

--- a/src/include/target/NamimnoRC_VOYAGER_900_TX.h
+++ b/src/include/target/NamimnoRC_VOYAGER_900_TX.h
@@ -23,13 +23,8 @@
 #define GPIO_PIN_BUFFER_OE_INVERTED 1
 #define GPIO_PIN_FAN_EN             PB1
 /* Backpack logger connection */
-#ifdef USE_ESP8266_BACKPACK
-    #define GPIO_PIN_DEBUG_RX       PA10
-    #define GPIO_PIN_DEBUG_TX       PA9
-#else
-    #define GPIO_PIN_DEBUG_RX       PA3
-    #define GPIO_PIN_DEBUG_TX       PA2
-#endif
+#define GPIO_PIN_DEBUG_RX       PA10
+#define GPIO_PIN_DEBUG_TX       PA9
 /* WS2812 led */
 #define GPIO_PIN_LED_WS2812         PB0
 #define GPIO_PIN_LED_WS2812_FAST    PB_0


### PR DESCRIPTION
Namimno Gen1 Targets now defaults to using Serial2 (PA3, PA2) for the Backpack.
Using the USE_ESP8266_BACKPACK define into my user_define (as a hint from @CapnBry ) have brought back the Backpack Functionalities into the NamimnoRC Flash module I have.

Tested VTX Admin, Enable VRX WiFi and Enable Backpack WiFi via Lua; all works now.
Flashing TX module firmware via Backpack WiFi page also works.