### PR TITLE
Restore HTTP upload functionality

### DIFF
--- a/src/python/upload_via_esp8266_backpack.py
+++ b/src/python/upload_via_esp8266_backpack.py
@@ -71,6 +71,7 @@ def on_upload(source, target, env):
 
     cmd = ["curl", "--max-time", "60",
            "--retry", "2", "--retry-delay", "1",
+           "--header", "X-FileSize: " + str(os.path.getsize(elrs_bin_target)),
            "-o", "%s" % (bin_upload_output)]
 
     pio_target = target[0].name
@@ -105,7 +106,7 @@ def on_upload(source, target, env):
             # Flash bootloader first if set
             if bootloader_target is not None:
                 print("** Flashing Bootloader...")
-                print(cmd_bootloader,cmd)
+                print(cmd_bootloader)
                 subprocess.check_call(cmd_bootloader + [addr])
                 print("** Bootloader Flashed!")
                 print()


### PR DESCRIPTION
Same as https://github.com/ExpressLRS/ExpressLRS/pull/1580 but for master

https://github.com/ExpressLRS/ExpressLRS/pull/1560 breaks uploading firmware over HTTP from curl / VS Code / Configurator(?) because the firmware expects the caller to send the file size. Only the webui upload does this so this pretty much breaks uploads on both master and 2.x. This adds the proper header to our upload script for curl.

This needs a different patch for 2.x because the script is different, but the solution is the same.