### PR TITLE
Incorrect board_config for HGLRC Hermes 2400 TX

### DIFF
--- a/src/hardware/TX/HGLRC Hermes 2400.json
+++ b/src/hardware/TX/HGLRC Hermes 2400.json
@@ -17,6 +17,7 @@
     "power_default": 2,
     "power_control": 0,
     "power_values": [-18,-15,-11,-8,-4],
+    "use_backpack": false,
     "debug_backpack_baud": 460800,
     "debug_backpack_rx": 3,
     "debug_backpack_tx": 1

--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -613,7 +613,7 @@
             }
         },
         "tx_2400": {
-            "target": {
+            "hermes": {
                 "product_name": "HGLRC Hermes 2.4GHz TX",
                 "lua_name": "HGLRC Hermes",
                 "layout_file": "HGLRC Hermes 2400.json",


### PR DESCRIPTION
The HGLRC Hermes 2400 TX references `board_config = hglrc.tx_2400.hermes` but it was named `hglrc.tx_2400.target` by mistake. This updates the target file to have the correct name and also adds the explicit `use_backpack: false` to the hardware.json. I know that's redundant but several other hardwares have it, so let me know if I should remove them all @pkendall64?

Without this, no hardware.json is appended to the unified target so we just bootloop when trying to load it.

Reported in #1711