### PR TITLE
Fix overflow calculating TLMBurst for F1000 1:2

### DIFF
--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -142,10 +142,10 @@ uint8_t TLMBurstMaxForRateRatio(uint16_t const rateHz, uint8_t const ratioDiv)
 
     // telemInterval = 1000 / (hz / ratiodiv);
     // burst = TELEM_MIN_LINK_INTERVAL_MS / telemInterval;
-    // This ^^^ rearranged to preserve precision vvv
-    uint8_t retVal = TELEM_MIN_LINK_INTERVAL_MS * rateHz / ratioDiv / 1000U;
+    // This ^^^ rearranged to preserve precision vvv, using u32 because F1000 1:2 = 256
+    unsigned retVal = TELEM_MIN_LINK_INTERVAL_MS * rateHz / ratioDiv / 1000U;
 
-    // Reserve one slot for LINK telemetry
+    // Reserve one slot for LINK telemetry. 256 becomes 255 here, safe for return in uint8_t
     if (retVal > 1)
         --retVal;
     else


### PR DESCRIPTION
Wez found this bug in TLMBurst when running F1000 at 1:2, it actually makes every other packet LinkStats when it should be every 256. Since Airport is post-3.0, master should have this fix.

The only change needed is in the math because the value is decremented by 1 to account for the LinkStats so the result still fits in 8-bit and the code that references it is `if (telemetryBurstCount < telemetryBurstMax)` so it should not overflow there either.

I can't really test it though because F1000 1:2 is so much telemetry that it always falls back to sending LinkStats as there is no Adv.Telem data to send. I do see that it does send multiple Adv.Telem back to back, which does indicate it is no longer overflowing.