### PR TITLE
Move the flag for config MAIN_CHANGED outside of an STM32 define

### DIFF
--- a/src/lib/CONFIG/config.cpp
+++ b/src/lib/CONFIG/config.cpp
@@ -468,7 +468,6 @@ TxConfig::UpgradeEepromV5ToV6()
 
         // Copy prev values to current config struct
         memcpy(&m_config, &v5Config, sizeof(v5Config));
-        m_modified |= MAIN_CHANGED;
     #endif
 
     DBGLN("EEPROM version %u is out of date... upgrading to version %u", PREV_TX_CONFIG_VERSION, TX_CONFIG_VERSION);

--- a/src/lib/CONFIG/config.cpp
+++ b/src/lib/CONFIG/config.cpp
@@ -482,6 +482,7 @@ TxConfig::UpgradeEepromV5ToV6()
     SetDvrAux(0);
     SetDvrStartDelay(0);
     SetDvrStopDelay(0);
+    m_modified |= MAIN_CHANGED; // force write the default DVR AUX settings
 
     Commit();
 


### PR DESCRIPTION
The `Commit()` function for writing EEPROM changes has 2x sections for ESP and STM.

The ESP section uses various flags to decide if we should write different config items, depending on whether they have changed state. The `MAIN_CHANGED` flag needs to be set in order to write the default values for the new DVR control config items.

This was was incorrectly being set high within a block of code that only runs on STM32, whereas it needs to be set for ESP32.

