### PR TITLE
Fix some targets using int for booleans in the json file

### DIFF
--- a/src/hardware/RX/BETAFPV Nano 2400.json
+++ b/src/hardware/RX/BETAFPV Nano 2400.json
@@ -8,7 +8,7 @@
     "radio_nss": 15,
     "radio_rst": 2,
     "radio_sck": 14,
-    "radio_dcdc": 1,
+    "radio_dcdc": true,
     "power_rxen": 9,
     "power_txen": 10,
     "power_min": 0,

--- a/src/hardware/RX/Frank 2400.json
+++ b/src/hardware/RX/Frank 2400.json
@@ -15,7 +15,7 @@
     "power_control": 0,
     "power_values": [13],
     "led_rgb": 2,
-    "led_rgb_isgrb": 1,
+    "led_rgb_isgrb": true,
     "ledidx_rgb_status": [0],
     "ledidx_rgb_vtx": [1],
     "ledidx_rgb_boot": [0,1],

--- a/src/hardware/RX/Generic 2400 Diversity and VTx.json
+++ b/src/hardware/RX/Generic 2400 Diversity and VTx.json
@@ -19,7 +19,7 @@
     "power_txen": 14,
     "power_rxen_2": 9,
     "power_txen_2": 15,
-    
+
     "power_min": 0,
     "power_high": 3,
     "power_max": 3,
@@ -28,11 +28,11 @@
     "power_values": [-10,-6,-3,1],
 
     "led_rgb": 22,
-    "led_rgb_isgrb": 1,
+    "led_rgb_isgrb": true,
     "ledidx_rgb_status": [0],
     "ledidx_rgb_vtx": [1],
     "ledidx_rgb_boot": [0,1],
-	
+
     "vtx_nss": 19,
     "vtx_miso": 23,
     "vtx_mosi": 18,

--- a/src/hardware/RX/Generic 2400 Diversity.json
+++ b/src/hardware/RX/Generic 2400 Diversity.json
@@ -19,7 +19,7 @@
     "power_txen": 14,
     "power_rxen_2": 9,
     "power_txen_2": 15,
-    
+
     "power_min": 0,
     "power_high": 3,
     "power_max": 3,
@@ -28,7 +28,7 @@
     "power_values": [-10,-6,-3,1],
 
     "led_rgb": 22,
-    "led_rgb_isgrb": 1,
+    "led_rgb_isgrb": true,
     "ledidx_rgb_status": [0],
     "ledidx_rgb_boot": [0]
 }

--- a/src/hardware/RX/Generic 2400 VTX.json
+++ b/src/hardware/RX/Generic 2400 VTX.json
@@ -15,7 +15,7 @@
     "power_control": 0,
     "power_values": [13],
     "led_rgb": 2,
-    "led_rgb_isgrb": 1,
+    "led_rgb_isgrb": true,
     "vtx_nss": 9,
     "vtx_amp_pwm": 0,
     "vtx_amp_vpd": 17,

--- a/src/hardware/RX/Generic 2400 Whoop Rx and VTx.json
+++ b/src/hardware/RX/Generic 2400 Whoop Rx and VTx.json
@@ -10,7 +10,7 @@
     "radio_busy": 36,
     "radio_dio1": 37,
     "radio_nss": 27,
-    
+
     "power_min": 0,
     "power_high": 0,
     "power_max": 0,
@@ -19,11 +19,11 @@
     "power_values": [13],
 
     "led_rgb": 22,
-    "led_rgb_isgrb": 1,
+    "led_rgb_isgrb": true,
     "ledidx_rgb_status": [0],
     "ledidx_rgb_vtx": [1],
     "ledidx_rgb_boot": [0,1],
-	
+
     "vtx_nss": 19,
     "vtx_miso": 23,
     "vtx_mosi": 18,


### PR DESCRIPTION
Just some cosmetic changes for consistency in the hardware layout files.
When a field is a boolean, use true/false rather than 1/0.

Tested with "Frank".