### PR TITLE
Minor Fix for Binding

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -772,6 +772,7 @@ void SendUIDOverMSP()
   MSPDataPackage[3] = MasterUID[4];
   MSPDataPackage[4] = MasterUID[5];
   BindingSendCount = 0;
+  MspSender.ResetState();
   MspSender.SetDataToTransmit(5, MSPDataPackage, ELRS_MSP_BYTES_PER_CALL);
 }
 


### PR DESCRIPTION
If the first time you press [BIND] fails then binding will never work because the MspSender gets stuck in the RESYNC_THEN_SEND state which can never resolve because the link is down. Resetting the MspSender state whenever bind mode is entered is a quick fix for this. 