### PR TITLE
R9MM RX resetting config on every reboot

### DIFF
--- a/src/src/rxtx_common.cpp
+++ b/src/src/rxtx_common.cpp
@@ -15,7 +15,13 @@ void setupTargetCommon()
 #if defined(USE_I2C)
   if(GPIO_PIN_SDA != UNDEF_PIN && GPIO_PIN_SCL != UNDEF_PIN)
   {
-    Wire.begin(GPIO_PIN_SDA, GPIO_PIN_SCL);
+#if defined(PLATFORM_STM32)
+    Wire.setSCL(GPIO_PIN_SCL);
+    Wire.setSDA(GPIO_PIN_SDA);
+#else
+    Wire.setPins(GPIO_PIN_SDA, GPIO_PIN_SDA);
+#endif
+    Wire.begin();
   }
 #endif
 }

--- a/src/src/rxtx_common.cpp
+++ b/src/src/rxtx_common.cpp
@@ -10,20 +10,29 @@ static uint32_t startDeferredTime = 0;
 static uint32_t deferredTimeout = 0;
 static std::function<void()> deferredFunction = nullptr;
 
-void setupTargetCommon()
+static void setupWire()
 {
 #if defined(USE_I2C)
-  if(GPIO_PIN_SDA != UNDEF_PIN && GPIO_PIN_SCL != UNDEF_PIN)
-  {
+    if(GPIO_PIN_SDA != UNDEF_PIN && GPIO_PIN_SCL != UNDEF_PIN)
+    {
 #if defined(PLATFORM_STM32)
-    Wire.setSCL(GPIO_PIN_SCL);
-    Wire.setSDA(GPIO_PIN_SDA);
+        // Wire::begin() passing ints is ambiguously overloaded, use the set functions
+        // which themselves might get the PinName overloads
+        Wire.setSCL(GPIO_PIN_SCL);
+        Wire.setSDA(GPIO_PIN_SDA);
+        Wire.begin();
 #else
-    Wire.setPins(GPIO_PIN_SDA, GPIO_PIN_SDA);
+        // ESP hopes to get Wire::begin(int, int)
+        // ESP32 hopes to get Wire::begin(int = -1, int = -1, uint32 = 0)
+        Wire.begin((int)GPIO_PIN_SCL, (int)GPIO_PIN_SDA);
 #endif
-    Wire.begin();
-  }
+    }
 #endif
+}
+
+void setupTargetCommon()
+{
+    setupWire();
 }
 
 void deferExecution(uint32_t ms, std::function<void()> f)


### PR DESCRIPTION
This resolves an issue in extEEPROM not being correctly initialized on STM32 targets which use it, which results in them resetting their config to defaults on every boot.

## Details
I brought this up in the 3.0 Config PR where I mentioned that R9MM failed the test every time due to EEPROM just reporting garbage, This I finally was able to track down and now it is so clear!
```asm
rxtx_common.cpp
_Z17setupTargetCommonv:
	@ args = 0, pretend = 0, frame = 0
	@ frame_needed = 0, uses_anonymous_args = 0
	@ link register save eliminated.
	movs	r2, #1
	movs	r1, #22
	ldr	r0, .L7
	b	_ZN7TwoWire5beginEib
.L8:
	.align	2
.L7:
	.word	Wire
	.size	_Z17setupTargetCommonv, .-_Z17setupTargetCommonv

Wire.cpp
	.section	.text._ZN7TwoWire5beginEib,"ax",%progbits
	.align	1
	.global	_ZN7TwoWire5beginEib
	.syntax unified
	.thumb
	.thumb_func
	.fpu softvfp
	.type	_ZN7TwoWire5beginEib, %function
_ZN7TwoWire5beginEib:
	@ args = 0, pretend = 0, frame = 0
	@ frame_needed = 0, uses_anonymous_args = 0
	@ link register save eliminated.
	uxtb	r1, r1
	b	_ZN7TwoWire5beginEhb
	.size	_ZN7TwoWire5beginEib, .-_ZN7TwoWire5beginEib
	.section	.text._ZN7TwoWire5beginEhb,"ax",%progbits
	.align	1
	.global	_ZN7TwoWire5beginEhb
	.syntax unified
	.thumb
	.thumb_func
	.fpu softvfp
	.type	_ZN7TwoWire5beginEhb, %function
_ZN7TwoWire5beginEhb:
	@ args = 0, pretend = 0, frame = 0
	@ frame_needed = 0, uses_anonymous_args = 0
	push	{r3, r4, r5, lr}
	movs	r3, #0
	mov	r4, r0
	strd	r3, r3, [r0, #16]
	strd	r3, r3, [r0, #24]
	str	r3, [r0, #188]
	lsls	r3, r1, #1
	uxtb	r3, r3
	strb	r3, [r0, #32]
	str	r0, [r0, #124]
	subs	r0, r1, #1
	rsbs	r1, r0, #0
	adcs	r1, r1, r0
	add	r5, r4, #36
	strb	r1, [r4, #186]
	strb	r2, [r4, #187]
	mov	r0, r5
	mov	r2, #16384
	ldr	r1, .L47
	bl	i2c_custom_init
	ldrb	r3, [r4, #186]	@ zero_extendqisi2
	cbnz	r3, .L45
	mov	r0, r5
	ldr	r1, .L47+4
	bl	i2c_attachSlaveTxEvent
	mov	r0, r5
	pop	{r3, r4, r5, lr}
	ldr	r1, .L47+8
	b	i2c_attachSlaveRxEvent
.L45:
	pop	{r3, r4, r5, pc}
.L48:
	.align	2
.L47:
	.word	100000
	.word	_ZN7TwoWire16onRequestServiceEP5i2c_s
	.word	_ZN7TwoWire16onReceiveServiceEP5i2c_s
	.size	_ZN7TwoWire5beginEhb, .-_ZN7TwoWire5beginEhb
```
I mean obvious right?! Let me explain it in C++
```C++
Wire.begin(GPIO_PIN_SDA, GPIO_PIN_SCL); 
// expects to call
void TwoWire::begin(uint32_t sda, uint32_t scl)
// but GPIO_PIN_SDA = PB7 = 22
// 22 has specifier so that is (int)22 and therefore we actually get
void TwoWire::begin(int address, bool generalCall = false);
```

To remedy this, all that's needed is to cast `(uint32_t)GPIO_PIN_SDA` but I thought that would just end up as a trap later when someone was like "WTF is this extra cast for?" and breaks it by removing it. I've replaced the code with explicit setters (which themselves are problematic because there are two matches for each of those functions too!) but this does link to the proper function. Still something to watch out for if we add STM32 targets that use PinName pin defines instead of integer pin defines.

### Tested
* R9MM RX - without this code, it reports "Config version 0" on every boot. With it, I get "Config version 5" (correct)
* BetaFPV Micro 1000mW - Uses I2C OLED and still works but also worked previously, since ESP32 doesn't have ambiguous overloads for `Wire::begin()`

### Weeping
Building DUPLETX_ESP worked fine, but VOYAGER_900_ESP doesn't?! How can people come up with 19 different ways of implementing `Wire.begin()`