### PR TITLE
Display warning/error when changing packet and baud-rate too low

### DIFF
--- a/src/lib/LUA/lua.cpp
+++ b/src/lib/LUA/lua.cpp
@@ -270,7 +270,7 @@ void sendELRSstatus()
     "[ ! Armed ! ]",      //warning2, AUX1 high / armed
     "",           //warning1, reserved for future use
     "Not while connected",  //critical warning3, trying to change a protected value while connected
-    "",  //critical warning2, reserved for future use
+    "Baud rate too low",  //critical warning2, changing packet rate and baud rate too low
     ""   //critical warning1, reserved for future use
   };
   const char * warningInfo = "";

--- a/src/lib/LUA/lua.h
+++ b/src/lib/LUA/lua.h
@@ -15,7 +15,7 @@ enum lua_Flags{
     LUA_FLAG_WARNING1,
     //bit 5,6,7 are critical warning flag, block the lua screen until user confirm to suppress the warning.
     LUA_FLAG_ERROR_CONNECTED,
-    LUA_FLAG_CRITICAL_WARNING1,
+    LUA_FLAG_ERROR_BAUDRATE,
     LUA_FLAG_CRITICAL_WARNING2,
 };
 

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -534,15 +534,19 @@ static void registerLuaParameters()
     registerLUAParameter(&luaAirRate, [](struct luaPropertiesCommon *item, uint8_t arg) {
     if (arg < RATE_MAX)
     {
-      uint8_t newRate = RATE_MAX - 1 - arg;
-      newRate = adjustPacketRateForBaud(newRate);
+      uint8_t selectedRate = RATE_MAX - 1 - arg;
+      uint8_t actualRate = adjustPacketRateForBaud(selectedRate);
       uint8_t newSwitchMode = adjustSwitchModeForAirRate(
-        (OtaSwitchMode_e)config.GetSwitchMode(), get_elrs_airRateConfig(newRate)->PayloadLength);
+        (OtaSwitchMode_e)config.GetSwitchMode(), get_elrs_airRateConfig(actualRate)->PayloadLength);
       // If the switch mode is going to change, block the change while connected
       if (newSwitchMode == OtaSwitchModeCurrent || connectionState == disconnected)
       {
-        config.SetRate(newRate);
+        config.SetRate(actualRate);
         config.SetSwitchMode(newSwitchMode);
+        if (actualRate != selectedRate)
+        {
+          setLuaWarningFlag(LUA_FLAG_ERROR_BAUDRATE, true);
+        }
       }
       else
         setLuaWarningFlag(LUA_FLAG_ERROR_CONNECTED, true);


### PR DESCRIPTION
# Problem
When a user changes the packet rate and the baud rate is too low, the packet rate doesn't "stick" and the user thinks it's a bug.

# Solution
Display an error/warning message so the user is aware that the baud rate is too low.