### PR TITLE
Rename and use define for radio chip

### DIFF
--- a/src/include/common.h
+++ b/src/include/common.h
@@ -3,9 +3,9 @@
 #ifndef UNIT_TEST
 #include "targets.h"
 
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868)  || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#if defined(RADIO_SX127X)
 #include "SX127xDriver.h"
-#elif defined(Regulatory_Domain_ISM_2400)
+#elif defined(RADIO_SX1280)
 #include "SX1280Driver.h"
 #else
 #error "Radio configuration is not valid!"
@@ -122,15 +122,14 @@ typedef struct expresslrs_mod_settings_s
 } expresslrs_mod_settings_t;
 
 #ifndef UNIT_TEST
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) \
-    || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#if defined(RADIO_SX127X)
 #define RATE_MAX 4
 #define RATE_DEFAULT 0
 #define RATE_BINDING 2 // 50Hz bind mode
 
 extern SX127xDriver Radio;
 
-#elif defined(Regulatory_Domain_ISM_2400)
+#elif defined(RADIO_SX1280)
 #define RATE_MAX 4
 #define RATE_DEFAULT 0
 #define RATE_BINDING 2  // 50Hz bind mode

--- a/src/include/native.h
+++ b/src/include/native.h
@@ -12,6 +12,8 @@
 #include <math.h>
 #include <sys/time.h>
 
+#define RADIO_SX1280 1
+
 typedef uint8_t byte;
 
 #define HEX 16

--- a/src/include/target/AXIS_THOR_2400_RX.h
+++ b/src/include/target/AXIS_THOR_2400_RX.h
@@ -1,4 +1,7 @@
 #define DEVICE_NAME "AXIS THOR 2400RX"
+
+#define RADIO_SX1280
+
 // GPIO pin definitions
 #define GPIO_PIN_NSS            15
 #define GPIO_PIN_BUSY           5
@@ -13,5 +16,3 @@
 #endif
 
 // Output Power - use default SX1280
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/AXIS_THOR_2400_TX.h
+++ b/src/include/target/AXIS_THOR_2400_TX.h
@@ -1,5 +1,6 @@
 #define DEVICE_NAME "AXIS THOR 2400TX"
 
+#define RADIO_SX1280
 #define USE_TX_BACKPACK
 
 #define HAS_TFT_SCREEN
@@ -52,5 +53,3 @@
 #define MaxPower            PWR_1000mW
 #define DefaultPower        PWR_10mW
 #define POWER_OUTPUT_VALUES {-16,-12,-9,-6,-2,0,7}
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/BETAFPV_2400_RX.h
+++ b/src/include/target/BETAFPV_2400_RX.h
@@ -2,6 +2,7 @@
 #define DEVICE_NAME "BETAFPV 2G4RX"
 #endif
 
+#define RADIO_SX1280
 #define USE_SX1280_DCDC
 
 // GPIO pin definitions
@@ -20,5 +21,3 @@
 
 // Output Power
 #define POWER_OUTPUT_FIXED      1 // -10=10mW, -6=25mW, -3=50mW, 1=100mW
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/BETAFPV_2400_TX.h
+++ b/src/include/target/BETAFPV_2400_TX.h
@@ -4,6 +4,7 @@
 
 // There is some special handling for this target
 #define TARGET_TX_BETAFPV_2400_V1
+#define RADIO_SX1280
 
 // GPIO pin definitions
 #define GPIO_PIN_NSS            5
@@ -26,5 +27,3 @@
 #define MinPower PWR_10mW
 #define MaxPower PWR_500mW
 #define POWER_OUTPUT_VALUES {-18,-15,-13,-9,-4,3}
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/BETAFPV_2400_TX_MICRO.h
+++ b/src/include/target/BETAFPV_2400_TX_MICRO.h
@@ -8,6 +8,7 @@
 
 // Any device features
 #define USE_TX_BACKPACK
+#define RADIO_SX1280
 #define USE_OLED_I2C
 #define OLED_REVERSED
 #define HAS_FIVE_WAY_BUTTON
@@ -50,5 +51,3 @@
 
 /* Joystick values              {UP, DOWN, LEFT, RIGHT, ENTER, IDLE}*/
 #define JOY_ADC_VALUES          {2839, 2191, 1616, 3511, 0, 4095}
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/BETAFPV_900_TX.h
+++ b/src/include/target/BETAFPV_900_TX.h
@@ -4,6 +4,7 @@
 
 // There is some special handling for this target
 #define TARGET_TX_BETAFPV_900_V1
+#define RADIO_SX127X
 #define USE_SX1276_RFO_HF
 
 // GPIO pin definitions

--- a/src/include/target/BETAFPV_900_TX_MICRO.h
+++ b/src/include/target/BETAFPV_900_TX_MICRO.h
@@ -3,6 +3,7 @@
 #endif
 
 // Any device features
+#define RADIO_SX127X
 #define USE_SX1276_RFO_HF
 #define USE_OLED_I2C
 #define OLED_REVERSED

--- a/src/include/target/DIY_2400_RX_ESP8285_SX1280.h
+++ b/src/include/target/DIY_2400_RX_ESP8285_SX1280.h
@@ -2,6 +2,8 @@
 #define DEVICE_NAME "ELRS 2400RX"
 #endif
 
+#define RADIO_SX1280
+
 // GPIO pin definitions
 #define GPIO_PIN_NSS            15
 #define GPIO_PIN_BUSY           5
@@ -16,5 +18,3 @@
 #endif
 
 // Output Power - use default SX1280
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/DIY_2400_RX_PWMP.h
+++ b/src/include/target/DIY_2400_RX_PWMP.h
@@ -2,6 +2,7 @@
 #define DEVICE_NAME "DIY2400 PWMP"
 #endif
 
+#define RADIO_SX1280
 #define CRSF_RCVR_NO_SERIAL
 
 // GPIO pin definitions
@@ -21,5 +22,3 @@
 #else
 #define GPIO_PIN_PWM_OUTPUTS    {0, 1, 3, 9, 10}
 #endif
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/DIY_2400_RX_STM32_CCG_Nano_v0_5.h
+++ b/src/include/target/DIY_2400_RX_STM32_CCG_Nano_v0_5.h
@@ -2,6 +2,8 @@
 #define DEVICE_NAME "ELRS 2400RX"
 #endif
 
+#define RADIO_SX1280
+
 // GPIO pin definitions
 #define GPIO_PIN_NSS         PA4
 #define GPIO_PIN_MOSI        PA7
@@ -18,5 +20,3 @@
 #define GPIO_PIN_LED_RED     PB5
 
 // Output Power - use default SX1280
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/DIY_2400_TX_DUPLETX_TX.h
+++ b/src/include/target/DIY_2400_TX_DUPLETX_TX.h
@@ -3,8 +3,9 @@
 #endif
 
 // Any device features
-#define USE_TX_BACKPACK
+#define RADIO_SX1280
 #define USE_SX1280_DCDC
+#define USE_TX_BACKPACK
 #define USE_SKY85321
 #define SKY85321_PDET_SLOPE     0.035
 #define SKY85321_PDET_INTERCEPT 2.4
@@ -35,5 +36,3 @@
 #define MinPower PWR_10mW
 #define MaxPower PWR_250mW
 #define POWER_OUTPUT_VALUES {-17,-13,-9,-6,-2}
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/DIY_2400_TX_ESP32_SX1280_E28.h
+++ b/src/include/target/DIY_2400_TX_ESP32_SX1280_E28.h
@@ -3,10 +3,11 @@
 #endif
 
 // Any device features
