### PR TITLE
Reduce Lua overhead incurred when querying 

### DIFF
--- a/src/bootloader/src/platformio.ini
+++ b/src/bootloader/src/platformio.ini
@@ -19,7 +19,7 @@ monitor_speed = 420000
 VERSION = -D BOOTLOADER_VERSION=0.5.4
 flags_hal =
     ${generic.VERSION}
-    -Wl,-Map,firmware.map
+    -Wl,-Map,"'${BUILD_DIR}/firmware.map'"
 flags =
     ${generic.flags_hal}
     -D USE_FULL_LL_DRIVER=1

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -66,6 +66,7 @@ typedef enum
 
 extern connectionState_e connectionState;
 extern connectionState_e connectionStatePrev;
+extern bool connectionHasModelMatch;
 
 typedef enum
 {

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -65,7 +65,6 @@ typedef enum
 } RXtimerState_e;
 
 extern connectionState_e connectionState;
-extern connectionState_e connectionStatePrev;
 extern bool connectionHasModelMatch;
 
 typedef enum

--- a/src/lib/LUA/devLUA.cpp
+++ b/src/lib/LUA/devLUA.cpp
@@ -201,7 +201,6 @@ extern uint8_t adjustPacketRateForBaud(uint8_t rate);
 extern void SetSyncSpam();
 extern void EnterBindingMode();
 extern bool InBindingMode;
-extern bool connectionHasModelMatch;
 extern bool RxWiFiReadyToSend;
 #if defined(USE_TX_BACKPACK)
 extern bool TxBackpackWiFiReadyToSend;
@@ -425,9 +424,6 @@ static void registerLuaParameters()
 
 static int event()
 {
-  setLuaWarningFlag(LUA_FLAG_MODEL_MATCH, connectionState == connected && connectionHasModelMatch == false);
-  setLuaWarningFlag(LUA_FLAG_CONNECTED, connectionState == connected);
-  setLuaWarningFlag(LUA_FLAG_ISARMED, IsArmed());
   uint8_t rate = adjustPacketRateForBaud(config.GetRate());
   setLuaTextSelectionValue(&luaAirRate, RATE_MAX - 1 - rate);
   setLuaTextSelectionValue(&luaTlmRate, config.GetTlm());

--- a/src/lib/LUA/lua.cpp
+++ b/src/lib/LUA/lua.cpp
@@ -6,7 +6,6 @@
 #include "logging.h"
 
 extern CRSF crsf;
-extern void devicesTriggerEvent();
 extern bool IsArmed();
 
 static volatile bool UpdateParamReq = false;

--- a/src/lib/LUA/lua.cpp
+++ b/src/lib/LUA/lua.cpp
@@ -202,7 +202,7 @@ void sendELRSstatus()
     "",                   //status2 = connected status
     "",                   //status1, reserved for future use
     "Model Mismatch",     //warning3, model mismatch
-    "[ ! Armed ! ]",      //warning2, reserved for future use
+    "[ ! Armed ! ]",      //warning2, AUX1 high / armed
     "",           //warning1, reserved for future use
     "",  //critical warning3, reserved for future use
     "",  //critical warning2, reserved for future use

--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -77,6 +77,7 @@ expresslrs_rf_pref_params_s *ExpressLRS_currAirRate_RFperfParams;
 
 connectionState_e connectionState = disconnected;
 connectionState_e connectionStatePrev = disconnected;
+bool connectionHasModelMatch;
 
 uint8_t BindingUID[6] = {0, 1, 2, 3, 4, 5}; // Special binding UID values
 #if defined(MY_UID)

--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -76,7 +76,6 @@ expresslrs_mod_settings_s *ExpressLRS_currAirRate_Modparams;
 expresslrs_rf_pref_params_s *ExpressLRS_currAirRate_RFperfParams;
 
 connectionState_e connectionState = disconnected;
-connectionState_e connectionStatePrev = disconnected;
 bool connectionHasModelMatch;
 
 uint8_t BindingUID[6] = {0, 1, 2, 3, 4, 5}; // Special binding UID values

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -547,7 +547,6 @@ void LostConnection()
     DBGLN("lost conn fc=%d fo=%d", FreqCorrection, hwTimer.FreqOffset);
 
     RFmodeCycleMultiplier = 1;
-    connectionStatePrev = connectionState;
     connectionState = disconnected; //set lost connection
     RXtimerState = tim_disconnected;
     hwTimer.resetFreqOffset();
@@ -579,7 +578,6 @@ void LostConnection()
 void ICACHE_RAM_ATTR TentativeConnection(unsigned long now)
 {
     PFDloop.reset();
-    connectionStatePrev = connectionState;
     connectionState = tentative;
     connectionHasModelMatch = false;
     RXtimerState = tim_disconnected;
@@ -605,7 +603,6 @@ void GotConnection(unsigned long now)
     LockRFmode = true;
 #endif
 
-    connectionStatePrev = connectionState;
     connectionState = connected; //we got a packet, therefore no lost connection
     RXtimerState = tim_tentative;
     GotConnectionMillis = now;

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -129,7 +129,6 @@ int32_t OffsetDx;
 int32_t prevOffset;
 RXtimerState_e RXtimerState;
 uint32_t GotConnectionMillis = 0;
-bool connectionHasModelMatch;
 const uint32_t ConsiderConnGoodMillis = 1000; // minimum time before we can consider a connection to be 'good'
 
 ///////////////////////////////////////////////

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -74,7 +74,6 @@ LQCALC<10> LQCalc;
 
 volatile bool busyTransmitting;
 static volatile bool ModelUpdatePending;
-volatile bool connectionHasModelMatch = true;
 
 bool InBindingMode = false;
 uint8_t MSPDataPackage[5];

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -90,7 +90,7 @@ board = bluepill_f103c8
 build_unflags = -Os
 build_flags =
 	-D PLATFORM_STM32=1
-	-Wl,-Map,firmware.map
+	-Wl,-Map,"'${BUILD_DIR}/firmware.map'"
 	-O2
 	-I ${PROJECTSRC_DIR}/hal
 src_filter = ${common_env_data.src_filter} -<ESP32*.*> -<ESP8266*.*> -<WS281B*.*>


### PR DESCRIPTION
In #1412 I raised a concern that now when we send the Good/Bad packet to Lua, it triggers a device event, which causes a flurry of activity as every device responds to the event. This is in there because that's the only way to update the flags needed in the packet. However, it is easier to just set the flags directly (since devLua actually doesn't care about the flags at all).

* Removed the devicesTriggerEvent() call that is triggered and instead replaced it with a call to update the flags
* Moved connectionHasModelMatch to common since it is common to both RX/TX
* Removed unused connectionStatePrev, which was only set and never used

Totally unrelated change:
The build process for STM32 drops a firmware.map in the project directory which is really annoying because the Find All searches it too, which returns lots of extra results. It should be in the build directory, so now it is.