### PR TITLE
Fix for traditional bind mode

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -458,7 +458,7 @@ void ICACHE_RAM_ATTR HWtimerCallbackTick() // this is 180 out of phase with the 
         uplinkLQ = LQCalcDVDA.getLQ();
         LQCalcDVDA.inc();
     }
-    
+
     crsf.LinkStatistics.uplink_Link_quality = uplinkLQ;
     // Only advance the LQI period counter if we didn't send Telemetry this period
     if (!alreadyTLMresp)
@@ -1240,6 +1240,7 @@ static void updateBindingMode()
         config.Commit();
 
         INFOLN("Power on counter >=3, enter binding mode...");
+        config.SetIsBound(false);
         EnterBindingMode();
     }
 #endif


### PR DESCRIPTION
After the "Model Loan" code was merged the traditional bind mode was broken, where powering the RX 3 times would enter bind mode to immediately exit again because the bound flag was not cleared in the code that entered bind mode on after checking the 3x power sequence.