+#define RADIO_SX1280
+#define USE_SX1280_DCDC
 #if !defined(USE_OLED_I2C)
 #define USE_OLED_SPI
 #endif
-#define USE_SX1280_DCDC
 
 // GPIO pin definitions
 #define GPIO_PIN_NSS            5
@@ -38,5 +39,3 @@
 #define MinPower            PWR_10mW
 #define MaxPower            PWR_250mW
 #define POWER_OUTPUT_VALUES {-15,-11,-8,-5,-1}
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/DIY_2400_TX_ESP32_SX1280_Mini.h
+++ b/src/include/target/DIY_2400_TX_ESP32_SX1280_Mini.h
@@ -2,6 +2,8 @@
 #define DEVICE_NAME "DIY2400 Mini"
 #endif
 
+#define RADIO_SX1280
+
 // GPIO pin definitions
 #define GPIO_PIN_NSS          5
 #define GPIO_PIN_BUSY         21
@@ -17,5 +19,3 @@
 #define MinPower PWR_10mW
 #define MaxPower PWR_25mW
 #define POWER_OUTPUT_VALUES {8, 13}
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/DIY_2400_TX_ESP8285_SX1280.h
+++ b/src/include/target/DIY_2400_TX_ESP8285_SX1280.h
@@ -2,6 +2,8 @@
 #define DEVICE_NAME "DIY2400 ESP8266"
 #endif
 
+#define RADIO_SX1280
+
 // GPIO pin definitions
 #define GPIO_PIN_NSS            15
 #define GPIO_PIN_BUSY           5
@@ -19,5 +21,3 @@
 #define MinPower PWR_10mW
 #define MaxPower PWR_10mW
 #define POWER_OUTPUT_VALUES {13}
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/DIY_900_RX_ESP8285_SX127x.h
+++ b/src/include/target/DIY_900_RX_ESP8285_SX127x.h
@@ -2,6 +2,8 @@
 #define DEVICE_NAME "ELRS 900RX"
 #endif
 
+#define RADIO_SX127X
+
 // GPIO pin definitions
 #define GPIO_PIN_NSS 15
 #define GPIO_PIN_DIO0 4

--- a/src/include/target/DIY_900_RX_HUZZAH_RFM95W.h
+++ b/src/include/target/DIY_900_RX_HUZZAH_RFM95W.h
@@ -2,6 +2,8 @@
 #define DEVICE_NAME "ELRS 900RX"
 #endif
 
+#define RADIO_SX127X
+
 // GPIO pin definitions
 #define GPIO_PIN_NSS 15
 #define GPIO_PIN_DIO0 5

--- a/src/include/target/DIY_900_RX_PWMP.h
+++ b/src/include/target/DIY_900_RX_PWMP.h
@@ -2,6 +2,7 @@
 #define DEVICE_NAME "DIY900 PWMP"
 #endif
 
+#define RADIO_SX127X
 #define CRSF_RCVR_NO_SERIAL
 
 // GPIO pin definitions

--- a/src/include/target/DIY_900_TX_ESP32_SX127x_E19.h
+++ b/src/include/target/DIY_900_TX_ESP32_SX127x_E19.h
@@ -3,6 +3,8 @@
 #define DEVICE_NAME "DIY900 E19"
 #endif
 
+#define RADIO_SX127X
+
 // GPIO pin definitions
 #define GPIO_PIN_NSS 5
 #define GPIO_PIN_DIO0 26

--- a/src/include/target/DIY_900_TX_ESP32_SX127x_RFM95.h
+++ b/src/include/target/DIY_900_TX_ESP32_SX127x_RFM95.h
@@ -3,6 +3,8 @@
 #define DEVICE_NAME "DIY900 RFM95"
 #endif
 
+#define RADIO_SX127X
+
 // GPIO pin definitions
 #define GPIO_PIN_NSS 5
 #define GPIO_PIN_DIO0 26

--- a/src/include/target/DIY_900_TX_TTGO_V1_SX127x.h
+++ b/src/include/target/DIY_900_TX_TTGO_V1_SX127x.h
@@ -4,6 +4,7 @@
 #endif
 
 // Any device features
+#define RADIO_SX127X
 #define USE_OLED_I2C
 
 // GPIO pin definitions

--- a/src/include/target/DIY_900_TX_TTGO_V2_SX127x.h
+++ b/src/include/target/DIY_900_TX_TTGO_V2_SX127x.h
@@ -4,6 +4,7 @@
 #endif
 
 // Any device features
+#define RADIO_SX127X
 #define USE_OLED_I2C
 
 // GPIO pin definitions

--- a/src/include/target/FM30_RX_MINI.h
+++ b/src/include/target/FM30_RX_MINI.h
@@ -12,6 +12,7 @@
     #endif
 #endif
 
+#define RADIO_SX1280
 #define USE_SX1280_DCDC
 
 // GPIO pin definitions
@@ -53,5 +54,3 @@
         #define POWER_OUTPUT_FIXED -1 // 100mW (uses values as above)
     #endif
 #endif
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/FM30_TX.h
+++ b/src/include/target/FM30_TX.h
@@ -4,6 +4,7 @@
 
 // There is some special handling for this target
 #define TARGET_TX_FM30
+#define RADIO_SX1280
 #define USE_SX1280_DCDC
 
 // GPIO pin definitions
@@ -45,5 +46,3 @@
 #define HighPower               PWR_100mW
 #define MaxPower                PWR_250mW
 #define POWER_OUTPUT_VALUES     {-15,-11,-7,-1,6}
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/Frsky_RX_R9M.h
+++ b/src/include/target/Frsky_RX_R9M.h
@@ -7,6 +7,8 @@ https://github.com/jaxxzer
     #define TARGET_EEPROM_ADDR              0x50
 #endif
 
+#define RADIO_SX127X
+
 #define GPIO_PIN_NSS            PB12 //confirmed on SLIMPLUS, R900MINI
 #define GPIO_PIN_DIO0           PA15 //confirmed on SLIMPLUS, R900MINI
 #define GPIO_PIN_DIO1           PA1  // NOT CORRECT!!! PIN STILL NEEDS TO BE FOUND BUT IS CURRENTLY UNUSED

--- a/src/include/target/Frsky_TX_R9M.h
+++ b/src/include/target/Frsky_TX_R9M.h
@@ -3,6 +3,7 @@
     #define DEVICE_NAME "FrSky R9M"
 #endif
 
+#define RADIO_SX127X
 #define TARGET_USE_EEPROM               1
 #define TARGET_EEPROM_ADDR              0x51
 #define TARGET_EEPROM_400K

--- a/src/include/target/Frsky_TX_R9M_LITE.h
+++ b/src/include/target/Frsky_TX_R9M_LITE.h
@@ -2,6 +2,7 @@
 #define DEVICE_NAME "FrSky R9M Lite"
 #endif
 
+#define RADIO_SX127X
 #define TARGET_USE_EEPROM           1
 #define TARGET_EEPROM_ADDR          0x51
 

--- a/src/include/target/Frsky_TX_R9M_LITE_PRO.h
+++ b/src/include/target/Frsky_TX_R9M_LITE_PRO.h
@@ -2,6 +2,7 @@
 #define DEVICE_NAME "FrSky R9M Lt Pro"
 #endif
 
+#define RADIO_SX127X
 #define TARGET_USE_EEPROM           1
 #define TARGET_EEPROM_ADDR          0x51
 

