### PR TITLE
Add button definition to RXs

### DIFF
--- a/src/hardware/RX/Frank 2400.json
+++ b/src/hardware/RX/Frank 2400.json
@@ -31,5 +31,6 @@
     "pwm_outputs": [4, 5, 12, 21, 22, 27, 32, 33],
     "vbat": 34,
     "vbat_offset": 12,
-    "vbat_scale": 410
+    "vbat_scale": 410,
+    "button": 0
 }

--- a/src/hardware/RX/Generic 2400 Diversity and VTx.json
+++ b/src/hardware/RX/Generic 2400 Diversity and VTx.json
@@ -19,7 +19,7 @@
     "power_txen": 14,
     "power_rxen_2": 9,
     "power_txen_2": 15,
-    
+
     "power_min": 0,
     "power_high": 3,
     "power_max": 3,
@@ -32,7 +32,7 @@
     "ledidx_rgb_status": [0],
     "ledidx_rgb_vtx": [1],
     "ledidx_rgb_boot": [0,1],
-	
+
     "vtx_nss": 19,
     "vtx_miso": 23,
     "vtx_mosi": 18,
@@ -43,5 +43,7 @@
     "vtx_amp_vref": 2,
 
     "vtx_amp_vpd_25mW": [1350,1350,1350,1350],
-    "vtx_amp_vpd_100mW": [1600,1600,1600,1600]
+    "vtx_amp_vpd_100mW": [1600,1600,1600,1600],
+
+    "button": 0
 }

--- a/src/hardware/RX/Generic 2400 Diversity.json
+++ b/src/hardware/RX/Generic 2400 Diversity.json
@@ -19,7 +19,7 @@
     "power_txen": 14,
     "power_rxen_2": 9,
     "power_txen_2": 15,
-    
+
     "power_min": 0,
     "power_high": 3,
     "power_max": 3,
@@ -30,5 +30,7 @@
     "led_rgb": 22,
     "led_rgb_isgrb": 1,
     "ledidx_rgb_status": [0],
-    "ledidx_rgb_boot": [0]
+    "ledidx_rgb_boot": [0],
+
+    "button": 0
 }

--- a/src/hardware/RX/Generic 2400 Whoop Rx and VTx.json
+++ b/src/hardware/RX/Generic 2400 Whoop Rx and VTx.json
@@ -10,7 +10,7 @@
     "radio_busy": 36,
     "radio_dio1": 37,
     "radio_nss": 27,
-    
+
     "power_min": 0,
     "power_high": 0,
     "power_max": 0,
@@ -23,7 +23,7 @@
     "ledidx_rgb_status": [0],
     "ledidx_rgb_vtx": [1],
     "ledidx_rgb_boot": [0,1],
-	
+
     "vtx_nss": 19,
     "vtx_miso": 23,
     "vtx_mosi": 18,
@@ -34,5 +34,7 @@
     "vtx_amp_vref": 2,
 
     "vtx_amp_vpd_25mW": [1350,1350,1350,1350],
-    "vtx_amp_vpd_100mW": [1600,1600,1600,1600]
+    "vtx_amp_vpd_100mW": [1600,1600,1600,1600],
+
+    "button": 0
 }

--- a/src/hardware/RX/Generic 900.json
+++ b/src/hardware/RX/Generic 900.json
@@ -14,5 +14,6 @@
     "power_default": 0,
     "power_control": 0,
     "power_values": [15],
-    "led": 16
+    "led": 16,
+    "button": 0
 }

--- a/src/hardware/RX/MATEK 2400.json
+++ b/src/hardware/RX/MATEK 2400.json
@@ -16,5 +16,6 @@
     "power_default": 3,
     "power_control": 0,
     "power_values": [-10,-6,-3,1],
-    "led": 16
+    "led": 16,
+    "button": 0
 }

--- a/src/hardware/RX/iFlight 2400.json
+++ b/src/hardware/RX/iFlight 2400.json
@@ -16,5 +16,6 @@
     "power_default": 3,
     "power_control": 0,
     "power_values": [-4,-2,2,5],
-    "led": 16
+    "led": 16,
+    "button": 0
 }


### PR DESCRIPTION
This adds the "button" definition to all RX's that don't use GPIO0 for something else like "ant_select" or "vtx_amp_pwm" etc.