### PR TITLE
Fix for failed g-sensor

### DIFF
--- a/src/lib/GSENSOR/devGsensor.cpp
+++ b/src/lib/GSENSOR/devGsensor.cpp
@@ -39,17 +39,19 @@ extern void deferExecution(uint32_t ms, std::function<void()> f);
 #define MULTIPLE_BUMP_INTERVAL 400U
 #define BUMP_COMMAND_IDLE_TIME 10000U
 
+static bool gSensorOk = false;
+
 static void initialize()
 {
     if (OPT_HAS_GSENSOR && GPIO_PIN_SCL != UNDEF_PIN && GPIO_PIN_SDA != UNDEF_PIN)
     {
-        gsensor.init();
+        gSensorOk = gsensor.init();
     }
 }
 
 static int start()
 {
-    if (OPT_HAS_GSENSOR && GPIO_PIN_SCL != UNDEF_PIN && GPIO_PIN_SDA != UNDEF_PIN)
+    if (gSensorOk && OPT_HAS_GSENSOR && GPIO_PIN_SCL != UNDEF_PIN && GPIO_PIN_SDA != UNDEF_PIN)
     {
         return DURATION_IMMEDIATELY;
     }

--- a/src/lib/GSENSOR/gsensor.cpp
+++ b/src/lib/GSENSOR/gsensor.cpp
@@ -41,17 +41,18 @@ ICACHE_RAM_ATTR void handleGsensorInterrupt()
     interrupt = true;
 }
 
-void Gsensor::init()
+bool Gsensor::init()
 {
-    uint8_t id = -1;
+    int16_t id = -1;
     if (OPT_HAS_GSENSOR_STK8xxx)
         id = stk8xxx.STK8xxx_Initialization();
     else
-        return;
+        return false;
 
     if(id == -1)
     {
         ERRLN("Gsensor failed!");
+        return false;
     }
     else
     {
@@ -71,6 +72,7 @@ void Gsensor::init()
 
     system_state = GSENSOR_SYSTEM_STATE_MOVING;
     is_flipped = false;
+    return true;
 }
 
 float get_data_average(float *data, int length)

--- a/src/lib/GSENSOR/gsensor.h
+++ b/src/lib/GSENSOR/gsensor.h
@@ -21,7 +21,7 @@ private:
     int system_state;
     bool is_flipped;
 public:
-    void init();
+    bool init();
     void handle();
     bool hasTriggered(unsigned long now);
     void getGSensorData(float *X_DataOut, float *Y_DataOut, float *Z_DataOut);


### PR DESCRIPTION
If the g-sensor fails (as they do) then we shouldn't be trying to read from it anymore as it has a huge timeout and the entire module becomes unusable!

This fix is to check the status of the g-sensor on startup and remember if it's ok and only use it if it was deemed to be working at initialisation time. i.e. if we managed to read a valid chip-id.