### PR TITLE
correct iFlight 2.4 rx output power

### DIFF
--- a/src/hardware/RX/iFlight 2400.json
+++ b/src/hardware/RX/iFlight 2400.json
@@ -15,6 +15,6 @@
     "power_max": 3,
     "power_default": 3,
     "power_control": 0,
-    "power_values": [-4,-2,2,9],
+    "power_values": [-4,-2,2,5],
     "led": 16
 }

--- a/src/hardware/RX/iFlight 2400.json
+++ b/src/hardware/RX/iFlight 2400.json
@@ -11,10 +11,10 @@
     "power_rxen": 9,
     "power_txen": 10,
     "power_min": 0,
-    "power_high": 0,
-    "power_max": 0,
-    "power_default": 0,
+    "power_high": 3,
+    "power_max": 3,
+    "power_default": 3,
     "power_control": 0,
-    "power_values": [13],
+    "power_values": [-4,-2,2,9],
     "led": 16
 }


### PR DESCRIPTION
Rx output power options got missed in https://github.com/ExpressLRS/ExpressLRS/pull/1362.