### PR TITLE
Add WS2812_IS_GRB for NamOLED TXes

### DIFF
--- a/src/include/target/NamimnoRC_FLASH_2400_OLED_TX.h
+++ b/src/include/target/NamimnoRC_FLASH_2400_OLED_TX.h
@@ -6,6 +6,7 @@
 #define USE_TX_BACKPACK
 #define USE_OLED_SPI
 #define HAS_FIVE_WAY_BUTTON
+#define WS2812_IS_GRB
 
 // GPIO pin definitions
 #define GPIO_PIN_RST            21

--- a/src/include/target/NamimnoRC_VOYAGER_900_OLED_TX.h
+++ b/src/include/target/NamimnoRC_VOYAGER_900_OLED_TX.h
@@ -5,6 +5,7 @@
 // Features
 #define USE_TX_BACKPACK
 #define USE_OLED_SPI
+#define WS2812_IS_GRB
 
 // GPIO pin definitions
 #define GPIO_PIN_RST            21


### PR DESCRIPTION
Noticed LED on my Namimno Flash OLED TX is flashing green instead of orange when not connected to radio.

This PR hopes to fix it.

NOTE: master branch do not need this.
This may be late in the game though.. 