--- a/src/include/target/GHOST_2400_TX.h
+++ b/src/include/target/GHOST_2400_TX.h
@@ -3,6 +3,7 @@
 #endif
 // There is some special handling for this target
 #define TARGET_TX_GHOST
+#define RADIO_SX1280
 
 // Any device features
 #if !defined(USE_OLED_SPI_SMALL)
@@ -48,5 +49,3 @@
 /* Joystick values              {UP, DOWN, LEFT, RIGHT, ENTER, IDLE}*/
 #define JOY_ADC_VALUES          {459, 509, 326, 182, 91, 1021}
 #endif
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/GHOST_ATTO_2400_RX.h
+++ b/src/include/target/GHOST_ATTO_2400_RX.h
@@ -3,6 +3,7 @@
 #endif
 // There is some special handling for this target
 #define TARGET_RX_GHOST_ATTO_V1
+#define RADIO_SX1280
 
 // GPIO pin definitions
 #define GPIO_PIN_NSS            PA15
@@ -22,5 +23,3 @@
 //#define GPIO_PIN_BUTTON         PA12
 
 // Output Power - use default SX1280
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/HGLRC_Hermes_2400_TX.h
+++ b/src/include/target/HGLRC_Hermes_2400_TX.h
@@ -3,6 +3,7 @@
 #endif
 
 // Any device features
+#define RADIO_SX1280
 #define USE_SX1280_DCDC
 
 // GPIO pin definitions
@@ -22,5 +23,3 @@
 #define MinPower PWR_10mW
 #define MaxPower PWR_250mW
 #define POWER_OUTPUT_VALUES {-18,-15,-11,-8,-4}
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/HappyModel_ES24TX_2400_TX.h
+++ b/src/include/target/HappyModel_ES24TX_2400_TX.h
@@ -3,8 +3,9 @@
 #endif
 
 // Any device features
-#define USE_TX_BACKPACK
+#define RADIO_SX1280
 #define USE_SX1280_DCDC
+#define USE_TX_BACKPACK
 
 // GPIO pin definitions
 #define GPIO_PIN_NSS            5
@@ -25,5 +26,3 @@
 #define MinPower PWR_10mW
 #define MaxPower PWR_250mW
 #define POWER_OUTPUT_VALUES {-17,-13,-9,-6,-2}
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/HappyModel_ES24TX_Pro_Series_2400_TX.h
+++ b/src/include/target/HappyModel_ES24TX_Pro_Series_2400_TX.h
@@ -3,8 +3,9 @@
 #endif
 
 // Any device features
-#define USE_TX_BACKPACK
+#define RADIO_SX1280
 #define USE_SX1280_DCDC
+#define USE_TX_BACKPACK
 #define WS2812_IS_GRB
 
 // GPIO pin definitions
@@ -26,5 +27,3 @@
 #define MinPower PWR_25mW
 #define MaxPower PWR_1000mW
 #define POWER_OUTPUT_VALUES {-18,-15,-12,-7,-4,2}
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/HappyModel_TX_ES900TX.h
+++ b/src/include/target/HappyModel_TX_ES900TX.h
@@ -2,6 +2,7 @@
 #define DEVICE_NAME          "HM ES900TX"
 #endif
 
+#define RADIO_SX127X
 #define USE_TX_BACKPACK
 
 // GPIO pin definitions

--- a/src/include/target/Jumper_AION_2400_T-Pro_TX.h
+++ b/src/include/target/Jumper_AION_2400_T-Pro_TX.h
@@ -1,6 +1,7 @@
 #define DEVICE_NAME "AION T-Pro TX"
 
 // Any device features
+#define RADIO_SX1280
 #define USE_SX1280_DCDC
 
 // GPIO pin definitions
@@ -20,11 +21,9 @@
 
 // Backpack pins
 #define GPIO_PIN_DEBUG_RX       13
-#define GPIO_PIN_DEBUG_TX       12 
+#define GPIO_PIN_DEBUG_TX       12
 
 // Output Power
 #define MinPower                PWR_25mW
 #define MaxPower                PWR_1000mW
 #define POWER_OUTPUT_VALUES     {-18,-13,-10,-5,-2,3}
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/Jumper_AION_NANO_2400_TX.h
+++ b/src/include/target/Jumper_AION_NANO_2400_TX.h
@@ -3,8 +3,9 @@
 #endif
 
 // Any device features
-#define USE_OLED_I2C
+#define RADIO_SX1280
 #define USE_SX1280_DCDC
+#define USE_OLED_I2C
 #define HAS_FIVE_WAY_BUTTON
 #define WS2812_IS_GRB
 
@@ -36,5 +37,3 @@
 /* Joystick values              {UP, DOWN, LEFT, RIGHT, ENTER, IDLE}*/
 #define JOY_ADC_VALUES          {870, 600, 230, 35, 0, 4095}
 #endif
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/MATEK_2400_RX.h
+++ b/src/include/target/MATEK_2400_RX.h
@@ -1,6 +1,9 @@
 #ifndef DEVICE_NAME
 #define DEVICE_NAME "MATEK R24"
 #endif
+
+#define RADIO_SX1280
+
 // GPIO pin definitions
 #define GPIO_PIN_NSS                15
 #define GPIO_PIN_BUSY               5
@@ -18,5 +21,3 @@
 
 // Output Power
 #define POWER_OUTPUT_FIXED          3
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/NamimnoRC_FLASH_2400_OLED_TX.h
+++ b/src/include/target/NamimnoRC_FLASH_2400_OLED_TX.h
@@ -3,6 +3,7 @@
 #endif
 
 // Features
+#define RADIO_SX1280
 #define USE_TX_BACKPACK
 #define USE_OLED_SPI
 #define HAS_FIVE_WAY_BUTTON
@@ -46,6 +47,3 @@
 
 /* Joystick values              {UP, DOWN, LEFT, RIGHT, ENTER, IDLE}*/
 #define JOY_ADC_VALUES          {1850, 900, 490, 1427, 0, 2978}
-
-/* Frequency */
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/NamimnoRC_FLASH_2400_RX_ESP8285.h
+++ b/src/include/target/NamimnoRC_FLASH_2400_RX_ESP8285.h
@@ -1,4 +1,7 @@
 #define DEVICE_NAME "Namimno 2400RX"
+
+#define RADIO_SX1280
+
 // GPIO pin definitions
 #define GPIO_PIN_NSS            15
 #define GPIO_PIN_BUSY           5
@@ -15,5 +18,3 @@
 #endif
 
 // Output Power - use default SX1280
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/NamimnoRC_FLASH_2400_RX_STM32.h
+++ b/src/include/target/NamimnoRC_FLASH_2400_RX_STM32.h
@@ -1,6 +1,9 @@
 #ifndef DEVICE_NAME
 #define DEVICE_NAME "Namimno 2G4RX"
 #endif
+
+#define RADIO_SX1280
+
 // GPIO pin definitions
 #define GPIO_PIN_RST            PB4
 #define GPIO_PIN_BUSY           PB5
@@ -16,5 +19,3 @@
 #define GPIO_PIN_RCSIGNAL_TX    PA9
 
 // Output Power - default for SX120
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/NamimnoRC_FLASH_2400_TX.h
+++ b/src/include/target/NamimnoRC_FLASH_2400_TX.h
@@ -2,6 +2,7 @@
 #define DEVICE_NAME "Namimno Flash"
 #endif
 
