### PR TITLE
More robust firmware upload

### DIFF
--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -246,6 +246,7 @@ function uploadFile() {
     ajax.addEventListener("error", errorHandler, false);
     ajax.addEventListener("abort", abortHandler, false);
     ajax.open("POST", "/update");
+    ajax.setRequestHeader("X-FileSize", file.size);
     ajax.send(formdata);
 }
 

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -327,9 +327,13 @@ static void WebUpdateHandleNotFound(AsyncWebServerRequest *request)
 }
 
 static void WebUploadResponseHandler(AsyncWebServerRequest *request) {
-  if (Update.hasError()) {
+  if (!Update.end()) {
     StreamString p = StreamString();
-    Update.printError(p);
+    if (Update.hasError()) {
+      Update.printError(p);
+    } else {
+      p.println("Not enough data uploaded!");
+    }
     p.trim();
     DBGLN("Failed to upload firmware: %s", p.c_str());
     AsyncWebServerResponse *response = request->beginResponse(200, "application/json", String("{\"status\": \"error\", \"msg\": \"") + p + "\"}");
@@ -363,15 +367,14 @@ static void WebUploadResponseHandler(AsyncWebServerRequest *request) {
 
 static void WebUploadDataHandler(AsyncWebServerRequest *request, const String& filename, size_t index, uint8_t *data, size_t len, bool final) {
   if (index == 0) {
-    DBGLN("Update: %s", filename.c_str());
+    size_t filesize = request->header("X-FileSize").toInt();
+    DBGLN("Update: '%s' size %u", filename.c_str(), filesize);
     #if defined(PLATFORM_ESP8266)
     Update.runAsync(true);
     uint32_t maxSketchSpace = (ESP.getFreeSketchSpace() - 0x1000) & 0xFFFFF000;
     DBGLN("Free space = %u", maxSketchSpace);
-    if (!Update.begin(maxSketchSpace, U_FLASH)){//start with max available size
-    #else
-    if (!Update.begin()) { //start with max available size
     #endif
+    if (!Update.begin(filesize, U_FLASH)) { // pass the size provided
       Update.printError(LOGGING_UART);
     }
     target_seen = false;
@@ -410,16 +413,8 @@ static void WebUploadDataHandler(AsyncWebServerRequest *request, const String& f
         }
       }
       totalSize += len;
-    }
-  }
-  if (final && !Update.getError()) {
-    DBGVLN("finish");
-    if (target_seen) {
-      if (Update.end(true)) { //true to set the size to the current progress
-        DBGLN("Upload Success: %ubytes\nPlease wait for LED to resume blinking before disconnecting power", totalSize);
-      } else {
-        Update.printError(LOGGING_UART);
-      }
+    } else {
+      DBGLN("write failed to write %d", len);
     }
   }
 }
@@ -427,11 +422,6 @@ static void WebUploadDataHandler(AsyncWebServerRequest *request, const String& f
 static void WebUploadForceUpdateHandler(AsyncWebServerRequest *request) {
   target_seen = true;
   if (request->arg("action").equals("confirm")) {
-    if (Update.end(true)) { //true to set the size to the current progress
-      DBGLN("Upload Success: %ubytes\nPlease wait for LED to resume blinking before disconnecting power", totalSize);
-    } else {
-      Update.printError(LOGGING_UART);
-    }
     WebUploadResponseHandler(request);
   } else {
     #if defined(PLATFORM_ESP32)


### PR DESCRIPTION
As I was explaining to user on discord how the wifi updates work I realised there was a case where a bad flash could occur!

This PR fixes that case by passing the size of the firmware file in a HTTP header that the device will use to pass to the updater. This means that once the upload is complete we can check with the updater class that it has received all the expected data and if not then the update can be cancelled and an error returned to the user.
Previously we set the updater expected size to as much free space as we had (or unlimited on ESP32) and at the end just blindly told the updater to go ahead!