### PR TITLE
OTA packets to use structure instead of direct byte handling

### DIFF
--- a/src/include/common.h
+++ b/src/include/common.h
@@ -138,14 +138,6 @@ extern SX1280Driver Radio;
 #endif
 
 
-#define SYNC_PACKET_SWITCH_OFFSET   1   // Switch encoding mode
-#define SYNC_PACKET_TLM_OFFSET      3   // Telemetry ratio
-#define SYNC_PACKET_RATE_OFFSET     6   // Rate index
-#define SYNC_PACKET_SWITCH_MASK     0b11
-#define SYNC_PACKET_TLM_MASK        0b111
-#define SYNC_PACKET_RATE_MASK       0b11
-
-
 expresslrs_mod_settings_s *get_elrs_airRateConfig(uint8_t index);
 expresslrs_rf_pref_params_s *get_elrs_RFperfParams(uint8_t index);
 

--- a/src/lib/OTA/OTA.h
+++ b/src/lib/OTA/OTA.h
@@ -3,6 +3,11 @@
 
 #include <functional>
 #include "CRSF.h"
+#include "telemetry_protocol.h"
+#include <stddef.h>
+
+#define OTA_PACKET_SIZE     8U
+#define OTA_CRC_CALC_LEN    offsetof(OTA_Packet_s, crcLow)
 
 // expresslrs packet header types
 // 00 -> standard channel data packet
@@ -17,12 +22,65 @@
 // Mask used to XOR the ModelId into the SYNC packet for ModelMatch
 #define MODELMATCH_MASK 0x3f
 
+
+typedef struct {
+    uint8_t type: 2,
+            crcHigh: 6;
+    union {
+        struct {
+            uint8_t fhssIndex;
+            uint8_t nonce;
+            uint8_t free:1,
+                    switchEncMode:2,
+                    newTlmRatio:3,
+                    rateIndex:2;
+            uint8_t UID3;
+            uint8_t UID4;
+            uint8_t UID5;
+        } sync;
+        struct {
+            uint8_t ch0High;
+            uint8_t ch1High;
+            uint8_t ch2High;
+            uint8_t ch3High;
+            uint8_t ch3Low:2,
+                    ch2Low:2,
+                    ch1Low:2,
+                    ch0Low:2;
+            uint8_t switches;
+        } rc;
+        struct {
+            uint8_t packageIndex;
+            uint8_t payload[ELRS_TELEMETRY_BYTES_PER_CALL];
+        } msp_ul;
+        struct {
+            uint8_t type:ELRS_TELEMETRY_SHIFT,
+                    packageIndex:(8 - ELRS_TELEMETRY_SHIFT);
+            union {
+                struct {
+                    uint8_t uplink_RSSI_1:7,
+                            antenna:1;
+                    uint8_t uplink_RSSI_2:7,
+                            modelMatch:1;
+                    uint8_t SNR;
+                    uint8_t lq;
+                    uint8_t mspConfirm:1,
+                            free:7;
+                } ul_link_stats;
+                uint8_t payload[ELRS_TELEMETRY_BYTES_PER_CALL];
+            };
+        } tlm_dl;
+    };
+    uint8_t crcLow;
+} PACKED OTA_Packet_s;
+
+
 enum OtaSwitchMode_e { sm1Bit, smHybrid, smHybridWide };
 void OtaSetSwitchMode(OtaSwitchMode_e mode);
 extern OtaSwitchMode_e OtaSwitchModeCurrent;
 
 #if defined(TARGET_TX) || defined(UNIT_TEST)
-typedef std::function<void (volatile uint8_t* Buffer, CRSF *crsf, bool TelemetryStatus, uint8_t nonce, uint8_t tlmDenom)> PackChannelData_t;
+typedef std::function<void (OTA_Packet_s * const otaPktPtr, CRSF const * const crsf, bool TelemetryStatus, uint8_t nonce, uint8_t tlmDenom)> PackChannelData_t;
 extern PackChannelData_t PackChannelData;
 #if defined(UNIT_TEST)
 void OtaSetHybrid8NextSwitchIndex(uint8_t idx);
@@ -30,7 +88,7 @@ void OtaSetHybrid8NextSwitchIndex(uint8_t idx);
 #endif
 
 #if defined(TARGET_RX) || defined(UNIT_TEST)