+#define RADIO_SX1280
 #define USE_TX_BACKPACK
 
 // GPIO pin definitions
@@ -40,5 +41,3 @@
 #define MinPower PWR_25mW
 #define MaxPower PWR_1000mW
 #define POWER_OUTPUT_VALUES {-18,-15,-12,-8,-5,3}
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/NamimnoRC_VOYAGER_900_ESP_RX.h
+++ b/src/include/target/NamimnoRC_VOYAGER_900_ESP_RX.h
@@ -1,6 +1,9 @@
 #ifndef DEVICE_NAME
 #define DEVICE_NAME "Namimno 900RX"
 #endif
+
+#define RADIO_SX127X
+
 // GPIO pin definitions
 #define GPIO_PIN_NSS          15
 #define GPIO_PIN_DIO0         5

--- a/src/include/target/NamimnoRC_VOYAGER_900_OLED_TX.h
+++ b/src/include/target/NamimnoRC_VOYAGER_900_OLED_TX.h
@@ -3,6 +3,7 @@
 #endif
 
 // Features
+#define RADIO_SX127X
 #define USE_TX_BACKPACK
 #define USE_OLED_SPI
 

--- a/src/include/target/NamimnoRC_VOYAGER_900_RX.h
+++ b/src/include/target/NamimnoRC_VOYAGER_900_RX.h
@@ -1,6 +1,9 @@
 #ifndef DEVICE_NAME
 #define DEVICE_NAME "Namimno 900RX"
 #endif
+
+#define RADIO_SX127X
+
 // GPIO pin definitions
 #define GPIO_PIN_RST            PC14
 #define GPIO_PIN_DIO0           PA15

--- a/src/include/target/NamimnoRC_VOYAGER_900_TX.h
+++ b/src/include/target/NamimnoRC_VOYAGER_900_TX.h
@@ -2,6 +2,7 @@
 #define DEVICE_NAME "Namimno Voyager"
 #endif
 
+#define RADIO_SX127X
 #define USE_TX_BACKPACK
 
 // GPIO pin definitions

--- a/src/include/target/QuadKopters_JR_2400_TX.h
+++ b/src/include/target/QuadKopters_JR_2400_TX.h
@@ -3,6 +3,7 @@
 #endif
 
 // Any device features
+#define RADIO_SX1280
 #define USE_TX_BACKPACK
 
 // GPIO pin definitions
@@ -23,5 +24,3 @@
 #define MinPower PWR_10mW
 #define MaxPower PWR_250mW
 #define POWER_OUTPUT_VALUES {-15,-11,-8,-5,0}
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/RadioMaster_Zorro_2400_TX.h
+++ b/src/include/target/RadioMaster_Zorro_2400_TX.h
@@ -4,11 +4,12 @@
 // Copied from DupleTX
 
 // Any device features
-#define USE_TX_BACKPACK
+#define RADIO_SX1280
 #define USE_SX1280_DCDC
 #define USE_SKY85321
 #define SKY85321_PDET_SLOPE     0.035
 #define SKY85321_PDET_INTERCEPT 2.4
+#define USE_TX_BACKPACK
 
 // GPIO pin definitions
 #define GPIO_PIN_NSS            5
@@ -36,5 +37,3 @@
 #define MinPower PWR_10mW
 #define MaxPower PWR_250mW
 #define POWER_OUTPUT_VALUES {-17,-13,-9,-6,-2}
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/Vantac_2400_RX.h
+++ b/src/include/target/Vantac_2400_RX.h
@@ -2,6 +2,8 @@
 #define DEVICE_NAME "Vantac 2400 RX"
 #endif
 
+#define RADIO_SX1280
+
 // GPIO pin definitions
 #define GPIO_PIN_NSS            15
 #define GPIO_PIN_BUSY           5
@@ -17,5 +19,3 @@
 
 // Output Power
 #define POWER_OUTPUT_FIXED      1 // -10=10mW, -6=25mW, -3=50mW, 1=100mW
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/Vantac_Lite_2400_TX.h
+++ b/src/include/target/Vantac_Lite_2400_TX.h
@@ -3,6 +3,7 @@
 #endif
 
 // Any device features
+#define RADIO_SX1280
 
 // GPIO pin definitions
 #define GPIO_PIN_NSS            5
@@ -25,5 +26,3 @@
 #define MinPower                PWR_10mW
 #define MaxPower                PWR_500mW
 #define POWER_OUTPUT_VALUES     {-17,-14,-11,-7,-1,2}
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/iFlight_2400_RX.h
+++ b/src/include/target/iFlight_2400_RX.h
@@ -1,5 +1,6 @@
 #define DEVICE_NAME "iFlight 2400RX"
 
+#define RADIO_SX1280
 #define USE_SX1280_DCDC
 
 // GPIO pin definitions
@@ -17,5 +18,3 @@
 
 // Output Power
 #define POWER_OUTPUT_FIXED          3
-
-#define Regulatory_Domain_ISM_2400  1

--- a/src/include/target/iFlight_2400_TX.h
+++ b/src/include/target/iFlight_2400_TX.h
@@ -2,6 +2,7 @@
 
 // Any device features
 #define TARGET_TX_IFLIGHT
+#define RADIO_SX1280
 #define USE_SX1280_DCDC
 
 // GPIO pin definitions
@@ -25,5 +26,3 @@
 #define MinPower                PWR_10mW
 #define MaxPower                PWR_500mW
 #define POWER_OUTPUT_VALUES     {-18,-15,-13,-9,-4,3}
-
-#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/iFlight_900_TX.h
+++ b/src/include/target/iFlight_900_TX.h
@@ -2,6 +2,7 @@
 
 // Any device features
 #define TARGET_TX_IFLIGHT
+#define RADIO_SX127X
 #define USE_SX1276_RFO_HF
 
 // GPIO pin definitions

--- a/src/include/targets.h
+++ b/src/include/targets.h
@@ -120,12 +120,9 @@
 #endif
 #endif
 
-#if defined(Regulatory_Domain_EU_CE_2400) && !defined(Regulatory_Domain_ISM_2400)
-#define Regulatory_Domain_ISM_2400
-#endif
-
-#if defined(Regulatory_Domain_ISM_2400)
-// ISM 2400 band is use => undefine other requlatory domain defines
+#if defined(RADIO_SX1280)
+#define Regulatory_Domain_ISM_2400 1
+// ISM 2400 band is in use => undefine other requlatory domain defines
 #undef Regulatory_Domain_AU_915
 #undef Regulatory_Domain_EU_868
 #undef Regulatory_Domain_IN_866
@@ -133,9 +130,13 @@
 #undef Regulatory_Domain_AU_433
 #undef Regulatory_Domain_EU_433
 
-#elif !(defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_FCC_915) || \
+#elif defined(RADIO_SX127X)
+#if !(defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_FCC_915) || \
         defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || \
         defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433) || \
         defined(UNIT_TEST))
-#error "Regulatory_Domain is not defined for 900MHz devices. Check user_defines.txt!"
+#error "Regulatory_Domain is not defined for 900MHz device. Check user_defines.txt!"
+#endif
+#else
+#error "Either RADIO_SX127X or RADIO_SX1280 must be defined!"
 #endif

