### PR TITLE
Resolve RX crash when changing ModelID from Lua

### DIFF
--- a/src/include/common.h
+++ b/src/include/common.h
@@ -36,7 +36,6 @@ typedef enum
     connected,
     tentative,
     disconnected,
-    disconnectPending, // used on modelmatch change to drop the connection
     MODE_STATES,
     // States below here are special mode states
     noCrossfire,

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -410,11 +410,7 @@ static void WebUpdateModelId(AsyncWebServerRequest *request)
   config.SetModelId((uint8_t)modelid);
   config.Commit();
 
-  AsyncWebServerResponse *response = request->beginResponse(200, "text/plain", "Model Match updated, rebooting receiver");
-  response->addHeader("Connection", "close");
-  request->send(response);
-  request->client()->close();
-  rebootTime = millis() + 100;
+  request->send(200, "text/plain", "Model Match updated");
 }
 #endif
 


### PR DESCRIPTION
Removes the bare `config.Commit()` when changing ModelID over MSP, which crashes every time before completing on master.

### Details
The actual fix for the crash is just removing these two lines of code from `UpdateModelMatch()`
```
    config.Commit();
    // This will be called from ProcessRFPacket(), schedule a disconnect
    // in the main loop once the ISR has exited
    connectionState = disconnectPending;
```
`UpdateModelMatch()` is called from `MspReceiveComplete()` which used to be called from the packet received ISR. Frank changed this to be (what I feel is) the correct way, of just being something called from loop. However, from the ISR the commit would block all execution until it finished and was therefore "safe". Now that it is outside the ISR, packets coming in try to run the ISR while the config commit has the flash locked and everything crashes.

Changing ModelID is no different than anything else, so this PR simply lets pkendall64's config commit code do the required commit. The PR looks bigger because I:
* Moved that code to its own function (`CheckConfigChangePending`) so make it structurally similar to the TX since it behaves similarly
* Moved `MspReceiveComplete()` out from being in the middle of all the ISR functions to make all the packet code still be together without having loop code in the middle of it. No changes were made to MspReceiveComplete.
* `LostConnection()` used to always start listening again before exiting, but our code is a 50/50 split of wanting to start listening again, and wanting to shut the radio down. It is safer to keep the radio shut down if the code that follows is trying to prevent new packets from coming. This makes sure that things that don't want new packets don't get new packets, and removes the caller's burden of switching back out of RX mode.

### 2.x
I had tested this 100x when I added it and it worked every time so I never put more effort into doing the correct solution (which I think we have with this PR). I tested it now on 2.5.0 and the commit does finish (because it is still committing from the ISR on 2.x) but then crashes right after and reboots with the new config so it appears to work every time still. 

### Unrelated
I always have one of these right? 😋The webui forces a reboot after changing the ModelID, I think because the ModelMatch code used to force a reboot on change. I don't see any reason to force a reboot for the change, maybe the user wants to change more than one thing, such as setting a ModelID and changing the PWM mapping (which doesn't do a reboot either). This makes the behavior consistent with the other "Model" config ui.