### PR TITLE
Variable autobaud

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -92,6 +92,13 @@ uint8_t CRSF::maxPeriodBytes = CRSF_MAX_PACKET_LEN;
 uint32_t CRSF::TxToHandsetBauds[] = {400000, 115200, 5250000, 3750000, 1870000, 921600};
 uint8_t CRSF::UARTcurrentBaudIdx = 0;
 uint32_t CRSF::UARTrequestedBaud = 400000;
+#if defined(PLATFORM_ESP32)
+#ifdef UART_INVERTED
+bool CRSF::UARTinverted = true;
+#else
+bool CRSF::UARTinverted = false;
+#endif
+#endif
 
 bool CRSF::CRSFstate = false;
 
@@ -703,15 +710,15 @@ void ICACHE_RAM_ATTR CRSF::duplex_set_RX()
 #if defined(PLATFORM_ESP32)
   #if (GPIO_PIN_RCSIGNAL_TX == GPIO_PIN_RCSIGNAL_RX)
     ESP_ERROR_CHECK(gpio_set_direction((gpio_num_t)GPIO_PIN_RCSIGNAL_RX, GPIO_MODE_INPUT));
-    #ifdef UART_INVERTED
-    gpio_matrix_in((gpio_num_t)GPIO_PIN_RCSIGNAL_RX, U0RXD_IN_IDX, true);
-    gpio_pulldown_en((gpio_num_t)GPIO_PIN_RCSIGNAL_RX);
-    gpio_pullup_dis((gpio_num_t)GPIO_PIN_RCSIGNAL_RX);
-    #else
-    gpio_matrix_in((gpio_num_t)GPIO_PIN_RCSIGNAL_RX, U0RXD_IN_IDX, false);
-    gpio_pullup_en((gpio_num_t)GPIO_PIN_RCSIGNAL_RX);
-    gpio_pulldown_dis((gpio_num_t)GPIO_PIN_RCSIGNAL_RX);
-    #endif
+    if (UARTinverted) {
+        gpio_matrix_in((gpio_num_t)GPIO_PIN_RCSIGNAL_RX, U0RXD_IN_IDX, true);
+        gpio_pulldown_en((gpio_num_t)GPIO_PIN_RCSIGNAL_RX);
+        gpio_pullup_dis((gpio_num_t)GPIO_PIN_RCSIGNAL_RX);
+    } else {
+        gpio_matrix_in((gpio_num_t)GPIO_PIN_RCSIGNAL_RX, U0RXD_IN_IDX, false);
+        gpio_pullup_en((gpio_num_t)GPIO_PIN_RCSIGNAL_RX);
+        gpio_pulldown_dis((gpio_num_t)GPIO_PIN_RCSIGNAL_RX);
+    }
   #endif
 #elif defined(PLATFORM_ESP8266)
     // Enable loopback on UART0 to connect the RX pin to the TX pin
@@ -729,19 +736,19 @@ void ICACHE_RAM_ATTR CRSF::duplex_set_TX()
   #if (GPIO_PIN_RCSIGNAL_TX == GPIO_PIN_RCSIGNAL_RX)
     ESP_ERROR_CHECK(gpio_set_pull_mode((gpio_num_t)GPIO_PIN_RCSIGNAL_TX, GPIO_FLOATING));
     ESP_ERROR_CHECK(gpio_set_pull_mode((gpio_num_t)GPIO_PIN_RCSIGNAL_RX, GPIO_FLOATING));
