### PR TITLE
Enable DCDC only when enabled

### DIFF
--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -101,7 +101,10 @@ bool SX1280Driver::Begin()
     hal.WriteRegister(0x0891, (hal.ReadRegister(0x0891, SX1280_Radio_1) | 0xC0), SX1280_Radio_1);   //default is low power mode, switch to high sensitivity instead
     hal.WriteCommand(SX1280_RADIO_SET_AUTOFS, 0x01, SX1280_Radio_All);                              //Enable auto FS
 #if defined(USE_SX1280_DCDC)
-    hal.WriteCommand(SX1280_RADIO_SET_REGULATORMODE, SX1280_USE_DCDC, SX1280_Radio_All);            // Enable DCDC converter instead of LDO
+    if (OPT_USE_SX1280_DCDC)
+    {
+        hal.WriteCommand(SX1280_RADIO_SET_REGULATORMODE, SX1280_USE_DCDC, SX1280_Radio_All);          // Enable DCDC converter instead of LDO
+    }
 #endif
 
     return true;

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -103,7 +103,7 @@ bool SX1280Driver::Begin()
 #if defined(USE_SX1280_DCDC)
     if (OPT_USE_SX1280_DCDC)
     {
-        hal.WriteCommand(SX1280_RADIO_SET_REGULATORMODE, SX1280_USE_DCDC, SX1280_Radio_All);          // Enable DCDC converter instead of LDO
+        hal.WriteCommand(SX1280_RADIO_SET_REGULATORMODE, SX1280_USE_DCDC, SX1280_Radio_All);        // Enable DCDC converter instead of LDO
     }
 #endif
 


### PR DESCRIPTION
In RC1/master the DCDC is always enabled on the SX1280 because the option **value** is not checked. This checks the value before enabling it.

### Pretty Stuff to Delight the Senses
I tried toggling the DCDC to see if it is actually working, because it seems that stuff without the external inductor still work OK without it and the feature enabled. Well turns out we were always turning it on for every target. I detected this by measuring the current draw (1mV/1mA) and noted they were the same, leading to finding the bug. With the proper code in place the current differs if the DCDC is enabled in hardware.json or not. (Tests are iFlight 2400 RX, which has the inductor, but no PA/LNA)

DCDC disabled (73mA transmit, 43mA receive)
![DS1Z_QuickPrint25](https://user-images.githubusercontent.com/677183/177910913-fc1482ef-b0b5-4e49-9725-313c04874f56.png)

DCDC enabled (51mA transmit, 36mA receive)
![DS1Z_QuickPrint26](https://user-images.githubusercontent.com/677183/177911033-679c1615-0b1a-4ae2-9e51-90009e221bf9.png)

### Unexpected Consequences
Well shoot, if it doesn't hurt to have it on all the time, who cares, just always enable DCDC right? I was going to recommend that but I remembered the Namimno OLED doesn't have the inductor, and that is the TX module I had so many problems on SF9 (50Hz before we changed it to SF8). With this PR, and taking 50Hz back to SF9 LI 4/6, the amount of CRC errors decreased dramatically. It was very obvious in the scoreboard when I enabled the DCDC on the Namimno even though it did not have the right hardware with these RF modparams. The LQ is noticeably lower when the DCDC option is incorrectly applied.

It also makes sense with what I saw that began the whole suite of 50Hz testing: my Zorro (has DCDC) would lose telemetry from an EP2 RX (no DCDC) but the uplink was 100LQ. This leads me to the conclusion that

### Enabling DCDC when the inductor is not present reduces link quality from the misconfigured side

And that means we need to PR a change to have separate Unified bases for those with DCDC and those without.