### PR TITLE
LUA makeup, Folder name display member values

### DIFF
--- a/src/include/native.h
+++ b/src/include/native.h
@@ -79,6 +79,8 @@ inline void delay(int32_t time) {
 
 inline unsigned long millis() { return 0; }
 inline void delayMicroseconds(int delay) { }
+inline char *itoa(int32_t value, char *str, int base) { sprintf(str, "%d", value); return str; }
+inline char *utoa(uint32_t value, char *str, int base) { sprintf(str, "%u", value); return str; }
 
 const char device_name[] = "testing";
 const uint8_t device_name_size = sizeof(device_name);

--- a/src/lib/LUA/lua.cpp
+++ b/src/lib/LUA/lua.cpp
@@ -57,7 +57,7 @@ uint8_t getLabelLength(char *text, char separator){
   return c-text;
 }
 
-uint8_t findLuaSelectionLabel(const void *luaStruct, char *outarray, uint8_t value, char separator)
+uint8_t findLuaSelectionLabel(const void *luaStruct, char *outarray, uint8_t value)
 {
   const struct luaItem_selection *p1 = (const struct luaItem_selection *)luaStruct;
   char *c = (char *)p1->options;
@@ -66,27 +66,11 @@ uint8_t findLuaSelectionLabel(const void *luaStruct, char *outarray, uint8_t val
     //if count is equal to the parameter value, print out the label to the array
     if(count == value){
         uint8_t labelLength = getLabelLength(c,';');
-        uint8_t labelSpace = getLabelLength(outarray,separator);
-        //don't add spacer if separator is null
-        if(separator != '\0'){
-        //write spacer to wipe old label text
-          for(int i = 0; i<(labelSpace - labelLength); i++){
-            *outarray++ = ' ';
-          }
-        }
         //write label to destination array
         for(int i = 0; i<labelLength; i++){
-          //stop writting if we hit separator or a null in the destination array
-          //if separator is null then keep printing upto labelLength
-          if(*outarray != separator && *outarray != '\0'){
             *outarray++ = *(c + i);
-          }
         }
-        if(separator != '\0'){
-          return labelSpace + 1;
-        } else {
-          return labelLength + 1;
-        }
+        return labelLength;
       }
     //increment the count until value is found
     if(*c == (char)';'){

--- a/src/lib/LUA/lua.cpp
+++ b/src/lib/LUA/lua.cpp
@@ -61,17 +61,25 @@ uint8_t findLuaSelectionLabel(const void *luaStruct, char *outarray, uint8_t val
 {
   const struct luaItem_selection *p1 = (const struct luaItem_selection *)luaStruct;
   char *c = (char *)p1->options;
+  char *u = (char *)p1->units;
   uint8_t count = 0;
   while (*c != '\0'){
     //if count is equal to the parameter value, print out the label to the array
     if(count == value){
-        uint8_t labelLength = getLabelLength(c,';');
-        //write label to destination array
-        for(int i = 0; i<labelLength; i++){
-            *outarray++ = *(c + i);
-        }
-        return labelLength;
+      uint8_t labelLength = getLabelLength(c,';');
+      uint8_t unitLength = 0;
+      //write label to destination array
+      for(int i = 0; i<labelLength; i++){
+          *outarray++ = *(c + i);
       }
+      if(*u != ' '){
+        unitLength = getLabelLength(u,'\0');
+        for(int i = 0; i<unitLength; i++){
+          *outarray++ = *(u + i);
+        }
+      }
+      return labelLength + unitLength;
+    }
     //increment the count until value is found
     if(*c == (char)';'){
       count++;

--- a/src/lib/LUA/lua.cpp
+++ b/src/lib/LUA/lua.cpp
@@ -61,27 +61,18 @@ uint8_t findLuaSelectionLabel(const void *luaStruct, char *outarray, uint8_t val
 {
   const struct luaItem_selection *p1 = (const struct luaItem_selection *)luaStruct;
   char *c = (char *)p1->options;
-  char *u = (char *)p1->units;
   uint8_t count = 0;
   while (*c != '\0'){
     //if count is equal to the parameter value, print out the label to the array
     if(count == value){
       uint8_t labelLength = getLabelLength(c,';');
-      uint8_t unitLength = 0;
       //write label to destination array
-      for(int i = 0; i<labelLength; i++){
-          *outarray++ = *(c + i);
-      }
-      if(*u != ' '){
-        unitLength = getLabelLength(u,'\0');
-        for(int i = 0; i<unitLength; i++){
-          *outarray++ = *(u + i);
-        }
-      }
-      return labelLength + unitLength;
+      strlcpy(outarray, c, labelLength+1);
+      strlcpy(outarray + labelLength, p1->units, strlen(p1->units)+1);
+      return strlen(outarray);
     }
     //increment the count until value is found
-    if(*c == (char)';'){
+    if(*c == ';'){
       count++;
     }
     c++;  
@@ -136,7 +127,7 @@ static uint8_t *luaFolderStructToArray(const void *luaStruct, uint8_t *next)
 {
   const struct luaItem_folder *p1 = (const struct luaItem_folder *)luaStruct;
   if(p1->dyn_name != NULL){
-  return (uint8_t *)stpcpy((char *)next, p1->dyn_name) + 1;
+    return (uint8_t *)stpcpy((char *)next, p1->dyn_name) + 1;
   } else {
     return (uint8_t *)stpcpy((char *)next, p1->common.name) + 1;
   }

--- a/src/lib/LUA/lua.cpp
+++ b/src/lib/LUA/lua.cpp
@@ -67,18 +67,26 @@ uint8_t findLuaSelectionLabel(const void *luaStruct, char *outarray, uint8_t val
     if(count == value){
         uint8_t labelLength = getLabelLength(c,';');
         uint8_t labelSpace = getLabelLength(outarray,separator);
+        //don't add spacer if separator is null
+        if(separator != '\0'){
         //write spacer to wipe old label text
-        for(int i = 0; i<(labelSpace - labelLength); i++){
-          *outarray++ = ' ';
+          for(int i = 0; i<(labelSpace - labelLength); i++){
+            *outarray++ = ' ';
+          }
         }
         //write label to destination array
         for(int i = 0; i<labelLength; i++){
           //stop writting if we hit separator or a null in the destination array
+          //if separator is null then keep printing upto labelLength
           if(*outarray != separator && *outarray != '\0'){
             *outarray++ = *(c + i);
           }
         }
-        return labelSpace + 1;
+        if(separator != '\0'){
+          return labelSpace + 1;
+        } else {
+          return labelLength + 1;
+        }
       }
     //increment the count until value is found
     if(*c == (char)';'){

--- a/src/lib/LUA/lua.cpp
+++ b/src/lib/LUA/lua.cpp
@@ -20,7 +20,6 @@ static volatile bool UpdateParamReq = false;
 
 #ifdef TARGET_TX
 static uint8_t luaWarningFlags = 0b00000000; //8 flag, 1 bit for each flag. set the bit to 1 to show specific warning. 3 MSB is for critical flag
-static uint8_t suppressedLuaWarningFlags = 0xFF; //8 flag, 1 bit for each flag. set the bit to 0 to suppress specific warning
 static void (*populateHandler)() = 0;
 #endif
 

--- a/src/lib/LUA/lua.h
+++ b/src/lib/LUA/lua.h
@@ -37,7 +37,7 @@ struct luaItem_selection {
     struct luaPropertiesCommon common;
     uint8_t value;
     const char* options; // selection options, separated by ';'
-    const char* const units;
+    const char* units;
 } PACKED;
 
 enum luaCmdStep_e : uint8_t {

--- a/src/lib/LUA/lua.h
+++ b/src/lib/LUA/lua.h
@@ -105,6 +105,7 @@ struct luaItem_string {
 
 struct luaItem_folder {
     const struct luaPropertiesCommon common;
+    char* dyn_name;
 } PACKED;
 
 struct tagLuaElrsParams {
@@ -129,6 +130,8 @@ extern void deferExecution(uint32_t ms, std::function<void()> f);
 
 typedef void (*luaCallback)(struct luaPropertiesCommon *item, uint8_t arg);
 void registerLUAParameter(void *definition, luaCallback callback = nullptr, uint8_t parent = 0);
+
+uint8_t luaSelectionFindLabel(uint8_t luaValue, const char *strOptions, uint8_t *outarray);
 
 void sendLuaDevicePacket(void);
 inline void setLuaTextSelectionValue(struct luaItem_selection *luaStruct, uint8_t newvalue) {

--- a/src/lib/LUA/lua.h
+++ b/src/lib/LUA/lua.h
@@ -131,7 +131,7 @@ extern void deferExecution(uint32_t ms, std::function<void()> f);
 typedef void (*luaCallback)(struct luaPropertiesCommon *item, uint8_t arg);
 void registerLUAParameter(void *definition, luaCallback callback = nullptr, uint8_t parent = 0);
 
-uint8_t luaSelectionFindLabel(uint8_t luaValue, const char *strOptions, uint8_t *outarray);
+uint8_t findLuaSelectionLabel(const void *luaStruct, char *outarray, uint8_t value, char separator);
 
 void sendLuaDevicePacket(void);
 inline void setLuaTextSelectionValue(struct luaItem_selection *luaStruct, uint8_t newvalue) {

--- a/src/lib/LUA/lua.h
+++ b/src/lib/LUA/lua.h
@@ -131,7 +131,7 @@ extern void deferExecution(uint32_t ms, std::function<void()> f);
 typedef void (*luaCallback)(struct luaPropertiesCommon *item, uint8_t arg);
 void registerLUAParameter(void *definition, luaCallback callback = nullptr, uint8_t parent = 0);
 
-uint8_t findLuaSelectionLabel(const void *luaStruct, char *outarray, uint8_t value, char separator);
+uint8_t findLuaSelectionLabel(const void *luaStruct, char *outarray, uint8_t value);
 
 void sendLuaDevicePacket(void);
 inline void setLuaTextSelectionValue(struct luaItem_selection *luaStruct, uint8_t newvalue) {

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -49,20 +49,11 @@ static struct luaItem_string luaELRSversion = {
 
 //---------------------------- WiFi -----------------------------
 
-static struct luaItem_command luaRxWebUpdate = {
-    {"Enable Rx WiFi", CRSF_COMMAND},
-    lcsIdle, // step
-    emptySpace
-};
 
 //---------------------------- WiFi -----------------------------
 
 
 extern RxConfig config;
-#if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
-extern unsigned long rebootTime;
-extern void beginWebsever();
-#endif
 
 
 #ifdef POWER_OUTPUT_VALUES
@@ -111,15 +102,6 @@ static void registerLuaParameters()
     config.SetPower(arg);
     POWERMGNT::setPower((PowerLevels_e)constrain(arg + MinPower, MinPower, MaxPower));
     });
-#endif
-#if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
-  registerLUAParameter(&luaRxWebUpdate, [](struct luaPropertiesCommon* item, uint8_t arg){
-    // Do it when polling for status i.e. going back to idle, because we're going to lose conenction to the TX
-    if (arg == 6) {
-        deferExecution(200, [](){ connectionState = wifiUpdate; });
-    }
-    sendLuaCommandResponse(&luaRxWebUpdate, arg < 5 ? lcsExecuting : lcsIdle, arg < 5 ? "Sending..." : "");
-  });
 #endif
   registerLUAParameter(&luaELRSversion);
   registerLUAParameter(NULL);

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -14,6 +14,7 @@
 static const char thisCommit[] = {LATEST_COMMIT, 0};
 static const char thisVersion[] = {LATEST_VERSION, 0};
 static const char emptySpace[1] = {0};
+static char modelString[] = "000";
 
 #ifdef POWER_OUTPUT_VALUES
 static char strPowerLevels[] = "10;25;50;100;250;500;1000;2000";
@@ -39,6 +40,11 @@ static struct luaItem_selection luaAntennaMode = {
 #endif
 
 //----------------------------Info-----------------------------------
+
+static struct luaItem_string luaModelNumber = {
+    {"Model Id", CRSF_INFO},
+    modelString
+};
 
 static struct luaItem_string luaELRSversion = {
     {thisVersion, CRSF_INFO},
@@ -103,6 +109,7 @@ static void registerLuaParameters()
     POWERMGNT::setPower((PowerLevels_e)constrain(arg + MinPower, MinPower, MaxPower));
     });
 #endif
+  registerLUAParameter(&luaModelNumber);
   registerLUAParameter(&luaELRSversion);
   registerLUAParameter(NULL);
 }
@@ -117,6 +124,16 @@ static int event()
 #ifdef POWER_OUTPUT_VALUES
   setLuaTextSelectionValue(&luaTlmPower, config.GetPower());
 #endif
+
+  if (config.GetModelId() == 255)
+  {
+    setLuaStringValue(&luaModelNumber, "Off");
+  }
+  else
+  {
+    itoa(config.GetModelId(), modelString, 10);
+    setLuaStringValue(&luaModelNumber, modelString);
+  }
   return DURATION_IMMEDIATELY;
 }
 

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -16,6 +16,7 @@ static const char emptySpace[1] = {0};
 static char strPowerLevels[] = "10;25;50;100;250;500;1000;2000";
 char pwrFolderDynamicName[] = "TX Power (1000 Dynamic)";
 char vtxFolderDynamicName[] = "VTX Admin (OFF:C:1 Aux11 )";
+static char modelMatchUnit[] = " ID: 00";
 static const char folderNameSeparator[2] = {' ',':'};
 
 static struct luaItem_selection luaAirRate = {
@@ -86,7 +87,7 @@ static struct luaItem_selection luaModelMatch = {
     {"Model Match", CRSF_TEXT_SELECTION},
     0, // value
     "Off;On",
-    emptySpace
+    modelMatchUnit
 };
 
 static struct luaItem_command luaBind = {
@@ -250,6 +251,11 @@ static uint8_t getSeparatorIndex(uint8_t index, char *searchArray)
   //if we reach null termination and haven't got the requested index, just return 0, which would overwrite the first label
   return returnvalue;
 }
+
+void luadevChangeModelID() {
+  itoa(CRSF::getModelID(), modelMatchUnit+5, 10);
+}
+
 static void luadevGeneratePowerOpts()
 {
   // This function modifies the strPowerLevels in place and must not
@@ -466,6 +472,7 @@ static void registerLuaParameters()
       msp.addByte(newModelMatch ? CRSF::getModelID() : 0xff);
       CRSF::AddMspMessage(&msp);
     }
+    luadevChangeModelID();
   });
 
   // POWER folder
@@ -566,6 +573,7 @@ static int timeout()
 static int start()
 {
   CRSF::RecvParameterUpdate = &luaParamUpdateReq;
+  luadevChangeModelID();
   registerLuaParameters();
   registerLUAPopulateParams([](){
     itoa(CRSF::BadPktsCountResult, luaBadGoodString, 10);

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -347,9 +347,10 @@ static void luahandWifiBle(struct luaPropertiesCommon *item, uint8_t arg)
 static void luahandSimpleSendCmd(struct luaPropertiesCommon *item, uint8_t arg)
 {
   const char *msg = "Sending...";
-  bool doExecute = arg < lcsCancel;
-  if (doExecute)
+  static uint32_t lastLcsPoll;
+  if (arg < lcsCancel)
   {
+    lastLcsPoll = millis();
     if ((void *)item == (void *)&luaBind)
     {
       msg = "Binding...";
@@ -357,7 +358,6 @@ static void luahandSimpleSendCmd(struct luaPropertiesCommon *item, uint8_t arg)
     }
     else if ((void *)item == (void *)&luaVtxSend)
     {
-      msg = "Sending...";
       VtxTriggerSend();
     }
     else if ((void *)item == (void *)&luaRxWebUpdate)
@@ -374,10 +374,9 @@ static void luahandSimpleSendCmd(struct luaPropertiesCommon *item, uint8_t arg)
       VRxBackpackWiFiReadyToSend = true;
     }
 #endif
-
     sendLuaCommandResponse((struct luaItem_command *)item, lcsExecuting, msg);
   } /* if doExecute */
-  else
+  else if(arg == lcsCancel || ((millis() - lastLcsPoll)> 2000))
   {
     sendLuaCommandResponse((struct luaItem_command *)item, lcsIdle, emptySpace);
   }

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -402,11 +402,11 @@ static void updateFolderName(){
       //show pitmode AuxSwitch or show P if not OFF
       if(vtxPit != 0){
         if(vtxPit != 1){
-        vtxFolderDynamicName[vtxFolderLabelOffset++] = folderNameSeparator[1];
-        vtxFolderLabelOffset += findLuaSelectionLabel(&luaVtxPit, &vtxFolderDynamicName[vtxFolderLabelOffset], vtxPit);
+          vtxFolderDynamicName[vtxFolderLabelOffset++] = folderNameSeparator[1];
+          vtxFolderLabelOffset += findLuaSelectionLabel(&luaVtxPit, &vtxFolderDynamicName[vtxFolderLabelOffset], vtxPit);
         } else {
-        vtxFolderDynamicName[vtxFolderLabelOffset++] = folderNameSeparator[1];
-        vtxFolderDynamicName[vtxFolderLabelOffset++] = 'P';
+          vtxFolderDynamicName[vtxFolderLabelOffset++] = folderNameSeparator[1];
+          vtxFolderDynamicName[vtxFolderLabelOffset++] = 'P';
         }
       }
     }

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -14,8 +14,8 @@
 
 static const char emptySpace[1] = {0};
 static char strPowerLevels[] = "10;25;50;100;250;500;1000;2000";
-char vtxFolderDynamicName[] = "VTX Admin: OFF:C:1 Aux11";
-char pwrFolderDynamicName[] = "TX Power: 1000:Dynamic";
+char vtxFolderDynamicName[] = "VTX Admin: OFF:C:1 Aux11 ";
+char pwrFolderDynamicName[] = "TX Power : 1000:Dynamic";
 static const char folderNameSeparator = ':';
 
 static struct luaItem_selection luaAirRate = {
@@ -176,7 +176,7 @@ static struct luaItem_selection luaVtxPwr = {
 static struct luaItem_selection luaVtxPit = {
     {"Pitmode", CRSF_TEXT_SELECTION},
     0, // value
-    "Off;Pit;AUX1" LUASYM_ARROW_UP ";AUX1" LUASYM_ARROW_DN ";AUX2" LUASYM_ARROW_UP ";AUX2" LUASYM_ARROW_DN
+    "Off;On;AUX1" LUASYM_ARROW_UP ";AUX1" LUASYM_ARROW_DN ";AUX2" LUASYM_ARROW_UP ";AUX2" LUASYM_ARROW_DN
     ";AUX3" LUASYM_ARROW_UP ";AUX3" LUASYM_ARROW_DN ";AUX4" LUASYM_ARROW_UP ";AUX4" LUASYM_ARROW_DN
     ";AUX5" LUASYM_ARROW_UP ";AUX5" LUASYM_ARROW_DN ";AUX6" LUASYM_ARROW_UP ";AUX6" LUASYM_ARROW_DN
     ";AUX7" LUASYM_ARROW_UP ";AUX7" LUASYM_ARROW_DN ";AUX8" LUASYM_ARROW_UP ";AUX8" LUASYM_ARROW_DN
@@ -230,8 +230,8 @@ static uint8_t getSeparatorIndex(uint8_t index, char *searchArray)
   int i = 0;
   while (c[i] != '\0')
   {
-    //treat symbols as separator except : !,",#,$,%,&,',(,),*,+,,,-,.,/
-    if (c[i] < ' ' || (c[i] > '9' && c[i] < 'A')) {
+    //treat symbols as separator except : !,",#,$,%,&,',(,),*,+,,,-,.,/ as these would probably inside our label names
+    if (c[i] < '!' || (c[i] > '9' && c[i] < 'A')) {
       SeparatorCount++;
       arrayCount++;
       //if found separator is equal to the nth(index) requested separator,
@@ -374,40 +374,43 @@ static void updateFolderName(){
   uint8_t vtxBand = config.GetVtxBand();
   if(vtxBand){
     luaVtxFolder.dyn_name = vtxFolderDynamicName;
-    uint8_t vtxFolderLabelOffset = getSeparatorIndex(1,vtxFolderDynamicName);
-    vtxFolderLabelOffset += findLuaSelectionLabel(&luaVtxBand, &vtxFolderDynamicName[vtxFolderLabelOffset], vtxBand, folderNameSeparator);
-    // it's possible that vtx channel might be the end of the folder name, therefore the separator would be \0 not :
-    vtxFolderLabelOffset += findLuaSelectionLabel(&luaVtxChannel, &vtxFolderDynamicName[vtxFolderLabelOffset], config.GetVtxChannel(), '\0');
+    uint8_t vtxFolderLabelOffset = getSeparatorIndex(3,vtxFolderDynamicName); // 3= 2 spaces, 1 colon
+    vtxFolderLabelOffset += findLuaSelectionLabel(&luaVtxBand, &vtxFolderDynamicName[vtxFolderLabelOffset], vtxBand);
+    vtxFolderDynamicName[vtxFolderLabelOffset++] = folderNameSeparator;
+    vtxFolderLabelOffset += findLuaSelectionLabel(&luaVtxChannel, &vtxFolderDynamicName[vtxFolderLabelOffset], config.GetVtxChannel());
     uint8_t vtxPwr = config.GetVtxPower();
-    //if power is no-change (-), don't show
+    //if power is no-change (-), don't show, also hide pitmode
     if(vtxPwr){
-      vtxFolderDynamicName[vtxFolderLabelOffset-1] = folderNameSeparator;
-      vtxFolderLabelOffset += findLuaSelectionLabel(&luaVtxPwr, &vtxFolderDynamicName[vtxFolderLabelOffset], vtxPwr, '\0');
-    }
-    uint8_t vtxPit = config.GetVtxPitmode();
-    //if pitmode is off, don't show
-    //show pitmode AuxSwitch or show P if not OFF
-    if(vtxPit != 0){
-      if(vtxPit != 1){
-        vtxFolderDynamicName[vtxFolderLabelOffset-1] = folderNameSeparator;
-        vtxFolderLabelOffset += findLuaSelectionLabel(&luaVtxPit, &vtxFolderDynamicName[vtxFolderLabelOffset], vtxPit, folderNameSeparator);
-      } else {
-        vtxFolderDynamicName[vtxFolderLabelOffset-1] = folderNameSeparator;
+      vtxFolderDynamicName[vtxFolderLabelOffset++] = folderNameSeparator;
+      vtxFolderLabelOffset += findLuaSelectionLabel(&luaVtxPwr, &vtxFolderDynamicName[vtxFolderLabelOffset], vtxPwr);
+      
+      uint8_t vtxPit = config.GetVtxPitmode();
+      //if pitmode is off, don't show
+      //show pitmode AuxSwitch or show P if not OFF
+      if(vtxPit != 0){
+        if(vtxPit != 1){
+        vtxFolderDynamicName[vtxFolderLabelOffset++] = folderNameSeparator;
+        vtxFolderLabelOffset += findLuaSelectionLabel(&luaVtxPit, &vtxFolderDynamicName[vtxFolderLabelOffset], vtxPit);
+        } else {
+        vtxFolderDynamicName[vtxFolderLabelOffset++] = folderNameSeparator;
         vtxFolderDynamicName[vtxFolderLabelOffset++] = 'P';
-        vtxFolderDynamicName[vtxFolderLabelOffset++] = '\0';
+        }
       }
-    } else {
-      vtxFolderDynamicName[vtxFolderLabelOffset-1] = '\0';
     }
+    vtxFolderDynamicName[vtxFolderLabelOffset] = '\0';
   } else {
   //don't show vtx settings if band is OFF
     luaVtxFolder.dyn_name = NULL;
   }
   //power folder name
-  uint8_t pwrFolderLabelOffset = getSeparatorIndex(1,pwrFolderDynamicName);
-  pwrFolderLabelOffset += findLuaSelectionLabel(&luaPower, &pwrFolderDynamicName[pwrFolderLabelOffset], config.GetPower(), folderNameSeparator);
-  pwrFolderLabelOffset += findLuaSelectionLabel(&luaDynamicPower, &pwrFolderDynamicName[pwrFolderLabelOffset], config.GetDynamicPower(), folderNameSeparator);
-  
+  uint8_t txPwrDyn = config.GetDynamicPower() ? config.GetBoostChannel() + 1 : 0;
+  uint8_t pwrFolderLabelOffset = getSeparatorIndex(4,pwrFolderDynamicName); //4 = 3 spaces, 1 colon
+  pwrFolderLabelOffset += findLuaSelectionLabel(&luaPower, &pwrFolderDynamicName[pwrFolderLabelOffset], config.GetPower() - MinPower);
+  if(txPwrDyn){
+    pwrFolderDynamicName[pwrFolderLabelOffset++] = folderNameSeparator;
+    pwrFolderLabelOffset += findLuaSelectionLabel(&luaDynamicPower, &pwrFolderDynamicName[pwrFolderLabelOffset], txPwrDyn);
+  }
+  pwrFolderDynamicName[pwrFolderLabelOffset] = '\0';
 }
 
 static void registerLuaParameters()

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -252,7 +252,7 @@ static uint8_t getSeparatorIndex(uint8_t index, char *searchArray)
   return returnvalue;
 }
 
-void luadevChangeModelID() {
+static void luadevUpdateModelID() {
   itoa(CRSF::getModelID(), modelMatchUnit+5, 10);
 }
 
@@ -472,7 +472,7 @@ static void registerLuaParameters()
       msp.addByte(newModelMatch ? CRSF::getModelID() : 0xff);
       CRSF::AddMspMessage(&msp);
     }
-    luadevChangeModelID();
+    luadevUpdateModelID();
   });
 
   // POWER folder
@@ -543,7 +543,7 @@ static int event()
   setLuaTextSelectionValue(&luaTlmRate, config.GetTlm());
   setLuaTextSelectionValue(&luaSwitch, (uint8_t)(config.GetSwitchMode() - 1)); // -1 for missing sm1Bit
   setLuaTextSelectionValue(&luaModelMatch, (uint8_t)config.GetModelMatch());
-  luadevChangeModelID();
+  luadevUpdateModelID();
   setLuaTextSelectionValue(&luaPower, config.GetPower() - MinPower);
 #if defined(GPIO_PIN_FAN_EN)
   setLuaTextSelectionValue(&luaFanThreshold, config.GetPowerFanThreshold());
@@ -574,7 +574,7 @@ static int timeout()
 static int start()
 {
   CRSF::RecvParameterUpdate = &luaParamUpdateReq;
-  luadevChangeModelID();
+  luadevUpdateModelID();
   registerLuaParameters();
   registerLUAPopulateParams([](){
     itoa(CRSF::BadPktsCountResult, luaBadGoodString, 10);

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -393,7 +393,7 @@ static void updateFolderName(){
   
   //power folder name
   uint8_t txPwrDyn = config.GetDynamicPower() ? config.GetBoostChannel() + 1 : 0;
-  uint8_t pwrFolderLabelOffset = getSeparatorIndex(2,pwrFolderDynamicName); //4 = 3 spaces, 1 colon
+  uint8_t pwrFolderLabelOffset = getSeparatorIndex(2,pwrFolderDynamicName); // start writing name after the 2nd space
   pwrFolderDynamicName[pwrFolderLabelOffset++] = '(';
   pwrFolderLabelOffset += findLuaSelectionLabel(&luaPower, &pwrFolderDynamicName[pwrFolderLabelOffset], config.GetPower() - MinPower);
   if(txPwrDyn){
@@ -406,7 +406,7 @@ static void updateFolderName(){
   uint8_t vtxBand = config.GetVtxBand();
   if(vtxBand){
     luaVtxFolder.dyn_name = vtxFolderDynamicName;
-    uint8_t vtxFolderLabelOffset = getSeparatorIndex(2,vtxFolderDynamicName); // 3= 2 spaces, 1 colon
+    uint8_t vtxFolderLabelOffset = getSeparatorIndex(2,vtxFolderDynamicName); // start writing name after the 2nd space
     vtxFolderDynamicName[vtxFolderLabelOffset++] = '(';
     vtxFolderLabelOffset += findLuaSelectionLabel(&luaVtxBand, &vtxFolderDynamicName[vtxFolderLabelOffset], vtxBand);
     vtxFolderDynamicName[vtxFolderLabelOffset++] = folderNameSeparator[1];
@@ -446,16 +446,12 @@ static void registerLuaParameters()
       uint8_t currentRate = RATE_MAX - 1 - arg;
       currentRate = adjustPacketRateForBaud(currentRate);
       config.SetRate(currentRate);
-      luadevUpdateTlmBandwidth();
     }
-    //no need to update sensitivity here as we are waiting for CurrAirRate to change first
-    //luadevUpdateRateSensitivity();
   });
   registerLUAParameter(&luaTlmRate, [](struct luaPropertiesCommon *item, uint8_t arg) {
     if ((arg <= (uint8_t)TLM_RATIO_1_2) && (arg >= (uint8_t)TLM_RATIO_NO_TLM))
     {
       config.SetTlm((expresslrs_tlm_ratio_e)arg);
-      luadevUpdateTlmBandwidth();
     }
   });
   #if defined(TARGET_TX_FM30)
@@ -559,6 +555,7 @@ static int event()
     uint8_t currentRate = adjustPacketRateForBaud(config.GetRate());
     luadevUpdateRateSensitivity();
     setLuaTextSelectionValue(&luaAirRate, RATE_MAX - 1 - currentRate);
+    luadevUpdateTlmBandwidth();
     setLuaTextSelectionValue(&luaTlmRate, config.GetTlm());
     setLuaTextSelectionValue(&luaSwitch, (uint8_t)(config.GetSwitchMode() - 1)); // -1 for missing sm1Bit
     luadevUpdateModelID();

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -265,12 +265,18 @@ static void luadevUpdateModelID() {
 }
 
 static void luadevUpdateTlmBandwidth() {
+  if((expresslrs_tlm_ratio_e)config.GetTlm()){
+  tlmBandwidth[0] = ' ';
   uint32_t hz = RateEnumToHz(ExpressLRS_currAirRate_Modparams->enum_rate);
   uint32_t tlmRatio = TLMratioEnumToValue((expresslrs_tlm_ratio_e)config.GetTlm());
   uint32_t bandwidthValue = ((float)hz / tlmRatio) *1/2*5*8;
   itoa(bandwidthValue,tlmBandwidth+2,10);
   strcat(tlmBandwidth,"bps)");
+  } else {
+    tlmBandwidth[0] = '\0';
+  }
 }
+
 static void luadevGeneratePowerOpts()
 {
   // This function modifies the strPowerLevels in place and must not

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -19,9 +19,9 @@ static char vtxFolderDynamicName[] = "VTX Admin B;C;L;P";
 static struct luaItem_selection luaAirRate = {
     {"Packet Rate", CRSF_TEXT_SELECTION},
     0, // value
-#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+#if defined(RADIO_SX127X)
     "25Hz(-123;50Hz(-120;100Hz(-117;200Hz(-112",
-#elif defined(Regulatory_Domain_ISM_2400)
+#elif defined(RADIO_SX128X)
     "50Hz(-117;150Hz(-112;250Hz(-108;500Hz(-105",
 #else
     #error Invalid radio configuration!

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -256,7 +256,7 @@ static uint8_t getSeparatorIndex(uint8_t index, char *searchArray)
 
 static void luadevUpdateRateSensitivity() {
   itoa(ExpressLRS_currAirRate_RFperfParams->RXsensitivity,rateSensitivity+2,10);
-  strcat(rateSensitivity,"dbm)");
+  strcat(rateSensitivity,"dBm)");
 }
 
 static void luadevUpdateModelID() {

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -14,6 +14,7 @@
 
 static const char emptySpace[1] = {0};
 static char strPowerLevels[] = "10;25;50;100;250;500;1000;2000";
+static char vtxFolderDynamicName[] = "VTX Admin B;C;L;P";
 
 static struct luaItem_selection luaAirRate = {
     {"Packet Rate", CRSF_TEXT_SELECTION},
@@ -146,7 +147,7 @@ static struct luaItem_command luaBLEJoystick = {
 
 //----------------------------VTX ADMINISTRATOR------------------
 static struct luaItem_folder luaVtxFolder = {
-    {"VTX Administrator", CRSF_FOLDER},
+    {"VTX Administrator", CRSF_FOLDER},vtxFolderDynamicName
 };
 
 static struct luaItem_selection luaVtxBand = {
@@ -418,7 +419,6 @@ static void registerLuaParameters()
       config.SetVtxPitmode(arg);
   }, luaVtxFolder.common.id);
   registerLUAParameter(&luaVtxSend, &luahandSimpleSendCmd, luaVtxFolder.common.id);
-
   // WIFI folder
   registerLUAParameter(&luaWiFiFolder);
   #if defined(PLATFORM_ESP32)
@@ -444,6 +444,10 @@ static void registerLuaParameters()
 static int event()
 {
   uint8_t rate = adjustPacketRateForBaud(config.GetRate());
+  vtxFolderDynamicName[10] = (config.GetVtxBand() + 65);
+  vtxFolderDynamicName[12] = (config.GetVtxChannel() + 48);
+  vtxFolderDynamicName[14] = (config.GetVtxChannel() + 48);
+  vtxFolderDynamicName[16] = (config.GetVtxChannel() + 80);
   setLuaTextSelectionValue(&luaAirRate, RATE_MAX - 1 - rate);
   setLuaTextSelectionValue(&luaTlmRate, config.GetTlm());
   setLuaTextSelectionValue(&luaSwitch, (uint8_t)(config.GetSwitchMode() - 1)); // -1 for missing sm1Bit

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -24,7 +24,7 @@ static struct luaItem_selection luaAirRate = {
 #if defined(RADIO_SX127X)
     "25Hz(-123;50Hz(-120;100Hz(-117;200Hz(-112",
 #elif defined(RADIO_SX128X)
-    "50Hz(-117;150Hz(-112;250Hz(-108;500Hz(-105",
+    "50Hz(-117;150Hz(-112;250Hz(-108;500Hz(-105;F500(-104;F1000(-104",
 #else
     #error Invalid radio configuration!
 #endif

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -20,8 +20,6 @@ static char modelMatchUnit[] = " ID: 00";
 static char tlmBandwidth[] = " xxxxbps";
 static const char folderNameSeparator[2] = {' ',':'};
 
-uint8_t currentRate;
-
 static struct luaItem_selection luaAirRate = {
     {"Packet Rate", CRSF_TEXT_SELECTION},
     0, // value
@@ -439,7 +437,7 @@ static void registerLuaParameters()
   registerLUAParameter(&luaAirRate, [](struct luaPropertiesCommon *item, uint8_t arg) {
     if ((arg < RATE_MAX) && (arg >= 0))
     {
-      currentRate = RATE_MAX - 1 - arg;
+      uint8_t currentRate = RATE_MAX - 1 - arg;
       currentRate = adjustPacketRateForBaud(currentRate);
       config.SetRate(currentRate);
       luadevUpdateTlmBandwidth();
@@ -550,12 +548,13 @@ static void registerLuaParameters()
 
 static int event()
 {
-  setLuaTextSelectionValue(&luaAirRate, RATE_MAX - 1 - currentRate);
-  setLuaTextSelectionValue(&luaTlmRate, config.GetTlm());
-  setLuaTextSelectionValue(&luaSwitch, (uint8_t)(config.GetSwitchMode() - 1)); // -1 for missing sm1Bit
-  setLuaTextSelectionValue(&luaModelMatch, (uint8_t)config.GetModelMatch());
-  luadevUpdateModelID();
-  setLuaTextSelectionValue(&luaPower, config.GetPower() - MinPower);
+    uint8_t currentRate = adjustPacketRateForBaud(config.GetRate());
+    setLuaTextSelectionValue(&luaAirRate, RATE_MAX - 1 - currentRate);
+    setLuaTextSelectionValue(&luaTlmRate, config.GetTlm());
+    setLuaTextSelectionValue(&luaSwitch, (uint8_t)(config.GetSwitchMode() - 1)); // -1 for missing sm1Bit
+    setLuaTextSelectionValue(&luaModelMatch, (uint8_t)config.GetModelMatch());
+    luadevUpdateModelID();
+    setLuaTextSelectionValue(&luaPower, config.GetPower() - MinPower);
 #if defined(GPIO_PIN_FAN_EN)
   setLuaTextSelectionValue(&luaFanThreshold, config.GetPowerFanThreshold());
 #endif

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -18,14 +18,14 @@ static char strPowerLevels[] = "10;25;50;100;250;500;1000;2000";
 static struct luaItem_selection luaAirRate = {
     {"Packet Rate", CRSF_TEXT_SELECTION},
     0, // value
-#if defined(RADIO_SX127X)
-    "25(-123dbm);50(-120dbm);100(-117dbm);200(-112dbm)",
-#elif defined(RADIO_SX128X)
-    "50(-117dbm);150(-112dbm);250(-108dbm);500(-105dbm);F500(-104dbm);F1000(-104dbm)",
+#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+    "25Hz|-123dBm;50Hz|-120dBm;100Hz|-117dBm;200Hz|-112dBm",
+#elif defined(Regulatory_Domain_ISM_2400)
+    "50Hz|-117dBm;150Hz|-112Bbm;250Hz|-108dBm;500Hz|-105dBm",
 #else
     #error Invalid radio configuration!
 #endif
-    "Hz"
+    emptySpace
 };
 
 static struct luaItem_selection luaTlmRate = {

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -543,6 +543,7 @@ static int event()
   setLuaTextSelectionValue(&luaTlmRate, config.GetTlm());
   setLuaTextSelectionValue(&luaSwitch, (uint8_t)(config.GetSwitchMode() - 1)); // -1 for missing sm1Bit
   setLuaTextSelectionValue(&luaModelMatch, (uint8_t)config.GetModelMatch());
+  luadevChangeModelID();
   setLuaTextSelectionValue(&luaPower, config.GetPower() - MinPower);
 #if defined(GPIO_PIN_FAN_EN)
   setLuaTextSelectionValue(&luaFanThreshold, config.GetPowerFanThreshold());

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -19,13 +19,13 @@ static struct luaItem_selection luaAirRate = {
     {"Packet Rate", CRSF_TEXT_SELECTION},
     0, // value
 #if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
-    "25Hz|-123dBm;50Hz|-120dBm;100Hz|-117dBm;200Hz|-112dBm",
+    "25Hz(-123;50Hz(-120;100Hz(-117;200Hz(-112",
 #elif defined(Regulatory_Domain_ISM_2400)
-    "50Hz|-117dBm;150Hz|-112Bbm;250Hz|-108dBm;500Hz|-105dBm",
+    "50Hz(-117;150Hz(-112;250Hz(-108;500Hz(-105",
 #else
     #error Invalid radio configuration!
 #endif
-    emptySpace
+    "dBm)"
 };
 
 static struct luaItem_selection luaTlmRate = {

--- a/src/lib/logging/logging.cpp
+++ b/src/lib/logging/logging.cpp
@@ -11,6 +11,8 @@
 void debugPrintf(const char* fmt, ...)
 {
   char c;
+  const char *v;
+  char buf[11];
   va_list  vlist;
   va_start(vlist,fmt);
 
@@ -19,22 +21,25 @@ void debugPrintf(const char* fmt, ...)
     if (c == '%') {
       fmt++;
       c = GETCHAR;
+      v = buf;
+      buf[0] = 0;
       switch (c) {
         case 's':
-          LOGGING_UART.print(va_arg(vlist,const char *));
+          v = va_arg(vlist, const char *);
           break;
         case 'd':
-          LOGGING_UART.print(va_arg(vlist,int32_t), DEC);
+          itoa(va_arg(vlist, int32_t), buf, DEC);
           break;
         case 'u':
-          LOGGING_UART.print(va_arg(vlist,uint32_t), DEC);
+          utoa(va_arg(vlist, uint32_t), buf, DEC);
           break;
         case 'x':
-          LOGGING_UART.print(va_arg(vlist,uint32_t), HEX);
+          utoa(va_arg(vlist, uint32_t), buf, HEX);
           break;
         default:
           break;
       }
+      LOGGING_UART.write((uint8_t*)v, strlen(v));
     } else {
       LOGGING_UART.write(c);
     }

--- a/src/lua/elrsV2.lua
+++ b/src/lua/elrsV2.lua
@@ -549,6 +549,7 @@ local function parseParameterInfoMessage(data)
     field.parent = parent
     field.type = type
     field.hidden = hidden
+    field.unit = nil
     field.name, offset = fieldGetString(fieldData, 3, field.name)
     if functions[field.type+1].load then
       functions[field.type+1].load(field, fieldData, offset)

--- a/src/lua/elrsV2.lua
+++ b/src/lua/elrsV2.lua
@@ -536,7 +536,7 @@ local function parseParameterInfoMessage(data)
     local type = fieldData[2] % 128
     local hidden = (bit32.rshift(fieldData[2], 7) == 1) or nil
     local offset
-    if field.name ~= nil then -- already seen this field before, so we can validate this packet is correct
+    if field.name ~= nil and type ~= 11 then -- already seen this field before, so we can validate this packet is correct
       if field.parent ~= parent or field.type ~= type or field.hidden ~= hidden then
         fieldData = {}
         return -- no data extraction

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -680,22 +680,20 @@ static void ICACHE_RAM_ATTR MspReceiveComplete()
 #endif
     else
     {
-        // No MSP data to the FC if no model match
-        if (connectionHasModelMatch)
-        {
-            crsf_ext_header_t *receivedHeader = (crsf_ext_header_t *) MspData;
-            if ((receivedHeader->dest_addr == CRSF_ADDRESS_BROADCAST || receivedHeader->dest_addr == CRSF_ADDRESS_FLIGHT_CONTROLLER))
-            {
-                crsf.sendMSPFrameToFC(MspData);
-            }
+        crsf_ext_header_t *receivedHeader = (crsf_ext_header_t *) MspData;
 
-            if ((receivedHeader->dest_addr == CRSF_ADDRESS_BROADCAST || receivedHeader->dest_addr == CRSF_ADDRESS_CRSF_RECEIVER))
-            {
-                crsf.ParameterUpdateData[0] = MspData[CRSF_TELEMETRY_TYPE_INDEX];
-                crsf.ParameterUpdateData[1] = MspData[CRSF_TELEMETRY_FIELD_ID_INDEX];
-                crsf.ParameterUpdateData[2] = MspData[CRSF_TELEMETRY_FIELD_CHUNK_INDEX];
-                luaParamUpdateReq();
-            }
+        // No MSP data to the FC if no model match
+        if (connectionHasModelMatch && (receivedHeader->dest_addr == CRSF_ADDRESS_BROADCAST || receivedHeader->dest_addr == CRSF_ADDRESS_FLIGHT_CONTROLLER))
+        {
+            crsf.sendMSPFrameToFC(MspData);
+        }
+
+        if ((receivedHeader->dest_addr == CRSF_ADDRESS_BROADCAST || receivedHeader->dest_addr == CRSF_ADDRESS_CRSF_RECEIVER))
+        {
+            crsf.ParameterUpdateData[0] = MspData[CRSF_TELEMETRY_TYPE_INDEX];
+            crsf.ParameterUpdateData[1] = MspData[CRSF_TELEMETRY_FIELD_ID_INDEX];
+            crsf.ParameterUpdateData[2] = MspData[CRSF_TELEMETRY_FIELD_CHUNK_INDEX];
+            luaParamUpdateReq();
         }
     }
 

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -806,10 +806,7 @@ void OnPowerSetCalibration(mspPacket_t *packet)
 void SendUIDOverMSP()
 {
   MSPDataPackage[0] = MSP_ELRS_BIND;
-  MSPDataPackage[1] = MasterUID[2];
-  MSPDataPackage[2] = MasterUID[3];
-  MSPDataPackage[3] = MasterUID[4];
-  MSPDataPackage[4] = MasterUID[5];
+  memcpy(&MSPDataPackage[1], &MasterUID[2], 4);
   BindingSendCount = 0;
   MspSender.SetDataToTransmit(5, MSPDataPackage, ELRS_MSP_BYTES_PER_CALL);
 }
@@ -829,12 +826,7 @@ void EnterBindingMode()
   SendUIDOverMSP();
 
   // Set UID to special binding values
-  UID[0] = BindingUID[0];
-  UID[1] = BindingUID[1];
-  UID[2] = BindingUID[2];
-  UID[3] = BindingUID[3];
-  UID[4] = BindingUID[4];
-  UID[5] = BindingUID[5];
+  memcpy(UID, BindingUID, UID_LEN);
 
   CRCInitializer = 0;
   NonceTX = 0; // Lock the NonceTX to prevent syncspam packets
@@ -859,12 +851,7 @@ void ExitBindingMode()
   }
 
   // Reset UID to defined values
-  UID[0] = MasterUID[0];
-  UID[1] = MasterUID[1];
-  UID[2] = MasterUID[2];
-  UID[3] = MasterUID[3];
-  UID[4] = MasterUID[4];
-  UID[5] = MasterUID[5];
+  memcpy(UID, MasterUID, UID_LEN);
 
   CRCInitializer = (UID[4] << 8) | UID[5];
 

--- a/src/targets/namimnorc_2400.ini
+++ b/src/targets/namimnorc_2400.ini
@@ -9,7 +9,6 @@ build_flags =
 	${env_common_stm32.build_flags}
 	${radio_2400.build_flags}
 	${common_env_data.build_flags_tx}
-	-flto
 	-D HSE_VALUE=12000000U
 	-D VECT_TAB_OFFSET=0x4000U
 	-include target/NamimnoRC_FLASH_2400_TX.h

--- a/src/targets/namimnorc_2400.ini
+++ b/src/targets/namimnorc_2400.ini
@@ -9,6 +9,7 @@ build_flags =
 	${env_common_stm32.build_flags}
 	${radio_2400.build_flags}
 	${common_env_data.build_flags_tx}
+	-flto
 	-D HSE_VALUE=12000000U
 	-D VECT_TAB_OFFSET=0x4000U
 	-include target/NamimnoRC_FLASH_2400_TX.h


### PR DESCRIPTION
PR to show current VTX settings as the folder name and TX Power value in the folder name, and also fix packet rate options.

LUA script is updated slightly to re-poll the parent folder name.

this is the screenshot of this commit : [1e9ebd5]
power : 100mw, dynamic is off
vtx : Band A, channel 3, power = as is (-)
![screen-2000-01-01-010105](https://user-images.githubusercontent.com/68074253/157633785-a8105a70-c360-4722-9cf9-97e175952b7e.jpg)


power : 100mw, dynamic ON
vtx : Band A, channel 3, power = index 1
![screen-2000-01-01-010126](https://user-images.githubusercontent.com/68074253/157634027-fa339b7d-9abb-4b10-9164-6d4f80c8aa00.jpg)


power : 100mw, dynamic is ON, AUX 9 is boost to max
vtx : Band A, channel 3, power = index 1, pitmode is on
![screen-2000-01-01-010154](https://user-images.githubusercontent.com/68074253/157634186-265517cc-108c-45aa-9daf-ab2c851e0e59.jpg)

power : 100mw, dynamic is ON, AUX 9 is boost to max
vtx admin function is off : Band is off
![screen-2000-01-01-011021](https://user-images.githubusercontent.com/68074253/157634592-68e2304e-2308-478a-90b8-d99864e0f495.jpg)



