### PR TITLE
Adds a rx option to force disable tlm

### DIFF
--- a/src/html/elrs.css
+++ b/src/html/elrs.css
@@ -325,4 +325,13 @@ body, input, select, textarea {
 
   /*==========================*/
 
+  .elrs-inline-form {
+	  display: flex;
+	  align-items: center;
+  }
+
+  .elrs-inline-form > * {
+	margin-right: 5px;
+  }
+
   @@include("mui.css")

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -85,12 +85,11 @@
 							<label>UART baud</label>
 						</div>
 						<div class="mui-checkbox">
-							<input id='rcvr-invert-tx' name='rcvr-invert-tx' type='checkbox'/>
-							<label>Invert TX pin</label>
+
+							<label><input id='rcvr-invert-tx' name='rcvr-invert-tx' type='checkbox'/> Invert TX pin</label>
 						</div>
 						<div class="mui-checkbox">
-							<input id='lock-on-first-connection' name='lock-on-first-connection' type='checkbox'/>
-							<label>Lock on first conenction</label>
+							<label><input id='lock-on-first-connection' name='lock-on-first-connection' type='checkbox'/> Lock on first conenction</label>
 						</div>
 @@end
 						<input id='submit-options' type='button' value='Save & Reboot' class="mui-btn mui-btn--primary">
@@ -126,16 +125,15 @@
 					Specify the 'Receiver' number in OpenTX/EdgeTX model setup page and turn on the 'Model Match'
 					in the ELRS Lua script for that model. 'Model Match' is between 0 and 63 inclusive.
 					<br/><br/>
-					<form class="mui-form--inline" action='/modelmatch' id='modelmatch' method='POST'>
+					<form class="mui-form--inline elrs-inline-form" action='/modelmatch' id='modelmatch' method='POST'>
 						<div class="mui-checkbox">
-							<input id='model-match' name='model-match' type='checkbox'/>
-							<label>Enable Model Match</label>
+							<label><input id='model-match' name='model-match' type='checkbox'/> Enable Model Match</label>
 						</div>
 						<div class="mui-textfield">
 							<input id='modelid' type='text' name='modelid' value="255" required/>
 							<label>Model ID</label>
 						</div>
-						<input type='submit' value='Save' class="mui-btn mui-btn--primary">
+						<input type='submit' value='Save' class="mui-btn mui-btn--small mui-btn--primary">
 					</form>
 				</div>
 				<div id="pwm_tab" class="mui-panel">
@@ -156,6 +154,18 @@
 					</ul>
 					<br/><br/>
 					<form action="/pwm" id="pwm" method="POST">
+					</form>
+				</div>
+				<div class="mui-panel">
+					<h2>Force telemetry off</h2>
+					You can run multiple receivers at the same time to increase the number of server outputs but only one rx can use telemetry.
+					Disable telemetry output of all other receivers with this option.
+					<br/><br/>
+					<form class="mui-form--inline elrs-inline-form" action='/forceTelemetry' id='forcetlm' method='POST'>
+						<div class="mui-checkbox">
+							<label><input id='force-tlm' name='force-tlm' type='checkbox' value="1"/> Disable the telemetry output of this rx</label>
+						</div>
+						<input type='submit' value='Save' class="mui-btn mui-btn--small mui-btn--primary">
 					</form>
 				</div>
 				<div class="mui-panel">

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -158,7 +158,7 @@
 				</div>
 				<div class="mui-panel">
 					<h2>Force telemetry off</h2>
-					You can run multiple receivers at the same time to increase the number of server outputs but only one rx can use telemetry.
+					You can run multiple receivers at the same time to increase the number of servo outputs but only one rx can use telemetry.
 					Disable telemetry output of all other receivers with this option.
 					<br/><br/>
 					<form class="mui-form--inline elrs-inline-form" action='/forceTelemetry' id='forcetlm' method='POST'>

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -158,12 +158,11 @@
 				</div>
 				<div class="mui-panel">
 					<h2>Force telemetry off</h2>
-					You can run multiple receivers at the same time to increase the number of servo outputs but only one rx can use telemetry.
-					Disable telemetry output of all other receivers with this option.
+					When running multiple receivers simultaneously from the same TX (to increase the number of PWM servo outputs), there can be at most one receiver with telemetry enabled.<br>Enable this option to ignore the Telem Ratio setting on the TX and never send telemetry from this receiver.
 					<br/><br/>
 					<form class="mui-form--inline elrs-inline-form" action='/forceTelemetry' id='forcetlm' method='POST'>
 						<div class="mui-checkbox">
-							<label><input id='force-tlm' name='force-tlm' type='checkbox' value="1"/> Disable the telemetry output of this rx</label>
+							<label><input id='force-tlm' name='force-tlm' type='checkbox' value="1"/> Force telemetry OFF on this receiver</label>
 						</div>
 						<input type='submit' value='Save' class="mui-btn mui-btn--small mui-btn--primary">
 					</form>

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -131,6 +131,10 @@ function initNetwork() {
       if (data.product_name) _('product_name').textContent = data.product_name;
       if (data.reg_domain) _('reg_domain').textContent = data.reg_domain;
       updatePwmSettings(data.pwm);
+
+      if (data.hasOwnProperty('forcetlm') && data.forcetlm) {
+        _('force-tlm').checked = true;
+      }
       scanTimer = setInterval(getNetworks, 2000);
     }
   };
