### PR TITLE
Add BETAFPV literadio3 target

### DIFF
--- a/src/include/target/BETAFPV_2400_TX_LITERADIO3.h
+++ b/src/include/target/BETAFPV_2400_TX_LITERADIO3.h
@@ -1,5 +1,5 @@
 #ifndef DEVICE_NAME
-#define DEVICE_NAME "BETAFPV LtRadio"
+#define DEVICE_NAME "BETAFPV LR3 Pro"
 #endif
 
 // Any device features

--- a/src/include/target/BETAFPV_2400_TX_LITERADIO3.h
+++ b/src/include/target/BETAFPV_2400_TX_LITERADIO3.h
@@ -1,0 +1,31 @@
+#ifndef DEVICE_NAME
+#define DEVICE_NAME "BETAFPV LtRadio"
+#endif
+
+// Any device features
+#define USE_SX1280_DCDC
+
+// GPIO pin definitions
+#define GPIO_PIN_NSS            5
+#define GPIO_PIN_BUSY           21
+#define GPIO_PIN_DIO1           4
+#define GPIO_PIN_DIO2           22
+#define GPIO_PIN_MOSI           23
+#define GPIO_PIN_MISO           19
+#define GPIO_PIN_SCK            18
+#define GPIO_PIN_RST            14
+#define GPIO_PIN_RX_ENABLE      27
+#define GPIO_PIN_TX_ENABLE      26
+#define GPIO_PIN_RCSIGNAL_RX    3
+#define GPIO_PIN_RCSIGNAL_TX    1
+
+// Backpack pins
+#define GPIO_PIN_DEBUG_RX       16
+#define GPIO_PIN_DEBUG_TX       17
+
+// Output Power
+#define MinPower PWR_10mW
+#define MaxPower PWR_250mW
+#define POWER_OUTPUT_VALUES {-17,-14,-10,-7,-2}
+
+#define Regulatory_Domain_ISM_2400 1

--- a/src/targets/betafpv_2400.ini
+++ b/src/targets/betafpv_2400.ini
@@ -47,6 +47,26 @@ build_flags =
 [env:BETAFPV_2400_TX_MICRO_1000mw_via_WIFI]
 extends = env:BETAFPV_2400_TX_MICRO_1000mw_via_UART
 
+[env:BETAFPV_2400_TX_LITERADIO3_via_ETX]
+extends = env_common_esp32, radio_2400
+build_flags =
+	${env_common_esp32.build_flags}
+	${common_env_data.build_flags_tx}
+	${radio_2400.build_flags}
+	-include target/BETAFPV_2400_TX_LITERADIO3.h
+	-D VTABLES_IN_FLASH=1
+	-O2
+src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+upload_speed = 460800
+lib_deps =
+	${env_common_esp32.lib_deps}
+
+[env:BETAFPV_2400_TX_LITERADIO3_via_UART]
+extends = env:BETAFPV_2400_TX_LITERADIO3_via_ETX
+
+[env:BETAFPV_2400_TX_LITERADIO3_via_WIFI]
+extends = env:BETAFPV_2400_TX_LITERADIO3_via_ETX
+
 
 # ********************************
 # Receiver targets


### PR DESCRIPTION
Testing completed:

- Test log: https://docs.google.com/document/d/1u4EL7C9RiPojMh4jc83nSAH4tadTj0Xr8L29n2OI_z4/edit?usp=sharing
- Testing limited to ELRS
- No issues found with the internal ELRS module, except when using 500mW RF output. Power has been limited to 250mW in the target as a result.
