### PR TITLE
GepRC Targets

### DIFF
--- a/src/platformio.ini
+++ b/src/platformio.ini
@@ -28,6 +28,8 @@ extra_configs =
 	targets/vantac_2400.ini
 	targets/Jumper_2400.ini
 	targets/radiomaster_2400.ini
+	targets/geprc_900.ini
+	targets/geprc_2400.ini
 
 # ------------------------- TARGET ENV DEFINITIONS -----------------
 

--- a/src/targets/betafpv_2400.ini
+++ b/src/targets/betafpv_2400.ini
@@ -70,3 +70,16 @@ upload_command = ${env_common_esp82xx.bf_upload_command}
 
 [env:BETAFPV_Nano_2400_RX_via_WIFI]
 extends = env:BETAFPV_Nano_2400_RX_via_UART
+
+# ********************************
+# Lite Receiver targets
+# ********************************
+
+[env:BETAFPV_Lite_2400_RX_via_UART]
+extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART
+
+[env:BETAFPV_Lite_2400_RX_via_BetaflightPassthrough]
+extends = env:DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough
+
+[env:BETAFPV_Lite_2400_RX_via_WIFI]
+extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART

--- a/src/targets/betafpv_2400.ini
+++ b/src/targets/betafpv_2400.ini
@@ -70,16 +70,3 @@ upload_command = ${env_common_esp82xx.bf_upload_command}
 
 [env:BETAFPV_Nano_2400_RX_via_WIFI]
 extends = env:BETAFPV_Nano_2400_RX_via_UART
-
-# ********************************
-# Lite Receiver targets
-# ********************************
-
-[env:BETAFPV_Lite_2400_RX_via_UART]
-extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART
-
-[env:BETAFPV_Lite_2400_RX_via_BetaflightPassthrough]
-extends = env:DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough
-
-[env:BETAFPV_Lite_2400_RX_via_WIFI]
-extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART

--- a/src/targets/geprc_2400.ini
+++ b/src/targets/geprc_2400.ini
@@ -1,0 +1,12 @@
+# ********************************
+# Receiver targets
+# ********************************
+
+[env:GepRC_Nano_2400_RX_via_UART]
+extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART
+
+[env:GepRC_Nano_2400_RX_via_BetaflightPassthrough]
+extends = env:DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough
+
+[env:GepRC_Nano_2400_RX_via_WIFI]
+extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART

--- a/src/targets/geprc_900.ini
+++ b/src/targets/geprc_900.ini
@@ -1,0 +1,12 @@
+# ********************************
+# Receiver targets
+# ********************************
+
+[env:GepRC_Nano_900_RX_via_UART]
+extends = env:DIY_900_RX_ESP8285_SX127x_via_UART
+
+[env:GepRC_Nano_900_RX_via_WIFI]
+extends = env:DIY_900_RX_ESP8285_SX127x_via_WIFI
+
+[env:GepRC_Nano_900_RX_via_BetaflightPassthrough]
+extends = env:DIY_900_RX_ESP8285_SX127x_via_BetaflightPassthrough


### PR DESCRIPTION
I know we're getting a long list of PlatformIO Targets and we could've used the Configurator's Aliases.

But users easily gets confused (among other things to get confused of because only a handful have time to read the docs, and they just want to fly) why their receiver ends up being a DIY receiver when they made sure to select the right Device in the Configurator.

Until the Uber RX see the light of day (hopefully soon), we'll have to make do with the long list of PlatformIO targets.. 

I'll make another PR over at the Configurator Repo with regards to these devices and these changes.
I can also do a PR based off 2.4.x-maintenance branch for an easier Release creation.

Tested these on my units via PlatformIO.
And I also know we still need to do testing on the actual hardware we have. Just to get the ball rolling and calm the crowd down.