### PR TITLE
Don't descale FreqCorrection stored in SNR

### DIFF
--- a/src/lib/SX1280Driver/SX1280_Regs.h
+++ b/src/lib/SX1280Driver/SX1280_Regs.h
@@ -12,7 +12,7 @@
 #define SX1280_REG_FLRC_SYNC_ADDR_CTRL_ZERO_MASK    0b11110000
 
 #define SX1280_XTAL_FREQ 52000000
-#define FREQ_STEP ((double)(SX1280_XTAL_FREQ / pow(2.0, 18.0)))
+#define FREQ_STEP ((double)(SX1280_XTAL_FREQ / pow(2.0, 18.0)))  // 198.3642578125
 
 typedef enum
 {

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -147,7 +147,12 @@ void ICACHE_RAM_ATTR LinkStatsFromOta(OTA_LinkStats_s * const ls)
   crsf.LinkStatistics.uplink_RSSI_1 = -(ls->uplink_RSSI_1);
   crsf.LinkStatistics.uplink_RSSI_2 = -(ls->uplink_RSSI_2);
   crsf.LinkStatistics.uplink_Link_quality = ls->lq;
+#if defined(DEBUG_FREQ_CORRECTION)
+  // Don't descale the FreqCorrection value being send in SNR
+  crsf.LinkStatistics.uplink_SNR = snrScaled;
+#else
   crsf.LinkStatistics.uplink_SNR = SNR_DESCALE(snrScaled);
+#endif
   crsf.LinkStatistics.active_antenna = ls->antenna;
   connectionHasModelMatch = ls->modelMatch;
   // -- downlink_SNR / downlink_RSSI is updated for any packet received, not just Linkstats

--- a/src/user_defines.txt
+++ b/src/user_defines.txt
@@ -109,4 +109,5 @@
 
 # Enable reporting of RF FreqCorrection in RX's SNR LinkStatistics, also decreases packet rate
 # on Team2.4 for the additional time needed to include the packet header / enable FreqCorrection
+# Dynamic power must be off, else it will adjust based on the FreqCorrection reported in SNR
 #-DDEBUG_FREQ_CORRECTION


### PR DESCRIPTION
When DEBUG_FREQ_CORRECTION is used, the SNR sent in Linkstats is actually the RX's FreqCorrection. The dynamic power PR made it scale the reported SNR down when it is received, but we don't want to do that when doing DEBUG_FREQ_CORRECTION. This removes it and adds a comment about not using Dynamic Power to the user_defines blurb about it.

###  Docs
Just in case this is googleable, DEBUG_FREQ_CORRECTION sends the current FreqCorrection from the RX in the SNR field, scaled from -127 to +127 where 127 is the maximum correction: 200kHz for Team2.4, 100kHz for Team900. Anything outside of +/-64 is probably not good and note that the value will change as the devices warm up.

**Dynamic Power must be disabled** when testing, as it needs the SNR to make adjustments and you want to lock the power anyway.