### PR TITLE
Add setup/teardown Unity functions to tests

### DIFF
--- a/src/test/test_crc/test_crc.cpp
+++ b/src/test/test_crc/test_crc.cpp
@@ -175,7 +175,7 @@ void test_crc14_flip5(void)
             for (int i = 0; i < 4; i++)
             {
                 int pos = random() % 50;
-                if (pos > 1) 
+                if (pos > 1)
                     pos += 6;
                 bytes[pos / 8] ^= 1 << (pos % 8);
             }
@@ -218,6 +218,10 @@ void test_crc8(void)
 
     TEST_ASSERT_EQUAL_MESSAGE((int)(crc & 0xFF), c, genMsg(bytes, sizeof(bytes)));
 }
+
+// Unity setup/teardown
+void setUp() {}
+void tearDown() {}
 
 int main(int argc, char **argv)
 {

--- a/src/test/test_crsf/test_crsf.cpp
+++ b/src/test/test_crsf/test_crsf.cpp
@@ -67,6 +67,9 @@ void test_device_info(void)
     TEST_ASSERT_EQUAL(test_crc.calc(&deviceInformation[2], DEVICE_INFORMATION_LENGTH-3), deviceInformation[DEVICE_INFORMATION_LENGTH - 1]);
 }
 
+// Unity setup/teardown
+void setUp() {}
+void tearDown() {}
 
 int main(int argc, char **argv)
 {

--- a/src/test/test_embedded/test_main.cpp
+++ b/src/test/test_embedded/test_main.cpp
@@ -4,6 +4,10 @@
 #include <unity.h>
 #include "eeprom_tests.h"
 
+// Unity setup/teardown
+void setUp() {}
+void tearDown() {}
+
 void setup() {
     // NOTE!!! Wait for >2 secs
     // if board doesn't support software reset via Serial.DTR/RTS

--- a/src/test/test_fhss/test_fhss.cpp
+++ b/src/test/test_fhss/test_fhss.cpp
@@ -84,6 +84,10 @@ void test_fhss_reg_same(void)
     }
 }
 
+// Unity setup/teardown
+void setUp() {}
+void tearDown() {}
+
 int main(int argc, char **argv)
 {
     UNITY_BEGIN();

--- a/src/test/test_fifo/test_fifo.cpp
+++ b/src/test/test_fifo/test_fifo.cpp
@@ -56,6 +56,10 @@ void test_fifo_ensure()
         TEST_ASSERT_EQUAL(10, f.pop()); // and that all the bytes in the head packet are what we expect
 }
 
+// Unity setup/teardown
+void setUp() {}
+void tearDown() {}
+
 int main(int argc, char **argv)
 {
     UNITY_BEGIN();

--- a/src/test/test_fmap/test_fmap.cpp
+++ b/src/test/test_fmap/test_fmap.cpp
@@ -35,6 +35,10 @@ void test_fmap_consistent_bider(void)
     }
 }
 
+// Unity setup/teardown
+void setUp() {}
+void tearDown() {}
+
 int main(int argc, char **argv)
 {
     UNITY_BEGIN();

--- a/src/test/test_msp/msp_tests.cpp
+++ b/src/test/test_msp/msp_tests.cpp
@@ -11,7 +11,7 @@ void test_msp_receive(void)
     // WHEN a valid packet is send to processReceivedByte() one byte at a time
     // THEN the complete packet will be available via getReceivedPacket()
     // AND the packet values will match the values from the sent bytes
-    
+
     uint8_t c;
     bool packetComplete;
 
@@ -54,7 +54,7 @@ void test_msp_receive(void)
     c = 125; // crc
     packetComplete = MSPProtocol.processReceivedByte(c);
     TEST_ASSERT_EQUAL(true, packetComplete);
-  
+
     // Assert that values in packet match sent values
     mspPacket_t* packet = MSPProtocol.getReceivedPacket();
     TEST_ASSERT_EQUAL(MSP_PACKET_COMMAND, packet->type);
@@ -71,7 +71,7 @@ void test_msp_send(void)
     // WHEN a valid packet is passed as an argument to sendPacket()
     // THEN the complete packet will be transmitted to the passed in Stream object
     // AND the return value will be true
-    
+
     // Build an MSP reply packet
     mspPacket_t packet;
     packet.reset();
@@ -103,6 +103,10 @@ void test_msp_send(void)
 
 extern void test_encapsulated_msp_send(void);
 extern void test_encapsulated_msp_send_too_long(void);
+
+// Unity setup/teardown
+void setUp() {}
+void tearDown() {}
 
 int main(int argc, char **argv)
 {

--- a/src/test/test_msp2crsf2msp/test_msp2crsf2msp.cpp
+++ b/src/test/test_msp2crsf2msp/test_msp2crsf2msp.cpp
@@ -152,6 +152,10 @@ void MSPV2_SERIAL_SETTINGS_TEST()
     // cout << endl;
 }
 
+// Unity setup/teardown
+void setUp() {}
+void tearDown() {}
+
 int main(int argc, char **argv)
 {
     UNITY_BEGIN();

--- a/src/test/test_ota/test_switches.cpp
+++ b/src/test/test_ota/test_switches.cpp
@@ -410,6 +410,10 @@ void test_decodingHybridWide_AUXX_low()
         test_decodingHybridWide(false, i, 0, CRSF_CHANNEL_VALUE_1000);
 }
 
+// Unity setup/teardown
+void setUp() {}
+void tearDown() {}
+
 int main(int argc, char **argv)
 {
     UNITY_BEGIN();

--- a/src/test/test_stubborn/test_stubborn.cpp
+++ b/src/test/test_stubborn/test_stubborn.cpp
@@ -378,6 +378,10 @@ static void test_stubborn_link_resync_then_send(void)
     TEST_ASSERT_EQUAL_UINT8_ARRAY(testSequence2, buffer, ARRAY_SIZE(testSequence2));
 }
 
+// Unity setup/teardown
+void setUp() {}
+void tearDown() {}
+
 int main(int argc, char **argv)
 {
     UNITY_BEGIN();

--- a/src/test/test_telemetry/test_telemetry.cpp
+++ b/src/test/test_telemetry/test_telemetry.cpp
@@ -204,6 +204,9 @@ void test_function_uart_in(void)
     TEST_ASSERT_EQUAL(true, telemetry.RXhandleUARTin(0xEC));
 }
 
+// Unity setup/teardown
+void setUp() {}
+void tearDown() {}
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
I get dis on master when executing `pio test -e native`, where my PIO just upgraded my Unity to 2.5.2
![Unity Error](https://cdn.discordapp.com/attachments/744445841779064863/979460858461696110/unknown.png)

So I have added them to all our tests?