### PR TITLE
T-lite elrs 2.5.1 target 

### DIFF
--- a/src/include/target/Jumper_AION_2400_T-Lite_TX.h
+++ b/src/include/target/Jumper_AION_2400_T-Lite_TX.h
@@ -1,0 +1,29 @@
+#define DEVICE_NAME "AION T-Lite TX"
+
+// Any device features
+#define USE_SX1280_DCDC
+
+// GPIO pin definitions
+#define GPIO_PIN_NSS            5
+#define GPIO_PIN_BUSY           21
+#define GPIO_PIN_DIO1           4
+#define GPIO_PIN_DIO2           22
+#define GPIO_PIN_MOSI           23
+#define GPIO_PIN_MISO           19
+#define GPIO_PIN_SCK            18
+#define GPIO_PIN_RST            14
+#define GPIO_PIN_RX_ENABLE      27
+#define GPIO_PIN_TX_ENABLE      26
+#define GPIO_PIN_RCSIGNAL_RX    3
+#define GPIO_PIN_RCSIGNAL_TX    1
+
+// Backpack pins
+#define GPIO_PIN_DEBUG_RX       13
+#define GPIO_PIN_DEBUG_TX       12 
+
+// Output Power
+#define MinPower                PWR_10mW
+#define MaxPower                PWR_100mW
+#define POWER_OUTPUT_VALUES     {-11,-7,-4,-1}
+
+#define Regulatory_Domain_ISM_2400 1

--- a/src/include/target/Jumper_AION_2400_T-Lite_TX.h
+++ b/src/include/target/Jumper_AION_2400_T-Lite_TX.h
@@ -24,6 +24,6 @@
 // Output Power
 #define MinPower                PWR_10mW
 #define MaxPower                PWR_100mW
-#define POWER_OUTPUT_VALUES     {-11,-7,-4,-1}
+#define POWER_OUTPUT_VALUES     {-11,-7,-4,1}
 
 #define Regulatory_Domain_ISM_2400 1

--- a/src/targets/Jumper_2400.ini
+++ b/src/targets/Jumper_2400.ini
@@ -25,7 +25,7 @@ build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}
 	${radio_2400.build_flags}
-	-include target/Jumper_AION_2400_T-Pro_TX.h
+	-include target/Jumper_AION_2400_T-Lite_TX.h
 	-D VTABLES_IN_FLASH=1
 	-O2
 build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>

--- a/src/targets/Jumper_2400.ini
+++ b/src/targets/Jumper_2400.ini
@@ -18,6 +18,21 @@ upload_speed = 460800
 lib_deps =
 	${env_common_esp32.lib_deps}
 
+[env:Jumper_AION_2400_T-Lite_TX_via_WIFI]
+extends = env_common_esp32, radio_2400
+board = pico32
+build_flags =
+	${env_common_esp32.build_flags}
+	${common_env_data.build_flags_tx}
+	${radio_2400.build_flags}
+	-include target/Jumper_AION_2400_T-Pro_TX.h
+	-D VTABLES_IN_FLASH=1
+	-O2
+build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
+upload_speed = 460800
+lib_deps =
+	${env_common_esp32.lib_deps}
+
 [env:Jumper_AION_NANO_2400_TX_via_UART]
 extends = env_common_esp32, radio_2400
 board = pico32


### PR DESCRIPTION
### Problem
T-lite ELRS comes with 3.x preinstalled, and we want fly ERLS SPI

### Solution
We can have this PR open, so users can downgrade their t-lite to 2.5.1 via ELRS Configurator.
Target is based on 3.x pin definitions and power values.
![image](https://user-images.githubusercontent.com/12091173/180287795-dfcd9eac-8ab7-4e87-a0a3-a5482c30de39.png)