-typedef std::function<bool (volatile uint8_t* Buffer, CRSF *crsf, uint8_t nonce, uint8_t tlmDenom)> UnpackChannelData_t;
+typedef std::function<bool (OTA_Packet_s const * const otaPktPtr, CRSF * const crsf, uint8_t nonce, uint8_t tlmDenom)> UnpackChannelData_t;
 extern UnpackChannelData_t UnpackChannelData;
 #endif
 

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -300,7 +300,7 @@ void ICACHE_RAM_ATTR SX127xDriver::TXnbISR()
   TXdoneCallback();
 }
 
-void ICACHE_RAM_ATTR SX127xDriver::TXnb()
+void ICACHE_RAM_ATTR SX127xDriver::TXnb(uint8_t * data, uint8_t size)
 {
   // if (currOpmode == SX127x_OPMODE_TX)
   // {
@@ -311,7 +311,7 @@ void ICACHE_RAM_ATTR SX127xDriver::TXnb()
 
   hal.TXenable();
   hal.writeRegister(SX127X_REG_FIFO_ADDR_PTR, SX127X_FIFO_TX_BASE_ADDR_MAX);
-  hal.writeRegisterFIFO(TXdataBuffer, PayloadLength);
+  hal.writeRegisterFIFO(data, size);
 
   SetMode(SX127x_OPMODE_TX);
 }

--- a/src/lib/SX127xDriver/SX127x.h
+++ b/src/lib/SX127xDriver/SX127x.h
@@ -19,7 +19,6 @@ public:
 
     ///////////Radio Variables////////
     #define TXRXBuffSize 16
-    volatile WORD_ALIGNED_ATTR uint8_t TXdataBuffer[TXRXBuffSize];
     volatile WORD_ALIGNED_ATTR uint8_t RXdataBuffer[TXRXBuffSize];
 
     bool headerExplMode = false;
@@ -82,7 +81,7 @@ public:
     int8_t GetCurrRSSI();
 
     ////////////Non-blocking TX related Functions/////////////////
-    void TXnb();
+    void TXnb(uint8_t * data, uint8_t size);
     /////////////Non-blocking RX related Functions///////////////
     void RXnb();
 

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -391,7 +391,7 @@ void ICACHE_RAM_ATTR SX1280Driver::TXnbISR()
 
 uint8_t FIFOaddr = 0;
 
