### PR TITLE
Update Lua when switching ModelID / Send version

### DIFF
--- a/src/include/native.h
+++ b/src/include/native.h
@@ -84,6 +84,7 @@ inline char *utoa(uint32_t value, char *str, int base) { sprintf(str, "%u", valu
 
 const char device_name[] = "testing";
 const uint8_t device_name_size = sizeof(device_name);
+const char version[] = "native"; // should resolve to 0x00000000
 
 #ifdef _WIN32
 #define random rand

--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -953,18 +953,18 @@ uint16_t CRSF::GetChannelOutput(uint8_t ch)
 /***
  * @brief: Convert `version` (string) to a integer version representation
  * e.g. "2.2.15 ISM24G" => 0x0002020f
- * Assumes all version fields are < 256
+ * Assumes all version fields are < 256, the number portion
+ * MUST be followed by a space to correctly be parsed
  ***/
-static uint32_t versionStrToInt()
+uint32_t CRSF::VersionStrToU32(const char *verStr)
 {
     uint32_t retVal = 0;
 #if !defined(FORCE_NO_DEVICE_VERSION)
-    const char *v = version;
     uint8_t accumulator = 0;
-    char c = '\0';
-    do
+    char c;
+    while (c = *verStr)
     {
-        c = *v;
+        ++verStr;
         // A decimal indicates moving to a new version field
         // and the space after the version ends that field
         if (c == '.' || c == ' ')
@@ -982,9 +982,7 @@ static uint32_t versionStrToInt()
         {
             break;
         }
-
-        ++v;
-    } while (c);
+    }
 #endif
     return retVal;
 }
@@ -997,7 +995,7 @@ void CRSF::GetDeviceInformation(uint8_t *frame, uint8_t fieldCount)
     // Followed by the device
     device->serialNo = htobe32(0x454C5253); // ['E', 'L', 'R', 'S'], seen [0x00, 0x0a, 0xe7, 0xc6] // "Serial 177-714694" (value is 714694)
     device->hardwareVer = 0; // unused currently by us, seen [ 0x00, 0x0b, 0x10, 0x01 ] // "Hardware: V 1.01" / "Bootloader: V 3.06"
-    device->softwareVer = htobe32(versionStrToInt()); // seen [ 0x00, 0x00, 0x05, 0x0f ] // "Firmware: V 5.15"
+    device->softwareVer = htobe32(VersionStrToU32(version)); // seen [ 0x00, 0x00, 0x05, 0x0f ] // "Firmware: V 5.15"
     device->fieldCnt = fieldCount;
     device->parameterVersion = 0;
 }

--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -950,6 +950,45 @@ uint16_t CRSF::GetChannelOutput(uint8_t ch)
 
 #endif // CRSF_RX_MODULE
 
