### PR TITLE
I forgot about the mDNS options!

### DIFF
--- a/src/lib/OPTIONS/options.cpp
+++ b/src/lib/OPTIONS/options.cpp
@@ -163,65 +163,6 @@ __attribute__ ((used)) const firmware_options_t firmwareOptions = {
 #endif
 };
 
-const char PROGMEM compile_options[] = {
-#ifdef MY_BINDING_PHRASE
-    "-DMY_BINDING_PHRASE=\"" STR(MY_BINDING_PHRASE) "\" "
-#endif
-
-#ifdef TARGET_TX
-    #ifdef UNLOCK_HIGHER_POWER
-        "-DUNLOCK_HIGHER_POWER "
-    #endif
-    #ifdef UART_INVERTED
-        "-DUART_INVERTED "
-    #endif
-    #ifdef DISABLE_ALL_BEEPS
-        "-DDISABLE_ALL_BEEPS "
-    #endif
-    #ifdef JUST_BEEP_ONCE
-        "-DJUST_BEEP_ONCE "
-    #endif
-    #ifdef DISABLE_STARTUP_BEEP
-        "-DDISABLE_STARTUP_BEEP "
-    #endif
-    #ifdef MY_STARTUP_MELODY
-        "-DMY_STARTUP_MELODY=\"" STR(MY_STARTUP_MELODY) "\" "
-    #endif
-    #ifdef WS2812_IS_GRB
-        "-DWS2812_IS_GRB "
-    #endif
-    #ifdef TLM_REPORT_INTERVAL_MS
-        "-DTLM_REPORT_INTERVAL_MS=" STR(TLM_REPORT_INTERVAL_MS) " "
-    #endif
-    #ifdef USE_TX_BACKPACK
-        "-DUSE_TX_BACKPACK "
-    #endif
-    #ifdef USE_BLE_JOYSTICK
-        "-DUSE_BLE_JOYSTICK "
-    #endif
-#endif
-
-#ifdef TARGET_RX
-    #ifdef LOCK_ON_FIRST_CONNECTION
-        "-DLOCK_ON_FIRST_CONNECTION "
-    #endif
-    #ifdef USE_R9MM_R9MINI_SBUS
-        "-DUSE_R9MM_R9MINI_SBUS "
-    #endif
-    #ifdef AUTO_WIFI_ON_INTERVAL
-        "-DAUTO_WIFI_ON_INTERVAL=" STR(AUTO_WIFI_ON_INTERVAL) " "
-    #endif
-    #ifdef RCVR_UART_BAUD
-        "-DRCVR_UART_BAUD=" STR(RCVR_UART_BAUD) " "
-    #endif
-    #ifdef RCVR_INVERT_TX
-        "-DRCVR_INVERT_TX "
-    #endif
-    #ifdef USE_R9MM_R9MINI_SBUS
-        "-DUSE_R9MM_R9MINI_SBUS "
-    #endif
-#endif
-};
 #else // TARGET_UNIFIED_TX || TARGET_UNIFIED_RX
 
 #include <ArduinoJson.h>
