### PR TITLE
Add LTO flag for Namimno 2400 STM target

### DIFF
--- a/src/lib/LED/STM32F3_WS2812B_LED.h
+++ b/src/lib/LED/STM32F3_WS2812B_LED.h
@@ -29,6 +29,7 @@ static inline void LEDsend_1(void) {
         __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
         __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
         __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+        __NOP();
 #endif
         __NOP(); __NOP(); __NOP(); __NOP();
 #if !defined(STM32F1)
@@ -42,8 +43,7 @@ static inline void LEDsend_1(void) {
         __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
         __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
         __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
-        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
-        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+        __NOP(); __NOP(); __NOP();
 #endif
         __NOP(); __NOP(); __NOP(); __NOP();
 #if !defined(STM32F1)
@@ -61,7 +61,6 @@ static inline void LEDsend_0(void) {
         __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
         __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
         __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
-        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
 #endif
         __NOP(); __NOP(); __NOP(); __NOP();
 #if !defined(STM32F1)
@@ -85,6 +84,7 @@ static inline void LEDsend_0(void) {
         __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
         __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
         __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+        __NOP(); __NOP(); __NOP(); __NOP();
 #endif
         __NOP(); __NOP(); __NOP(); __NOP();
 #if !defined(STM32F1)
@@ -135,12 +135,6 @@ void WS281BsetLED(uint8_t const * const RGB) // takes RGB data
     interrupts();
     memcpy(current_rgb, RGB, sizeof(current_rgb));
     delayMicroseconds(50); // needed to latch in the values
-}
-
-void WS281BsetLED(uint8_t const r, uint8_t const g, uint8_t const b) // takes RGB data
-{
-    uint8_t data[3] = {r, g, b};
-    WS281BsetLED(data);
 }
 
 void WS281BsetLED(uint32_t const color) // takes RGB data

--- a/src/lib/LED/STM32F3_WS2812B_LED.h
+++ b/src/lib/LED/STM32F3_WS2812B_LED.h
@@ -20,6 +20,16 @@ static inline void LEDsend_1(void) {
         __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
         __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
         __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+#if defined(STM32F1)
+        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+#endif
         __NOP(); __NOP(); __NOP(); __NOP();
 #if !defined(STM32F1)
         __NOP();
@@ -27,6 +37,14 @@ static inline void LEDsend_1(void) {
         digitalWriteFast(GPIO_PIN_LED_WS2812_FAST, LOW);
         __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
         __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+#if defined(STM32F1)
+        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+#endif
         __NOP(); __NOP(); __NOP(); __NOP();
 #if !defined(STM32F1)
         __NOP(); __NOP(); __NOP(); __NOP();
@@ -37,6 +55,14 @@ static inline void LEDsend_0(void) {
         digitalWriteFast(GPIO_PIN_LED_WS2812_FAST, HIGH);
         __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
         __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+#if defined(STM32F1)
+        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+#endif
         __NOP(); __NOP(); __NOP(); __NOP();
 #if !defined(STM32F1)
         __NOP(); __NOP(); __NOP(); __NOP();
@@ -50,6 +76,16 @@ static inline void LEDsend_0(void) {
         __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
         __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
         __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+#if defined(STM32F1)
+        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+        __NOP(); __NOP(); __NOP(); __NOP(); __NOP();
+#endif
         __NOP(); __NOP(); __NOP(); __NOP();
 #if !defined(STM32F1)
         __NOP();
@@ -90,11 +126,13 @@ void WS281BsetLED(uint8_t const * const RGB) // takes RGB data
         (bitReverse(RGB[0]) << 8) +  // Red
         (bitReverse(RGB[2]) << 16);  // Blue
     uint8_t bits = 24;
+    noInterrupts();
     while (bits--)
     {
         (LedColourData & 0x1) ? LEDsend_1() : LEDsend_0();
         LedColourData >>= 1;
     }
+    interrupts();
     memcpy(current_rgb, RGB, sizeof(current_rgb));
     delayMicroseconds(50); // needed to latch in the values
 }

--- a/src/lib/LED/STM32F3_WS2812B_LED.h
+++ b/src/lib/LED/STM32F3_WS2812B_LED.h
@@ -8,7 +8,7 @@
 #define BRIGHTNESS 10 // 1...256
 #endif
 
-static uint8_t current_rgb[3];
+static uint32_t current_rgb;
 
 static inline void LEDsend_1(void) {
         digitalWriteFast(GPIO_PIN_LED_WS2812_FAST, HIGH);
@@ -92,58 +92,32 @@ static inline void LEDsend_0(void) {
 #endif
 }
 
-static inline uint32_t bitReverse(uint32_t input)
-{
-    // r will be reversed bits of v; first get LSB of v
-    uint8_t r = (uint8_t)((input * BRIGHTNESS) >> 8);
-    uint8_t s = 8 - 1; // extra shift needed at end
-
-    for (input >>= 1; input; input >>= 1)
-    {
-        r <<= 1;
-        r |= input & 1;
-        s--;
-    }
-    r <<= s; // shift when input's highest bits are zero
-    return r;
-}
-
 void WS281Binit(void) // takes RGB data
 {
     pinMode(GPIO_PIN_LED_WS2812, OUTPUT);
 }
 
-void WS281BsetLED(uint8_t const * const RGB) // takes RGB data
+void WS281BsetLED(uint32_t const RGB) // takes RGB data
 {
     /* Check if update is needed */
-    if ((current_rgb[0] == RGB[0] &&
-         current_rgb[1] == RGB[1] &&
-         current_rgb[2] == RGB[2]))
+    if (current_rgb == RGB)
         return;
+    current_rgb = RGB;
 
-    uint32_t LedColourData =
-        bitReverse(RGB[1]) +       // Green
-        (bitReverse(RGB[0]) << 8) +  // Red
-        (bitReverse(RGB[2]) << 16);  // Blue
-    uint8_t bits = 24;
-    noInterrupts();
-    while (bits--)
+    // Convert to GRB
+    uint32_t GRB = (RGB & 0x0000FF00) << 8;
+    GRB |= (RGB & 0x00FF0000) >> 8;
+    GRB |= (RGB & 0x000000FF);
+
+    uint32_t bit = 1<<23;
+    while (bit)
     {
-        (LedColourData & 0x1) ? LEDsend_1() : LEDsend_0();
-        LedColourData >>= 1;
+        noInterrupts();
+        (GRB & bit) ? LEDsend_1() : LEDsend_0();
+        interrupts();
+        bit >>= 1;
     }
-    interrupts();
-    memcpy(current_rgb, RGB, sizeof(current_rgb));
     delayMicroseconds(50); // needed to latch in the values
-}
-
-void WS281BsetLED(uint32_t const color) // takes RGB data
-{
-    uint8_t data[3];
-    data[0] = (color & 0x00FF0000) >> 16;
-    data[1] = (color & 0x0000FF00) >> 8;
-    data[2] = (color & 0x000000FF) >> 0;
-    WS281BsetLED(data);
 }
 
 #endif /* (GPIO_PIN_LED_WS2812 != UNDEF_PIN) && (GPIO_PIN_LED_WS2812_FAST != UNDEF_PIN) */

--- a/src/targets/namimnorc_2400.ini
+++ b/src/targets/namimnorc_2400.ini
@@ -9,6 +9,7 @@ build_flags =
 	${env_common_stm32.build_flags}
 	${radio_2400.build_flags}
 	${common_env_data.build_flags_tx}
+	-flto
 	-D HSE_VALUE=12000000U
 	-D VECT_TAB_OFFSET=0x4000U
 	-include target/NamimnoRC_FLASH_2400_TX.h


### PR DESCRIPTION
Added the LTO flag to the old Namimno 2400 STM32 target.

_Then the can of worms sprang open..._

The RGB disco lights were borked! I had to break out the scope and check the timing and they were way off so I had to add more `__NOP()`s to the code, just a few 😈 

In the process I also optimised a bit of the code to shave off a few more bytes in the process.

The timings are well within spec now.
![pic_26_2](https://user-images.githubusercontent.com/512740/159615882-123ce65e-db69-4468-a6a0-6c9656f94b9a.png)
![pic_26_4](https://user-images.githubusercontent.com/512740/159615892-786f4073-4579-41c2-afeb-d51b611c5b16.png)

