### PR TITLE
Fix OpenTX LUA compatibility

### DIFF
--- a/src/lua/elrsV2.lua
+++ b/src/lua/elrsV2.lua
@@ -340,7 +340,13 @@ end
 
 local function fieldTextSelectionDisplay_color(field, y, attr)
   lcd.drawText(COL2, y, (field.values[field.value+1] or "ERR"), attr)
-  lcd.drawText(COL2 + (lcd.sizeText(field.values[field.value+1])), y, field.unit, 0)
+  local ver, radio, maj, minor, rev, osname = getVersion()
+  if (osname ~= nil and osname == "EdgeTX") then
+    lcd.drawText(COL2 + (lcd.sizeText(field.values[field.value+1])), y, field.unit, 0)
+  else
+    -- not EdgeTX
+    lcd.drawText(COL2 + 10*string.len(field.values[field.value+1]), y, field.unit, 0)
+  end	
 end
 
 local function fieldTextSelectionDisplay_bw(field, y, attr)

--- a/src/lua/elrsV2.lua
+++ b/src/lua/elrsV2.lua
@@ -340,11 +340,9 @@ end
 
 local function fieldTextSelectionDisplay_color(field, y, attr)
   lcd.drawText(COL2, y, (field.values[field.value+1] or "ERR"), attr)
-  local ver, radio, maj, minor, rev, osname = getVersion()
-  if (osname ~= nil and osname == "EdgeTX") then
+  if (lcd.sizeText ~= nil) then
     lcd.drawText(COL2 + (lcd.sizeText(field.values[field.value+1])), y, field.unit, 0)
   else
-    -- not EdgeTX
     lcd.drawText(COL2 + 10*string.len(field.values[field.value+1]), y, field.unit, 0)
   end	
 end


### PR DESCRIPTION
Tested with OpenTX 2.3.15-nightly on RM TX16S mkII with internal ELRS.
As only EdgeTX has lcd.sizeText() function presently, need to use a workaround for other OSes.