### PR TITLE
Remove extra ClearIrqStatus call

### DIFF
--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -559,5 +559,9 @@ void ICACHE_RAM_ATTR SX1280Driver::IsrCallback(SX1280_Radio_Number_t radioNumber
             irqClearRadio = SX1280_Radio_All; // Packet received so clear all radios and dont spend extra time retrieving data.
         }
     }
+    else
+    {
+        return;
+    }
     instance->ClearIrqStatus(SX1280_IRQ_RADIO_ALL, irqClearRadio);
 }


### PR DESCRIPTION
The refact in https://github.com/ExpressLRS/ExpressLRS/pull/1644 introduced an extra ClearIrqStatus() call when using diversity receivers.

With dual radios, after a successful packet has been received both IRQs are cleared.  But the second radios interrupt may still call IsrCallback().  It should just call GetIrqStatus(), return no IRQs, and exit.  The refract ends up calling ClearIrqStatus() again and clears nothing.

You can see the extra SPI transaction at the end.
![image](https://user-images.githubusercontent.com/14170229/176109353-bd9574d4-a0d8-4572-afa6-61b0cec842b7.png)

And now it is removed as per OG PR.
![image](https://user-images.githubusercontent.com/14170229/176109480-9f2d475c-fd95-49a3-9de0-da0bd75f2d51.png)
