### PR TITLE
Display error information on the idle screen

### DIFF
--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -685,6 +685,10 @@ static void registerLuaParameters()
 
 static int event()
 {
+  if (connectionState > FAILURE_STATES)
+  {
+    return DURATION_NEVER;
+  }
   uint8_t currentRate = adjustPacketRateForBaud(config.GetRate());
   setLuaTextSelectionValue(&luaAirRate, RATE_MAX - 1 - currentRate);
   setLuaTextSelectionValue(&luaTlmRate, config.GetTlm());
@@ -728,6 +732,10 @@ static int timeout()
 
 static int start()
 {
+  if (connectionState > FAILURE_STATES)
+  {
+    return DURATION_NEVER;
+  }
   CRSF::RecvParameterUpdate = &luaParamUpdateReq;
   registerLuaParameters();
 

--- a/src/lib/SCREEN/OLED/oleddisplay.cpp
+++ b/src/lib/SCREEN/OLED/oleddisplay.cpp
@@ -7,6 +7,7 @@
 #include "XBMStrings.h" // Contains all the ELRS logos and animations for the UI
 #include "options.h"
 #include "logging.h"
+#include "common.h"
 
 #if defined(PLATFORM_ESP32)
 #include "WiFi.h"
@@ -65,6 +66,11 @@ static void ghostChase()
 #endif
 
 static void helperDrawImage(menu_item_t menu);
+static void drawCentered(u8g2_int_t y, const char *str)
+{
+    u8g2_int_t x = (u8g2->getDisplayWidth() - u8g2->getStrWidth(str)) / 2;
+    u8g2->drawStr(x, y, str);
+}
 
 void OLEDDisplay::init()
 {
@@ -119,9 +125,19 @@ void OLEDDisplay::displayIdleScreen(uint8_t changed, uint8_t rate_index, uint8_t
         power += " *";
     }
 
-    if (OPT_USE_OLED_SPI_SMALL)
+    u8g2->setFont(u8g2_font_t0_15_mr);
+    if (connectionState == radioFailed)
     {
-        u8g2->setFont(u8g2_font_t0_15_mr);
+        drawCentered(15, "BAD");
+        drawCentered(32, "RADIO");
+    }
+    else if (connectionState == noCrossfire)
+    {
+        drawCentered(15, "NO");
+        drawCentered(32, "HANDSET");
+    }
+    else if (OPT_USE_OLED_SPI_SMALL)
+    {
         u8g2->drawStr(0, 15, getValue(STATE_PACKET, rate_index));
         u8g2->drawStr(70, 15, getValue(STATE_TELEMETRY, ratio_index));
         u8g2->drawStr(0, 32, power.c_str());
@@ -129,7 +145,6 @@ void OLEDDisplay::displayIdleScreen(uint8_t changed, uint8_t rate_index, uint8_t
     }
     else
     {
-        u8g2->setFont(u8g2_font_t0_15_mr);
         u8g2->drawStr(0, 13, message_string[message_index]);
         u8g2->drawStr(0, 45, getValue(STATE_PACKET, rate_index));
         u8g2->drawStr(70, 45, getValue(STATE_TELEMETRY, ratio_index));
@@ -312,11 +327,11 @@ void OLEDDisplay::displayBindStatus()
     u8g2->setFont(u8g2_font_t0_17_mr);
     if (OPT_USE_OLED_SPI_SMALL)
     {
-        u8g2->drawStr(0,15, "BINDING");
+        drawCentered(15, "BINDING...");
     }
     else
     {
-        u8g2->drawStr(0,29, "BINDING");
+        drawCentered(29, "BINDING...");
     }
     u8g2->sendBuffer();
 }
@@ -328,11 +343,11 @@ void OLEDDisplay::displayRunning()
     u8g2->setFont(u8g2_font_t0_17_mr);
     if (OPT_USE_OLED_SPI_SMALL)
     {
-        u8g2->drawStr(0,15, "RUNNING");
+        drawCentered(15, "RUNNING...");
     }
     else
     {
-        u8g2->drawStr(0,29, "RUNNING");
+        drawCentered(29, "RUNNING...");
     }
     u8g2->sendBuffer();
 }
@@ -344,11 +359,11 @@ void OLEDDisplay::displaySending()
     u8g2->setFont(u8g2_font_t0_17_mr);
     if (OPT_USE_OLED_SPI_SMALL)
     {
-        u8g2->drawStr(0,15, "SENDING...");
+        drawCentered(15, "SENDING...");
     }
     else
     {
-        u8g2->drawStr(0,29, "SENDING...");
+        drawCentered(29, "SENDING...");
     }
     u8g2->sendBuffer();
 }

--- a/src/lib/SCREEN/TFT/tftdisplay.cpp
+++ b/src/lib/SCREEN/TFT/tftdisplay.cpp
@@ -10,6 +10,7 @@
 #include "logos.h"
 #include "options.h"
 #include "logging.h"
+#include "common.h"
 
 #include "WiFi.h"
 extern WiFiMode_t wifiMode;
@@ -47,7 +48,8 @@ constexpr uint16_t elrs_banner_bgColor[] = {
     0x4315, // MSG_NONE          => #4361AA (ELRS blue)
     0x9E2D, // MSG_CONNECTED     => #9FC76F (ELRS green)
     0xAA08, // MSG_ARMED         => #AA4343 (red)
-    0xF501  // MSG_MISMATCH      => #F0A30A (amber)
+    0xF501, // MSG_MISMATCH      => #F0A30A (amber)
+    0xF800  // MSG_ERROR         => #F0A30A (very red)
 };
 
 #define SCREEN_X    160
@@ -181,6 +183,12 @@ void TFTDisplay::displaySplashScreen()
 
 void TFTDisplay::displayIdleScreen(uint8_t changed, uint8_t rate_index, uint8_t power_index, uint8_t ratio_index, uint8_t motion_index, uint8_t fan_index, bool dynamic, uint8_t running_power_index, uint8_t temperature, message_index_t message_index)
 {
+    if (connectionState == radioFailed || connectionState == noCrossfire)
+    {
+        changed = 0xFF;
+        message_index = MSG_ERROR;
+    }
+
     if (changed == 0xFF)
     {
         // Everything has changed! So clear the right side
@@ -206,28 +214,46 @@ void TFTDisplay::displayIdleScreen(uint8_t changed, uint8_t rate_index, uint8_t 
     // The Radio Params right half of the screen
     uint16_t text_color = (message_index == MSG_ARMED) ? DARKGREY : BLACK;
 
-    if (changed & CHANGED_RATE)
+    if (connectionState == radioFailed)
     {
-        displayFontCenter(IDLE_PAGE_STAT_START_X, SCREEN_X, IDLE_PAGE_RATE_START_Y,  SCREEN_NORMAL_FONT_SIZE, SCREEN_NORMAL_FONT,
-                            getValue(STATE_PACKET, rate_index), text_color, WHITE);
+        displayFontCenter(IDLE_PAGE_STAT_START_X, SCREEN_X, MAIN_PAGE_WORD_START_Y1,  SCREEN_NORMAL_FONT_SIZE, SCREEN_NORMAL_FONT,
+            "BAD", BLACK, WHITE);
+        displayFontCenter(IDLE_PAGE_STAT_START_X, SCREEN_X, MAIN_PAGE_WORD_START_Y2,  SCREEN_NORMAL_FONT_SIZE, SCREEN_NORMAL_FONT,
+            "RADIO", BLACK, WHITE);
     }
-
-    if (changed & CHANGED_POWER)
+    else if (connectionState == noCrossfire)
     {
-        String power = getValue(STATE_POWER, dynamic ? running_power_index : power_index);
-        if (dynamic)
+        displayFontCenter(IDLE_PAGE_STAT_START_X, SCREEN_X, MAIN_PAGE_WORD_START_Y1,  SCREEN_NORMAL_FONT_SIZE, SCREEN_NORMAL_FONT,
+            "NO", BLACK, WHITE);
+        displayFontCenter(IDLE_PAGE_STAT_START_X, SCREEN_X, MAIN_PAGE_WORD_START_Y2,  SCREEN_NORMAL_FONT_SIZE, SCREEN_NORMAL_FONT,
+            "HANDSET", BLACK, WHITE);
+    }
+    else
+    {
+        if (changed & CHANGED_RATE)
         {
-            power += " *";
+            displayFontCenter(IDLE_PAGE_STAT_START_X, SCREEN_X, IDLE_PAGE_RATE_START_Y,  SCREEN_NORMAL_FONT_SIZE, SCREEN_NORMAL_FONT,
+                                getValue(STATE_PACKET, rate_index), text_color, WHITE);
         }
-        displayFontCenter(IDLE_PAGE_STAT_START_X, SCREEN_X, IDLE_PAGE_POWER_START_Y, SCREEN_NORMAL_FONT_SIZE, SCREEN_NORMAL_FONT,
-                            power, text_color, WHITE);
+
+        if (changed & CHANGED_POWER)
+        {
+            String power = getValue(STATE_POWER, dynamic ? running_power_index : power_index);
+            if (dynamic)
+            {
+                power += " *";
+            }
+            displayFontCenter(IDLE_PAGE_STAT_START_X, SCREEN_X, IDLE_PAGE_POWER_START_Y, SCREEN_NORMAL_FONT_SIZE, SCREEN_NORMAL_FONT,
+                                power, text_color, WHITE);
+        }
+
+        if (changed & CHANGED_TELEMETRY)
+        {
+            displayFontCenter(IDLE_PAGE_STAT_START_X, SCREEN_X, IDLE_PAGE_RATIO_START_Y,  SCREEN_NORMAL_FONT_SIZE, SCREEN_NORMAL_FONT,
+                                getValue(STATE_TELEMETRY, ratio_index), text_color, WHITE);
+        }
     }
 
-    if (changed & CHANGED_TELEMETRY)
-    {
-        displayFontCenter(IDLE_PAGE_STAT_START_X, SCREEN_X, IDLE_PAGE_RATIO_START_Y,  SCREEN_NORMAL_FONT_SIZE, SCREEN_NORMAL_FONT,
-                            getValue(STATE_TELEMETRY, ratio_index), text_color, WHITE);
-    }
 }
 
 void TFTDisplay::displayMainMenu(menu_item_t menu)
@@ -337,7 +363,7 @@ void TFTDisplay::displayBindStatus()
     gfx->fillScreen(WHITE);
 
     displayFontCenter(SUB_PAGE_BINDING_WORD_START_X, SCREEN_X, SUB_PAGE_BINDING_WORD_START_Y,  SCREEN_LARGE_FONT_SIZE, SCREEN_LARGE_FONT,
-                        "BINDING", BLACK, WHITE);
+                        "BINDING...", BLACK, WHITE);
 }
 
 void TFTDisplay::displayRunning()
@@ -345,7 +371,7 @@ void TFTDisplay::displayRunning()
     gfx->fillScreen(WHITE);
 
     displayFontCenter(SUB_PAGE_BINDING_WORD_START_X, SCREEN_X, SUB_PAGE_BINDING_WORD_START_Y,  SCREEN_LARGE_FONT_SIZE, SCREEN_LARGE_FONT,
-                        "RUNNING", BLACK, WHITE);
+                        "RUNNING...", BLACK, WHITE);
 }
 
 void TFTDisplay::displaySending()

--- a/src/lib/SCREEN/display.h
+++ b/src/lib/SCREEN/display.h
@@ -44,6 +44,7 @@ typedef enum message_index_e {
     MSG_CONNECTED,
     MSG_ARMED,
     MSG_MISMATCH,
+    MSG_ERROR,
     MSG_INVALID
 } message_index_t;
 


### PR DESCRIPTION
Displays information on the OLED/TFT idle screen if there is
- no connection to the handset, i.e. CRSF not detected
  - NO HANDSET
- the radio chip is not detected on boot up
  - BAD RADIO