### PR TITLE
Add ability to forceupdate via wifi with a single call on 2.x

### DIFF
--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -362,6 +362,7 @@ static void WebUploadResponseHandler(AsyncWebServerRequest *request) {
 }
 
 static void WebUploadDataHandler(AsyncWebServerRequest *request, const String& filename, size_t index, uint8_t *data, size_t len, bool final) {
+  force_update = force_update || request->hasArg("force");
   if (index == 0) {
     DBGLN("Update: %s", filename.c_str());
     #if defined(PLATFORM_ESP8266)


### PR DESCRIPTION
This backports part of #1371 (forceupdate). No firmware can be forceupdate'd over wifi by the configurator until the firmware **already on the device** actually allows it.

Getting this in the 2.x releases (that come at a moment's notice) will allow a migration path across target names (environments) with the 3.0 forceupdate PIO targets.

I really don't want to backport all of 1371 to maintenance, but at least this will allow a user running 2.4.1 or 2.5.0 or above to forceupdate when their target name changes in 3.0.