-    #ifdef UART_INVERTED
-    ESP_ERROR_CHECK(gpio_set_level((gpio_num_t)GPIO_PIN_RCSIGNAL_TX, 0));
-    ESP_ERROR_CHECK(gpio_set_direction((gpio_num_t)GPIO_PIN_RCSIGNAL_TX, GPIO_MODE_OUTPUT));
-    constexpr uint8_t MATRIX_DETACH_IN_LOW = 0x30; // routes 0 to matrix slot
-    gpio_matrix_in(MATRIX_DETACH_IN_LOW, U0RXD_IN_IDX, false); // Disconnect RX from all pads
-    gpio_matrix_out((gpio_num_t)GPIO_PIN_RCSIGNAL_TX, U0TXD_OUT_IDX, true, false);
-    #else
-    ESP_ERROR_CHECK(gpio_set_level((gpio_num_t)GPIO_PIN_RCSIGNAL_TX, 1));
-    ESP_ERROR_CHECK(gpio_set_direction((gpio_num_t)GPIO_PIN_RCSIGNAL_TX, GPIO_MODE_OUTPUT));
-    constexpr uint8_t MATRIX_DETACH_IN_HIGH = 0x38; // routes 1 to matrix slot
-    gpio_matrix_in(MATRIX_DETACH_IN_HIGH, U0RXD_IN_IDX, false); // Disconnect RX from all pads
-    gpio_matrix_out((gpio_num_t)GPIO_PIN_RCSIGNAL_TX, U0TXD_OUT_IDX, false, false);
-    #endif
+    if (UARTinverted) {
+        ESP_ERROR_CHECK(gpio_set_level((gpio_num_t)GPIO_PIN_RCSIGNAL_TX, 0));
+        ESP_ERROR_CHECK(gpio_set_direction((gpio_num_t)GPIO_PIN_RCSIGNAL_TX, GPIO_MODE_OUTPUT));
+        constexpr uint8_t MATRIX_DETACH_IN_LOW = 0x30; // routes 0 to matrix slot
+        gpio_matrix_in(MATRIX_DETACH_IN_LOW, U0RXD_IN_IDX, false); // Disconnect RX from all pads
+        gpio_matrix_out((gpio_num_t)GPIO_PIN_RCSIGNAL_TX, U0TXD_OUT_IDX, true, false);
+    } else {
+        ESP_ERROR_CHECK(gpio_set_level((gpio_num_t)GPIO_PIN_RCSIGNAL_TX, 1));
+        ESP_ERROR_CHECK(gpio_set_direction((gpio_num_t)GPIO_PIN_RCSIGNAL_TX, GPIO_MODE_OUTPUT));
+        constexpr uint8_t MATRIX_DETACH_IN_HIGH = 0x38; // routes 1 to matrix slot
+        gpio_matrix_in(MATRIX_DETACH_IN_HIGH, U0RXD_IN_IDX, false); // Disconnect RX from all pads
+        gpio_matrix_out((gpio_num_t)GPIO_PIN_RCSIGNAL_TX, U0TXD_OUT_IDX, false, false);
+    }
   #endif
 #elif defined(PLATFORM_ESP8266)
     // Disable loopback to disconnect the RX pin from the TX pin
