### PR TITLE
src_filter and Namimno STM Voyager TX bootloader Fix

### DIFF
--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -362,6 +362,7 @@ static void WebUploadResponseHandler(AsyncWebServerRequest *request) {
 }
 
 static void WebUploadDataHandler(AsyncWebServerRequest *request, const String& filename, size_t index, uint8_t *data, size_t len, bool final) {
+  force_update = force_update || request->hasArg("force");
   if (index == 0) {
     DBGLN("Update: %s", filename.c_str());
     #if defined(PLATFORM_ESP8266)

--- a/src/platformio.ini
+++ b/src/platformio.ini
@@ -36,7 +36,7 @@ platform = native
 framework =
 test_ignore = test_embedded
 lib_ignore = BUTTON, DAC, EEPROM, LQCALC, POWERMGNT
-src_filter = ${common_env_data.src_filter} -<ESP32*.*> -<STM32*.*> -<ESP8*.*> -<tx_*.cpp> -<rx_*.cpp> -<common.*> -<config.*>
+build_src_filter = ${common_env_data.build_src_filter} -<ESP32*.*> -<STM32*.*> -<ESP8*.*> -<tx_*.cpp> -<rx_*.cpp> -<common.*> -<config.*>
 build_flags =
 	-std=c++11
 	-Iinclude

--- a/src/targets/HGLRC_2400.ini
+++ b/src/targets/HGLRC_2400.ini
@@ -12,7 +12,7 @@ build_flags =
 	-include target/HGLRC_Hermes_2400_TX.h
 	-D VTABLES_IN_FLASH=1
 	-O2
-src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 lib_deps = 
 	${env_common_esp32.lib_deps}
 

--- a/src/targets/Jumper_2400.ini
+++ b/src/targets/Jumper_2400.ini
@@ -13,7 +13,7 @@ build_flags =
 	-include target/Jumper_AION_2400_T-Pro_TX.h
 	-D VTABLES_IN_FLASH=1
 	-O2
-src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 upload_speed = 460800
 lib_deps =
 	${env_common_esp32.lib_deps}
@@ -28,7 +28,7 @@ build_flags =
 	-include target/Jumper_AION_NANO_2400_TX.h
 	-D VTABLES_IN_FLASH=1
 	-O2
-src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 lib_deps =
 	${env_common_esp32.lib_deps}
 	olikraus/U8g2@^2.28.8

--- a/src/targets/MATEK_2400.ini
+++ b/src/targets/MATEK_2400.ini
@@ -11,7 +11,7 @@ build_flags =
 	${common_env_data.build_flags_rx}
 	${radio_2400.build_flags}
 	-include target/MATEK_2400_RX.h
-src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
+build_src_filter = ${env_common_esp82xx.build_src_filter} -<tx_*.cpp>
 
 [env:MATEK_2400_RX_via_BetaflightPassthrough]
 extends = env:MATEK_2400_RX_via_UART

--- a/src/targets/axis_2400.ini
+++ b/src/targets/axis_2400.ini
@@ -13,7 +13,7 @@ build_flags =
 	-D VTABLES_IN_FLASH=1
 	-O2
 monitor_speed = 420000
-src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 lib_deps =
     ${env_common_esp32.lib_deps}
     Bodmer/TFT_eSPI @ 2.4.11
@@ -31,7 +31,7 @@ build_flags =
 	${env_common_esp82xx.build_flags}
 	${common_env_data.build_flags_rx}
 	-include target/AXIS_THOR_2400_RX.h
-src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
+build_src_filter = ${env_common_esp82xx.build_src_filter} -<tx_*.cpp>
 
 [env:AXIS_THOR_2400_RX_via_WIFI]
 extends = env:AXIS_THOR_2400_RX_via_UART

--- a/src/targets/betafpv_2400.ini
+++ b/src/targets/betafpv_2400.ini
@@ -12,7 +12,7 @@ build_flags =
 	-D VTABLES_IN_FLASH=1
 	-O2
 upload_speed = 460800
-src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 
 [env:BETAFPV_2400_TX_via_WIFI]
 extends = env:BETAFPV_2400_TX_via_UART
@@ -26,7 +26,7 @@ build_flags =
 	-D VTABLES_IN_FLASH=1
 	-O2
 upload_speed = 460800
-src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 lib_deps = 
 	${env_common_esp32.lib_deps}
 	olikraus/U8g2@^2.28.8
@@ -59,7 +59,7 @@ build_flags =
 	${common_env_data.build_flags_rx}
 	${radio_2400.build_flags}
 	-include target/BETAFPV_2400_RX.h
-src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
+build_src_filter = ${env_common_esp82xx.build_src_filter} -<tx_*.cpp>
 
 [env:BETAFPV_2400_RX_via_BetaflightPassthrough]
 extends = env:BETAFPV_2400_RX_via_UART

--- a/src/targets/betafpv_900.ini
+++ b/src/targets/betafpv_900.ini
@@ -10,7 +10,7 @@ build_flags =
 	${radio_900.build_flags}
 	-include target/BETAFPV_900_TX.h
 upload_speed = 460800
-src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 
 [env:BETAFPV_900_TX_via_WIFI]
 extends = env:BETAFPV_900_TX_via_UART
@@ -22,7 +22,7 @@ build_flags =
 	${common_env_data.build_flags_tx}
 	-include target/BETAFPV_900_TX_MICRO.h
 upload_speed = 460800
-src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 lib_deps = 
 	${env_common_esp32.lib_deps}
 	olikraus/U8g2@^2.28.8
@@ -41,7 +41,7 @@ build_flags =
 	${common_env_data.build_flags_rx}
 	${radio_900.build_flags}
 	-include target/DIY_900_RX_ESP8285_SX127x.h
-src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
+build_src_filter = ${env_common_esp82xx.build_src_filter} -<tx_*.cpp>
 
 [env:BETAFPV_900_RX_via_BetaflightPassthrough]
 extends = env:BETAFPV_900_RX_via_UART

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -11,7 +11,7 @@ monitor_dtr = 0
 monitor_rts = 0
 
 [common_env_data]
-src_filter = +<*> -<.git/> -<svn/> -<example/> -<examples/> -<test/> -<tests/> -<*.py> -<*test*.*>
+build_src_filter = +<*> -<.git/> -<svn/> -<example/> -<examples/> -<test/> -<tests/> -<*.py> -<*test*.*>
 build_flags = -Wall -Iinclude
 build_flags_tx = -DTARGET_TX=1 ${common_env_data.build_flags}
 build_flags_rx = -DTARGET_RX=1 ${common_env_data.build_flags}
@@ -42,7 +42,7 @@ build_flags =
 	-D BEARSSL_SSL_BASIC
 	-D NO_GLOBAL_SERIAL
 	-I ${PROJECTSRC_DIR}/hal
-src_filter = ${common_env_data.src_filter} -<ESP8266*.*> -<STM32*.*>
+build_src_filter = ${common_env_data.build_src_filter} -<ESP8266*.*> -<STM32*.*>
 lib_deps =
 	makuna/NeoPixelBus @ ^2.6.7
 	ottowinter/ESPAsyncWebServer-esphome @ ^2.1.0
@@ -63,7 +63,7 @@ build_flags =
 	-I ${PROJECTSRC_DIR}/hal
 board_build.f_cpu = 160000000L
 board_build.ldscript = eagle.flash.1m.ld
-src_filter = ${common_env_data.src_filter} -<ESP32*.*> -<STM32*.*> -<WS281B*.*>
+build_src_filter = ${common_env_data.build_src_filter} -<ESP32*.*> -<STM32*.*> -<WS281B*.*>
 extra_scripts =
 	${env.extra_scripts}
 	pre:python/build_html.py
@@ -87,7 +87,7 @@ build_flags =
 	-Wl,-Map,firmware.map
 	-O2
 	-I ${PROJECTSRC_DIR}/hal
-src_filter = ${common_env_data.src_filter} -<ESP32*.*> -<ESP8266*.*> -<WS281B*.*>
+build_src_filter = ${common_env_data.build_src_filter} -<ESP32*.*> -<ESP8266*.*> -<WS281B*.*>
 lib_deps =
 	paolop74/extEEPROM @ ^3.4.1
 monitor_speed = 420000

--- a/src/targets/diy_2400.ini
+++ b/src/targets/diy_2400.ini
@@ -12,7 +12,7 @@ build_flags =
 	-include target/DIY_2400_TX_ESP32_SX1280_Mini.h
 	-D VTABLES_IN_FLASH=1
 	-O2
-src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 
 [env:DIY_2400_TX_ESP32_SX1280_Mini_via_WIFI]
 extends = env:DIY_2400_TX_ESP32_SX1280_Mini_via_UART
@@ -26,7 +26,7 @@ build_flags =
 	-include target/DIY_2400_TX_ESP32_SX1280_E28.h
 	-D VTABLES_IN_FLASH=1
 	-O2
-src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 lib_deps =
 	${env_common_esp32.lib_deps}
 	olikraus/U8g2@^2.28.8
@@ -43,7 +43,7 @@ build_flags =
 	-include target/DIY_2400_TX_ESP32_SX1280_LORA1280F27.h
 	-D VTABLES_IN_FLASH=1
 	-O2
-src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 lib_deps =
 	${env_common_esp32.lib_deps}
 	olikraus/U8g2@^2.28.8
@@ -60,7 +60,7 @@ build_flags =
 	${common_env_data.build_flags_tx}
 	${radio_2400.build_flags}
 	-include target/DIY_2400_TX_ESP8285_SX1280.h
-src_filter = ${env_common_esp82xx.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp82xx.build_src_filter} -<rx_*.cpp>
 upload_speed = 921600
 
 [env:DIY_2400_TX_DUPLETX_via_ETX]
@@ -72,7 +72,7 @@ build_flags =
 	-include target/DIY_2400_TX_DUPLETX_TX.h
 	-D VTABLES_IN_FLASH=1
 	-O2
-src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 upload_speed = 460800
 lib_deps =
 	${env_common_esp32.lib_deps}
@@ -95,7 +95,7 @@ build_flags =
 	${common_env_data.build_flags_rx}
 	${radio_2400.build_flags}
 	-include target/DIY_2400_RX_ESP8285_SX1280.h
-src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
+build_src_filter = ${env_common_esp82xx.build_src_filter} -<tx_*.cpp>
 
 [env:DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough]
 extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART
@@ -112,7 +112,7 @@ build_flags =
 	${env_common_esp82xx.build_flags}
 	${common_env_data.build_flags_rx}
 	-include target/DIY_2400_RX_PWMP.h
-src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
+build_src_filter = ${env_common_esp82xx.build_src_filter} -<tx_*.cpp>
 
 [env:DIY_2400_RX_PWMP_via_WIFI]
 extends = env:DIY_2400_RX_PWMP_via_UART
@@ -137,7 +137,7 @@ build_flags =
 	-D VECT_TAB_OFFSET=0x4000U
     -D FLASH_APP_OFFSET=0x4000U
     -Wl,--defsym=FLASH_APP_OFFSET=16K
-src_filter = ${env_common_stm32.src_filter} -<tx_*.cpp>
+build_src_filter = ${env_common_stm32.build_src_filter} -<tx_*.cpp>
 upload_flags =
     BOOTLOADER=bootloader/sx1280_rx_nano_pcb_v0.5_bootloader.bin
     VECT_OFFSET=0x4000

--- a/src/targets/diy_900.ini
+++ b/src/targets/diy_900.ini
@@ -10,7 +10,7 @@ build_flags =
 	${common_env_data.build_flags_tx}
 	${radio_900.build_flags}
 	-include target/DIY_900_TX_TTGO_V1_SX127x.h
-src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 lib_deps = 	${env_common_esp32.lib_deps}
 		olikraus/U8g2@^2.28.8
 
@@ -24,7 +24,7 @@ build_flags =
 	${common_env_data.build_flags_tx}
 	${radio_900.build_flags}
 	-include target/DIY_900_TX_TTGO_V2_SX127x.h
-src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 lib_deps = 	${env_common_esp32.lib_deps}
 		olikraus/U8g2@^2.28.8
 
@@ -38,7 +38,7 @@ build_flags =
 	${common_env_data.build_flags_tx}
 	${radio_900.build_flags}
 	-include target/DIY_900_TX_ESP32_SX127x_E19.h
-src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 
 [env:DIY_900_TX_ESP32_SX127x_E19_via_WIFI]
 extends = env:DIY_900_TX_ESP32_SX127x_E19_via_UART
@@ -50,7 +50,7 @@ build_flags =
 	${common_env_data.build_flags_tx}
 	${radio_900.build_flags}
 	-include target/DIY_900_TX_ESP32_SX127x_RFM95.h
-src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 
 [env:DIY_900_TX_ESP32_SX127x_RFM95_via_WIFI]
 extends = env:DIY_900_TX_ESP32_SX127x_RFM95_via_UART
@@ -69,7 +69,7 @@ build_flags =
 	${common_env_data.build_flags_rx}
 	${radio_900.build_flags}
 	-include target/DIY_900_RX_ESP8285_SX127x.h
-src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
+build_src_filter = ${env_common_esp82xx.build_src_filter} -<tx_*.cpp>
 
 [env:DIY_900_RX_ESP8285_SX127x_via_BetaflightPassthrough]
 extends = env:DIY_900_RX_ESP8285_SX127x_via_UART
@@ -87,7 +87,7 @@ build_flags =
 	${common_env_data.build_flags_rx}
 	${radio_900.build_flags}
 	-include target/DIY_900_RX_HUZZAH_RFM95W.h
-src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
+build_src_filter = ${env_common_esp82xx.build_src_filter} -<tx_*.cpp>
 
 [env:DIY_900_RX_HUZZAH_RFM95W_via_BetaflightPassthrough]
 extends = env:DIY_900_RX_HUZZAH_RFM95W_via_UART
@@ -104,7 +104,7 @@ build_flags =
 	${env_common_esp82xx.build_flags}
 	${common_env_data.build_flags_rx}
 	-include target/DIY_900_RX_PWMP.h
-src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
+build_src_filter = ${env_common_esp82xx.build_src_filter} -<tx_*.cpp>
 
 [env:DIY_900_RX_PWMP_via_WIFI]
 extends = env:DIY_900_RX_PWMP_via_UART

--- a/src/targets/diy_ble_joystick.ini
+++ b/src/targets/diy_ble_joystick.ini
@@ -13,7 +13,7 @@ build_flags =
 	-include target/DIY_2400_TX_ESP32_SX1280_E28.h
 	-D VTABLES_IN_FLASH=1
 	-O2
-src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 lib_deps = 
 	${env_common_esp32.lib_deps}
 	olikraus/U8g2@^2.28.8

--- a/src/targets/frsky.ini
+++ b/src/targets/frsky.ini
@@ -16,7 +16,7 @@ build_flags =
 	-DVECT_TAB_OFFSET=0x4000U
 board_build.ldscript = variants/R9M_ldscript.ld
 board_build.flash_offset = 0x4000
-src_filter = ${env_common_stm32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_stm32.build_src_filter} -<rx_*.cpp>
 upload_flags =
 	BOOTLOADER=bootloader/r9m_bootloader.bin
 	VECT_OFFSET=0x4000
@@ -58,7 +58,7 @@ board_build.flash_offset = 0x8000
 upload_flags =
 	BOOTLOADER=bootloader/r9m_lite_pro_bootloader.bin
 	VECT_OFFSET=0x8000
-src_filter = ${env_common_stm32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_stm32.build_src_filter} -<rx_*.cpp>
 lib_deps =
 	https://github.com/PaoloP74/extEEPROM.git
 
@@ -77,7 +77,7 @@ build_flags =
 	-include target/Frsky_RX_R9M.h
 	-D HSE_VALUE=24000000U
 	-DVECT_TAB_OFFSET=0x08008000U
-src_filter = ${env_common_stm32.src_filter} -<tx_*.cpp>
+build_src_filter = ${env_common_stm32.build_src_filter} -<tx_*.cpp>
 upload_flags =
     BOOTLOADER=bootloader/r9mm_bootloader.bin
     VECT_OFFSET=0x8000
@@ -102,7 +102,7 @@ build_flags =
 	-D HSE_VALUE=12000000U
 	-DVECT_TAB_OFFSET=0x08008000U
 board_build.ldscript = variants/R9MM/R9MM_ldscript.ld
-src_filter = ${common_env_data.src_filter} -<ESP32*.*> -<ESP8266*.*> -<WS281B*.*> -<tx_*.cpp>
+build_src_filter = ${common_env_data.build_src_filter} -<ESP32*.*> -<ESP8266*.*> -<WS281B*.*> -<tx_*.cpp>
 lib_deps =
 	https://github.com/PaoloP74/extEEPROM.git
 	Wire
@@ -124,7 +124,7 @@ build_flags =
 	-include target/Frsky_RX_R9M.h
 	-D HSE_VALUE=12000000U
 	-DVECT_TAB_OFFSET=0x8000U
-src_filter = ${env_common_stm32.src_filter} -<tx_*.cpp>
+build_src_filter = ${env_common_stm32.build_src_filter} -<tx_*.cpp>
 
 [env:Frsky_RX_R9SLIMPLUS_OTA_via_STLINK]
 extends = env:Frsky_RX_R9SLIMPLUS_via_BetaflightPassthrough
@@ -149,7 +149,7 @@ build_flags =
 	-DVECT_TAB_OFFSET=0x08008000U
 	-D HSI_VALUE=16000000
 	-Wl,--defsym=FLASH_OFFSET=0x8000
-src_filter = ${env_common_stm32.src_filter} -<tx_*.cpp>
+build_src_filter = ${env_common_stm32.build_src_filter} -<tx_*.cpp>
 upload_flags =
 	BOOTLOADER=bootloader/r9mx_bootloader.bin
 	VECT_OFFSET=0x8000
@@ -174,4 +174,4 @@ build_flags =
 	-D HSE_VALUE=12000000U
 	-DVECT_TAB_OFFSET=0x8000U
 board_build.ldscript = variants/R9MM/R9MM_ldscript.ld
-src_filter = ${env_common_stm32.src_filter} -<tx_*.cpp>
+build_src_filter = ${env_common_stm32.build_src_filter} -<tx_*.cpp>

--- a/src/targets/happymodel_2400.ini
+++ b/src/targets/happymodel_2400.ini
@@ -12,7 +12,7 @@ build_flags =
 	-include target/HappyModel_ES24TX_2400_TX.h
 	-D VTABLES_IN_FLASH=1
 	-O2
-src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 lib_deps = 
 	${env_common_esp32.lib_deps}
 
@@ -28,7 +28,7 @@ build_flags =
 	-include target/HappyModel_ES24TX_Pro_Series_2400_TX.h
 	-D VTABLES_IN_FLASH=1
 	-O2
-src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 lib_deps = 
 	${env_common_esp32.lib_deps}
 

--- a/src/targets/happymodel_900.ini
+++ b/src/targets/happymodel_900.ini
@@ -15,7 +15,7 @@ build_flags =
 	-D VECT_TAB_OFFSET=0x4000U
 board_build.ldscript = variants/R9M_ldscript.ld
 board_build.flash_offset = 0x4000
-src_filter = ${env_common_stm32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_stm32.build_src_filter} -<rx_*.cpp>
 upload_flags =
 	BOOTLOADER=bootloader/r9m_bootloader.bin
 	VECT_OFFSET=0x4000
@@ -33,7 +33,7 @@ build_flags =
 	${common_env_data.build_flags_tx}
 	${radio_900.build_flags}
 	-include target/HappyModel_TX_ES900TX.h
-src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 
 [env:HappyModel_TX_ES900TX_via_WIFI]
 extends = env:HappyModel_TX_ES900TX_via_UART
@@ -53,7 +53,7 @@ build_flags =
 	-include target/Frsky_RX_R9M.h
 	-D HSE_VALUE=24000000U
 	-DVECT_TAB_OFFSET=0x08008000U
-src_filter = ${env_common_stm32.src_filter} -<tx_*.cpp>
+build_src_filter = ${env_common_stm32.build_src_filter} -<tx_*.cpp>
 upload_flags =
     BOOTLOADER=bootloader/r9mm_bootloader.bin
     VECT_OFFSET=0x8000

--- a/src/targets/iFlight_2400.ini
+++ b/src/targets/iFlight_2400.ini
@@ -12,7 +12,7 @@ build_flags =
 	-include target/iFlight_2400_TX.h
 	-D VTABLES_IN_FLASH=1
 	-O2
-src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 lib_deps = 
 	${env_common_esp32.lib_deps}
 
@@ -30,7 +30,7 @@ build_flags =
 	${common_env_data.build_flags_rx}
 	${radio_2400.build_flags}
 	-include target/iFlight_2400_RX.h
-src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
+build_src_filter = ${env_common_esp82xx.build_src_filter} -<tx_*.cpp>
 
 [env:iFlight_2400_RX_via_BetaflightPassthrough]
 extends = env:iFlight_2400_RX_via_UART

--- a/src/targets/iFlight_900.ini
+++ b/src/targets/iFlight_900.ini
@@ -10,7 +10,7 @@ build_flags =
 	${radio_900.build_flags}
 	-include target/iFlight_900_TX.h
 upload_speed = 460800
-src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 
 [env:iFlight_900_TX_via_WIFI]
 extends = env:iFlight_900_TX_via_UART

--- a/src/targets/imrc.ini
+++ b/src/targets/imrc.ini
@@ -15,7 +15,7 @@ build_flags =
  	-D HSE_VALUE=32000000U
 	-DVECT_TAB_OFFSET=0x08004000U
 	-Wl,--defsym=FLASH_APP_OFFSET=0x4000
-src_filter = ${env_common_stm32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_stm32.build_src_filter} -<rx_*.cpp>
 upload_flags =
 	BOOTLOADER=bootloader/ghost/ghost_tx_bootloader.bin
 	VECT_OFFSET=0x4000
@@ -44,7 +44,7 @@ build_flags =
  	-D HSE_VALUE=32000000U
 	-DVECT_TAB_OFFSET=0x08004000U
 	-Wl,--defsym=FLASH_APP_OFFSET=0x4000
-src_filter = ${env_common_stm32.src_filter} -<tx_*.cpp>
+build_src_filter = ${env_common_stm32.build_src_filter} -<tx_*.cpp>
 lib_deps =
 lib_ignore = Servo
 upload_flags =

--- a/src/targets/namimnorc_2400.ini
+++ b/src/targets/namimnorc_2400.ini
@@ -13,7 +13,7 @@ build_flags =
 	-D VECT_TAB_OFFSET=0x4000U
 	-include target/NamimnoRC_FLASH_2400_TX.h
 board_build.ldscript = variants/NamimnoRC_Alpha.ld
-src_filter = ${env_common_stm32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_stm32.build_src_filter} -<rx_*.cpp>
 upload_flags =
     BOOTLOADER=bootloader/namimnorc/tx/namimnorc_tx_bootloader.bin
     VECT_OFFSET=0x4000
@@ -29,7 +29,7 @@ build_flags =
 	-include target/NamimnoRC_FLASH_2400_OLED_TX.h
 	-D VTABLES_IN_FLASH=1
 	-O2
-src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 lib_deps =
 	${env_common_esp32.lib_deps}
 	olikraus/U8g2@^2.28.8
@@ -52,7 +52,7 @@ build_flags =
 	-D VECT_TAB_OFFSET=0x8000U
 	-include target/NamimnoRC_FLASH_2400_RX_STM32.h
 board_build.ldscript = variants/R9MM/R9MM_ldscript.ld
-src_filter = ${env_common_stm32.src_filter} -<tx_*.cpp>
+build_src_filter = ${env_common_stm32.build_src_filter} -<tx_*.cpp>
 upload_flags =
     BOOTLOADER=bootloader/namimnorc/rx/flash_2400_bootloader.bin
     VECT_OFFSET=0x8000
@@ -67,7 +67,7 @@ build_flags =
 	${common_env_data.build_flags_rx}
 	${radio_2400.build_flags}
 	-include target/NamimnoRC_FLASH_2400_RX_ESP8285.h
-src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
+build_src_filter = ${env_common_esp82xx.build_src_filter} -<tx_*.cpp>
 
 [env:NamimnoRC_FLASH_2400_ESP_RX_via_BetaflightPassthrough]
 extends = env:NamimnoRC_FLASH_2400_ESP_RX_via_UART
@@ -86,7 +86,7 @@ build_flags =
 	${radio_2400.build_flags}
 	${common_env_data.build_flags_rx}
 	-include target/NamimnoRC_FLASH_2400_RX_ESP8285_PA.h
-src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
+build_src_filter = ${env_common_esp82xx.build_src_filter} -<tx_*.cpp>
 
 [env:NamimnoRC_FLASH_2400_ESP_RX_PA_via_BetaflightPassthrough]
 extends = env:NamimnoRC_FLASH_2400_ESP_RX_PA_via_UART

--- a/src/targets/namimnorc_900.ini
+++ b/src/targets/namimnorc_900.ini
@@ -16,7 +16,7 @@ build_flags =
 board_build.ldscript = variants/NamimnoRC_Alpha.ld
 src_filter = ${env_common_stm32.src_filter} -<rx_*.cpp>
 upload_flags =
-    BOOTLOADER=bootloader/namimnorc/tx/firmware.bin
+    BOOTLOADER=bootloader/namimnorc/tx/namimnorc_tx_bootloader.bin
     VECT_OFFSET=0x4000
 lib_deps =
 

--- a/src/targets/namimnorc_900.ini
+++ b/src/targets/namimnorc_900.ini
@@ -14,7 +14,7 @@ build_flags =
 	-D HSE_VALUE=12000000U
 	-D VECT_TAB_OFFSET=0x4000U
 board_build.ldscript = variants/NamimnoRC_Alpha.ld
-src_filter = ${env_common_stm32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_stm32.build_src_filter} -<rx_*.cpp>
 upload_flags =
     BOOTLOADER=bootloader/namimnorc/tx/namimnorc_tx_bootloader.bin
     VECT_OFFSET=0x4000
@@ -31,7 +31,7 @@ build_flags =
 	-include target/NamimnoRC_VOYAGER_900_OLED_TX.h
 	-D VTABLES_IN_FLASH=1
 	-O2
-src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 lib_deps =
 	${env_common_esp32.lib_deps}
 	olikraus/U8g2@^2.28.8
@@ -54,7 +54,7 @@ build_flags =
 	-D VECT_TAB_OFFSET=0x8000U
 	-include target/NamimnoRC_VOYAGER_900_RX.h
 board_build.ldscript = variants/R9MM/R9MM_ldscript.ld
-src_filter = ${env_common_stm32.src_filter} -<tx_*.cpp>
+build_src_filter = ${env_common_stm32.build_src_filter} -<tx_*.cpp>
 upload_flags =
     BOOTLOADER=bootloader/namimnorc/rx/voyager_900_bootloader.bin
     VECT_OFFSET=0x8000
@@ -70,7 +70,7 @@ build_flags =
 	${common_env_data.build_flags_rx}
 	${radio_900.build_flags}
 	-include target/NamimnoRC_VOYAGER_900_ESP_RX.h
-src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
+build_src_filter = ${env_common_esp82xx.build_src_filter} -<tx_*.cpp>
 
 [env:NamimnoRC_VOYAGER_900_ESP_RX_via_BetaflightPassthrough]
 extends = env:NamimnoRC_VOYAGER_900_ESP_RX_via_UART

--- a/src/targets/quadkopters_2400.ini
+++ b/src/targets/quadkopters_2400.ini
@@ -12,7 +12,7 @@ build_flags =
 	-include target/QuadKopters_JR_2400_TX.h
 	-D VTABLES_IN_FLASH=1
 	-O2
-src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 lib_deps = 
 	${env_common_esp32.lib_deps}
 

--- a/src/targets/radiomaster_2400.ini
+++ b/src/targets/radiomaster_2400.ini
@@ -7,7 +7,7 @@ build_flags =
 	-include target/RadioMaster_Zorro_2400_TX.h
 	-D VTABLES_IN_FLASH=1
 	-O2
-src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 upload_speed = 460800
 lib_deps =
 	${env_common_esp32.lib_deps}
@@ -27,7 +27,7 @@ build_flags =
 	-include target/RadioMaster_TX16S_2400_TX.h
 	-D VTABLES_IN_FLASH=1
 	-O2
-src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 upload_speed = 460800
 lib_deps =
 	${env_common_esp32.lib_deps}

--- a/src/targets/siyi.ini
+++ b/src/targets/siyi.ini
@@ -16,7 +16,7 @@ build_flags =
 	-DHSE_VALUE=16000000U
 	-DVECT_TAB_OFFSET=0x1000U
 	-Wl,--defsym=FLASH_APP_OFFSET=0x1000
-src_filter = ${env_common_stm32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_stm32.build_src_filter} -<rx_*.cpp>
 upload_flags =
 	BOOTLOADER=bootloader/fm30_bootloader.bin
 	VECT_OFFSET=0x1000
@@ -42,7 +42,7 @@ build_flags =
 upload_flags =
 	BOOTLOADER=bootloader/fm30_mini_bootloader.bin
 	VECT_OFFSET=0x4000
-src_filter = ${env_common_stm32.src_filter} -<tx_*.cpp>
+build_src_filter = ${env_common_stm32.build_src_filter} -<tx_*.cpp>
 
 [env:FM30_RX_MINI_via_BetaflightPassthrough]
 extends = env:FM30_RX_MINI_via_STLINK
@@ -62,7 +62,7 @@ build_flags =
 upload_flags =
 	BOOTLOADER=bootloader/fm30_mini_rxtx_bootloader.bin
 	VECT_OFFSET=0x4000
-src_filter = ${env_common_stm32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_stm32.build_src_filter} -<rx_*.cpp>
 
 [env:FM30_RX_MINI_AS_TX_via_UART]
 extends = env:FM30_RX_MINI_AS_TX_via_STLINK

--- a/src/targets/vantac_2400.ini
+++ b/src/targets/vantac_2400.ini
@@ -12,7 +12,7 @@ build_flags =
 	-include target/Vantac_Lite_2400_TX.h
 	-D VTABLES_IN_FLASH=1
 	-O2
-src_filter = ${env_common_esp32.src_filter} -<rx_*.cpp>
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 lib_deps =
 	${env_common_esp32.lib_deps}
 
@@ -30,7 +30,7 @@ build_flags =
 	${common_env_data.build_flags_rx}
 	${radio_2400.build_flags}
 	-include target/Vantac_2400_RX.h
-src_filter = ${env_common_esp82xx.src_filter} -<tx_*.cpp>
+build_src_filter = ${env_common_esp82xx.build_src_filter} -<tx_*.cpp>
 
 [env:Vantac_2400_RX_via_BetaflightPassthrough]
 extends = env:Vantac_2400_RX_via_UART


### PR DESCRIPTION
As it says on the tin, replaces the `src_filter` with `build_src_filter` as per PlatformIO notifications, should remove that spammy wall of text from the build procedure as well as fixed the building of firmware for the NamimnoRC STM32 based Voyager TX (how did this slip through?) 