### PR TITLE
Fix the default led on R9M

### DIFF
--- a/src/lib/LED/devLED.cpp
+++ b/src/lib/LED/devLED.cpp
@@ -16,7 +16,7 @@
 #endif
 #endif
 #ifndef GPIO_PIN_LED
-#define GPIO_PIN_LED UNDEF_PIN
+#define GPIO_PIN_LED GPIO_PIN_LED_RED
 #endif
 #ifndef GPIO_PIN_LED_GREEN
 #define GPIO_PIN_LED_GREEN UNDEF_PIN


### PR DESCRIPTION
I noticed while testing that when in traditional mode, the LED on the R9M was not doing the correct bind flash.
This was because the default led was not setup correctly. i.e. the default led (if not defined) should be the red led.
