### PR TITLE
Fix slow TLMBoost causing TX->RX MSP timeouts

### DIFF
--- a/src/lib/StubbornReceiver/stubborn_receiver.cpp
+++ b/src/lib/StubbornReceiver/stubborn_receiver.cpp
@@ -1,5 +1,6 @@
 #include <cstdint>
 #include <algorithm>
+#include <cstring>
 #include "stubborn_receiver.h"
 
 StubbornReceiver::StubbornReceiver()
@@ -72,10 +73,8 @@ void StubbornReceiver::ReceiveData(uint8_t const packageIndex, uint8_t const * c
     if (acceptData)
     {
         uint8_t len = std::min((uint8_t)(length - currentOffset), dataLen);
-        for (unsigned i = 0; i < len; i++)
-        {
-            data[currentOffset++] = receiveData[i];
-        }
+        memcpy(&data[currentOffset], receiveData, len);
+        currentOffset += len;
         telemetryConfirm = !telemetryConfirm;
     }
 }

--- a/src/lib/StubbornSender/stubborn_sender.cpp
+++ b/src/lib/StubbornSender/stubborn_sender.cpp
@@ -1,5 +1,6 @@
 #include <cstdint>
 #include <algorithm>
+#include <cstring>
 #include "stubborn_sender.h"
 
 StubbornSender::StubbornSender()
@@ -65,16 +66,14 @@ uint8_t StubbornSender::GetCurrentPayload(uint8_t *outData, uint8_t maxLen)
     case SENDING:
         {
             bytesLastPayload = std::min((uint8_t)(length - currentOffset), maxLen);
-            for (unsigned n = 0; n < bytesLastPayload; ++n)
-            {
-                outData[n] = data[currentOffset + n];
-            }
             // If this is the last data chunk, and there has been at least one other packet
             // skip the blank packet needed for WAIT_UNTIL_NEXT_CONFIRM
             if (currentPackage > 1 && (currentOffset + bytesLastPayload) >= length)
                 packageIndex = 0;
             else
                 packageIndex = currentPackage;
+
+            memcpy(outData, &data[currentOffset], bytesLastPayload);
         }
         break;
     default:

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -533,7 +533,7 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
       BindingSendCount++;
       // If the telemetry ratio isn't already 1:2, send a sync packet to boost it
       // to add bandwidth for the reply
-      if (ExpressLRS_currAirRate_Modparams->TLMinterval != TLM_RATIO_1_2)
+      if (ExpressLRS_currTlmDenom != 2)
         syncSpamCounter = 1;
     }
     else


### PR DESCRIPTION
Fixes a bug from #1599 that was causing the BF.lua to often not work due to me missing a line that needed to be changed. This manifests as BF.lua taking a minute to load, or perhaps not at all, as well as some of the "Other Devices" failing to load.

### Details
When the TX has MSP to send, it attempts to boost the telemetry ratio to 1:2 because:
* It can't send another chunk of the MSP packet until the RX toggles the stubborn bit in the linkstats packet
* The RX will probably have data to send back, which would want more TLM bandwidth

Rather than wait for the next sync packet (up to a 5 second delay), the TX does a single syncspam to push the TLM ratio change immediately. I missed this line when I converted everything to use `ExpressLRS_currTlmDenom` instead of `ExpressLRS_currAirRate_Modparams->TLMinterval` so it was never triggering the syncspam. This fix is the one-liner in https://github.com/ExpressLRS/ExpressLRS/commit/8f161ac3b40f17284b782497c085bad76a86fc68

Turns out that when we don't go into TLMBoost fast enough, BF.lua retries sending faster than we can actually send the data, which causes us to keep resetting the uplink transmission and going through RESYNC sometimes. The whole send can wedge or become a minute-long process if the Lua keeps retrying faster than the reset can take place.

### Related?
When adding some stubborn debugging to find this, I converted the for loops to just use `memcpy`, which master already has linked in so why not. That and a little code rearrangement saves 12 flash bytes. woo. hoo. 😑