--- a/src/lib/BLE/devBLE.cpp
+++ b/src/lib/BLE/devBLE.cpp
@@ -1,14 +1,8 @@
-#include "common.h"
 #include "devBLE.h"
 
 #if defined(PLATFORM_ESP32)
 
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
-extern SX127xDriver Radio;
-#elif defined(Regulatory_Domain_ISM_2400)
-extern SX1280Driver Radio;
-#endif
-
+#include "common.h"
 #include "CRSF.h"
 #include "POWERMGNT.h"
 #include "hwTimer.h"

--- a/src/lib/Backpack/devBackpack.cpp
+++ b/src/lib/Backpack/devBackpack.cpp
@@ -18,14 +18,6 @@ bool VRxBackpackWiFiReadyToSend = false;
 #error "Backpack passthrough flashing requires BACKPACK_LOGGING_BAUD==460800"
 #endif
 
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
-#include "SX127xDriver.h"
-extern SX127xDriver Radio;
-#elif defined(Regulatory_Domain_ISM_2400)
-#include "SX1280Driver.h"
-extern SX1280Driver Radio;
-#endif
-
 #include "CRSF.h"
 #include "hwTimer.h"
 

--- a/src/lib/CRSF/devCRSF.cpp
+++ b/src/lib/CRSF/devCRSF.cpp
@@ -1,5 +1,4 @@
 #include "targets.h"
-#include "common.h"
 #include "device.h"
 
 #include "CRSF.h"

--- a/src/lib/DEVICE/device.cpp
+++ b/src/lib/DEVICE/device.cpp
@@ -7,12 +7,12 @@
 ///////////////////////////////////////
 // Even though we aren't using anything this keeps the PIO dependency analyzer happy!
 
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868)  || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#if defined(RADIO_SX127X)
 #include "SX127xDriver.h"
-#endif
-
-#if defined(Regulatory_Domain_ISM_2400)
+#elif defined(RADIO_SX1280)
 #include "SX1280Driver.h"
+#else
+#error Invalid radio configuration!
 #endif
 
 ///////////////////////////////////////

--- a/src/lib/FHSS/FHSS.cpp
+++ b/src/lib/FHSS/FHSS.cpp
@@ -2,6 +2,12 @@
 #include "logging.h"
 #include <string.h>
 
