### PR TITLE
Fix version number parsing

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -1027,26 +1027,32 @@ uint32_t CRSF::VersionStrToU32(const char *verStr)
 #if !defined(FORCE_NO_DEVICE_VERSION)
     uint8_t accumulator = 0;
     char c;
+    bool trailing_data = false;
     while ((c = *verStr))
     {
         ++verStr;
         // A decimal indicates moving to a new version field
-        // and the space after the version ends that field
-        if (c == '.' || c == ' ')
+        if (c == '.')
         {
             retVal = (retVal << 8) | accumulator;
             accumulator = 0;
+            trailing_data = false;
         }
         // Else if this is a number add it up
         else if (c >= '0' && c <= '9')
         {
             accumulator = (accumulator * 10) + (c - '0');
+            trailing_data = true;
         }
-        // Anything except [0-9. ] ends the parsing
+        // Anything except [0-9.] ends the parsing
         else
         {
             break;
         }
+    }
+    if (trailing_data)
+    {
+        retVal = (retVal << 8) | accumulator;
     }
 #endif
     return retVal;

--- a/src/lib/OPTIONS/options.cpp
+++ b/src/lib/OPTIONS/options.cpp
@@ -9,7 +9,11 @@
 const unsigned char target_name[] = "\xBE\xEF\xCA\xFE" STR(TARGET_NAME);
 const uint8_t target_name_size = sizeof(target_name);
 const char commit[] {LATEST_COMMIT, 0};
+#if defined(UNIT_TEST)
+const char version[] = "1.2.3";
+#else
 const char version[] = {LATEST_VERSION, 0};
+#endif
 
 #if defined(TARGET_TX)
 const char *wifi_hostname = "elrs_tx";

--- a/src/test/test_crsf/test_crsf.cpp
+++ b/src/test/test_crsf/test_crsf.cpp
@@ -26,6 +26,7 @@ void test_ver_to_u32(void)
         {{0x32, 0x2e, 0x32, 0x2e, 0x31, 0x35, 32,73,83,77,50,71,52,0}, 0x0002020f}, // 2.2.15 ISM2G4
         {{0x31, 0x2e, 0x32, 0x2e, 0x33, 0x2e, 0x34, 32,73,83,77,50,71,52,0}, 0x01020304}, // 1.2.3.4 ISM2G4
         {{0x31, 0x30, 0x30, 0x2e, 0x32, 0x35, 0x35, 32,0}, 0x000064ff}, // 100.255(space)
+        {"3.1.2",0x00030102},
         {{0}, 0},
     };
 
@@ -57,12 +58,9 @@ void test_device_info(void)
     TEST_ASSERT_EQUAL(DEVICE_INFORMATION_FRAME_SIZE, header->frame_size);
 
     uint8_t *data = deviceInformation + sizeof(crsf_ext_header_t);
-    uint8_t compare [] = {0x74, 0x65, 0x73, 0x74, 0x69, 0x6e, 0x67, 0x0, 0x45, 0x4c, 0x52, 0x53, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    uint8_t compare [] = {'t', 'e', 's', 't', 'i', 'n', 'g', 0x0, 0x45, 0x4c, 0x52, 0x53, 0x0, 0x0, 0x0, 0x0, 0x0, 1, 2, 3, 0x0, 0x0};
 
-    for(int i = 0; i < DEVICE_INFORMATION_PAYLOAD_LENGTH; i++)
-    {
-        TEST_ASSERT_EQUAL(compare[i], data[i]);
-    }
+    TEST_ASSERT_EQUAL_INT8_ARRAY(compare, data, sizeof(compare));
 
     TEST_ASSERT_EQUAL(test_crc.calc(&deviceInformation[2], DEVICE_INFORMATION_LENGTH-3), deviceInformation[DEVICE_INFORMATION_LENGTH - 1]);
 }


### PR DESCRIPTION
The parser for version numbers assumed that there was a trailing text on the end of the version number (e.g. ' ISMG24'), that was true for 2.x but not for 3.x!
