### PR TITLE
Add CORS headers to web UI for web flasher

### DIFF
--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -477,6 +477,11 @@ static void WebUpdateHandleNotFound(AsyncWebServerRequest *request)
   request->send(response);
 }
 
+static void corsPreflightResponse(AsyncWebServerRequest *request) {
+  AsyncWebServerResponse *response = request->beginResponse(204, "text/plain");
+  request->send(response);
+}
+
 static void WebUploadResponseHandler(AsyncWebServerRequest *request) {
   if (target_seen) {
     String msg;
@@ -783,7 +788,14 @@ static void startServices()
   server.on("/fwlink", WebUpdateHandleRoot);
 
   server.on("/update", HTTP_POST, WebUploadResponseHandler, WebUploadDataHandler);
+  server.on("/update", HTTP_OPTIONS, corsPreflightResponse);
   server.on("/forceupdate", WebUploadForceUpdateHandler);
+  server.on("/forceupdate", HTTP_OPTIONS, corsPreflightResponse);
+  
+  DefaultHeaders::Instance().addHeader("Access-Control-Allow-Origin", "*");
+  DefaultHeaders::Instance().addHeader("Access-Control-Max-Age", "600");
+  DefaultHeaders::Instance().addHeader("Access-Control-Allow-Methods", "POST,GET,OPTIONS");
+  DefaultHeaders::Instance().addHeader("Access-Control-Allow-Headers", "*");
 
   #if defined(TARGET_RX)
     server.on("/model", WebUpdateModelId);


### PR DESCRIPTION
I know this is not a bug per-se, but I'd like to get this into 3.0 so the web-flasher can to wifi flashing after an initial flash of 3.0.