+#if defined(RADIO_SX127X)
+#include "SX127xDriver.h"
+#elif defined(RADIO_SX1280)
+#include "SX1280Driver.h"
+#endif
+
 // Our table of FHSS frequencies. Define a regulatory domain to select the correct set for your location and radio
 #ifdef Regulatory_Domain_AU_433
 const uint32_t FHSSfreqs[] = {

--- a/src/lib/FHSS/FHSS.h
+++ b/src/lib/FHSS/FHSS.h
@@ -1,32 +1,7 @@
 #pragma once
 
 #include "targets.h"
-
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
-#include "SX127xDriver.h"
-#elif Regulatory_Domain_ISM_2400
-#include "SX1280Driver.h"
-#endif
-
 #include "random.h"
-
-#ifdef Regulatory_Domain_AU_915
-#define Regulatory_Domain_Index 1
-#elif defined Regulatory_Domain_FCC_915
-#define Regulatory_Domain_Index 2
-#elif defined Regulatory_Domain_EU_868
-#define Regulatory_Domain_Index 3
-#elif defined Regulatory_Domain_AU_433
-#define Regulatory_Domain_Index 4
-#elif defined Regulatory_Domain_EU_433
-#define Regulatory_Domain_Index 5
-#elif defined Regulatory_Domain_ISM_2400
-#define Regulatory_Domain_Index 6
-#elif defined Regulatory_Domain_IN_866
-#define Regulatory_Domain_Index 7
-#else
-#define Regulatory_Domain_Index 8
-#endif
 
 #define FreqCorrectionMax ((int32_t)(100000/FREQ_STEP))
 #define FreqCorrectionMin ((int32_t)(-100000/FREQ_STEP))

--- a/src/lib/LUA/devLUA.cpp
+++ b/src/lib/LUA/devLUA.cpp
@@ -18,10 +18,12 @@ static char strPowerLevels[] = "10;25;50;100;250;500;1000;2000";
 static struct luaItem_selection luaAirRate = {
     {"Packet Rate", CRSF_TEXT_SELECTION},
     0, // value
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#if defined(RADIO_SX127X)
     "25(-123dbm);50(-120dbm);100(-117dbm);200(-112dbm)",
-#elif defined(Regulatory_Domain_ISM_2400)
+#elif defined(RADIO_SX1280)
     "50(-117dbm);150(-112dbm);250(-108dbm);500(-105dbm)",
+#else
+    #error Invalid radio configuration!
 #endif
     "Hz"
 };

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -2,7 +2,6 @@
 #include "POWERMGNT.h"
 #include "DAC.h"
 #include "helpers.h"
-#include "common.h"
 
 /*
  * Moves the power management values and special cases out of the main code and into `targets.h`.

--- a/src/lib/SCREEN/screen.cpp
+++ b/src/lib/SCREEN/screen.cpp
@@ -6,7 +6,7 @@ void Screen::nullCallback(int updateType) {}
 void (*Screen::updatecallback)(int updateType) = &nullCallback;
 
 
-#ifdef Regulatory_Domain_ISM_2400
+#if defined(RADIO_SX1280)
 const char *Screen::rate_string[RATE_MAX_NUMBER] = {
     "500Hz",
     "250Hz",

--- a/src/python/build_flags.py
+++ b/src/python/build_flags.py
@@ -95,7 +95,7 @@ def regulatory_domain_to_env():
     regions = [("AU_915", "AU915"), ("EU_868", "EU868"), ("IN_866", "IN866"), ("AU_433", "AU433"), ("EU_433", "EU433"), ("FCC_915","FCC915"), ("ISM_2400", "ISM2G4"), ("EU_CE_2400", "CE2G4")]
     retVal = "UNK"
     if ("_2400" in target_name or \
-        '-DRADIO_2400=1' in build_flags) and \
+        '-DRADIO_SX1280=1' in build_flags) and \
         '-DRegulatory_Domain_EU_CE_2400' not in build_flags:
         retVal = "ISM2G4"
     else:
@@ -124,11 +124,11 @@ build_flags.append("-DLATEST_VERSION=" + get_ver_and_reg()) # version and domain
 build_flags.append("-DTARGET_NAME=" + re.sub("_VIA_.*", "", target_name))
 condense_flags()
 
-if '-DRADIO_900=1' in build_flags:
+if '-DRADIO_SX127X=1' in build_flags:
     # disallow setting 2400s for 900
     if fnmatch.filter(build_flags, '*-DRegulatory_Domain_ISM_2400') or \
         fnmatch.filter(build_flags, '*-DRegulatory_Domain_EU_CE_2400'):
-        print_error('Regulatory_Domain 2400 not compatible with RADIO_900')
+        print_error('Regulatory_Domain 2400 not compatible with RADIO_SX127X')
 
     # require a domain be set for 900
     if not fnmatch.filter(build_flags, '*-DRegulatory_Domain*'):

--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -5,8 +5,7 @@ static_assert(RATE_DEFAULT < RATE_MAX, "Default rate must be below RATE_MAX");
 static_assert(RATE_BINDING < RATE_MAX, "Binding rate must be below RATE_MAX");
 
 
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) \
-    || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#if defined(RADIO_SX127X)
 
 #include "SX127xDriver.h"
 SX127xDriver DMA_ATTR Radio;
@@ -24,7 +23,7 @@ expresslrs_rf_pref_params_s ExpressLRS_AirRateRFperf[RATE_MAX] = {
     {3, RATE_25HZ, -123, 29950, 6000, 4000, 0, 5000}};
 #endif
 
-#if defined(Regulatory_Domain_ISM_2400)
+#if defined(RADIO_SX1280)
 
 #include "SX1280Driver.h"
 SX1280Driver DMA_ATTR Radio;

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -523,7 +523,7 @@ void ICACHE_RAM_ATTR HWtimerCallbackTock()
     bool didFHSS = HandleFHSS();
     bool tlmSent = HandleSendTelemetryResponse();
 
-    #if !defined(Regulatory_Domain_ISM_2400)
+    #if defined(RADIO_SX127X)
     if (!didFHSS && !tlmSent && LQCalc.currentIsSet())
     {
         HandleFreqCorr(Radio.GetFrequencyErrorbool());      // Adjusts FreqCorrection for RX freq offset
@@ -532,7 +532,7 @@ void ICACHE_RAM_ATTR HWtimerCallbackTock()
     #else
         (void)didFHSS;
         (void)tlmSent;
-    #endif /* Regulatory_Domain_ISM_2400 */
+    #endif /* RADIO_SX127X */
 
     #if defined(DEBUG_RX_SCOREBOARD)
     static bool lastPacketWasTelemetry = false;
@@ -553,7 +553,7 @@ void LostConnection()
     RXtimerState = tim_disconnected;
     hwTimer.resetFreqOffset();
     FreqCorrection = 0;
-    #if !defined(Regulatory_Domain_ISM_2400)
+    #if defined(RADIO_SX127X)
     Radio.SetPPMoffsetReg(0);
     #endif
     Offset = 0;
@@ -987,7 +987,7 @@ static void HandleUARTin()
 static void setupRadio()
 {
     Radio.currFreq = GetInitialFreq();
-#if !defined(Regulatory_Domain_ISM_2400)
+#if defined(RADIO_SX127X)
     //Radio.currSyncWord = UID[3];
 #endif
     bool init_success = Radio.Begin();

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -339,7 +339,7 @@ void ICACHE_RAM_ATTR GenerateSyncPacketData()
 
 uint8_t adjustPacketRateForBaud(uint8_t rateIndex)
 {
-  #if defined(Regulatory_Domain_ISM_2400)
+  #if defined(RADIO_SX1280)
     // Packet rate limited to 250Hz if we are on 115k baud
     if (crsf.GetCurrentBaudRate() == 115200) {
       while (rateIndex < RATE_MAX) {
@@ -996,7 +996,7 @@ void setup()
   config.Load(); // Load the stored values from eeprom
 
   Radio.currFreq = GetInitialFreq(); //set frequency first or an error will occur!!!
-  #if !defined(Regulatory_Domain_ISM_2400)
+  #if defined(RADIO_SX127X)
   //Radio.currSyncWord = UID[3];
   #endif
   bool init_success = Radio.Begin();

--- a/src/targets/HGLRC_2400.ini
+++ b/src/targets/HGLRC_2400.ini
@@ -8,7 +8,6 @@ extends = env_common_esp32, radio_2400
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_2400.build_flags}
 	-include target/HGLRC_Hermes_2400_TX.h
 	-D VTABLES_IN_FLASH=1
 	-O2

--- a/src/targets/Jumper_2400.ini
+++ b/src/targets/Jumper_2400.ini
@@ -9,7 +9,6 @@ board = pico32
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_2400.build_flags}
 	-include target/Jumper_AION_2400_T-Pro_TX.h
 	-D VTABLES_IN_FLASH=1
 	-O2
@@ -28,7 +27,6 @@ board = pico32
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_2400.build_flags}
 	-include target/Jumper_AION_NANO_2400_TX.h
 	-D VTABLES_IN_FLASH=1
 	-O2

--- a/src/targets/MATEK_2400.ini
+++ b/src/targets/MATEK_2400.ini
@@ -9,7 +9,6 @@ extends = env_common_esp82xx, radio_2400
 build_flags =
 	${env_common_esp82xx.build_flags}
 	${common_env_data.build_flags_rx}
-	${radio_2400.build_flags}
 	-include target/MATEK_2400_RX.h
 src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 

--- a/src/targets/axis_2400.ini
+++ b/src/targets/axis_2400.ini
@@ -2,7 +2,7 @@
 # Transmitter targets
 # ********************************
 [env:AXIS_THOR_2400_TX_via_UART]
-extends = env_common_esp32
+extends = env_common_esp32, radio_2400
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
@@ -25,7 +25,7 @@ extends = env:AXIS_THOR_2400_TX_via_UART
 # ********************************
 
 [env:AXIS_THOR_2400_RX_via_UART]
-extends = env_common_esp82xx
+extends = env_common_esp82xx, radio_2400
 build_flags =
 	${env_common_esp82xx.build_flags}
 	${common_env_data.build_flags_rx}

--- a/src/targets/betafpv_2400.ini
+++ b/src/targets/betafpv_2400.ini
@@ -7,7 +7,6 @@ extends = env_common_esp32, radio_2400
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_2400.build_flags}
 	-include target/BETAFPV_2400_TX.h
 	-D VTABLES_IN_FLASH=1
 	-O2
@@ -18,7 +17,7 @@ src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 extends = env:BETAFPV_2400_TX_via_UART
 
 [env:BETAFPV_2400_TX_MICRO_via_UART]
-extends = env_common_esp32
+extends = env_common_esp32, radio_2400
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
@@ -56,7 +55,6 @@ extends = env_common_esp82xx, radio_2400
 build_flags =
 	${env_common_esp82xx.build_flags}
 	${common_env_data.build_flags_rx}
-	${radio_2400.build_flags}
 	-include target/BETAFPV_2400_RX.h
 src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 

--- a/src/targets/betafpv_900.ini
+++ b/src/targets/betafpv_900.ini
@@ -7,7 +7,6 @@ extends = env_common_esp32, radio_900
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_900.build_flags}
 	-include target/BETAFPV_900_TX.h
 upload_speed = 460800
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
@@ -16,7 +15,7 @@ src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 extends = env:BETAFPV_900_TX_via_UART
 
 [env:BETAFPV_900_TX_MICRO_via_UART]
-extends = env_common_esp32
+extends = env_common_esp32, radio_900
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
@@ -38,7 +37,6 @@ extends = env_common_esp82xx, radio_900
 build_flags =
 	${env_common_esp82xx.build_flags}
 	${common_env_data.build_flags_rx}
-	${radio_900.build_flags}
 	-include target/DIY_900_RX_ESP8285_SX127x.h
 src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -17,11 +17,9 @@ build_flags_tx = -DTARGET_TX=1 ${common_env_data.build_flags}
 build_flags_rx = -DTARGET_RX=1 ${common_env_data.build_flags}
 
 [radio_900]
-build_flags = -DRADIO_900=1
 lib_ignore = SX1280Driver
 
 [radio_2400]
-build_flags = -DRADIO_2400=1
 lib_ignore = SX127xDriver
 
 # ------------------------- COMMON ESP32 DEFINITIONS -----------------

--- a/src/targets/diy_2400.ini
+++ b/src/targets/diy_2400.ini
@@ -8,7 +8,6 @@ extends = env_common_esp32, radio_2400
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_2400.build_flags}
 	-include target/DIY_2400_TX_ESP32_SX1280_Mini.h
 	-D VTABLES_IN_FLASH=1
 	-O2
