### PR TITLE
use diversity by default, split Matek R24D target

### DIFF
--- a/src/targets/MATEK_2400.ini
+++ b/src/targets/MATEK_2400.ini
@@ -3,6 +3,26 @@
 # ********************************
 
 # ELRS-R24-D
+[env:MATEK_2400_RX_R24D_via_UART]
+extends = env_common_esp82xx, radio_2400
+build_flags =
+	${env_common_esp82xx.build_flags}
+	${radio_2400.build_flags}
+	${common_env_data.build_flags_rx}
+	-include target/MATEK_2400_RX.h
+	-D USE_DIVERSITY=1
+src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
+
+[env:MATEK_2400_RX_R24D_via_BetaflightPassthrough]
+extends = env:MATEK_2400_RX_R24D_via_UART
+upload_protocol = custom
+upload_speed = 420000
+upload_command = ${env_common_esp82xx.bf_upload_command}
+
+[env:MATEK_2400_RX_R24D_via_WIFI]
+extends = env:MATEK_2400_RX_R24D_via_UART
+
+
 # ELRS-R24-S
 [env:MATEK_2400_RX_via_UART]
 extends = env_common_esp82xx, radio_2400

--- a/src/targets/frsky.ini
+++ b/src/targets/frsky.ini
@@ -117,6 +117,7 @@ build_flags =
 	-include target/Frsky_RX_R9M.h
 	-D HSE_VALUE=12000000U
 	-DVECT_TAB_OFFSET=0x8000U
+	-D USE_DIVERSITY=1
 src_filter = ${env_common_stm32.src_filter} -<tx_*.cpp>
 
 [env:Frsky_RX_R9SLIMPLUS_OTA_via_STLINK]

--- a/src/targets/namimnorc_2400.ini
+++ b/src/targets/namimnorc_2400.ini
@@ -86,6 +86,7 @@ build_flags =
 	${radio_2400.build_flags}
 	${common_env_data.build_flags_rx}
 	-include target/NamimnoRC_FLASH_2400_RX_ESP8285_PA.h
+	-D USE_DIVERSITY=1
 src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
 
 [env:NamimnoRC_FLASH_2400_ESP_RX_PA_via_BetaflightPassthrough]

--- a/src/user_defines.txt
+++ b/src/user_defines.txt
@@ -83,9 +83,6 @@
 # Startup plays you own custom tune and crsf connect/disconnct do beep-boop
 #-DMY_STARTUP_MELODY="B5 16 P16 B5 16 P16 B5 16 P16 B5 2 G5 2 A5 2 B5 8 P4 A5 8 B5 1|140|-3"
 
-#Comment this to disable diversity function
-#-DUSE_DIVERSITY
-
 #If commented out the LED is RGB otherwise GRB
 #-DWS2812_IS_GRB
 

--- a/src/user_defines.txt
+++ b/src/user_defines.txt
@@ -83,6 +83,9 @@
 # Startup plays you own custom tune and crsf connect/disconnct do beep-boop
 #-DMY_STARTUP_MELODY="B5 16 P16 B5 16 P16 B5 16 P16 B5 2 G5 2 A5 2 B5 8 P4 A5 8 B5 1|140|-3"
 
+#Comment this to disable diversity function
+#-DUSE_DIVERSITY
+
 #If commented out the LED is RGB otherwise GRB
 #-DWS2812_IS_GRB
 


### PR DESCRIPTION
since diversity RX antenna selection can be selected through LUA ( #1362 ), USE_DIVERSITY is no longer needed to toggle it.
this PR should be merged after #1503 or PR #1503 should re-adjust to define the USE_DIVERSITY in the target.ini build flag if this PR get merged first.

will add configurator target for Matek R24D after this is merged.