### PR TITLE
Fix LED not showing WIFI mode when started from Binding mode

### DIFF
--- a/src/lib/BUTTON/devButton.cpp
+++ b/src/lib/BUTTON/devButton.cpp
@@ -49,13 +49,15 @@ static void cyclePower()
 #include <FS.h>
 #endif
 
+extern void setWifiUpdateMode();
+
 static void buttonRxLong()
 {
 #if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
     // ESP/ESP32 goes to wifi mode in 5x longpress
     if (button.getLongCount() > 4 && connectionState != wifiUpdate)
     {
-        connectionState = wifiUpdate;
+        setWifiUpdateMode();
     }
 #endif
 

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -342,9 +342,7 @@ static void luahandWifiBle(struct luaPropertiesCommon *item, uint8_t arg)
   const char *textRunning;
   if ((void *)item == (void *)&luaWebUpdate)
   {
-    setTargetState = []() {
-      setWifiUpdateMode();
-    };
+    setTargetState = setWifiUpdateMode;
     textConfirm = "Enter WiFi Update?";
     textRunning = "WiFi Running...";
   }

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -246,7 +246,7 @@ extern bool VRxBackpackWiFiReadyToSend;
 #endif
 #if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
 extern unsigned long rebootTime;
-extern void beginWebsever();
+extern void setWifiUpdateMode();
 #endif
 
 static void luadevUpdateRateSensitivity() {
@@ -336,18 +336,23 @@ static void luadevGeneratePowerOpts()
 static void luahandWifiBle(struct luaPropertiesCommon *item, uint8_t arg)
 {
   struct luaItem_command *cmd = (struct luaItem_command *)item;
+  std::function<void()> setTargetState;
   connectionState_e targetState;
   const char *textConfirm;
   const char *textRunning;
   if ((void *)item == (void *)&luaWebUpdate)
   {
-    targetState = wifiUpdate;
+    setTargetState = []() {
+      setWifiUpdateMode();
+    };
     textConfirm = "Enter WiFi Update?";
     textRunning = "WiFi Running...";
   }
   else
   {
-    targetState = bleJoystick;
+    setTargetState = []() {
+      connectionState = bleJoystick;
+    };
     textConfirm = "Start BLE Joystick?";
     textRunning = "Joystick Running...";
   }
@@ -364,7 +369,7 @@ static void luahandWifiBle(struct luaPropertiesCommon *item, uint8_t arg)
 
     case lcsConfirmed:
       sendLuaCommandResponse(cmd, lcsExecuting, textRunning);
-      connectionState = targetState;
+      setTargetState();
       break;
 
     case lcsCancel:

--- a/src/lib/SCREEN/menu.cpp
+++ b/src/lib/SCREEN/menu.cpp
@@ -22,6 +22,7 @@ extern bool RxWiFiReadyToSend;
 extern bool TxBackpackWiFiReadyToSend;
 extern bool VRxBackpackWiFiReadyToSend;
 extern void VtxTriggerSend();
+extern void setWifiUpdateMode();
 
 extern Display *display;
 
@@ -307,7 +308,9 @@ static void executeWiFi(bool init)
         switch (state_machine.getParentState())
         {
             case STATE_WIFI_TX:
-                connectionState = wifiUpdate;
+#if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
+                setWifiUpdateMode();
+#endif
                 break;
             case STATE_WIFI_RX:
                 RxWiFiReadyToSend = true;

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -646,6 +646,8 @@ static void startWiFi(unsigned long now)
     connectionState = wifiUpdate;
 
     DBGLN("Stopping Radio");
+    InBindingMode = false;
+    devicesTriggerEvent();
     Radio.End();
   }
 

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -91,7 +91,6 @@ void setWifiUpdateMode()
   // Need to change this before the mode change event so the LED is updated
   InBindingMode = false;
   connectionState = wifiUpdate;
-  devicesTriggerEvent();
 }
 
 /** Is this an IP? */
@@ -653,12 +652,9 @@ static void startWiFi(unsigned long now)
     // Set transmit power to minimum
     POWERMGNT::setPower(MinPower);
 
-    // Calling this means the LED and other devices will be notified of the change in state.
     setWifiUpdateMode();
 
     DBGLN("Stopping Radio");
-    InBindingMode = false;
-    devicesTriggerEvent();
     Radio.End();
   }
 

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -184,6 +184,7 @@ void reset_into_bootloader(void);
 void EnterBindingMode();
 void ExitBindingMode();
 void OnELRSBindMSP(uint8_t* packet);
+extern void setWifiUpdateMode();
 
 static uint8_t minLqForChaos()
 {
@@ -933,7 +934,7 @@ void MspReceiveComplete()
         // The MSP packet needs to be ACKed so the TX doesn't
         // keep sending it, so defer the switch to wifi
         deferExecution(500, []() {
-            connectionState = wifiUpdate;
+            setWifiUpdateMode();
         });
 #endif
     }


### PR DESCRIPTION
When using the button on an RX to enter wifi mode and the RX was in binding mode, binding mode was not cancelled and non of the other devices informed of the state change.
The problem with this is that the RX does go to WiFi mode, but the LED says it's still in binding mode and confuses the users.