@@ -349,6 +353,12 @@ if (_('modelmatch') != undefined) {
   _('modelmatch').addEventListener('submit', callback('Set Model Match', 'An error occurred updating the model match number', '/model',
       () => {
         return new FormData(_('modelmatch'));
+      }));
+}
+if (_('forcetlm') != undefined) {
+  _('forcetlm').addEventListener('submit', callback('Set force telemetry', 'An error occurred updating the force telemetry setting', '/forceTelemetry',
+      () => {
+        return new FormData(_('forcetlm'));
       }));
 }
 

--- a/src/lib/CONFIG/config.cpp
+++ b/src/lib/CONFIG/config.cpp
@@ -666,4 +666,14 @@ RxConfig::SetPwmChannelRaw(uint8_t ch, uint32_t raw)
 }
 #endif
 
+void
+RxConfig::SetForceTlmOff(bool forceTlmOff)
+{
+    if (m_config.forceTlmOff != forceTlmOff)
+    {
+        m_config.forceTlmOff = forceTlmOff;
+        m_modified = true;
+    }
+}
+
 #endif

--- a/src/lib/CONFIG/config.h
+++ b/src/lib/CONFIG/config.h
@@ -140,6 +140,7 @@ typedef struct {
     uint8_t     antennaMode;    //keep antenna mode in struct even in non diversity RX,
                                 // because turning feature diversity on and off would require change of RX config version.
     rx_config_pwm_t pwmChannels[PWM_MAX_CHANNELS];
+    bool        forceTlmOff;
 } rx_config_t;
 
 class RxConfig
@@ -161,6 +162,7 @@ public:
     #if defined(GPIO_PIN_PWM_OUTPUTS)
     const rx_config_pwm_t *GetPwmChannel(uint8_t ch) { return &m_config.pwmChannels[ch]; }
     #endif
+    bool GetForceTlmOff() const { return m_config.forceTlmOff; }
 
     // Setters
     void SetIsBound(bool isBound);
@@ -177,6 +179,7 @@ public:
     void SetPwmChannel(uint8_t ch, uint16_t failsafe, uint8_t inputCh, bool inverted, uint8_t mode, bool narrow);
     void SetPwmChannelRaw(uint8_t ch, uint32_t raw);
     #endif
