### PR TITLE
SetRFLinkRate must execute if only switchmode changes

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -313,9 +313,12 @@ void ICACHE_RAM_ATTR SetRFLinkRate(uint8_t index) // Set speed of RF link (hz)
   expresslrs_mod_settings_s *const ModParams = get_elrs_airRateConfig(index);
   expresslrs_rf_pref_params_s *const RFperf = get_elrs_RFperfParams(index);
   bool invertIQ = UID[5] & 0x01;
+  OtaSwitchMode_e newSwitchMode = (OtaSwitchMode_e)config.GetSwitchMode();
+
   if ((ModParams == ExpressLRS_currAirRate_Modparams)
     && (RFperf == ExpressLRS_currAirRate_RFperfParams)
-    && (invertIQ == Radio.IQinverted))
+    && (invertIQ == Radio.IQinverted)
+    && (OtaSwitchModeCurrent == newSwitchMode))
     return;
 
   DBGLN("set rate %u", index);
@@ -330,7 +333,7 @@ void ICACHE_RAM_ATTR SetRFLinkRate(uint8_t index) // Set speed of RF link (hz)
                , uidMacSeedGet(), OtaCrcInitializer, (ModParams->radio_type == RADIO_TYPE_SX128x_FLRC)
 #endif
                );
-  OtaUpdateSerializers((OtaSwitchMode_e)config.GetSwitchMode(), ModParams->PayloadLength);
+  OtaUpdateSerializers(newSwitchMode, ModParams->PayloadLength);
   MspSender.setMaxPackageIndex(ELRS_MSP_MAX_PACKAGES);
   TelemetryReceiver.setMaxPackageIndex(OtaIsFullRes ? ELRS8_TELEMETRY_MAX_PACKAGES : ELRS4_TELEMETRY_MAX_PACKAGES);
 


### PR DESCRIPTION
Forces `SetRFLinkRate()` to execute on the TX even if only the switchmode changes.

### The Bug
If ModelID=0 has the same air rate as the another model config, and that second model is selected in EdgeTX, and the switchmode is different, the TX will use the switchmode from ModelID 0 instead of the switchmode from the selected model. This is because `SetRFLinkRate` only checks the air rate parameters and only executes if they are different. However, the switch mode is different so it needs to run to update the serializers.

* Configure Model A in EdgeTX with receiver ID 0
* Set Model A to 100Hz Full (although any mode breaks it, this one is just the most fun)
* Set Model A to Switchmode 16ch Rate/2
* Select Model B in EdgeTX and assign it any other receiver number
* Set Model B to 100Hz Full
* Set Model B to Switchmode 8ch
* Power down the radio, power it back up (should power up to Model B)
* Connect an RX connected to a flight controller and watch ch0-ch3 flip back and forth between ch0-ch3 and ch8-ch12 with each packet. Bonus fun on a fixed wing where they go 1500, 988, 1500, 988, 1500, 988.

Simple solution is that the switchmode needs to be checked too and if it is different, you know, change switch modes.