### PR TITLE
Adds a Generic Whoop Serial Rx + VTx Target

### DIFF
--- a/src/hardware/RX/Generic 2400 Whoop Rx and VTx.json
+++ b/src/hardware/RX/Generic 2400 Whoop Rx and VTx.json
@@ -1,0 +1,38 @@
+{
+    "serial_rx": 3,
+    "serial_tx": 1,
+
+    "radio_miso": 33,
+    "radio_mosi": 32,
+    "radio_rst": 26,
+    "radio_sck": 25,
+
+    "radio_busy": 36,
+    "radio_dio1": 37,
+    "radio_nss": 27,
+    
+    "power_min": 0,
+    "power_high": 0,
+    "power_max": 0,
+    "power_default": 0,
+    "power_control": 0,
+    "power_values": [13],
+
+    "led_rgb": 22,
+    "led_rgb_isgrb": 1,
+    "ledidx_rgb_status": [0],
+    "ledidx_rgb_vtx": [1],
+    "ledidx_rgb_boot": [0,1],
+	
+    "vtx_nss": 19,
+    "vtx_miso": 23,
+    "vtx_mosi": 18,
+    "vtx_sck": 5,
+
+    "vtx_amp_pwm": 12,
+    "vtx_amp_vpd": 4,
+    "vtx_amp_vref": 2,
+
+    "vtx_amp_vpd_25mW": [1350,1350,1350,1350],
+    "vtx_amp_vpd_100mW": [1600,1600,1600,1600]
+}

--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -204,6 +204,12 @@
                 "lua_name": "Frank 2400RX",
                 "layout_file": "Frank 2400.json",
                 "upload_methods": ["uart", "wifi", "betaflight"]
+            },
+            "rx_vtx": {
+                "product_name": "Generic ESP32 2.4Ghz Rx and VTx",
+                "lua_name": "Rx+VTx 2400RX",
+                "layout_file": "Generic 2400 Whoop Rx and VTx.json",
+                "upload_methods": ["uart", "wifi", "betaflight"]
             }
         }
     },


### PR DESCRIPTION
This PR adds a Rx + VTx target based on the ESP32 Pico D4.  The below schematic can be used as a reference based on the pins use in `Generic 2400 Whoop Rx and VTx.json`.

For Whoop AIO the VTx MCU can be removed and replaced with an ESP32 Pico.  This will allow the addition of a serial Rx with integrated VTx control.

![Schematic_ExpressLRS Whoop Rx VTx Receiver_2022-06-06](https://user-images.githubusercontent.com/14170229/172070076-f1728e45-2627-4fe6-8012-a6fc80e8b7e8.png)