### PR TITLE
Fix display name of LUA

### DIFF
--- a/src/lua/elrsV2.lua
+++ b/src/lua/elrsV2.lua
@@ -1,4 +1,4 @@
--- TNS|ExpressLRS Touch|TNE
+-- TNS|ExpressLRS|TNE
 ---- #########################################################################
 ---- #                                                                       #
 ---- # Copyright (C) OpenTX                                                  #


### PR DESCRIPTION
Fix copy/paste error when redoing the LUA after the full-res merge.