### PR TITLE
Adjust T-Lite power levels with power meter

### DIFF
--- a/src/hardware/TX/Jumper T-Lite.json
+++ b/src/hardware/TX/Jumper T-Lite.json
@@ -17,7 +17,7 @@
     "power_max": 3,
     "power_default": 2,
     "power_control": 0,
-    "power_values": [-10,-6,-3,6],
+    "power_values": [-11,-7,-4,1],
     "use_backpack": false,
     "debug_backpack_baud": 460800,
     "debug_backpack_rx": 13,


### PR DESCRIPTION
The T-Lite is outputting more power than it should, at least my sample unit. This adjusts them as measured with my IMRC power meter.

| Set Power | Measured Power | This PR |
|--|--|--|
|10mW | 12mW | 10.3mW |
| 25mW | 31mW | 24.1mW |
| 50mW | 61mW  | 49.5mW |
| 100mW | 138mW | 109mW |

Trying to get 100mW right, +0 ends up being 97mW which eventually degrades after 10 minutes to 94-95mW. Since Jumper claims 150mW (which I can't get at any power level) I figure it is better to go a little high for the final power level.

```
0=97mW
1=111
3=127
6=138
7=139
8=140
9=140
```