### PR TITLE
Fix RX LUA crashing on commit

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1395,9 +1395,10 @@ void loop()
 
     if (config.IsModified() && !InBindingMode)
     {
-        Radio.SetTxIdleMode();
         LostConnection();
+        Radio.SetTxIdleMode();
         config.Commit();
+        Radio.RXnb();
         devicesTriggerEvent();
     }
 


### PR DESCRIPTION
# Problem
When updating a value in the RX LUA it would sometime (1/5-ish) crash and reboot the RX, resetting all the values back to defaults.

# Root Cause
In the main loop, if there are config changes to persist, the code would disable the Radio from listening and then call `LostConnection` before calling commit. The problem is that `LostConnection` put the radio back into receive mode!
If a packet arrives (which it will in 1000Hz modes) causes an interrupt which crashes hard because the ESP is trying to write to the flash.

# Solution
Change the order of things.
First, call `LostConnection`, then put the radio in idle mode, and after the commit put it back into receive mode.
