### PR TITLE
OLED/TFT menu fixes after VTX menu changes

### DIFF
--- a/src/lib/SCREEN/OLED/oleddisplay.cpp
+++ b/src/lib/SCREEN/OLED/oleddisplay.cpp
@@ -389,6 +389,7 @@ static void helperDrawImage(menu_item_t menu)
             case STATE_VTX_CHANNEL:
             case STATE_VTX_POWER:
             case STATE_VTX_PITMODE:
+            case STATE_VTX_SEND:
                 u8g2->drawXBM(x_pos, y_pos, 32, 32, vtx_img32);
                 break;
             case STATE_WIFI:

--- a/src/lib/SCREEN/TFT/tftdisplay.cpp
+++ b/src/lib/SCREEN/TFT/tftdisplay.cpp
@@ -20,10 +20,10 @@ const uint16_t *main_menu_icons[] = {
     elrs_ratio,
     elrs_motion,
     elrs_fan,
-    elrs_vtx,
     elrs_joystick,
     elrs_bind,
     elrs_wifimode,
+    elrs_vtx,
 
     elrs_power,
     elrs_power,

--- a/src/lib/SCREEN/menu.h
+++ b/src/lib/SCREEN/menu.h
@@ -23,7 +23,6 @@ enum fsm_state_s {
     STATE_VTX_POWER,
     STATE_VTX_PITMODE,
     STATE_VTX_SEND,
-    STATE_VTX_SAVESEND,
 
     STATE_WIFI_TX,
     STATE_WIFI_RX,
@@ -47,6 +46,7 @@ enum fsm_state_s {
     STATE_BIND_EXECUTE,
 
     STATE_VTX_SAVE,
+    STATE_VTX_SAVESEND,
 
     STATE_VALUE_INIT,
     STATE_VALUE_SELECT,


### PR DESCRIPTION
After the changes in PR #1595 the tft/oled menu had a few glitches in the wifi area because some text and icons were in the wrong positions.