@@ -22,7 +21,6 @@ extends = env_common_esp32, radio_2400
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_2400.build_flags}
 	-include target/DIY_2400_TX_ESP32_SX1280_E28.h
 	-D VTABLES_IN_FLASH=1
 	-O2
@@ -38,7 +36,6 @@ extends = env_common_esp32, radio_2400
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_2400.build_flags}
 	-include target/DIY_2400_TX_ESP32_SX1280_LORA1280F27.h
 	-D VTABLES_IN_FLASH=1
 	-O2
@@ -56,7 +53,6 @@ extends = env_common_esp82xx, radio_2400
 build_flags =
 	${env_common_esp82xx.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_2400.build_flags}
 	-include target/DIY_2400_TX_ESP8285_SX1280.h
 src_filter = ${env_common_esp82xx.src_filter} -<rx_*.cpp>
 upload_speed = 921600
@@ -66,7 +62,6 @@ extends = env_common_esp32, radio_2400
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_2400.build_flags}
 	-include target/DIY_2400_TX_DUPLETX_TX.h
 	-D VTABLES_IN_FLASH=1
 	-O2
@@ -89,7 +84,6 @@ extends = env_common_esp82xx, radio_2400
 build_flags =
 	${env_common_esp82xx.build_flags}
 	${common_env_data.build_flags_rx}
-	${radio_2400.build_flags}
 	-include target/DIY_2400_RX_ESP8285_SX1280.h
 src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 
@@ -103,7 +97,7 @@ upload_command = ${env_common_esp82xx.bf_upload_command}
 extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART
 
 [env:DIY_2400_RX_PWMP_via_UART]
-extends = env_common_esp82xx
+extends = env_common_esp82xx, radio_2400
 build_flags =
 	${env_common_esp82xx.build_flags}
 	${common_env_data.build_flags_rx}
@@ -121,7 +115,6 @@ board_upload.maximum_size = 114688
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_rx}
-	${radio_2400.build_flags}
 	-include target/DIY_2400_RX_STM32_CCG_Nano_v0_5.h
 	-D HAL_RTC_MODULE_DISABLED=1
 	-D HAL_ADC_MODULE_DISABLED=1

--- a/src/targets/diy_900.ini
+++ b/src/targets/diy_900.ini
@@ -8,7 +8,6 @@ extends = env_common_esp32, radio_900
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_900.build_flags}
 	-include target/DIY_900_TX_TTGO_V1_SX127x.h
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 lib_deps =
@@ -22,7 +21,6 @@ extends = env_common_esp32, radio_900
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_900.build_flags}
 	-include target/DIY_900_TX_TTGO_V2_SX127x.h
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 lib_deps =
@@ -36,7 +34,6 @@ extends = env_common_esp32, radio_900
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_900.build_flags}
 	-include target/DIY_900_TX_ESP32_SX127x_E19.h
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 
@@ -48,7 +45,6 @@ extends = env_common_esp32, radio_900
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_900.build_flags}
 	-include target/DIY_900_TX_ESP32_SX127x_RFM95.h
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 
@@ -67,7 +63,6 @@ upload_speed = 460800
 build_flags =
 	${env_common_esp82xx.build_flags}
 	${common_env_data.build_flags_rx}
-	${radio_900.build_flags}
 	-include target/DIY_900_RX_ESP8285_SX127x.h
 src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 
@@ -85,7 +80,6 @@ extends = env_common_esp82xx, radio_900
 build_flags =
 	${env_common_esp82xx.build_flags}
 	${common_env_data.build_flags_rx}
-	${radio_900.build_flags}
 	-include target/DIY_900_RX_HUZZAH_RFM95W.h
 src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 
@@ -99,7 +93,7 @@ upload_command = ${env_common_esp82xx.bf_upload_command}
 extends = env:DIY_900_RX_HUZZAH_RFM95W_via_UART
 
 [env:DIY_900_RX_PWMP_via_UART]
-extends = env_common_esp82xx
+extends = env_common_esp82xx, radio_900
 build_flags =
 	${env_common_esp82xx.build_flags}
 	${common_env_data.build_flags_rx}

--- a/src/targets/diy_ble_joystick.ini
+++ b/src/targets/diy_ble_joystick.ini
@@ -9,7 +9,6 @@ build_flags =
     -DUSE_BLE_JOYSTICK
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_2400.build_flags}
 	-include target/DIY_2400_TX_ESP32_SX1280_E28.h
 	-D VTABLES_IN_FLASH=1
 	-O2

--- a/src/targets/frsky.ini
+++ b/src/targets/frsky.ini
@@ -9,7 +9,6 @@ extends = env_common_stm32, radio_900
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_900.build_flags}
 	-include target/Frsky_TX_R9M.h
 	-flto
 	-D HSE_VALUE=12000000U
@@ -32,7 +31,6 @@ extends = env:Frsky_TX_R9M_via_STLINK
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_900.build_flags}
 	-include target/Frsky_TX_R9M_LITE.h
 	-flto
 	-D HSE_VALUE=12000000U
@@ -47,7 +45,6 @@ board = robotdyn_blackpill_f303cc
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_900.build_flags}
 	-include target/Frsky_TX_R9M_LITE_PRO.h
 	-D HSE_VALUE=12000000U
 	-DVECT_TAB_OFFSET=0x8000U
@@ -69,7 +66,6 @@ board = R9MM
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_rx}
-	${radio_900.build_flags}
 	-include target/Frsky_RX_R9M.h
 	-D HSE_VALUE=24000000U
 	-DVECT_TAB_OFFSET=0x08008000U
@@ -92,7 +88,6 @@ extends = env_common_stm32, radio_900
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_rx}
-	${radio_900.build_flags}
 	-D TARGET_R9SLIM_RX
 	-include target/Frsky_RX_R9M.h
 	-D HSE_VALUE=12000000U
@@ -112,7 +107,6 @@ board_build.ldscript = variants/R9MM/R9MM_ldscript.ld
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_rx}
-	${radio_900.build_flags}
 	-D TARGET_R9SLIMPLUS_RX
 	-include target/Frsky_RX_R9M.h
 	-D HSE_VALUE=12000000U
@@ -136,7 +130,6 @@ board = r9mx
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_rx}
-	${radio_900.build_flags}
 	-D TARGET_R9MX_RX
 	-include target/Frsky_RX_R9M.h
 	-DVECT_TAB_OFFSET=0x08008000U
@@ -161,7 +154,6 @@ extends = env_common_stm32, radio_900
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_rx}
-	${radio_900.build_flags}
 	-D TARGET_R900MINI_RX
 	-include target/Frsky_RX_R9M.h
 	-D HSE_VALUE=12000000U

--- a/src/targets/happymodel_2400.ini
+++ b/src/targets/happymodel_2400.ini
@@ -8,7 +8,6 @@ extends = env_common_esp32, radio_2400
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_2400.build_flags}
 	-include target/HappyModel_ES24TX_2400_TX.h
 	-D VTABLES_IN_FLASH=1
 	-O2
@@ -22,7 +21,6 @@ extends = env_common_esp32, radio_2400
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_2400.build_flags}
 	-include target/HappyModel_ES24TX_Pro_Series_2400_TX.h
 	-D VTABLES_IN_FLASH=1
 	-O2

--- a/src/targets/happymodel_900.ini
+++ b/src/targets/happymodel_900.ini
@@ -8,7 +8,6 @@ extends = env_common_stm32, radio_900
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_900.build_flags}
 	-include target/HappyModel_TX_ES915TX.h
 	-flto
 	-D HSE_VALUE=12000000U
