### PR TITLE
Fix log level on RF mode cycling

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1215,7 +1215,7 @@ static void cycleRfMode(unsigned long now)
         // Display the current air rate to the user as an indicator something is happening
         scanIndex++;
         Radio.RXnb();
-        INFOLN("%u", ExpressLRS_currAirRate_Modparams->interval);
+        DBGLN("%u", ExpressLRS_currAirRate_Modparams->interval);
 
         // Switch to FAST_SYNC if not already in it (won't be if was just connected)
         RFmodeCycleMultiplier = 1;


### PR DESCRIPTION
Flashing firmware via BF passthrough can sometimes fail when the receiver is cycling the RF mode at the same time as the flashing script attempts to read the target name.
This results in a target name mismatch, as the script thinks the target is some thing like "1000" instead of "Happymodel EP RX" or whatever.
This change sets the RF mode cycling message to debug, which should prevent this from happening.