### PR TITLE
correct SYNC_PACKET_RATE_MASK for greater than 4 rf modes

### DIFF
--- a/src/include/common.h
+++ b/src/include/common.h
@@ -144,7 +144,7 @@ extern SX1280Driver Radio;
 #define SYNC_PACKET_RATE_OFFSET     5   // Rate index
 #define SYNC_PACKET_SWITCH_MASK     0b11
 #define SYNC_PACKET_TLM_MASK        0b111
-#define SYNC_PACKET_RATE_MASK       0b11
+#define SYNC_PACKET_RATE_MASK       0b111
 
 
 expresslrs_mod_settings_s *get_elrs_airRateConfig(uint8_t index);


### PR DESCRIPTION
Fixes rf modes 50 and 150 Hz.