### PR TITLE
Fix for FHSS hopping where freq_count is a power of 2

### DIFF
--- a/src/lib/FHSS/FHSS.cpp
+++ b/src/lib/FHSS/FHSS.cpp
@@ -65,7 +65,7 @@ void FHSSrandomiseFHSSsequence(const uint32_t seed)
     rngSeed(seed);
 
     // initialize the sequence array
-    for (uint8_t i = 0; i < FHSSgetSequenceCount(); i++)
+    for (uint16_t i = 0; i < FHSSgetSequenceCount(); i++)
     {
         if (i % FHSSconfig->freq_count == 0) {
             FHSSsequence[i] = sync_channel;
@@ -76,7 +76,7 @@ void FHSSrandomiseFHSSsequence(const uint32_t seed)
         }
     }
 
-    for (uint8_t i=0; i < FHSSgetSequenceCount(); i++)
+    for (uint16_t i=0; i < FHSSgetSequenceCount(); i++)
     {
         // if it's not the sync channel
         if (i % FHSSconfig->freq_count != 0)
@@ -92,7 +92,7 @@ void FHSSrandomiseFHSSsequence(const uint32_t seed)
     }
 
     // output FHSS sequence
-    for (uint8_t i=0; i < FHSSgetSequenceCount(); i++)
+    for (uint16_t i=0; i < FHSSgetSequenceCount(); i++)
     {
         DBG("%u ",FHSSsequence[i]);
         if (i % 10 == 9)

--- a/src/lib/FHSS/FHSS.h
+++ b/src/lib/FHSS/FHSS.h
@@ -37,7 +37,7 @@ static inline uint32_t FHSSgetChannelCount(void)
 }
 
 // get the number of entries in the FHSS sequence
-static inline uint8_t FHSSgetSequenceCount()
+static inline uint16_t FHSSgetSequenceCount()
 {
     return (256 / FHSSconfig->freq_count) * FHSSconfig->freq_count;
 }


### PR DESCRIPTION
The calculation for the `FHSSgetSequenceCount` was `uint8_t`, but if a domain had a number of frequencies equal to a power of 2 i.e. IN_866 which has 4, then the calculation overflowed to 256 which as a `uint8_t` is zero.

e.g `(256 / 4) * 4 == 256` (as an `int`, but is 0 when assigned to a `uint8_t`)

Luckily the only domain affected is IN_866.