+/***
+ * @brief: Convert `version` (string) to a integer version representation
+ * e.g. "2.2.15 ISM24G" => 0x0002020f
+ * Assumes all version fields are < 256
+ ***/
+static uint32_t versionStrToInt()
+{
+    uint32_t retVal = 0;
+#if !defined(FORCE_NO_DEVICE_VERSION)
+    const char *v = version;
+    uint8_t accumulator = 0;
+    char c = '\0';
+    do
+    {
+        c = *v;
+        // A decimal indicates moving to a new version field
+        // and the space after the version ends that field
+        if (c == '.' || c == ' ')
+        {
+            retVal = (retVal << 8) | accumulator;
+            accumulator = 0;
+        }
+        // Else if this is a number add it up
+        else if (c >= '0' && c <= '9')
+        {
+            accumulator = (accumulator * 10) + (c - '0');
+        }
+        // Anything except [0-9. ] ends the parsing
+        else
+        {
+            break;
+        }
+
+        ++v;
+    } while (c);
+#endif
+    return retVal;
+}
+
 void CRSF::GetDeviceInformation(uint8_t *frame, uint8_t fieldCount)
 {
     deviceInformationPacket_t *device = (deviceInformationPacket_t *)(frame + sizeof(crsf_ext_header_t) + device_name_size);
@@ -958,7 +997,7 @@ void CRSF::GetDeviceInformation(uint8_t *frame, uint8_t fieldCount)
     // Followed by the device
     device->serialNo = htobe32(0x454C5253); // ['E', 'L', 'R', 'S'], seen [0x00, 0x0a, 0xe7, 0xc6] // "Serial 177-714694" (value is 714694)
     device->hardwareVer = 0; // unused currently by us, seen [ 0x00, 0x0b, 0x10, 0x01 ] // "Hardware: V 1.01" / "Bootloader: V 3.06"
-    device->softwareVer = 0; // unused currently by us, seen [ 0x00, 0x00, 0x05, 0x0f ] // "Firmware: V 5.15"
+    device->softwareVer = htobe32(versionStrToInt()); // seen [ 0x00, 0x00, 0x05, 0x0f ] // "Firmware: V 5.15"
     device->fieldCnt = fieldCount;
     device->parameterVersion = 0;
 }

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -86,6 +86,7 @@ public:
     static void GetDeviceInformation(uint8_t *frame, uint8_t fieldCount);
     static void SetHeaderAndCrc(uint8_t *frame, uint8_t frameType, uint8_t frameSize, uint8_t destAddr);
     static void SetExtendedHeaderAndCrc(uint8_t *frame, uint8_t frameType, uint8_t frameSize, uint8_t senderAddr, uint8_t destAddr);
+    static uint32_t VersionStrToU32(const char *verStr);
 
     #ifdef CRSF_TX_MODULE
     static void ICACHE_RAM_ATTR sendLinkStatisticsToTX();

--- a/src/lib/LUA/devLUA.h
+++ b/src/lib/LUA/devLUA.h
@@ -3,3 +3,7 @@
 #include "device.h"
 
 extern device_t LUA_device;
+
+#if defined(TARGET_TX)
+void luadevUpdateFolderNames();
+#endif

--- a/src/lib/LUA/lua.cpp
+++ b/src/lib/LUA/lua.cpp
@@ -20,7 +20,7 @@ static volatile bool UpdateParamReq = false;
 
 #ifdef TARGET_TX
 static uint8_t luaWarningFlags = 0b00000000; //8 flag, 1 bit for each flag. set the bit to 1 to show specific warning. 3 MSB is for critical flag
-static void (*populateHandler)() = 0;
+static void (*devicePingCallback)() = nullptr;
 #endif
 
 #define LUA_MAX_PARAMS 32
@@ -75,7 +75,7 @@ uint8_t findLuaSelectionLabel(const void *luaStruct, char *outarray, uint8_t val
     if(*c == ';'){
       count++;
     }
-    c++;  
+    c++;
   }
   return 0;
 }
@@ -300,10 +300,9 @@ void sendELRSstatus()
   crsf.packetQueueExtended(0x2E, &buffer, sizeof(buffer));
 }
 
-void registerLUAPopulateParams(void (*populate)())
+void luaRegisterDevicePingCallback(void (*callback)())
 {
-  populateHandler = populate;
-  populate();
+  devicePingCallback = callback;
 }
 
 #endif
@@ -397,7 +396,7 @@ bool luaHandleUpdateParameter()
 
     case CRSF_FRAMETYPE_DEVICE_PING:
 #ifdef TARGET_TX
-        populateHandler();
+        devicePingCallback();
         luaSupressCriticalErrors();
 #endif
         sendLuaDevicePacket();

