### PR TITLE
Update Lua bandwidth indicator to account for TLM Burst

### DIFF
--- a/src/include/common.h
+++ b/src/include/common.h
@@ -150,8 +150,9 @@ extern SX1280Driver Radio;
 expresslrs_mod_settings_s *get_elrs_airRateConfig(uint8_t index);
 expresslrs_rf_pref_params_s *get_elrs_RFperfParams(uint8_t index);
 
-uint8_t TLMratioEnumToValue(uint8_t enumval);
-uint16_t RateEnumToHz(uint8_t eRate);
+uint8_t TLMratioEnumToValue(uint8_t const enumval);
+uint8_t TLMBurstMaxForRateRatio(uint16_t const rateHz, uint8_t const ratioDiv);
+uint16_t RateEnumToHz(uint8_t const eRate);
 
 extern expresslrs_mod_settings_s *ExpressLRS_currAirRate_Modparams;
 extern expresslrs_rf_pref_params_s *ExpressLRS_currAirRate_RFperfParams;

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -403,42 +403,63 @@ static void luahandSimpleSendCmd(struct luaPropertiesCommon *item, uint8_t arg)
   }
 }
 
-static void updateFolderName()
+static void updateFolderName_TxPower()
 {
-  //power folder name
   uint8_t txPwrDyn = config.GetDynamicPower() ? config.GetBoostChannel() + 1 : 0;
-  uint8_t pwrFolderLabelOffset = getSeparatorIndex(2,pwrFolderDynamicName); // start writing name after the 2nd space
+  uint8_t pwrFolderLabelOffset = getSeparatorIndex(2, pwrFolderDynamicName); // start writing name after the 2nd space
+
+  // Power Level
   pwrFolderDynamicName[pwrFolderLabelOffset++] = '(';
   pwrFolderLabelOffset += findLuaSelectionLabel(&luaPower, &pwrFolderDynamicName[pwrFolderLabelOffset], config.GetPower() - MinPower);
-  if(txPwrDyn){
+
+  // Dynamic Power
+  if (txPwrDyn)
+  {
     pwrFolderDynamicName[pwrFolderLabelOffset++] = folderNameSeparator[0];
     pwrFolderLabelOffset += findLuaSelectionLabel(&luaDynamicPower, &pwrFolderDynamicName[pwrFolderLabelOffset], txPwrDyn);
   }
+
   pwrFolderDynamicName[pwrFolderLabelOffset++] = ')';
   pwrFolderDynamicName[pwrFolderLabelOffset] = '\0';
-  //vtx folder
+}
+
+static void updateFolderName_VtxAdmin()
+{
   uint8_t vtxBand = config.GetVtxBand();
-  if(vtxBand){
+  if (vtxBand)
+  {
     luaVtxFolder.dyn_name = vtxFolderDynamicName;
     uint8_t vtxFolderLabelOffset = getSeparatorIndex(2,vtxFolderDynamicName); // start writing name after the 2nd space
     vtxFolderDynamicName[vtxFolderLabelOffset++] = '(';
+
+    // Band
     vtxFolderLabelOffset += findLuaSelectionLabel(&luaVtxBand, &vtxFolderDynamicName[vtxFolderLabelOffset], vtxBand);
     vtxFolderDynamicName[vtxFolderLabelOffset++] = folderNameSeparator[1];
+
+    // Channel
     vtxFolderLabelOffset += findLuaSelectionLabel(&luaVtxChannel, &vtxFolderDynamicName[vtxFolderLabelOffset], config.GetVtxChannel());
+
+    // VTX Power
     uint8_t vtxPwr = config.GetVtxPower();
     //if power is no-change (-), don't show, also hide pitmode
-    if(vtxPwr){
+    if (vtxPwr)
+    {
       vtxFolderDynamicName[vtxFolderLabelOffset++] = folderNameSeparator[1];
       vtxFolderLabelOffset += findLuaSelectionLabel(&luaVtxPwr, &vtxFolderDynamicName[vtxFolderLabelOffset], vtxPwr);
 
+      // Pit Mode
       uint8_t vtxPit = config.GetVtxPitmode();
       //if pitmode is off, don't show
       //show pitmode AuxSwitch or show P if not OFF
-      if(vtxPit != 0){
-        if(vtxPit != 1){
+      if (vtxPit != 0)
+      {
+        if (vtxPit != 1)
+        {
           vtxFolderDynamicName[vtxFolderLabelOffset++] = folderNameSeparator[1];
           vtxFolderLabelOffset += findLuaSelectionLabel(&luaVtxPit, &vtxFolderDynamicName[vtxFolderLabelOffset], vtxPit);
-        } else {
+        }
+        else
+        {
           vtxFolderDynamicName[vtxFolderLabelOffset++] = folderNameSeparator[1];
           vtxFolderDynamicName[vtxFolderLabelOffset++] = 'P';
         }
@@ -446,10 +467,18 @@ static void updateFolderName()
     }
     vtxFolderDynamicName[vtxFolderLabelOffset++] = ')';
     vtxFolderDynamicName[vtxFolderLabelOffset] = '\0';
-  } else {
-  //don't show vtx settings if band is OFF
+  }
+  else
+  {
+    //don't show vtx settings if band is OFF
     luaVtxFolder.dyn_name = NULL;
   }
+}
+
+static void updateFolderNames()
+{
+  updateFolderName_TxPower();
+  updateFolderName_VtxAdmin();
 }
 
 static void registerLuaParameters()
@@ -508,12 +537,12 @@ static void registerLuaParameters()
   luadevGeneratePowerOpts();
   registerLUAParameter(&luaPower, [](struct luaPropertiesCommon *item, uint8_t arg) {
     config.SetPower((PowerLevels_e)constrain(arg + MinPower, MinPower, MaxPower));
-    updateFolderName();
+    updateFolderName_TxPower();
   }, luaPowerFolder.common.id);
   registerLUAParameter(&luaDynamicPower, [](struct luaPropertiesCommon *item, uint8_t arg) {
     config.SetDynamicPower(arg > 0);
     config.SetBoostChannel((arg - 1) > 0 ? arg - 1 : 0);
-    updateFolderName();
+    updateFolderName_TxPower();
   }, luaPowerFolder.common.id);
 #if defined(GPIO_PIN_FAN_EN)
   registerLUAParameter(&luaFanThreshold, [](struct luaPropertiesCommon *item, uint8_t arg){
@@ -527,19 +556,19 @@ static void registerLuaParameters()
   registerLUAParameter(&luaVtxFolder);
   registerLUAParameter(&luaVtxBand, [](struct luaPropertiesCommon *item, uint8_t arg) {
     config.SetVtxBand(arg);
-    updateFolderName();
+    updateFolderName_VtxAdmin();
   }, luaVtxFolder.common.id);
   registerLUAParameter(&luaVtxChannel, [](struct luaPropertiesCommon *item, uint8_t arg) {
     config.SetVtxChannel(arg);
-    updateFolderName();
+    updateFolderName_VtxAdmin();
   }, luaVtxFolder.common.id);
   registerLUAParameter(&luaVtxPwr, [](struct luaPropertiesCommon *item, uint8_t arg) {
     config.SetVtxPower(arg);
-    updateFolderName();
+    updateFolderName_VtxAdmin();
   }, luaVtxFolder.common.id);
   registerLUAParameter(&luaVtxPit, [](struct luaPropertiesCommon *item, uint8_t arg) {
     config.SetVtxPitmode(arg);
-    updateFolderName();
+    updateFolderName_VtxAdmin();
   }, luaVtxFolder.common.id);
   registerLUAParameter(&luaVtxSend, &luahandSimpleSendCmd, luaVtxFolder.common.id);
   // WIFI folder
@@ -604,9 +633,6 @@ static int timeout()
 static int start()
 {
   CRSF::RecvParameterUpdate = &luaParamUpdateReq;
-  luadevUpdateModelID();
-  luadevUpdateRateSensitivity();
-  luadevUpdateTlmBandwidth();
   registerLuaParameters();
   registerLUAPopulateParams([](){
     itoa(CRSF::BadPktsCountResult, luaBadGoodString, 10);
@@ -614,7 +640,7 @@ static int start()
     itoa(CRSF::GoodPktsCountResult, luaBadGoodString + strlen(luaBadGoodString), 10);
     setLuaStringValue(&luaInfo, luaBadGoodString);
   });
-  updateFolderName();
+  updateFolderNames();
   event();
   return DURATION_IMMEDIATELY;
 }

--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -132,6 +132,33 @@ uint8_t ICACHE_RAM_ATTR TLMratioEnumToValue(uint8_t const enumval)
     }
 }
 
+/***
+ * @brief: Calculate number of 'burst' telemetry frames for the specified air rate and tlm ratio
+ *
+ * When attempting to send a LinkStats telemetry frame at most every TELEM_MIN_LINK_INTERVAL_MS,
+ * calculate the number of sequential advanced telemetry frames before another LinkStats is due.
+ ****/
+uint8_t TLMBurstMaxForRateRatio(uint16_t const rateHz, uint8_t const ratioDiv)
+{
+    // Maximum ms between LINK_STATISTICS packets for determining burst max
+    constexpr uint32_t TELEM_MIN_LINK_INTERVAL_MS = 512U;
+
+    // telemInterval = 1000 / (hz / ratiodiv);
+    // burst = TELEM_MIN_LINK_INTERVAL_MS / telemInterval;
+    // This ^^^ rearranged to preserve precision vvv
+    uint8_t retVal = TELEM_MIN_LINK_INTERVAL_MS * rateHz / ratioDiv / 1000U;
+
+    // Reserve one slot for LINK telemetry
+    if (retVal > 1)
+        --retVal;
+    else
+        retVal = 1;
+    //DBGLN("TLMburst: %d", retVal);
+
+    return retVal;
+}
+
+
 uint16_t RateEnumToHz(uint8_t const eRate)
 {
     switch(eRate)

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -96,8 +96,6 @@ CRSF crsf(CRSF_TX_SERIAL);
 StubbornSender TelemetrySender(ELRS_TELEMETRY_MAX_PACKAGES);
 static uint8_t telemetryBurstCount;
 static uint8_t telemetryBurstMax;
-// Maximum ms between LINK_STATISTICS packets for determining burst max
-#define TELEM_MIN_LINK_INTERVAL 512U
 
 StubbornReceiver MspReceiver(ELRS_MSP_MAX_PACKAGES);
 uint8_t MspData[ELRS_MSP_BUFFER];
@@ -1085,17 +1083,7 @@ static void updateTelemetryBurst()
 
     uint32_t hz = RateEnumToHz(ExpressLRS_currAirRate_Modparams->enum_rate);
     uint32_t ratiodiv = TLMratioEnumToValue(ExpressLRS_currAirRate_Modparams->TLMinterval);
-    // telemInterval = 1000 / (hz / ratiodiv);
-    // burst = TELEM_MIN_LINK_INTERVAL / telemInterval;
-    // This ^^^ rearranged to preserve precision vvv
-    telemetryBurstMax = TELEM_MIN_LINK_INTERVAL * hz / ratiodiv / 1000U;
-
-    // Reserve one slot for LINK telemetry
-    if (telemetryBurstMax > 1)
-        --telemetryBurstMax;
-    else
-        telemetryBurstMax = 1;
-    //DBGLN("TLMburst: %d", telemetryBurstMax);
+    telemetryBurstMax = TLMBurstMaxForRateRatio(hz, ratiodiv);
 
     // Notify the sender to adjust its expected throughput
     TelemetrySender.UpdateTelemetryRate(hz, ratiodiv, telemetryBurstMax);


### PR DESCRIPTION
This fixes the bug that the bps display in master's Lua is far lower than the actual advanced telemetry bandwidth, as it does not account for Telemetry Burst.

* Moved the MaxBurst calculation from rx_main to common: `TLMBurstMaxForRateRatio`
* Split `updateFolderName()` (which updates two folder names) into two functions, and only call the one needing updates
* Removed redundant calls from the tx_devLua `start()` since it calls them, then calls `event()` which also calls the same function
```
  luadevUpdateModelID();
  luadevUpdateRateSensitivity();
  luadevUpdateTlmBandwidth();
```

Tested at all Team2.4 rates and ratios against [TEH DOX](https://www.expresslrs.org/2.0/info/telem-bandwidth/) and it is only off by at most 1bps due to rounding, since this is all integer math now.