### PR TITLE
adds missing GetLastPacketStats()

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -297,6 +297,8 @@ bool ICACHE_RAM_ATTR ProcessTLMpacket(SX12xxDriverCommon::rx_status const status
   LastTLMpacketRecvMillis = millis();
   LQCalc.add();
 
+  Radio.GetLastPacketStats();
+
   // Full res mode
   if (OtaIsFullRes)
   {


### PR DESCRIPTION
Looks like GetLastPacketStats() accidentally got removed in https://github.com/ExpressLRS/ExpressLRS/pull/1572

This fixes the missing SNR and RSSI for tlm packets.