### PR TITLE
Return LoRa operation after IRQ changes

### DIFF
--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -316,7 +316,7 @@ void SX1280Driver::SetPacketParamsFLRC(uint8_t HeaderType,
         buf[1] = temp;
         // For SX1280_FLRC_CR_3_4 the datasheet also says
         // "In addition to this the two LSB values XX XX must not be in the range 0x0000 to 0x3EFF"
-        if (cr == SX1280_FLRC_CR_3_4 && buf[3] < 0x3e)
+        if (cr == SX1280_FLRC_CR_3_4 && buf[3] <= 0x3e)
             buf[3] |= 0x80; // 0x80 or 0x40 would work
     }
 

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -403,8 +403,6 @@ void ICACHE_RAM_ATTR SX1280Driver::TXnbISR()
     TXdoneCallback();
 }
 
-uint8_t FIFOaddr = 0;
-
 void ICACHE_RAM_ATTR SX1280Driver::TXnb(uint8_t * data, uint8_t size)
 {
     if (currOpmode == SX1280_MODE_TX) //catch TX timeout

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -316,7 +316,6 @@ void SX1280Driver::SetPacketParamsFLRC(uint8_t HeaderType,
         buf[1] = temp;
         // For SX1280_FLRC_CR_3_4 the datasheet also says
         // "In addition to this the two LSB values XX XX must not be in the range 0x0000 to 0x3EFF"
-        // but let's evaluate this if we ever use CR 3/4
         if (cr == SX1280_FLRC_CR_3_4 && buf[3] < 0x3e)
             buf[3] |= 0x80; // 0x80 or 0x40 would work
     }

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -317,7 +317,8 @@ void SX1280Driver::SetPacketParamsFLRC(uint8_t HeaderType,
         // For SX1280_FLRC_CR_3_4 the datasheet also says
         // "In addition to this the two LSB values XX XX must not be in the range 0x0000 to 0x3EFF"
         // but let's evaluate this if we ever use CR 3/4
-        // if (cr == SX1280_FLRC_CR_3_4) buf[3] |= 0x80; // 0x80 or 0x40 would work
+        if (cr == SX1280_FLRC_CR_3_4 && buf[3] < 0x3e)
+            buf[3] |= 0x80; // 0x80 or 0x40 would work
     }
 
     hal.WriteRegister(SX1280_REG_FLRC_SYNC_WORD, buf, 4, SX1280_Radio_All);


### PR DESCRIPTION
#1619 started checking for `SX1280_IRQ_SYNCWORD_VALID` as a requirement for a valid packet, but LoRa has no sync word so every LoRa packet was rejected. This changes the IRQ handler to only check for CRC, Sync Valid, Sync Invalid when in FLRC mode.

Since we only check these flags in FLRC mode, it is safe to enable their IRQs even in LoRa mode, which makes the `Config()` code simpler since it just sets the flags now instead of building them. The `IsrCallback()` was also simplified to just make one `ClearIrqStatus()` call instead of having one per code path (4 of em).

I also removed the giant block of ERRLN because it takes almost 200 bytes on all targets for something we don't even use. ERRLN is very flash intensive and always on. I added the CR2/3 swap to the if statement, but did not implement the low part modification. We can always do that later when we actually use a CR2/3 mode.
DIY SX1280 - 244 bytes saved
FM30 TX - 170 bytes saved

Tested on Namimno OLED, FM30 TX, and DIY SX1280 RX. I also verified that I was getting errors reported in the IRQ, but I didn't verify that all types were present.