### PR TITLE
fix binding after OTA change

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1558,6 +1558,8 @@ void ExitBindingMode()
         return;
     }
 
+    MspReceiver.ResetState();
+
     // Prevent any new packets from coming in
     Radio.SetTxIdleMode();
     // Write the values to eeprom

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1588,11 +1588,11 @@ void ExitBindingMode()
     devicesTriggerEvent();
 }
 
-void ICACHE_RAM_ATTR OnELRSBindMSP(uint8_t* packet)
+void ICACHE_RAM_ATTR OnELRSBindMSP(uint8_t* newUid4)
 {
     for (int i = 0; i < 4; i++)
     {
-        UID[i + 2] = packet[i];
+        UID[i + 2] = newUid4[i];
     }
 
     DBGLN("New UID = %d, %d, %d, %d, %d, %d", UID[0], UID[1], UID[2], UID[3], UID[4], UID[5]);

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1590,9 +1590,9 @@ void ExitBindingMode()
 
 void ICACHE_RAM_ATTR OnELRSBindMSP(uint8_t* packet)
 {
-    for (int i = 1; i <=4; i++)
+    for (int i = 0; i < 4; i++)
     {
-        UID[i + 1] = packet[i];
+        UID[i + 2] = packet[i];
     }
 
     DBGLN("New UID = %d, %d, %d, %d, %d, %d", UID[0], UID[1], UID[2], UID[3], UID[4], UID[5]);

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -788,6 +788,8 @@ void ExitBindingMode()
     return;
   }
 
+  MspSender.ResetState();
+
   // Reset UID to defined values
   memcpy(UID, MasterUID, UID_LEN);
   OtaUpdateCrcInitFromUid();


### PR DESCRIPTION
Fixes the UID bytes that were not being set correctly during manual binding.

The tx was also not exiting TLM 1:2 mode after binding.  Im not sure if this is the correct way to fix it, but Ive added a MspSender.ResetState().