### PR TITLE
Vantac RX has a special hardware, not Generic

### DIFF
--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -446,7 +446,7 @@
             "plain": {
                 "product_name": "Vantac 2.4GHz RX",
                 "lua_name": "Vantac 2400 RX",
-                "layout_file": "Generic 2400.json",
+                "layout_file": "Vantac 2400.json",
                 "upload_methods": ["uart", "wifi", "betaflight"]
             }
         }


### PR DESCRIPTION
* Changes the Vantac 2.4GHz RX definition to `vantac.rx_2400.plain.layout_file = "Vantac 2400.json"` as this hardware has a custom json

I was all wtf wow my transmitter is dead, I'm gettin' -89dBm on this receiver and I am 10cm away! When I tried another receiver it was fine, which lead me to try it on 2.5.0, where it got -30dBm and I started to wonder if something was amiss in the unified target.