### PR TITLE
Only build the necessary targets on github

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - id: set-targets
-      run: echo "::set-output name=targets::[$(grep -r "\[env:" src/targets | sed 's/.*://' | sed s/.$// | egrep "(STLINK|UART)" | grep -v DEPRECATED | tr '\n' ','  | sed 's/,$/"\n/' | sed 's/,/","/'g | sed 's/^/"/')]"
+      run: echo "::set-output name=targets::[$( (grep -r "\[env:.*STLINK\]" src/targets/ ; grep "\[env:.*UART\]" src/targets/unified.ini) | sed 's/.*://' | sed s/.$// | egrep "(STLINK|UART)" | grep -v DEPRECATED | tr '\n' ','  | sed 's/,$/"\n/' | sed 's/,/","/'g | sed 's/^/"/')]"
 
   build:
     needs: targets
@@ -108,6 +108,10 @@ jobs:
             mv .pio/build/${{ matrix.target }} ~/artifacts/FCC/`echo ${{ matrix.target }} | sed s/_via.*//`
             ;;
         esac
+        if [[ ${{matrix.target}} == *ESP32* ]] ; then 
+          cp ~/.platformio/packages/framework-arduinoespressif32/tools/sdk/bin/bootloader_dio_40m.bin ~/artifacts/
+          cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin ~/artifacts/
+        fi
 
     - name: Store Artifacts
       uses: actions/upload-artifact@v2-preview


### PR DESCRIPTION
Reduce the number of builds we do in github.

Currently we are building every unique target, which means that for the ESP based targets we are building the same file over and over again because they all extend the Unified target.
This PR reduces the number of builds by selecting on targets which use STLINK (i.e. STM32) and `Unified*UART` targets.
So we go from _86_ builds to _29_. This also reduces the size of the build atrifact from _99.2MB_ to _10.6MB_, which means when we really do binary firmware flashing we reduce the size of peoples download for a particular version.