### PR TITLE
[2.x] Restore HTTP upload functionality

### DIFF
--- a/src/python/upload_via_esp8266_backpack.py
+++ b/src/python/upload_via_esp8266_backpack.py
@@ -23,7 +23,7 @@ def on_upload(source, target, env):
             if "BOOTLOADER=" in flag:
                 bootloader_file = flag.split("=")[1]
                 bootloader_target = os.path.join((env.get('PROJECT_DIR')), bootloader_file)
-			
+
 
     firmware_path = str(source[0])
     bin_path = os.path.dirname(firmware_path)
@@ -35,13 +35,14 @@ def on_upload(source, target, env):
 
     cmd = ["curl", "--max-time", "60",
            "--retry", "2", "--retry-delay", "1",
+           "--header", "X-FileSize: " + str(os.path.getsize(elrs_bin_target)),
            "-F", "data=@%s" % (elrs_bin_target,)]
 
     if  bootloader_target is not None and isstm:
         cmd_bootloader = ["curl", "--max-time", "60",
             "--retry", "2", "--retry-delay", "1",
             "-F", "data=@%s" % (bootloader_target,), "-F", "flash_address=0x0000"]
-		   
+
     if isstm:
         cmd += ["-F", "flash_address=0x%X" % (app_start,)]
 
@@ -53,9 +54,9 @@ def on_upload(source, target, env):
         addr = "http://%s/%s" % (addr, ['update', 'upload'][isstm])
         print(" ** UPLOADING TO: %s" % addr)
         try:
-            if  bootloader_target is not None:  
+            if  bootloader_target is not None:
                 print("** Flashing Bootloader...")
-                print(cmd_bootloader,cmd)
+                print(cmd_bootloader)
                 subprocess.check_call(cmd_bootloader + [addr])
                 print("** Bootloader Flashed!")
                 print()


### PR DESCRIPTION
#1560 breaks uploading firmware over HTTP from curl / VS Code / Configurator(?) because the firmware expects the caller to send the file size. Only the webui upload does this so this pretty much breaks uploads on both master and 2.x. This adds the proper header to our upload script for curl.

I believe this is worth doing a 2.5.1 because nobody will be able to upload their firmware on 2.5.0 if they've already updated to 2.5.0 (such as if they want to change a build parameter). 

This needs a different patch for master because the script is different, but the solution is the same. Sorry about the whitespace, but, this isn't my fault so you're gonna get whitespace too. :-P