@@ -767,14 +774,27 @@ void ICACHE_RAM_ATTR CRSF::adjustMaxPacketSize()
 #if defined(PLATFORM_ESP32)
 uint32_t CRSF::autobaud()
 {
+    static enum { INIT, MEASURED, INVERTED } state;
+
     uint32_t *autobaud_reg = (uint32_t *)UART_AUTOBAUD_REG(0);
     uint32_t *rxd_cnt_reg = (uint32_t *)UART_RXD_CNT_REG(0);
 
+     if (state == MEASURED) {
+        UARTinverted = !UARTinverted;
+        state = INVERTED;
+        return UARTrequestedBaud;
+    } else if (state == INVERTED) {
+        UARTinverted = !UARTinverted;
+        state = INIT;
+    }
+    
     if ((*autobaud_reg & 1) == 0) {
         *autobaud_reg = (4 << 8) | 1;    // enable, glitch filter 4
         return 400000;
     } else if ((*autobaud_reg & 1) && (*rxd_cnt_reg < 300))
         return 400000;
+
+    state = MEASURED;
 
     uint32_t low_period  = *(uint32_t *)UART_LOWPULSE_REG(0);
     uint32_t high_period = *(uint32_t *)UART_HIGHPULSE_REG(0);

--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -779,7 +779,7 @@ uint32_t CRSF::autobaud()
     uint32_t *autobaud_reg = (uint32_t *)UART_AUTOBAUD_REG(0);
     uint32_t *rxd_cnt_reg = (uint32_t *)UART_RXD_CNT_REG(0);
 
-     if (state == MEASURED) {
+    if (state == MEASURED) {
         UARTinverted = !UARTinverted;
         state = INVERTED;
         return UARTrequestedBaud;
@@ -801,9 +801,10 @@ uint32_t CRSF::autobaud()
     *autobaud_reg = (4 << 8) | 0;
 
     DBGLN("autobaud: low %d, high %d", low_period, high_period);
-    // tech ref says baud rate = 80000000/min(UART_LOWPULSE_REG, UART_HIGHPULSE_REG);
-    // add 2 based on testing for lowest deviation
-    int32_t calulatedBaud = 80000000 / (min(low_period, high_period) + 2);
+    // sample code at https://github.com/espressif/esp-idf/issues/3336
+    // says baud rate = 80000000/min(UART_LOWPULSE_REG, UART_HIGHPULSE_REG);
+    // Based on testing use max and add 2 for lowest deviation
+    int32_t calulatedBaud = 80000000 / (max(low_period, high_period) + 2);
     int32_t bestBaud = (int32_t)TxToHandsetBauds[0];
     for(int i=0 ; i<ARRAY_SIZE(TxToHandsetBauds) ; i++)
     {

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -158,6 +158,9 @@ private:
     static uint32_t UARTrequestedBaud;
     static uint8_t MspData[ELRS_MSP_BUFFER];
     static uint8_t MspDataLength;
+    #if defined(PLATFORM_ESP32)
+    static bool UARTinverted;
+    #endif
 
     static void ICACHE_RAM_ATTR adjustMaxPacketSize();
     static void duplex_set_RX();

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -113,7 +113,7 @@ public:
     static void ResetMspQueue();
     static volatile uint32_t OpenTXsyncLastSent;
     static uint8_t GetMaxPacketBytes() { return maxPacketBytes; }
-    static uint32_t GetCurrentBaudRate() { return TxToHandsetBauds[UARTcurrentBaudIdx]; }
+    static uint32_t GetCurrentBaudRate() { return UARTrequestedBaud; }
 
     static uint32_t ICACHE_RAM_ATTR GetRCdataLastRecv();
     static void ICACHE_RAM_ATTR updateSwitchValues();
@@ -155,6 +155,7 @@ private:
     static uint8_t maxPeriodBytes;
     static uint32_t TxToHandsetBauds[6];
     static uint8_t UARTcurrentBaudIdx;
+    static uint32_t UARTrequestedBaud;
     static uint8_t MspData[ELRS_MSP_BUFFER];
     static uint8_t MspDataLength;
 
@@ -164,6 +165,7 @@ private:
     static bool ProcessPacket();
     static void handleUARTout();
     static bool UARTwdt();
+    static uint32_t autobaud();
 #endif
 
     static void flush_port_input(void);

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -50,7 +50,7 @@ public:
 
     /////Variables/////
 
-    
+
     static volatile uint8_t ParameterUpdateData[3];
 
     #ifdef CRSF_TX_MODULE
@@ -153,7 +153,7 @@ private:
     static uint32_t UARTwdtLastChecked;
     static uint8_t maxPacketBytes;
     static uint8_t maxPeriodBytes;
-    static uint32_t TxToHandsetBauds[6];
+    static uint32_t TxToHandsetBauds[7];
     static uint8_t UARTcurrentBaudIdx;
     static uint32_t UARTrequestedBaud;
     static uint8_t MspData[ELRS_MSP_BUFFER];


### PR DESCRIPTION
The autobaud registers count edges and keep track of the shortest high and low pulses.  This information is used to calculate the bitrate.  This method makes it easier to support a variety of bitrates, adapts to individual handset differences, and is faster than trying a list of baudrates.  Original motivation was making it easier to test what rate a handset can support.

While the reference manual states the baud rate should be 80MHz / min(low pulse count, high pulse count) it seems that adding 2 to the count produces better results.  In the table the 2.25MHz datarate was tested on a T8SG+, and the others with a T16.  Radios were HappyModel ES2400TX and EP1 RX. The calculated rate is what I think the handsets run at based on the stm32f4 reference manual and edgetx code (84MHz pclk, 8x sampling for rates over 400k).

| handset baud rate | calculated rate | autobaud count | UARTrequestedBaud clk/count | error % | UARTrequestedBaud clk/(count+1) | error % | UARTrequestedBaud clk/(count+2) | error % |
|-------------------|------------|----------------|------------|----------------|------------|----------------|------------|----------------|
| 115200 | 115226 | 692 | 115,606 | 0.33% | 115,440 | 0.19% | 115,273 | 0.04% |
| 400000 | 400000 | 198* | 404,040 | 1.01% | 402,010 | 0.50% | 400,000 | 0.00% |
| 921600 | 923076 | 86 | 930,232 | 0.78% | 919,540 | -0.38% | 909,090 | -1.52% |
| 1870000 | 1866666 | 40 | 2,000,000 | 7.14% | 1,951,219 | 4.53% | 1,904,761 | 2.04% |
| 3750000 | 3818181 | 19 | 4,210,526 | 10.28% | 4,000,000 | 4.76% | 3,809,523 | -0.23% |
| 2250000 | 2250000 | 34 | 2,352,941 | 4.58% | 2,285,714 | 1.59% | 2,222,222 | -1.23% |

\* tested but unused as 400K is the default datarate


Update 23 Mar 2022: Added automatic uart inversion detection.  Helps users who swap between inverted and non-inverted handsets.

