### PR TITLE
Switch Jumper TPro GPIO_PIN_DEBUG pins... mod for TPro Backpack

### DIFF
--- a/src/include/target/Jumper_AION_2400_T-Pro_TX.h
+++ b/src/include/target/Jumper_AION_2400_T-Pro_TX.h
@@ -19,8 +19,8 @@
 #define GPIO_PIN_RCSIGNAL_TX    1
 
 // Backpack pins
-#define GPIO_PIN_DEBUG_RX       13
-#define GPIO_PIN_DEBUG_TX       12
+#define GPIO_PIN_DEBUG_RX       12
+#define GPIO_PIN_DEBUG_TX       13
 
 // Output Power
 #define MinPower                PWR_25mW


### PR DESCRIPTION
This will allow users to now add a Backpack to the TPro.  Just add the Backpack define to the Configurator and solder a rx you dont want to use inside.  The receiver rx pad is solder to the modules SP pad.

![image](https://user-images.githubusercontent.com/14170229/166186464-a69ff96e-9452-4e54-8f1c-de471fbdc72d.png)

![image](https://user-images.githubusercontent.com/14170229/166186609-feeba05e-980a-4195-bce4-bd3fa2e4b439.png)

