### PR TITLE
Fix no-joystick screen updates

### DIFF
--- a/src/lib/SCREEN/devScreen.cpp
+++ b/src/lib/SCREEN/devScreen.cpp
@@ -24,7 +24,6 @@ static bool is_pre_screen_flipped = false;
 
 extern bool ICACHE_RAM_ATTR IsArmed();
 
-#ifdef HAS_FIVE_WAY_BUTTON
 static int handle(void)
 {
 #if defined(JOY_ADC_VALUES) && defined(PLATFORM_ESP32)
@@ -54,6 +53,7 @@ static int handle(void)
 #endif
     uint32_t now = millis();
 
+#ifdef HAS_FIVE_WAY_BUTTON
     if (!IsArmed())
     {
         int key;
@@ -94,17 +94,12 @@ static int handle(void)
         state_machine.handleEvent(now, fsm_event);
     }
     else
+#endif
     {
         state_machine.handleEvent(now, EVENT_TIMEOUT);
     }
     return SCREEN_DURATION;
 }
-#else
-static int handle(void)
-{
-    return DURATION_NEVER;
-}
-#endif
 
 static void initialize()
 {


### PR DESCRIPTION
With the refactoring of the Screen devices there was an error introduced for devices with a screen but no input device. Where the timeout function did not forward to the state machine so the screen never updated from the splash screen rendering it pretty much useless!

This PR moves the ifdef for FIVE_WAY into the main function, and remove the special case function, so a device without a joystick will still call the state machine and get screen updates.