--- a/src/lib/LUA/lua.h
+++ b/src/lib/LUA/lua.h
@@ -119,7 +119,7 @@ struct tagLuaElrsParams {
 void setLuaWarningFlag(lua_Flags flag, bool value);
 uint8_t getLuaWarningFlags(void);
 
-void registerLUAPopulateParams(void (*populate)());
+void luaRegisterDevicePingCallback(void (*callback)());
 #endif
 
 void sendLuaCommandResponse(struct luaItem_command *cmd, luaCmdStep_e step, const char *message);

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -15,8 +15,6 @@
 extern bool InLoanBindingMode;
 extern bool returnModelFromLoan;
 
-static const char thisCommit[] = {LATEST_COMMIT, 0};
-static const char thisVersion[] = {LATEST_VERSION, 0};
 static const char emptySpace[1] = {0};
 static char modelString[] = "000";
 
@@ -51,8 +49,8 @@ static struct luaItem_string luaModelNumber = {
 };
 
 static struct luaItem_string luaELRSversion = {
-    {thisVersion, CRSF_INFO},
-    thisCommit
+    {version, CRSF_INFO},
+    commit
 };
 
 //----------------------------Info-----------------------------------

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -234,12 +234,13 @@ static uint8_t getSeparatorIndex(uint8_t index, char *searchArray)
   while (c[i] != '\0')
   {
     //treat symbols as separator except : !,",#,$,%,&,',(,),*,+,,,-,.,/ as these would probably inside our label names
-    if (c[i] < '!' || (c[i] > '9' && c[i] < 'A')) {
+    if (c[i] < '!' || (c[i] > '9' && c[i] < 'A'))
+    {
       SeparatorCount++;
       arrayCount++;
       //if found separator is equal to the nth(index) requested separator,
       //return the start of the labelSpace
-      if(SeparatorCount == index+1){
+      if (SeparatorCount == index+1) {
         return returnvalue;
       } else {
         returnvalue = arrayCount;
@@ -255,13 +256,13 @@ static uint8_t getSeparatorIndex(uint8_t index, char *searchArray)
 }
 
 static void luadevUpdateRateSensitivity() {
-  itoa(ExpressLRS_currAirRate_RFperfParams->RXsensitivity,rateSensitivity+2,10);
-  strcat(rateSensitivity,"dBm)");
+  itoa(ExpressLRS_currAirRate_RFperfParams->RXsensitivity, rateSensitivity+2, 10);
+  strcat(rateSensitivity, "dBm)");
 }
 
 static void luadevUpdateModelID() {
   itoa(CRSF::getModelID(), modelMatchUnit+6, 10);
-  strcat(modelMatchUnit,")");
+  strcat(modelMatchUnit, ")");
 }
 
 static void luadevUpdateTlmBandwidth()
@@ -519,6 +520,7 @@ static void registerLuaParameters()
   #if defined(TARGET_TX_FM30)
   registerLUAParameter(&luaBluetoothTelem, [](struct luaPropertiesCommon *item, uint8_t arg) {
     digitalWrite(GPIO_PIN_BLUETOOTH_EN, !arg);
+    // An event must be triggered manually because this option is not saved to config
     devicesTriggerEvent();
   });
   #endif
@@ -539,7 +541,8 @@ static void registerLuaParameters()
   registerLUAParameter(&luaModelMatch, [](struct luaPropertiesCommon *item, uint8_t arg) {
     bool newModelMatch = arg;
     config.SetModelMatch(newModelMatch);
-    if (connectionState == connected) {
+    if (connectionState == connected)
+    {
       mspPacket_t msp;
       msp.reset();
       msp.makeCommand();

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -481,6 +481,16 @@ static void updateFolderNames()
   updateFolderName_VtxAdmin();
 }
 
+static void luadevUpdateBadGood()
+{
+  // Update the luaBadGoodString with the current bad/good count
+  // This item is hidden on our Lua and only displayed in other systems that don't poll our status
+  // called from luaRegisterDeicePingCallback
+  itoa(CRSF::BadPktsCountResult, luaBadGoodString, 10);
+  strcat(luaBadGoodString, "/");
+  itoa(CRSF::GoodPktsCountResult, luaBadGoodString + strlen(luaBadGoodString), 10);
+}
+
 static void registerLuaParameters()
 {
   registerLUAParameter(&luaAirRate, [](struct luaPropertiesCommon *item, uint8_t arg) {
@@ -634,12 +644,10 @@ static int start()
 {
   CRSF::RecvParameterUpdate = &luaParamUpdateReq;
   registerLuaParameters();
-  registerLUAPopulateParams([](){
-    itoa(CRSF::BadPktsCountResult, luaBadGoodString, 10);
-    strcat(luaBadGoodString, "/");
-    itoa(CRSF::GoodPktsCountResult, luaBadGoodString + strlen(luaBadGoodString), 10);
-    setLuaStringValue(&luaInfo, luaBadGoodString);
-  });
+
+  setLuaStringValue(&luaInfo, luaBadGoodString);
+  luaRegisterDevicePingCallback(&luadevUpdateBadGood);
+
   updateFolderNames();
   event();
   return DURATION_IMMEDIATELY;

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -559,12 +559,10 @@ static void registerLuaParameters()
   luadevGeneratePowerOpts();
   registerLUAParameter(&luaPower, [](struct luaPropertiesCommon *item, uint8_t arg) {
     config.SetPower((PowerLevels_e)constrain(arg + MinPower, MinPower, MaxPower));
-    //updateFolderName_TxPower();
   }, luaPowerFolder.common.id);
   registerLUAParameter(&luaDynamicPower, [](struct luaPropertiesCommon *item, uint8_t arg) {
     config.SetDynamicPower(arg > 0);
     config.SetBoostChannel((arg - 1) > 0 ? arg - 1 : 0);
-    //updateFolderName_TxPower();
   }, luaPowerFolder.common.id);
 #if defined(GPIO_PIN_FAN_EN)
   registerLUAParameter(&luaFanThreshold, [](struct luaPropertiesCommon *item, uint8_t arg){
@@ -578,19 +576,15 @@ static void registerLuaParameters()
   registerLUAParameter(&luaVtxFolder);
   registerLUAParameter(&luaVtxBand, [](struct luaPropertiesCommon *item, uint8_t arg) {
     config.SetVtxBand(arg);
-    //updateFolderName_VtxAdmin();
   }, luaVtxFolder.common.id);
   registerLUAParameter(&luaVtxChannel, [](struct luaPropertiesCommon *item, uint8_t arg) {
     config.SetVtxChannel(arg);
-    //updateFolderName_VtxAdmin();
   }, luaVtxFolder.common.id);
   registerLUAParameter(&luaVtxPwr, [](struct luaPropertiesCommon *item, uint8_t arg) {
     config.SetVtxPower(arg);
-    //updateFolderName_VtxAdmin();
   }, luaVtxFolder.common.id);
   registerLUAParameter(&luaVtxPit, [](struct luaPropertiesCommon *item, uint8_t arg) {
     config.SetVtxPitmode(arg);
-    //updateFolderName_VtxAdmin();
   }, luaVtxFolder.common.id);
   registerLUAParameter(&luaVtxSend, &luahandSimpleSendCmd, luaVtxFolder.common.id);
   // WIFI folder

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -605,6 +605,8 @@ static void ConfigChangeCommit()
   ChangeRadioParams();
   // Resume the timer, will take one hop for the radio to be on the right frequency if we missed a hop
   hwTimer.callbackTock = &timerCallbackNormal;
+  // UpdateFolderNames is expensive so it is called directly instead of in event() which gets called a lot
+  luadevUpdateFolderNames();
   devicesTriggerEvent();
 }
 

--- a/src/test/crsf_native/test_crsf.cpp
+++ b/src/test/crsf_native/test_crsf.cpp
@@ -16,6 +16,27 @@ CRSF crsf(&ss);
 
 GENERIC_CRC8 test_crc(CRSF_CRC_POLY);
 
+void test_ver_to_u32(void)
+{
+    constexpr struct tagVerItem {
+        const char verStr[128];
+        const uint32_t verU32;
+    } VERSION_STRINGS[] = {
+        {{108,117,97,45,102,111,108,100,101,114,45,117,112,100,97,116,101,32,73,83,77,50,71,52,0}, 0}, // lua-folder-update ISM2G4
+        {{0x32, 0x2e, 0x32, 0x2e, 0x31, 0x35, 32,73,83,77,50,71,52,0}, 0x0002020f}, // 2.2.15 ISM2G4
+        {{0x31, 0x2e, 0x32, 0x2e, 0x33, 0x2e, 0x34, 32,73,83,77,50,71,52,0}, 0x01020304}, // 1.2.3.4 ISM2G4
+        {{0x31, 0x30, 0x30, 0x2e, 0x32, 0x35, 0x35, 32,0}, 0x000064ff}, // 100.255(space)
+        {{0}, 0},
+    };
+
+    const struct tagVerItem *ver = VERSION_STRINGS;
+    while (ver->verStr[0])
+    {
+        TEST_ASSERT_EQUAL_HEX32(ver->verU32, CRSF::VersionStrToU32(ver->verStr));
+        ++ver;
+    }
+}
+
 void test_device_info(void)
 {
     uint8_t deviceInformation[DEVICE_INFORMATION_LENGTH];
@@ -50,6 +71,7 @@ void test_device_info(void)
 int main(int argc, char **argv)
 {
     UNITY_BEGIN();
+    RUN_TEST(test_ver_to_u32);
     RUN_TEST(test_device_info);
     UNITY_END();
 


### PR DESCRIPTION
## TX Power caption
Fix the bug in master that when the ModelID is changed, the TX Power folder item still shows the original model's power setting. This happens because the text is not updated in event(), because event happens a lot and the code to build all the strings is a little fat. Now any time the TX commits a config change, it updates all the folder names and config item suffixes (such as the `(-105dBm)` or TLM bandwidth string). I've also removed the individual calls in the config parameter updaters since they are now redundant and it saves ~100 bytes.

There is a concern that the Lua will refresh the value before it updates but it didn't seem to be a problem. 🤷‍♀️ hashtag YOLO

To reproduce this bug for testing:
* Set ModelID=0 in the EdgeTX model setup
* Go into the Lua and set power to one value e.g. 10mW
* Now load another EdgeTX model, with ModelID=1
* Go into the Lua and set power to a different value e.g. 50mW
* Reboot the handset and enter the Lua. You'll see ModelID==1 and the TX Power folder will say 10mW, but if you go into the folder, the TX Power will actually be the correct 50mW. Only the folder flavor text is wrong

## Send version number
Adds our version number to the deviceInfo structure. EdgeTX now has a place for us to display our version number so let's do it. I had concerns about this, because some dumb software looks directly ant the Crossfire version number and changes their behavior based on that so when I coded this initially, I just set it to 0x00000000. Progress waits for noone though, so they're going to have to get their shit together and look for the ELRS indicator in the deviceInfo packet (`serialNo == 0x454C5253`).

The version number comes from our version string already baked into options.cpp. The algorithm parses out any numbers, periods, or spaces and exits on the first character that isn't one of those. In the example below I set the version string to "2.0.15 ISM2G4" on the TX and "2.2.15 ISM2G4" on the RX.
![image](https://user-images.githubusercontent.com/677183/163865987-d946fc3f-c1ca-4c27-91d7-5cbf56030107.png)

If the `version` is a branch name, the version number reported will be 0, since it does not begin with a number.

Because I am sure some a-hole is going to complain that sending the software version in the software version field is destroying everything TBS has worked so hard to build, the defining `-DFORCE_NO_DEVICE_VERSION` will zero out the field always.

## Minor refactors
* `registerLUAPopulateParams`-- I renamed this to what it is `luaRegisterDevicePingCallback`. It doesn't populate params, and the code doesn't expect it to. It just updates the bad/good string, and I moved that to a function instead of a lambda.
* Removed the duplicate version, commit strings from RX

## Tested on
* OpenTX 2.3.14 + Namimno OLED and SIYI FM30
* EdgeTX + DupleTX (TX16S)

Because it doesn't work on branch names, you'll need to fake any version number you want to try (python/elrs_helpers.py)
![image](https://user-images.githubusercontent.com/677183/163877525-b7d20ed0-9b9f-4b84-a212-a12661cd5cc7.png)
