### PR TITLE
Reduce default TLM_REPORT_INTERVAL_MS to 240ms

### DIFF
--- a/src/lib/OPTIONS/options.cpp
+++ b/src/lib/OPTIONS/options.cpp
@@ -372,7 +372,7 @@ bool options_init()
     strlcpy(firmwareOptions.home_wifi_ssid, doc["wifi-ssid"] | "", sizeof(firmwareOptions.home_wifi_ssid));
     strlcpy(firmwareOptions.home_wifi_password, doc["wifi-password"] | "", sizeof(firmwareOptions.home_wifi_password));
     #if defined(TARGET_UNIFIED_TX)
-    firmwareOptions.tlm_report_interval = doc["tlm-interval"] | 320U;
+    firmwareOptions.tlm_report_interval = doc["tlm-interval"] | 240U;
     firmwareOptions.fan_min_runtime = doc["fan-runtime"] | 30U;
     firmwareOptions.no_sync_on_arm = doc["no-sync-on-arm"] | false;
     firmwareOptions.uart_inverted = doc["uart-inverted"] | true;

--- a/src/lib/OPTIONS/options.cpp
+++ b/src/lib/OPTIONS/options.cpp
@@ -125,7 +125,7 @@ __attribute__ ((used)) const firmware_options_t firmwareOptions = {
 #if defined(TLM_REPORT_INTERVAL_MS)
     .tlm_report_interval = TLM_REPORT_INTERVAL_MS,
 #else
-    .tlm_report_interval = 320U,
+    .tlm_report_interval = 240U,
 #endif
 #if defined(FAN_MIN_RUNTIME)
     .fan_min_runtime = FAN_MIN_RUNTIME,

--- a/src/user_defines.txt
+++ b/src/user_defines.txt
@@ -61,7 +61,7 @@
 # Does not output SBUS protocol, just inverted CRSF.
 #-DUSE_R9MM_R9MINI_SBUS
 
-#-DTLM_REPORT_INTERVAL_MS=320LU
+#-DTLM_REPORT_INTERVAL_MS=240LU
 
 ### OTHER OPTIONS: ###
 


### PR DESCRIPTION
Increases the default number of LinkStats we send to the handset from 3 to 4.

### Why?
"Telemetry Lost" is somewhat of our bane, and it usually has nothing to do with us, but rather it is the communication back to the handset that stuffs it somehow. This decreases the chance of that happening by giving OpenTX/EdgeTX 4 chances to get it instead of 3. I originally wrote this so have it start trying to send at 190ms, but skip sending if the FIFO already had data and delay a bit (to prevent messing with any other telemetry). However, in 5 minutes at 500Hz with full telemetry I never saw a single instance where it was skipped so it seems unnecessary.

On the FC side, we send LinkStats 10x per second so it seemed like a nobrainer to at least try sending a little more to the handset.