### PR TITLE
revert 2.4ghz binding rate index to 3

### DIFF
--- a/src/include/common.h
+++ b/src/include/common.h
@@ -132,7 +132,7 @@ extern SX127xDriver Radio;
 #elif defined(RADIO_SX128X)
 #define RATE_MAX 4
 #define RATE_DEFAULT 0
-#define RATE_BINDING 2  // 50Hz bind mode
+#define RATE_BINDING 3  // 50Hz bind mode
 
 extern SX1280Driver Radio;
 #endif


### PR DESCRIPTION
Binding rate index for 2.4 GHz was accidentally changed to 2 instead of 3. 