### PR TITLE
Fix reboot when auto wifi is off

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1218,7 +1218,7 @@ void loop()
 
     devicesUpdate(now);
 
-    #if defined(PLATFORM_ESP8266) && defined(AUTO_WIFI_ON_INTERVAL)
+    #if defined(PLATFORM_ESP8266)
     // If the reboot time is set and the current time is past the reboot time then reboot.
     if (rebootTime != 0 && now > rebootTime) {
         ESP.restart();


### PR DESCRIPTION
This fixes a very nefarious little bug!

If auto wifi is disabled then the reboot code was not included this means that after a wifi upgrade the reboot didn't happen and the eboot flag to install the new firmware is a non-persistent value, i.e. it only gets activated after a reboot. So this bug means that with auto wifi off you can't perform wifi updates!