### PR TITLE
XOR major version number with OtaCrcInitializer and macSeed 

### DIFF
--- a/src/include/common.h
+++ b/src/include/common.h
@@ -13,6 +13,10 @@
 
 #endif // UNIT_TEST
 
+// Used to XOR with OtaCrcInitializer and macSeed and break compatibility with previous versions.
+// It should be incremented every major release.
+#define ELRS_MAJOR_VERSION_NUMBER      3
+
 extern uint8_t BindingUID[6];
 extern uint8_t UID[6];
 extern uint8_t MasterUID[6];

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -15,7 +15,7 @@
 
 // Used to XOR with OtaCrcInitializer and macSeed and break compatibility with previous versions.
 // It should be incremented every major release.
-#define ELRS_MAJOR_VERSION_NUMBER      3
+#define OTA_VERSION_ID      3
 
 extern uint8_t BindingUID[6];
 extern uint8_t UID[6];

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -13,8 +13,8 @@
 
 #endif // UNIT_TEST
 
-// Used to XOR with OtaCrcInitializer and macSeed and break compatibility with previous versions.
-// It should be incremented every major release.
+// Used to XOR with OtaCrcInitializer and macSeed to reduce compatibility with previous versions.
+// It should be incremented when the OTA packet structure is modified.
 #define OTA_VERSION_ID      3
 
 extern uint8_t BindingUID[6];

--- a/src/lib/OTA/OTA.cpp
+++ b/src/lib/OTA/OTA.cpp
@@ -26,6 +26,7 @@ GeneratePacketCrc_t OtaGeneratePacketCrc;
 void OtaUpdateCrcInitFromUid()
 {
     OtaCrcInitializer = (UID[4] << 8) | UID[5];
+    OtaCrcInitializer ^= ELRS_MAJOR_VERSION_NUMBER;
 }
 
 static inline uint8_t ICACHE_RAM_ATTR HybridWideNonceToSwitchIndex(uint8_t const nonce)

--- a/src/lib/OTA/OTA.cpp
+++ b/src/lib/OTA/OTA.cpp
@@ -26,7 +26,7 @@ GeneratePacketCrc_t OtaGeneratePacketCrc;
 void OtaUpdateCrcInitFromUid()
 {
     OtaCrcInitializer = (UID[4] << 8) | UID[5];
-    OtaCrcInitializer ^= ELRS_MAJOR_VERSION_NUMBER;
+    OtaCrcInitializer ^= OTA_VERSION_ID;
 }
 
 static inline uint8_t ICACHE_RAM_ATTR HybridWideNonceToSwitchIndex(uint8_t const nonce)

--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -181,7 +181,7 @@ uint16_t RateEnumToHz(expresslrs_RFrates_e const eRate)
 uint32_t uidMacSeedGet(void)
 {
     const uint32_t macSeed = ((uint32_t)UID[2] << 24) + ((uint32_t)UID[3] << 16) +
-                             ((uint32_t)UID[4] << 8) + UID[5]^ELRS_MAJOR_VERSION_NUMBER;
+                             ((uint32_t)UID[4] << 8) + UID[5]^OTA_VERSION_ID;
     return macSeed;
 }
 

--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -181,7 +181,7 @@ uint16_t RateEnumToHz(expresslrs_RFrates_e const eRate)
 uint32_t uidMacSeedGet(void)
 {
     const uint32_t macSeed = ((uint32_t)UID[2] << 24) + ((uint32_t)UID[3] << 16) +
-                             ((uint32_t)UID[4] << 8) + UID[5];
+                             ((uint32_t)UID[4] << 8) + UID[5]^ELRS_MAJOR_VERSION_NUMBER;
     return macSeed;
 }
 


### PR DESCRIPTION
This PR aims to further break compatibility with previous major version that have different OTA packets.  It should also be easy to update for future major releases.

Changing the OtaCrcInitializer is enough stop receivers of on different major releases.  Additionally macSeed is modified to change the FHSS hop table, and the FLRC sync word.