### PR TITLE
Receiver baud rate was not correctly parsed in the build file

### DIFF
--- a/src/python/build_flags.py
+++ b/src/python/build_flags.py
@@ -52,7 +52,7 @@ def process_json_flag(define):
         if parts.group(1) == "FAN_MIN_RUNTIME"  and not isRX:
             parts = re.search("-D(.*)\s*=\s*\"?([0-9]+).*\"?$", define)
             json_flags['fan-runtime'] = int(dequote(parts.group(2)))
-        if define == "-DRCVR_UART_BAUD" and isRX:
+        if parts.group(1) == "RCVR_UART_BAUD" and isRX:
             parts = re.search("-D(.*)\s*=\s*\"?([0-9]+).*\"?$", define)
             json_flags['rcvr-uart-baud'] = int(dequote(parts.group(2)))
     if define == "-DUART_INVERTED" and not isRX:


### PR DESCRIPTION
After the mammoth merge for Unified targets the receiver UART baud rate parameter was not properly parsed for the JSON options files.