### PR TITLE
Include unchecked checkboxes in options submit

### DIFF
--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -388,7 +388,7 @@ function submitOptions(e) {
   xhr.send(JSON.stringify(formObject, function(k, v) {
     if (v === '') return undefined;
     if (_(k) && _(k).type == 'checkbox') {
-      return true; // all checkboxes in FormData are checked
+      return v == 'on' ? true : false;
     }
     if (_(k) && _(k).classList.contains('array')) {
       const arr = v.split(',').map((element) => {

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -388,7 +388,7 @@ function submitOptions(e) {
   xhr.send(JSON.stringify(formObject, function(k, v) {
     if (v === '') return undefined;
     if (_(k) && _(k).type == 'checkbox') {
-      return v == 'on' ? true : false;
+      return true; // all checkboxes in FormData are checked
     }
     if (_(k) && _(k).classList.contains('array')) {
       const arr = v.split(',').map((element) => {

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -379,8 +379,13 @@ function submitOptions(e) {
   const xhr = new XMLHttpRequest();
   xhr.open('POST', '/options.json');
   xhr.setRequestHeader('Content-Type', 'application/json');
-  const formData = new FormData(_('upload_options'));
-  xhr.send(JSON.stringify(Object.fromEntries(formData), function(k, v) {
+  // Convert the DOM element into a JSON object containing the form elements
+  const formElem = _('upload_options');
+  const formObject = Object.fromEntries(new FormData(formElem));
+  // Add in all the unchecked checkboxes which will be absent from a FormData object
+  formElem.querySelectorAll('input[type=checkbox]:not(:checked)').forEach((k) => formObject[k.name] = false);
+  // Serialize and send the formObject
+  xhr.send(JSON.stringify(formObject, function(k, v) {
     if (v === '') return undefined;
     if (_(k) && _(k).type == 'checkbox') {
       return v == 'on' ? true : false;


### PR DESCRIPTION
This adds unchecked checkboxes to options, which is preventing them from being saved with "false" values. Currently you can not uncheck an Options value in the webui and have it stick. (The individual checkboxes on the model settings page are fine)

### Details
Reported by @robustini [Discord](https://discord.com/channels/596350022191415318/797109686285107241/999907879647707156). If you try to uncheck the box it stays checked.

The issue is because in HTML, always and forever, unchecked checkboxes are not considered to exist at all. Someone in like 1991 thought this would be a brilliant way to save bandwidth or something and we're still saddled with it. When constructing a `new FormData` from a form, only checked checkboxes will be in the new object. Our side when it loads the json, if the value is not in the document, it gets the default value, not "false", so lock-on-first-connection is always true. In order for the value to be false it must be in the JSON.

This code just takes the FormData-derived object and appends all unchecked checkboxes to it manually. The other option would be to add hidden input fields with the same name and value=false, but then they'd be in the JSON twice if checked. HTML checkboxes are a real Pippin.

### Extra
Note that after setting the Options value, the RX/TX code expects to be rebooted, so if the page is reloaded it will have the old values. This is because the string is only updated on init, so just setting the SPIFFS file does nothing until the module is rebooted and the string is recreated.