@@ -31,7 +30,6 @@ extends = env_common_esp32, radio_900
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_900.build_flags}
 	-include target/HappyModel_TX_ES900TX.h
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
 
@@ -49,7 +47,6 @@ board = R9MM
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_rx}
-	${radio_900.build_flags}
 	-include target/Frsky_RX_R9M.h
 	-D HSE_VALUE=24000000U
 	-DVECT_TAB_OFFSET=0x08008000U

--- a/src/targets/iFlight_2400.ini
+++ b/src/targets/iFlight_2400.ini
@@ -8,7 +8,6 @@ extends = env_common_esp32, radio_2400
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_2400.build_flags}
 	-include target/iFlight_2400_TX.h
 	-D VTABLES_IN_FLASH=1
 	-O2
@@ -26,7 +25,6 @@ extends = env_common_esp82xx, radio_2400
 build_flags =
 	${env_common_esp82xx.build_flags}
 	${common_env_data.build_flags_rx}
-	${radio_2400.build_flags}
 	-include target/iFlight_2400_RX.h
 src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 

--- a/src/targets/iFlight_900.ini
+++ b/src/targets/iFlight_900.ini
@@ -7,7 +7,6 @@ extends = env_common_esp32, radio_900
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_900.build_flags}
 	-include target/iFlight_900_TX.h
 upload_speed = 460800
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>

--- a/src/targets/imrc.ini
+++ b/src/targets/imrc.ini
@@ -9,7 +9,6 @@ board = GHOST_TX
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_2400.build_flags}
 	-include target/GHOST_2400_TX.h
 	-D DEBUG=1
  	-D HSE_VALUE=32000000U
@@ -38,7 +37,6 @@ board = GHOST_ATTO
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_rx}
-	${radio_2400.build_flags}
  	-include target/GHOST_ATTO_2400_RX.h
  	-D HSE_VALUE=32000000U
 	-DVECT_TAB_OFFSET=0x08004000U

--- a/src/targets/namimnorc_2400.ini
+++ b/src/targets/namimnorc_2400.ini
@@ -8,7 +8,6 @@ extends = env_common_stm32, radio_2400
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_2400.build_flags}
 	-D HSE_VALUE=12000000U
 	-D VECT_TAB_OFFSET=0x4000U
 	-include target/NamimnoRC_FLASH_2400_TX.h
@@ -22,7 +21,7 @@ upload_flags =
 extends = env:NamimnoRC_FLASH_2400_TX_via_STLINK
 
 [env:NamimnoRC_FLASH_2400_OLED_TX_via_UART]
-extends = env_common_esp32
+extends = env_common_esp32, radio_2400
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
@@ -46,7 +45,6 @@ extends = env_common_stm32, radio_2400
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_rx}
-	${radio_2400.build_flags}
 	-D HSE_VALUE=12000000U
 	-D VECT_TAB_OFFSET=0x8000U
 	-include target/NamimnoRC_FLASH_2400_RX_STM32.h
@@ -64,7 +62,6 @@ extends = env_common_esp82xx, radio_2400
 build_flags =
 	${env_common_esp82xx.build_flags}
 	${common_env_data.build_flags_rx}
-	${radio_2400.build_flags}
 	-include target/NamimnoRC_FLASH_2400_RX_ESP8285.h
 src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 

--- a/src/targets/namimnorc_900.ini
+++ b/src/targets/namimnorc_900.ini
@@ -8,7 +8,6 @@ extends = env_common_stm32, radio_900
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_900.build_flags}
 	-include target/NamimnoRC_VOYAGER_900_TX.h
 	-flto
 	-D HSE_VALUE=12000000U
@@ -24,7 +23,7 @@ lib_deps =
 extends = env:NamimnoRC_VOYAGER_900_TX_via_STLINK
 
 [env:NamimnoRC_VOYAGER_900_OLED_TX_via_UART]
-extends = env_common_esp32
+extends = env_common_esp32, radio_900
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
@@ -48,7 +47,6 @@ extends = env_common_stm32, radio_900
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_rx}
-	${radio_900.build_flags}
 	-D HSE_VALUE=12000000U
 	-D VECT_TAB_OFFSET=0x8000U
 	-include target/NamimnoRC_VOYAGER_900_RX.h
@@ -67,7 +65,6 @@ extends = env_common_esp82xx, radio_900
 build_flags =
 	${env_common_esp82xx.build_flags}
 	${common_env_data.build_flags_rx}
-	${radio_900.build_flags}
 	-include target/NamimnoRC_VOYAGER_900_ESP_RX.h
 src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 

--- a/src/targets/quadkopters_2400.ini
+++ b/src/targets/quadkopters_2400.ini
@@ -8,12 +8,11 @@ extends = env_common_esp32, radio_2400
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_2400.build_flags}
 	-include target/QuadKopters_JR_2400_TX.h
 	-D VTABLES_IN_FLASH=1
 	-O2
 src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
-lib_deps = 
+lib_deps =
 	${env_common_esp32.lib_deps}
 
 [env:QuadKopters_JR_2400_TX_via_WIFI]

--- a/src/targets/radiomaster_2400.ini
+++ b/src/targets/radiomaster_2400.ini
@@ -3,7 +3,6 @@ extends = env_common_esp32, radio_2400
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_2400.build_flags}
 	-include target/RadioMaster_Zorro_2400_TX.h
 	-D VTABLES_IN_FLASH=1
 	-O2

--- a/src/targets/siyi.ini
+++ b/src/targets/siyi.ini
@@ -9,7 +9,6 @@ debug_tool = stlink
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_2400.build_flags}
 	-include target/FM30_TX.h
     -DUSBCON
     -DPIO_FRAMEWORK_ARDUINO_ENABLE_CDC
@@ -34,7 +33,6 @@ board = FM30_mini
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_rx}
-	${radio_2400.build_flags}
 	-include target/FM30_RX_MINI.h
 	-D HSE_VALUE=16000000U
 	-D VECT_TAB_OFFSET=0x4000U
@@ -53,7 +51,6 @@ board = FM30_mini
 build_flags =
 	${env_common_stm32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_2400.build_flags}
 	-D RX_AS_TX
 	-include target/FM30_RX_MINI.h
 	-D HSE_VALUE=16000000U

--- a/src/targets/vantac_2400.ini
+++ b/src/targets/vantac_2400.ini
@@ -8,7 +8,6 @@ extends = env_common_esp32, radio_2400
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
-	${radio_2400.build_flags}
 	-include target/Vantac_Lite_2400_TX.h
 	-D VTABLES_IN_FLASH=1
 	-O2
@@ -28,7 +27,6 @@ extends = env_common_esp82xx, radio_2400
 build_flags =
 	${env_common_esp82xx.build_flags}
 	${common_env_data.build_flags_rx}
-	${radio_2400.build_flags}
 	-include target/Vantac_2400_RX.h
 src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 


### PR DESCRIPTION
In a lot of places we are using the regulatory domain as a surrogate for the radio chip. So rather than using the regulatory domain, I've renamed the RADIO_900/2400 defines from the .ini files to RADIO_SX127X/SX1280 and defined them in the target header files. In most places where there were check for Regulatory_Domain_* they have been changed to check the appropriate radio chip define.

The only places left checking for specific regulatory domains are EU_CE_2400 for LBT specific code paths, some _868 ones for different power values in some targets, and the FHSS tables.

This PR is part of the larger to build a "single" for each target. Actually two for 2G4, FCC and LBT.