### PR TITLE
Return size optimization to STM32

### DIFF
--- a/src/include/target/FM30_TX.h
+++ b/src/include/target/FM30_TX.h
@@ -5,7 +5,7 @@
 // There is some special handling for this target
 #define TARGET_TX_FM30
 #define USE_SX1280_DCDC
-#define CRITICAL_FLASH
+//#define CRITICAL_FLASH
 
 // GPIO pin definitions
 #define GPIO_PIN_NSS            PB12

--- a/src/lib/logging/logging.h
+++ b/src/lib/logging/logging.h
@@ -35,7 +35,7 @@ extern void debugPrintf(const char* fmt, ...);
 
 #if defined(CRITICAL_FLASH) || ((defined(DEBUG_RCVR_LINKSTATS)) && !defined(DEBUG_LOG))
   #define INFOLN(msg, ...)
-  #define ERRLN(msg)
+  #define ERRLN(msg, ...)
 #else
   #define INFOLN(msg, ...) { \
       debugPrintf(msg, ##__VA_ARGS__); \

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -95,6 +95,8 @@ build_flags =
 	-Wl,-Map,"'${BUILD_DIR}/firmware.map'"
 	-O2
 	-I ${PROJECTSRC_DIR}/hal
+	-D __FILE__='""'
+	-Wno-builtin-macro-redefined
 build_src_filter = ${common_env_data.build_src_filter} -<ESP32*.*> -<ESP8266*.*> -<WS281B*.*>
 lib_deps =
 	paolop74/extEEPROM @ 3.4.1

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -90,14 +90,11 @@ bf_upload_command =
 [env_common_stm32]
 platform = ststm32@15.1.0
 board = bluepill_f103c8
-build_unflags = -Os
 build_flags =
 	-D PLATFORM_STM32=1
 	-Wl,-Map,"'${BUILD_DIR}/firmware.map'"
 	-O2
 	-I ${PROJECTSRC_DIR}/hal
-	-D __FILE__='""'
-	-Wno-builtin-macro-redefined
 build_src_filter = ${common_env_data.build_src_filter} -<ESP32*.*> -<ESP8266*.*> -<WS281B*.*>
 lib_deps =
 	paolop74/extEEPROM @ 3.4.1


### PR DESCRIPTION
You m-er f-ers have had PK and I fighting an uphill battle making things keep fitting on the STM32, sandbagging us the whole way. `env_common_stm32` includes `build_unflags = -Os`, which goes back to 26f583db0be5baf5800910578e51215dc7480a37. I think this just carried through from back then because it kept getting copy pasted, then eventually consolidated into the common env. I've removed this and everything seems to work still.

Tested on FM30 TX (8KB smaller), R9MM RX (6KB smaller), and FR Mini RX (mumbles a number he forgot to write down). All still do their job.

### YOUR THE PORBLEM
It works on the R9MM, the reference hardware. Were there even any other RX targets at the time? I don't think anything needs it. I say merge this and /*\you/*\ PR turning it back on just for the target that doesn't work. Fite me!

### Why other lines?
~I removed the builtin `__FILE__` override too because why is this here? Also `-Wno-builtin-macro-redefined`, which was added to prevent the warning about overriding the builtin.~