### PR TITLE
Fix issue with WIFI upload reporting success when upload fails

### DIFF
--- a/src/python/upload_via_esp8266_backpack.py
+++ b/src/python/upload_via_esp8266_backpack.py
@@ -122,4 +122,4 @@ def on_upload(source, target, env):
 
     pio_target = target[0].name
     isstm = env.get('PIOPLATFORM', '') in ['ststm32']
-    do_upload(elrs_bin_target, pio_target, upload_addr, isstm, env)
+    return do_upload(elrs_bin_target, pio_target, upload_addr, isstm, env)


### PR DESCRIPTION
Missing return statement at the end of the on_upload function in upload_via_esp8266_backpack.py is causing PIO and the configurator to report success even when the WIFI upload fails.

![image](https://user-images.githubusercontent.com/38869875/178041609-bcf9c074-f315-4b77-8590-6dec50f134b7.png)
