### PR TITLE
fixes not resetting sx1280 module

### DIFF
--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -66,6 +66,12 @@ bool SX1280Driver::Begin()
     hal.init();
     hal.IsrCallback = &SX1280Driver::IsrCallback;
 
+    //if the module cant initialize, this ensures the correct clock and resets the fault state
+    SetMode(SX1280_MODE_STDBY_RC);                                                                                                //Put in STDBY_RC mode
+
+    //this should return 'Status: 2, 1, 1'
+    GetStatus();
+
     hal.reset();
     
     uint16_t firmwareRev = (((hal.ReadRegister(REG_LR_FIRMWARE_VERSION_MSB)) << 8) | (hal.ReadRegister(REG_LR_FIRMWARE_VERSION_MSB + 1)));
@@ -76,7 +82,6 @@ bool SX1280Driver::Begin()
         return false;
     }
 
-    SetMode(SX1280_MODE_STDBY_RC);                                                                                                //Put in STDBY_RC mode
     hal.WriteCommand(SX1280_RADIO_SET_PACKETTYPE, SX1280_PACKET_TYPE_LORA);                                                       //Set packet type to LoRa
     ConfigModParamsLoRa(SX1280_LORA_BW_0800, SX1280_LORA_SF6, SX1280_LORA_CR_4_7);                                                //Configure Modulation Params
     hal.WriteCommand(SX1280_RADIO_SET_AUTOFS, 0x01);                                                                              //Enable auto FS

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -61,12 +61,13 @@ void SX1280Driver::End()
 
 bool SX1280Driver::Begin()
 {
+    DBGLN("SX1280 Begin");
+
     hal.init();
     hal.IsrCallback = &SX1280Driver::IsrCallback;
 
     hal.reset();
-    DBGLN("SX1280 Begin");
-    delay(100);
+    
     uint16_t firmwareRev = (((hal.ReadRegister(REG_LR_FIRMWARE_VERSION_MSB)) << 8) | (hal.ReadRegister(REG_LR_FIRMWARE_VERSION_MSB + 1)));
     DBGLN("Read Vers: %d", firmwareRev);
     if ((firmwareRev == 0) || (firmwareRev == 65535))

--- a/src/lib/SX1280Driver/SX1280_hal.cpp
+++ b/src/lib/SX1280Driver/SX1280_hal.cpp
@@ -120,6 +120,11 @@ void SX1280Hal::reset(void)
 #endif
 
 #if defined(GPIO_PIN_BUSY) && (GPIO_PIN_BUSY != UNDEF_PIN)
+    // if the module is not responding or reporting a busy status, this will somehow reset it, and clear the status
+    uint8_t status = 0;
+    ReadCommand(SX1280_RADIO_GET_STATUS, (uint8_t *)&status, 1);
+
+    DBGLN("Status: %x, %x, %x", (0b11100000 & status) >> 5, (0b00011100 & status) >> 2, 0b00000001 & status);
     while (digitalRead(GPIO_PIN_BUSY) == HIGH) // wait for busy
     {
         #ifdef PLATFORM_STM32

--- a/src/lib/SX1280Driver/SX1280_hal.cpp
+++ b/src/lib/SX1280Driver/SX1280_hal.cpp
@@ -102,18 +102,6 @@ void SX1280Hal::init()
     SPI.setClockDivider(SPI_CLOCK_DIV4); // 72 / 8 = 9 MHz
 #endif
 
-    //this block is just for forcing SPI mode on SX1280 modules, that (nobody knows why) defaults into UART mode
-    digitalWrite(GPIO_PIN_NSS, LOW);
-
-    WORD_ALIGNED_ATTR uint8_t OutBuffer[3];
-
-    OutBuffer[0] = (uint8_t)SX1280_RADIO_GET_STATUS;
-    OutBuffer[1] = 0x00;
-    OutBuffer[2] = 0x00;
-    SPI.transfer(OutBuffer, 3);
-
-    digitalWrite(GPIO_PIN_NSS, HIGH);
-
     //attachInterrupt(digitalPinToInterrupt(GPIO_PIN_BUSY), this->busyISR, CHANGE); //not used atm
     attachInterrupt(digitalPinToInterrupt(GPIO_PIN_DIO1), this->dioISR, RISING);
 }


### PR DESCRIPTION
My module doesnt reset properly, i dont know why. But if i try to read something beforehand, it works and the module initilizes successfull.

I talked with JamesK (Discord) and this could be just my module!

The state of my module:
```
first: i bridged dio3 to gnd once and powered it (fixed that)
second: i havnt soldered every gnd pad of the module
third: i did second, because some pads ripped of that module
fourth: i had to use some jumper wire to get the top pads soldered to the pcb pads
```