-void ICACHE_RAM_ATTR SX1280Driver::TXnb()
+void ICACHE_RAM_ATTR SX1280Driver::TXnb(uint8_t * data, uint8_t size)
 {
     if (currOpmode == SX1280_MODE_TX) //catch TX timeout
     {
@@ -401,7 +401,7 @@ void ICACHE_RAM_ATTR SX1280Driver::TXnb()
         return;
     }
     hal.TXenable();                      // do first to allow PA stablise
-    hal.WriteBuffer(0x00, TXdataBuffer, PayloadLength); //todo fix offset to equal fifo addr
+    hal.WriteBuffer(0x00, data, size);   //todo fix offset to equal fifo addr
     instance->SetMode(SX1280_MODE_TX);
 #ifdef DEBUG_SX1280_OTA_TIMING
     beginTX = micros();

--- a/src/lib/SX1280Driver/SX1280.h
+++ b/src/lib/SX1280Driver/SX1280.h
@@ -15,7 +15,6 @@ public:
 
     ///////////Radio Variables////////
     #define TXRXBuffSize 16
-    volatile WORD_ALIGNED_ATTR uint8_t TXdataBuffer[TXRXBuffSize];
     volatile WORD_ALIGNED_ATTR uint8_t RXdataBuffer[TXRXBuffSize];
 
     uint16_t timeout = 0xFFFF;
@@ -45,7 +44,7 @@ public:
 
     int32_t GetFrequencyError();
 
-    void TXnb();
+    void TXnb(uint8_t * data, uint8_t size);
     void RXnb();
 
     uint16_t GetIrqStatus();

--- a/src/lib/StubbornReceiver/stubborn_receiver.cpp
+++ b/src/lib/StubbornReceiver/stubborn_receiver.cpp
@@ -32,7 +32,7 @@ void StubbornReceiver::SetDataToReceive(uint8_t maxLength, uint8_t* dataToReceiv
     this->bytesPerCall = bytesPerCall;
 }
 
-void StubbornReceiver::ReceiveData(uint8_t packageIndex, volatile uint8_t* receiveData)
+void StubbornReceiver::ReceiveData(uint8_t const packageIndex, uint8_t const * const receiveData)
 {
     if  (packageIndex == 0 && currentPackage > 1)
     {

--- a/src/lib/StubbornReceiver/stubborn_receiver.h
+++ b/src/lib/StubbornReceiver/stubborn_receiver.h
@@ -8,7 +8,7 @@ public:
     StubbornReceiver(uint8_t maxPackageIndex);
     void ResetState();
     void SetDataToReceive(uint8_t maxLength, uint8_t* dataToReceive, uint8_t bytesPerCall);
-    void ReceiveData(uint8_t packageIndex, volatile uint8_t* data);
+    void ReceiveData(uint8_t const packageIndex, uint8_t const * const receiveData);
     bool HasFinishedData();
     void Unlock();
     bool GetCurrentConfirm();

--- a/src/lib/logging/logging.h
+++ b/src/lib/logging/logging.h
@@ -16,7 +16,7 @@
 
 // DEBUG_LOG_VERBOSE and DEBUG_RX_SCOREBOARD implies DEBUG_LOG
 #if !defined(DEBUG_LOG)
-  #if defined(DEBUG_LOG_VERBOSE) || defined(DEBUG_RX_SCOREBOARD)
+  #if defined(DEBUG_LOG_VERBOSE) || (defined(DEBUG_RX_SCOREBOARD) && TARGET_RX)
     #define DEBUG_LOG
   #endif
 #endif

--- a/src/test/ota_native/test_switches.cpp
+++ b/src/test/ota_native/test_switches.cpp
@@ -67,7 +67,8 @@ void test_encodingHybrid8(bool highResChannel)
     constexpr uint8_t N_SWITCHES = 8;
     uint8_t UID[6] = {0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE};
     uint8_t expected;
-    uint8_t TXdataBuffer[8];
+    uint8_t TXdataBuffer[8] = {0};
+    OTA_Packet_s * const otaPktPtr = (OTA_Packet_s *)TXdataBuffer;
 
     // Define the input data
     // 4 channels of analog data
@@ -91,7 +92,7 @@ void test_encodingHybrid8(bool highResChannel)
 
     // encode it
     OtaSetSwitchMode(smHybrid);
-    PackChannelData(TXdataBuffer, &crsf, false, 0, 0);
+    PackChannelData(otaPktPtr, &crsf, false, 0, 0);
 
     // check it looks right
     // 1st byte is CRC & packet type
@@ -145,7 +146,8 @@ void test_decodingHybrid8(uint8_t forceSwitch, uint8_t switchval)
 {
     constexpr uint8_t N_SWITCHES = 8;
     uint8_t UID[6] = {0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE};
-    uint8_t TXdataBuffer[8];
+    uint8_t TXdataBuffer[8] = {0};
+    OTA_Packet_s * const otaPktPtr = (OTA_Packet_s *)TXdataBuffer;
     // uint8_t expected;
 
     // Define the input data
@@ -176,10 +178,10 @@ void test_decodingHybrid8(uint8_t forceSwitch, uint8_t switchval)
 
     // use the encoding method to pack it into TXdataBuffer
     OtaSetSwitchMode(smHybrid);
-    PackChannelData(TXdataBuffer, &crsf, false, 0, 0);
+    PackChannelData(otaPktPtr, &crsf, false, 0, 0);
 
     // run the decoder, results in crsf->PackedRCdataOut
-    UnpackChannelData(TXdataBuffer, &crsf, 0, 0);
+    UnpackChannelData(otaPktPtr, &crsf, 0, 0);
 
     // compare the unpacked results with the input data
     TEST_ASSERT_EQUAL(crsf.ChannelDataIn[0] & 0b11111111110, crsf.PackedRCdataOut.ch0); // analog channels are truncated to 10 bits
@@ -229,7 +231,8 @@ void test_encodingHybridWide(bool highRes, uint8_t nonce)
 {
     uint8_t UID[6] = {0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE};
     uint8_t expected;
-    uint8_t TXdataBuffer[8];
+    uint8_t TXdataBuffer[8] = {0};
+    OTA_Packet_s * const otaPktPtr = (OTA_Packet_s *)TXdataBuffer;
 
     // Define the input data
     // 4 channels of analog data
@@ -252,7 +255,7 @@ void test_encodingHybridWide(bool highRes, uint8_t nonce)
     // encode it
     uint8_t tlmDenom = (highRes) ? 64 : 4;
     OtaSetSwitchMode(smHybridWide);
-    PackChannelData(TXdataBuffer, &crsf, nonce % 2, nonce, tlmDenom);
+    PackChannelData(otaPktPtr, &crsf, nonce % 2, nonce, tlmDenom);
 
     // check it looks right
     // 1st byte is CRC & packet type
@@ -314,7 +317,8 @@ void test_encodingHybridWide_low()
 void test_decodingHybridWide(bool highRes, uint8_t nonce, uint8_t forceSwitch, uint16_t forceVal)
 {
     uint8_t UID[6] = {0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE};
-    uint8_t TXdataBuffer[8];
+    uint8_t TXdataBuffer[8] = {0};
+    OTA_Packet_s * const otaPktPtr = (OTA_Packet_s *)TXdataBuffer;
     // uint8_t expected;
 
     // Define the input data
@@ -341,13 +345,13 @@ void test_decodingHybridWide(bool highRes, uint8_t nonce, uint8_t forceSwitch, u
     // encode it
     uint8_t tlmDenom = (highRes) ? 64 : 4;
     OtaSetSwitchMode(smHybridWide);
-    PackChannelData(TXdataBuffer, &crsf, nonce % 2, nonce, tlmDenom);
+    PackChannelData(otaPktPtr, &crsf, nonce % 2, nonce, tlmDenom);
 
     // Clear the LinkStatistics to receive it from the encoding
     crsf.LinkStatistics.uplink_TX_Power = 0;
 
     // run the decoder, results in crsf->PackedRCdataOut
-    bool telemResult = UnpackChannelData(TXdataBuffer, &crsf, nonce, tlmDenom);
+    bool telemResult = UnpackChannelData(otaPktPtr, &crsf, nonce, tlmDenom);
 
     // compare the unpacked results with the input data
     TEST_ASSERT_EQUAL(crsf.ChannelDataIn[0] & 0b11111111110, crsf.PackedRCdataOut.ch0); // analog channels are truncated to 10 bits

--- a/src/test/stubborn_native/test_stubborn.cpp
+++ b/src/test/stubborn_native/test_stubborn.cpp
@@ -118,7 +118,7 @@ void test_stubborn_link_sends_data_larger_frame_size(void)
 
 void test_stubborn_link_receives_data(void)
 {
-    volatile uint8_t batterySequence[] = {0xEC,10, 0x08,0,0,0,0,0,0,0,0,109};
+    uint8_t batterySequence[] = {0xEC,10, 0x08,0,0,0,0,0,0,0,0,109};
     uint8_t buffer[100];
     receiver.ResetState();
     receiver.SetDataToReceive(sizeof(buffer), buffer, 1);
@@ -139,7 +139,7 @@ void test_stubborn_link_receives_data(void)
 
 void test_stubborn_link_receives_data_with_multiple_bytes(void)
 {
-    volatile uint8_t batterySequence[] = {0xEC,10, 0x08,0,0,0,0,0,0,0,0,109,0,0,0};
+    uint8_t batterySequence[] = {0xEC,10, 0x08,0,0,0,0,0,0,0,0,109,0,0,0};
     uint8_t buffer[100];
     receiver.ResetState();
     receiver.SetDataToReceive(sizeof(buffer), buffer, 5);


### PR DESCRIPTION
OTA packet handling is complex already so struct will make it easier to follow and modify later. 
This should not break compatibility with existing v2.x versions.

This is preparation for coming v3.0 FLRC work with 12b channels and bigger OTA packets.

TODO:

- [x] native tests
- [x] testing: TX with master to RX with PR
- [x] testing: TX with PR and RX with master
- [x] testing: TX and RX with PR
- [x] testing: TX with PR and BF4.3-RC3