### PR TITLE
Decrease Mixer Sync Offset Safe Margin

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -79,7 +79,7 @@ uint32_t CRSF::RequestedRCpacketInterval = 5000; // default to 200hz as per 'nor
 volatile uint32_t CRSF::RCdataLastRecv = 0;
 volatile int32_t CRSF::OpenTXsyncOffset = 0;
 bool CRSF::OpentxSyncActive = true;
-uint32_t CRSF::OpenTXsyncOffsetSafeMargin = 4000; // 400us
+uint32_t CRSF::OpenTXsyncOffsetSafeMargin = 2000; // 200us
 
 /// UART Handling ///
 uint32_t CRSF::GoodPktsCount = 0;

--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -79,7 +79,7 @@ uint32_t CRSF::RequestedRCpacketInterval = 5000; // default to 200hz as per 'nor
 volatile uint32_t CRSF::RCdataLastRecv = 0;
 volatile int32_t CRSF::OpenTXsyncOffset = 0;
 bool CRSF::OpentxSyncActive = true;
-uint32_t CRSF::OpenTXsyncOffsetSafeMargin = 1000; // 200us
+uint32_t CRSF::OpenTXsyncOffsetSafeMargin = 1000; // 100us
 
 /// UART Handling ///
 uint32_t CRSF::GoodPktsCount = 0;

--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -79,7 +79,7 @@ uint32_t CRSF::RequestedRCpacketInterval = 5000; // default to 200hz as per 'nor
 volatile uint32_t CRSF::RCdataLastRecv = 0;
 volatile int32_t CRSF::OpenTXsyncOffset = 0;
 bool CRSF::OpentxSyncActive = true;
-uint32_t CRSF::OpenTXsyncOffsetSafeMargin = 2000; // 200us
+uint32_t CRSF::OpenTXsyncOffsetSafeMargin = 1000; // 200us
 
 /// UART Handling ///
 uint32_t CRSF::GoodPktsCount = 0;


### PR DESCRIPTION
Since EdgeTx is awesome and all that, we should consider lowering the mixer offset.

Below are some 1kHz latency test results with decreasing offset.  We can see at 50us there are a lot of packets with 'late' data, at 75us maybe some, but at 100us we look in the clear. 

The below plots are taken with the latency tester.  X-axis 1000-4000us.
![image](https://user-images.githubusercontent.com/14170229/163704783-91234a2f-19a6-4094-9f24-077c855ca58a.png)
