### PR TITLE
Display bugs: F500, TLM Ratio, Fullres modes

### DIFF
--- a/src/lib/SCREEN/OLED/oleddisplay.cpp
+++ b/src/lib/SCREEN/OLED/oleddisplay.cpp
@@ -139,7 +139,7 @@ void OLEDDisplay::displayIdleScreen(uint8_t changed, uint8_t rate_index, uint8_t
     else if (OPT_USE_OLED_SPI_SMALL)
     {
         u8g2->drawStr(0, 15, getValue(STATE_PACKET, rate_index));
-        u8g2->drawStr(70, 15, getValue(STATE_TELEMETRY, ratio_index));
+        u8g2->drawStr(70, 15, getValue(STATE_TELEMETRY_CURR, ratio_index));
         u8g2->drawStr(0, 32, power.c_str());
         u8g2->drawStr(70, 32, version);
     }
@@ -147,7 +147,7 @@ void OLEDDisplay::displayIdleScreen(uint8_t changed, uint8_t rate_index, uint8_t
     {
         u8g2->drawStr(0, 13, message_string[message_index]);
         u8g2->drawStr(0, 45, getValue(STATE_PACKET, rate_index));
-        u8g2->drawStr(70, 45, getValue(STATE_TELEMETRY, ratio_index));
+        u8g2->drawStr(70, 45, getValue(STATE_TELEMETRY_CURR, ratio_index));
         u8g2->drawStr(0, 60, power.c_str());
         u8g2->setFont(u8g2_font_profont10_mr);
         u8g2->drawStr(70, 56, "TLM");

--- a/src/lib/SCREEN/TFT/tftdisplay.cpp
+++ b/src/lib/SCREEN/TFT/tftdisplay.cpp
@@ -250,7 +250,7 @@ void TFTDisplay::displayIdleScreen(uint8_t changed, uint8_t rate_index, uint8_t 
         if (changed & CHANGED_TELEMETRY)
         {
             displayFontCenter(IDLE_PAGE_STAT_START_X, SCREEN_X, IDLE_PAGE_RATIO_START_Y,  SCREEN_NORMAL_FONT_SIZE, SCREEN_NORMAL_FONT,
-                                getValue(STATE_TELEMETRY, ratio_index), text_color, WHITE);
+                                getValue(STATE_TELEMETRY_CURR, ratio_index), text_color, WHITE);
         }
     }
 

--- a/src/lib/SCREEN/display.cpp
+++ b/src/lib/SCREEN/display.cpp
@@ -89,6 +89,17 @@ static const char *ratio_string[] = {
     "Race"
 };
 
+static const char *ratio_curr_string[] = {
+    "Off",
+    "1:2",
+    "1:4",
+    "1:8",
+    "1:16",
+    "1:32",
+    "1:64",
+    "1:128"
+};
+
 static const char *powersaving_string[] = {
     "OFF",
     "ON"
@@ -187,6 +198,8 @@ const char *Display::getValue(menu_item_t menu, uint8_t value_index)
         return rate_string[value_index];
     case STATE_TELEMETRY:
         return ratio_string[value_index];
+    case STATE_TELEMETRY_CURR:
+        return ratio_curr_string[value_index];
     case STATE_POWERSAVE:
         return powersaving_string[value_index];
     case STATE_SMARTFAN:

--- a/src/lib/SCREEN/display.cpp
+++ b/src/lib/SCREEN/display.cpp
@@ -50,6 +50,7 @@ const char *rate_string[] = {
 #else
 static const char *rate_string[] = {
     "200Hz",
+    "100 Full",
     "100Hz",
     "50Hz",
     "25Hz"

--- a/src/lib/SCREEN/display.cpp
+++ b/src/lib/SCREEN/display.cpp
@@ -37,14 +37,14 @@ const char *Display::main_menu_strings[][2] = {
 #if defined(RADIO_SX128X)
 const char *rate_string[] = {
     "F1000Hz",
-    "F500",
+    "F500Hz",
     "D500Hz",
     "D250Hz",
     "500Hz",
-    "333Hz Full",
+    "333 Full",
     "250Hz",
     "150Hz",
-    "100Hz Full",
+    "100 Full",
     "50Hz"
 };
 #else

--- a/src/lib/SCREEN/menu.cpp
+++ b/src/lib/SCREEN/menu.cpp
@@ -70,6 +70,8 @@ static void displayIdleScreen(bool init)
 
     message_index_t disp_message = CRSF::IsArmed() ? MSG_ARMED : ((connectionState == connected) ? (connectionHasModelMatch ? MSG_CONNECTED : MSG_MISMATCH) : MSG_NONE);
     uint8_t changed = init ? 0xFF : 0;
+    // compute log2(ExpressLRS_currTlmDenom) (e.g. 128=7, 64=6, etc)
+    uint8_t tlmIdx = __builtin_ffs(ExpressLRS_currTlmDenom) - 1;
     if (changed == 0)
     {
         changed |= last_message != disp_message ? CHANGED_MESSAGE : 0;
@@ -78,7 +80,7 @@ static void displayIdleScreen(bool init)
         changed |= last_power != config.GetPower() ? CHANGED_POWER : 0;
         changed |= last_dynamic != config.GetDynamicPower() ? CHANGED_POWER : 0;
         changed |= last_run_power != (uint8_t)(POWERMGNT::currPower()) ? CHANGED_POWER : 0;
-        changed |= last_tlm != config.GetTlm() ? CHANGED_TELEMETRY : 0;
+        changed |= last_tlm != tlmIdx ? CHANGED_TELEMETRY : 0;
         changed |= last_motion != config.GetMotionMode() ? CHANGED_MOTION : 0;
         changed |= last_fan != config.GetFanMode() ? CHANGED_FAN : 0;
     }
@@ -89,7 +91,7 @@ static void displayIdleScreen(bool init)
         last_temperature = temperature;
         last_rate = config.GetRate();
         last_power = config.GetPower();
-        last_tlm = config.GetTlm();
+        last_tlm = tlmIdx;
         last_motion = config.GetMotionMode();
         last_fan = config.GetFanMode();
         last_dynamic = config.GetDynamicPower();

--- a/src/lib/SCREEN/menu.h
+++ b/src/lib/SCREEN/menu.h
@@ -33,6 +33,7 @@ enum fsm_state_s {
     // These do not have menu text or icons
     STATE_SPLASH = 100,
     STATE_IDLE,
+    STATE_TELEMETRY_CURR,
 
     STATE_BLE_CONFIRM,
     STATE_BLE_EXECUTE,


### PR DESCRIPTION
Cornucopia of minor display-related issues 
* Fixes "F500" to match the other F-modes -> "F500Hz"
* Shortens fullres display, as they do not fit on OLED (but do on TFT) e.g 333Hz Full -> "333 Full". I tried it also with "333Hz Full" and "333HzFull" while also shifting over the TLM ratio on the idle screen, but you have to move it **a ton** to make the former fit and leaving a gap, and the latter is so crammed together it is hard to read on all displays. LMK if you have a better idea.
* Adds missing 100Hz Fullres to Team900 -> "100 Full"
* Fixes TLM on the idle screen always showing the configured value, not the current value. This is how 2.x shows it, and the other values are "live" as well so this is a bug to me. 🙃