### PR TITLE
Reduce flash

### DIFF
--- a/src/include/target/FM30_TX.h
+++ b/src/include/target/FM30_TX.h
@@ -5,6 +5,7 @@
 // There is some special handling for this target
 #define TARGET_TX_FM30
 #define USE_SX1280_DCDC
+#define CRITICAL_FLASH
 
 // GPIO pin definitions
 #define GPIO_PIN_NSS            PB12

--- a/src/include/target/NamimnoRC_FLASH_2400_TX.h
+++ b/src/include/target/NamimnoRC_FLASH_2400_TX.h
@@ -3,6 +3,7 @@
 #endif
 
 #define USE_TX_BACKPACK
+#define CRITICAL_FLASH
 
 // GPIO pin definitions
 #define GPIO_PIN_RST            PB4

--- a/src/lib/logging/logging.h
+++ b/src/lib/logging/logging.h
@@ -32,7 +32,7 @@ extern Stream *LoggingBackpack;
 
 extern void debugPrintf(const char* fmt, ...);
 
-#if defined(CRSF_RCVR_NO_SERIAL) && !defined(DEBUG_LOG)
+#if defined(CRITICAL_FLASH) || (defined(CRSF_RCVR_NO_SERIAL) && !defined(DEBUG_LOG))
   #define INFOLN(msg, ...)
   #define ERRLN(msg)
 #else
@@ -48,7 +48,7 @@ extern void debugPrintf(const char* fmt, ...);
   })(LOGGING_UART.println("ERROR: " msg))
 #endif
 
-#if defined(DEBUG_LOG)
+#if defined(DEBUG_LOG) && !defined(CRITICAL_FLASH)
   #define DBGCR   LOGGING_UART.println()
   #define DBGW(c) LOGGING_UART.write(c)
   #ifndef LOG_USE_PROGMEM

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -95,6 +95,8 @@ build_flags =
 	-Wl,-Map,"'${BUILD_DIR}/firmware.map'"
 	-O2
 	-I ${PROJECTSRC_DIR}/hal
+	-D __FILE__='""'
+	-Wno-builtin-macro-redefined
 src_filter = ${common_env_data.src_filter} -<ESP32*.*> -<ESP8266*.*> -<WS281B*.*>
 lib_deps =
 	paolop74/extEEPROM @ 3.4.1


### PR DESCRIPTION
Some reductions in flash usage on space challenged targets.
These have been done as defining `-flto` on the Namimno 2400 seems to interfere with the RGB LED!?
I will look into that further, but these changes allow the unit to at least function with the upcoming LUA changes.

1. Added CRITICAL_FLASH define which can be use to remove all non "work" related serial output.
   * added this define to NAMIMNO_2400 TX & FM30 TX
3. There are some files in the platform that print this and waste 400+ bytes of precious flash!