### PR TITLE
expose msp telemetry via websocket

### DIFF
--- a/src/lib/Telemetry/telemetry.cpp
+++ b/src/lib/Telemetry/telemetry.cpp
@@ -6,8 +6,8 @@
 #if defined(USE_MSP_WIFI) && defined(TARGET_RX) // enable MSP2WIFI for RX only at the moment
 #include "tcpsocket.h"
 #include "CRSF.h"
-extern TCPSOCKET wifi2tcp;
 extern CRSF crsf;
+extern bool WifiHasMSPClient();
 #endif
 
 #if defined(UNIT_TEST)
@@ -256,7 +256,7 @@ bool Telemetry::AppendTelemetryPackage(uint8_t *package)
 
             #if defined(USE_MSP_WIFI) && defined(TARGET_RX)
                 // this probably needs refactoring in the future, I think we should have this telemetry class inside the crsf module
-                if (wifi2tcp.hasClient() && (header->type == CRSF_FRAMETYPE_MSP_RESP || header->type == CRSF_FRAMETYPE_MSP_REQ)) // if we have a client we probs wanna talk to it
+                if (WifiHasMSPClient() && (header->type == CRSF_FRAMETYPE_MSP_RESP || header->type == CRSF_FRAMETYPE_MSP_REQ)) // if we have a client we probs wanna talk to it
                 {
                     DBGLN("Got MSP frame, forwarding to client, len: %d", currentTelemetryByte);
                     crsf.crsf2msp.parse(package);


### PR DESCRIPTION
adds a websocket route to the http server which proxies data to the existing msp2crsf bridge.
idea is is to allow for web-based configurators to connect directly to this websocket in the browser,
enabling eg. mobile devices to connect via wifi to the flight-controller without a native app.

[Prototype Demo](https://www.youtube.com/shorts/wISFeOom2Uw)