### PR TITLE
Adjust PWMPEX vbat_scale with testing results

### DIFF
--- a/src/hardware/RX/Generic 2400 PWMP6.json
+++ b/src/hardware/RX/Generic 2400 PWMP6.json
@@ -15,5 +15,5 @@
     "pwm_outputs": [0,1,3,9,10,5],
     "vbat": 17,
     "vbat_offset": 12,
-    "vbat_scale": 299
+    "vbat_scale": 310
 }

--- a/src/hardware/RX/Generic 2400 PWMP7.json
+++ b/src/hardware/RX/Generic 2400 PWMP7.json
@@ -14,5 +14,5 @@
     "pwm_outputs": [0,1,3,9,10,5,2],
     "vbat": 17,
     "vbat_offset": 12,
-    "vbat_scale": 299
+    "vbat_scale": 310
 }


### PR DESCRIPTION
This updates the vbat_scale for 6ch PWMPEX receivers with a value obtained from testing with 2x R24-P6 samples provided by Matek. The values tracked from 3.5V to 31.0V exactly in bench testing after this adjustment. 3.0V read as 3.1V but I didn't want to try to mess with it after 310 flippin' nailed the other  more than 25 test points. 🤘 The 7ch is adjusted too, but that target doesn't work currently.

The divider 33k/1k should be 301 per Matek_Sampson, we had 299, but that read too high for me-- 11.35V read as 11.8V. This is something that obviously could be slightly different per batch or temperature (testing was performed at 26C) and can be changed in hardware.html.

Post-3.0 we can work this into the Lua or something better (dedicated webui field?). I've already got space set aside in the config struct to override the hardware definition.