@@ -238,7 +179,6 @@ const char PROGMEM compile_options[] = {
 char product_name[129];
 char device_name[17];
 
-const char PROGMEM compile_options[] = "";
 firmware_options_t firmwareOptions;
 
 extern bool hardware_init(uint32_t *config);

--- a/src/lib/OPTIONS/options.h
+++ b/src/lib/OPTIONS/options.h
@@ -4,7 +4,6 @@ extern const unsigned char target_name[];
 extern const uint8_t target_name_size;
 extern const char commit[];
 extern const char version[];
-extern const char PROGMEM compile_options[];
 
 extern const char *wifi_hostname;
 extern const char *wifi_ap_ssid;

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -659,19 +659,6 @@ static void startMDNS()
 
   String options = "-DAUTO_WIFI_ON_INTERVAL=" + String(firmwareOptions.wifi_auto_on_interval / 1000);
 
-  if (firmwareOptions.hasUID)
-  {
-    options += " -DMY_UID=";
-    for (int i=0 ; i<sizeof(firmwareOptions.uid) ; i++)
-    {
-      options += firmwareOptions.uid[i];
-      if (i!=sizeof(firmwareOptions.uid)-1)
-      {
-        options += ",";
-      }
-    }
-  }
-
   #ifdef TARGET_TX
   if (firmwareOptions.unlock_higher_power)
   {

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -657,6 +657,42 @@ static void startMDNS()
     return;
   }
 
+  String options = " -DAUTO_WIFI_ON_INTERVAL=" + firmwareOptions.wifi_auto_on_interval / 1000;
+
+  if (firmwareOptions.hasUID)
+  {
+    options += " -DMY_UID=";
+    for (int i=0 ; i<sizeof(firmwareOptions.uid) ; i++)
+    {
+      options += firmwareOptions.uid[i];
+    }
+  }
+
+  #ifdef TARGET_TX
+  if (firmwareOptions.unlock_higher_power)
+  {
+    options += " -DUNLOCK_HIGHER_POWER";
+  }
+  if (firmwareOptions.uart_inverted)
+  {
+    options += " -DUART_INVERTED";
+  }
+  options += " -DTLM_REPORT_INTERVAL_MS=" + firmwareOptions.tlm_report_interval;
+  options += " -DFAN_MIN_RUNTIME=" + firmwareOptions.fan_min_runtime;
+  #endif
+
+  #ifdef TARGET_RX
+  if (firmwareOptions.lock_on_first_connection)
+  {
+    options += " -DLOCK_ON_FIRST_CONNECTION";
+  }
+  if (firmwareOptions.invert_tx)
+  {
+    options += " -DRCVR_INVERT_TX";
+  }
+  options += " -DRCVR_UART_BAUD=" + firmwareOptions.uart_baud;
+  #endif
+
   String instance = String(wifi_hostname) + "_" + WiFi.macAddress();
   instance.replace(":", "");
   #ifdef PLATFORM_ESP8266
@@ -666,7 +702,7 @@ static void startMDNS()
     MDNS.addServiceTxt(service, "vendor", "elrs");
     MDNS.addServiceTxt(service, "target", (const char *)&target_name[4]);
     MDNS.addServiceTxt(service, "version", VERSION);
-    MDNS.addServiceTxt(service, "options", String(FPSTR(compile_options)).c_str());
+    MDNS.addServiceTxt(service, "options", options.c_str());
     MDNS.addServiceTxt(service, "type", "rx");
     // If the probe result fails because there is another device on the network with the same name
     // use our unique instance name as the hostname. A better way to do this would be to use
@@ -684,7 +720,7 @@ static void startMDNS()
     MDNS.addServiceTxt("http", "tcp", "target", (const char *)&target_name[4]);
     MDNS.addServiceTxt("http", "tcp", "device", (const char *)device_name);
     MDNS.addServiceTxt("http", "tcp", "version", VERSION);
-    MDNS.addServiceTxt("http", "tcp", "options", String(FPSTR(compile_options)).c_str());
+    MDNS.addServiceTxt("http", "tcp", "options", options.c_str());
     MDNS.addServiceTxt("http", "tcp", "type", "tx");
   #endif
 }

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -657,7 +657,7 @@ static void startMDNS()
     return;
   }
 
-  String options = " -DAUTO_WIFI_ON_INTERVAL=" + firmwareOptions.wifi_auto_on_interval / 1000;
+  String options = "-DAUTO_WIFI_ON_INTERVAL=" + String(firmwareOptions.wifi_auto_on_interval / 1000);
 
   if (firmwareOptions.hasUID)
   {
@@ -665,6 +665,10 @@ static void startMDNS()
     for (int i=0 ; i<sizeof(firmwareOptions.uid) ; i++)
     {
       options += firmwareOptions.uid[i];
+      if (i!=sizeof(firmwareOptions.uid)-1)
+      {
+        options += ",";
+      }
     }
   }
 
@@ -677,8 +681,8 @@ static void startMDNS()
   {
     options += " -DUART_INVERTED";
   }
-  options += " -DTLM_REPORT_INTERVAL_MS=" + firmwareOptions.tlm_report_interval;
-  options += " -DFAN_MIN_RUNTIME=" + firmwareOptions.fan_min_runtime;
+  options += " -DTLM_REPORT_INTERVAL_MS=" + String(firmwareOptions.tlm_report_interval);
+  options += " -DFAN_MIN_RUNTIME=" + String(firmwareOptions.fan_min_runtime);
   #endif
 
   #ifdef TARGET_RX
@@ -690,7 +694,7 @@ static void startMDNS()
   {
     options += " -DRCVR_INVERT_TX";
   }
-  options += " -DRCVR_UART_BAUD=" + firmwareOptions.uart_baud;
+  options += " -DRCVR_UART_BAUD=" + String(firmwareOptions.uart_baud);
   #endif
 
   String instance = String(wifi_hostname) + "_" + WiFi.macAddress();


### PR DESCRIPTION
When I did the work on the unified targets I completely forgot about the mDNS options value.
This brings it back, but puts it into the wifi code where it really belongs.