### PR TITLE
Bug Fix - Do not send VRx Backpack MSP while armed

### DIFF
--- a/src/lib/VTX/devVTX.cpp
+++ b/src/lib/VTX/devVTX.cpp
@@ -14,6 +14,8 @@ extern CRSF crsf;
 extern Stream *LoggingBackpack;
 uint8_t pitmodeAuxState = 0;
 
+extern bool ICACHE_RAM_ATTR IsArmed();
+
 static enum VtxSendState_e
 {
   VTXSS_UNKNOWN,   // Status of the remote side is unknown, so we should send immediately if connected
@@ -80,7 +82,11 @@ static void VtxConfigToMSPOut()
     }
 
     crsf.AddMspMessage(&packet);
-    MSP::sendPacket(&packet, LoggingBackpack); // send to tx-backpack as MSP
+
+    if (!IsArmed()) // Do not send while armed.  There is no need to change the video frqency while armed.  It can also cause VRx modules to flash up their OSD menu e.g. Rapidfire.
+    {
+        MSP::sendPacket(&packet, LoggingBackpack); // send to tx-backpack as MSP
+    }
 }
 
 static int event()

--- a/src/lib/VTX/devVTX.cpp
+++ b/src/lib/VTX/devVTX.cpp
@@ -83,7 +83,7 @@ static void VtxConfigToMSPOut()
 
     crsf.AddMspMessage(&packet);
 
-    if (!IsArmed()) // Do not send while armed.  There is no need to change the video frqency while armed.  It can also cause VRx modules to flash up their OSD menu e.g. Rapidfire.
+    if (!IsArmed()) // Do not send while armed.  There is no need to change the video frequency while armed.  It can also cause VRx modules to flash up their OSD menu e.g. Rapidfire.
     {
         MSP::sendPacket(&packet, LoggingBackpack); // send to tx-backpack as MSP
     }


### PR DESCRIPTION
As part of PR https://github.com/ExpressLRS/ExpressLRS/pull/1284 the IsArmed() guard was removed to allow VTx MSP packet to be sent.  Long term this will allow for dynamic VTx power.  When armed BF ignores VTx freq changes but will update VTx power.

Removing the guard also allowed VRx MSP packets to be sent.  This is unnecessary as the VRx doesn't need to change while armed.  It can also cause some modules (Rapidfire) to flash the OSD menu mid flight :unamused: