### PR TITLE
NamimnoRC Flash Gen2 is GRB

### DIFF
--- a/src/include/target/NamimnoRC_FLASH_2400_OLED_TX.h
+++ b/src/include/target/NamimnoRC_FLASH_2400_OLED_TX.h
@@ -6,6 +6,7 @@
 #define USE_TX_BACKPACK
 #define USE_OLED_SPI
 #define HAS_FIVE_WAY_BUTTON
+#define WS2812_IS_GRB
 
 // GPIO pin definitions
 #define GPIO_PIN_RST            21


### PR DESCRIPTION
Just adds define WS2812_IS_GRB for the NamimnoRC Gen2 Flash.