+    void SetForceTlmOff(bool forceTlmOff);
 
 private:
     rx_config_t m_config;

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -424,10 +424,7 @@ static void WebUpdateForceTelemetry(AsyncWebServerRequest *request)
   config.SetForceTlmOff(forceTlm != 0);
   config.Commit();
 
-  AsyncWebServerResponse *response = request->beginResponse(200, "text/plain", "Force telemetry updated");
-  response->addHeader("Connection", "close");
-  request->send(response);
-  request->client()->close();
+  request->send(200, "text/plain", "Force telemetry updated");
 }
 #endif
 

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -284,6 +284,7 @@ static void WebUpdateSendMode(AsyncWebServerRequest *request)
   }
   #if defined(TARGET_RX)
   s += ",\"modelid\":" + String(config.GetModelId());
+  s += ",\"forcetlm\":" + String(config.GetForceTlmOff());
   #endif
   #if defined(GPIO_PIN_PWM_OUTPUTS)
   if (GPIO_PIN_PWM_OUTPUTS_COUNT > 0) {
@@ -413,6 +414,20 @@ static void WebUpdateModelId(AsyncWebServerRequest *request)
   request->send(response);
   request->client()->close();
   rebootTime = millis() + 100;
+}
+
+static void WebUpdateForceTelemetry(AsyncWebServerRequest *request)
+{
+  long forceTlm = request->arg("force-tlm").toInt();
+
+  DBGLN("Setting force telemetry %u", (uint8_t)forceTlm);
+  config.SetForceTlmOff(forceTlm != 0);
+  config.Commit();
+
+  AsyncWebServerResponse *response = request->beginResponse(200, "text/plain", "Force telemetry updated");
+  response->addHeader("Connection", "close");
+  request->send(response);
+  request->client()->close();
 }
 #endif
 
@@ -716,6 +731,7 @@ static void startServices()
 
   #if defined(TARGET_RX)
     server.on("/model", WebUpdateModelId);
+    server.on("/forceTelemetry", WebUpdateForceTelemetry);
   #endif
   #if defined(GPIO_PIN_PWM_OUTPUTS)
     server.on("/pwm", WebUpdatePwm);

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -325,7 +325,7 @@ bool ICACHE_RAM_ATTR HandleSendTelemetryResponse()
 {
     uint8_t modresult = (OtaNonce + 1) % ExpressLRS_currTlmDenom;
 
-    if ((connectionState == disconnected) || (ExpressLRS_currTlmDenom == 1) || (alreadyTLMresp == true) || (modresult != 0))
+    if (config.GetForceTlmOff() || (connectionState == disconnected) || (ExpressLRS_currTlmDenom == 1) || (alreadyTLMresp == true) || (modresult != 0))
     {
         return false; // don't bother sending tlm if disconnected or TLM is off
     }

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -893,6 +893,12 @@ bool ICACHE_RAM_ATTR ProcessRFPacket(SX12xxDriverCommon::rx_status const status)
         return false;
     }
 
+    // don't use telemetry packets for PDF calculation since TX does not send such data and tlm frames from other rx are not in sync
+    if (otaPktPtr->std.type == PACKET_TYPE_TLM)
+    {
+        return true;
+    }
+
     PFDloop.extEvent(beginProcessing + PACKET_TO_TOCK_SLACK);
 
     bool doStartTimer = false;
@@ -913,7 +919,6 @@ bool ICACHE_RAM_ATTR ProcessRFPacket(SX12xxDriverCommon::rx_status const status)
             OtaIsFullRes ? &otaPktPtr->full.sync.sync : &otaPktPtr->std.sync)
             && !InBindingMode;
         break;
-    case PACKET_TYPE_TLM: // telemetry packets from TX not implemented
     default:
         break;
     }


### PR DESCRIPTION
It possible to run multiple receivers at the same time to increase the number of server outputs but only one rx can use telemetry.
This PR adds a web option on the rx to force disable tlm so it's possible to use tlm with one rx.