### PR TITLE
adds SX1280 SX1280_IRQ_SYNCWORD_VALID check... and other IRQ changes

### DIFF
--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -110,7 +110,8 @@ void SX1280Driver::Config(uint8_t bw, uint8_t sf, uint8_t cr, uint32_t regfreq,
                           uint8_t PreambleLength, bool InvertIQ, uint8_t _PayloadLength, uint32_t interval,
                           uint32_t flrcSyncWord, uint16_t flrcCrcSeed, uint8_t flrc)
 {
-    uint8_t irqs = SX1280_IRQ_TX_DONE | SX1280_IRQ_RX_DONE;
+    uint8_t irqMask = SX1280_IRQ_TX_DONE | SX1280_IRQ_RX_DONE;
+    uint8_t dio1Mask = SX1280_IRQ_TX_DONE | SX1280_IRQ_RX_DONE;
     uint8_t const mode = (flrc) ? SX1280_PACKET_TYPE_FLRC : SX1280_PACKET_TYPE_LORA;
 
     PayloadLength = _PayloadLength;
@@ -124,7 +125,7 @@ void SX1280Driver::Config(uint8_t bw, uint8_t sf, uint8_t cr, uint32_t regfreq,
         ConfigModParamsFLRC(bw, cr, sf);
         SetPacketParamsFLRC(SX1280_FLRC_PACKET_FIXED_LENGTH, /*crc=*/1,
                             PreambleLength, _PayloadLength, flrcSyncWord, flrcCrcSeed);
-        irqs |= SX1280_IRQ_CRC_ERROR;
+        irqMask |= SX1280_IRQ_SYNCWORD_VALID | SX1280_IRQ_SYNCWORD_ERROR | SX1280_IRQ_CRC_ERROR;
     }
     else
     {
@@ -139,7 +140,7 @@ void SX1280Driver::Config(uint8_t bw, uint8_t sf, uint8_t cr, uint32_t regfreq,
                             _PayloadLength, SX1280_LORA_CRC_OFF, InvertIQ);
     }
     SetFrequencyReg(regfreq);
-    SetDioIrqParams(SX1280_IRQ_RADIO_ALL, irqs);
+    SetDioIrqParams(irqMask, dio1Mask);
     SetRxTimeoutUs(interval);
 }
 
@@ -430,7 +431,7 @@ bool ICACHE_RAM_ATTR SX1280Driver::RXnbISR(uint16_t const irqStatus, SX1280_Radi
 {
     rx_status const fail =
         ((irqStatus & SX1280_IRQ_CRC_ERROR) ? SX12XX_RX_CRC_FAIL : SX12XX_RX_OK) |
-        ((irqStatus & SX1280_IRQ_RX_TX_TIMEOUT) ? SX12XX_RX_TIMEOUT : SX12XX_RX_OK) |
+        ((irqStatus & SX1280_IRQ_SYNCWORD_VALID) ? SX12XX_RX_OK : SX12XX_RX_SYNCWORD_ERROR) |
         ((irqStatus & SX1280_IRQ_SYNCWORD_ERROR) ? SX12XX_RX_SYNCWORD_ERROR : SX12XX_RX_OK);
     // In continuous receive mode, the device stays in Rx mode
     if (timeout != 0xFFFF)
@@ -530,7 +531,7 @@ void ICACHE_RAM_ATTR SX1280Driver::IsrCallback(SX1280_Radio_Number_t radioNumber
         instance->ClearIrqStatus(SX1280_IRQ_RADIO_ALL, SX1280_Radio_All);
     }
     else
-    if (irqStatus & (SX1280_IRQ_RX_DONE | SX1280_IRQ_CRC_ERROR | SX1280_IRQ_RX_TX_TIMEOUT))
+    if (irqStatus & SX1280_IRQ_RX_DONE)
     {
         if (instance->RXnbISR(irqStatus, radioNumber))
         {
@@ -541,5 +542,9 @@ void ICACHE_RAM_ATTR SX1280Driver::IsrCallback(SX1280_Radio_Number_t radioNumber
         {
             instance->ClearIrqStatus(SX1280_IRQ_RADIO_ALL, radioNumber);
         }
+    }
+    else // Only SX1280_IRQ_TX_DONE and SX1280_IRQ_RX_DONE IRQs are set, so this should never happen.
+    {
+        instance->ClearIrqStatus(SX1280_IRQ_RADIO_ALL, radioNumber);
     }
 }


### PR DESCRIPTION
This started off as a check of the sync word and that the IRQ was set correctly, but turned into half a day of understanding the IRQ.  This isnt clear from our current code so Ill try and explain below.

irqMask is anything we would like to set as an IRQ to dio1/2/3, or make available through GetIrqStatus().  For example, SX1280_IRQ_RX_DONE should be added to irqMask and as a IRQ on dio1.  But SX1280_IRQ_CRC_ERROR should be added to irqMask but not dio1, since we do not want SX1280_IRQ_CRC_ERROR to trigger an interrupt but must be available to checking after a SX1280_IRQ_RX_DONE interrupt.

To make this clear in code Ive added `irqMask` and `dio1Mask` as separate variables.

As a result I have also removed SX1280_IRQ_CRC_ERROR as an IRQ on dio1.  We only want SX1280_IRQ_TX_DONE and SX1280_IRQ_RX_DONE to trigger IRQs.  Then we check for a crc error and valid sync word.

During testing I forced mismatched sync words, but never saw SX1280_IRQ_SYNCWORD_ERROR triggered.  I am unsure what it actually does, maybe reports a malformed syncword?  But it does not get set with mismatched sync words.  However, mismatched syncwords do set SX1280_IRQ_CRC_ERROR!  So they are dealt as a crc error in the scoreboard stats.

SX1280_IRQ_RX_TX_TIMEOUT was also not set or used, so for now I have removed it to make that clear in the codebase.