### PR TITLE
Only change RF power when idle, delay disconnected

### DIFF
--- a/src/lib/DAC/DAC.cpp
+++ b/src/lib/DAC/DAC.cpp
@@ -40,14 +40,6 @@ void DAC::resume()
     }
 }
 
-void DAC::setVoltageMV(uint32_t voltsMV)
-{
-    uint8_t ScaledVolts = map(voltsMV, 0, DAC_REF_VCC, 0, 255);
-    setVoltageRegDirect(ScaledVolts);
-    m_currVoltageMV = voltsMV;
-    DBGLN("DAC Voltage %dmV", m_currVoltageMV);
-}
-
 void DAC::setVoltageRegDirect(uint8_t voltReg)
 {
     m_currVoltageRegVal = voltReg;
@@ -60,9 +52,11 @@ void DAC::setVoltageRegDirect(uint8_t voltReg)
     Wire.endTransmission();
 }
 
-void DAC::setPower(int16_t milliVolts)
+void DAC::setPower(uint32_t milliVolts)
 {
-    DAC::setVoltageMV(milliVolts);
+    uint8_t ScaledVolts = map(milliVolts, 0, DAC_REF_VCC, 0, 255);
+    setVoltageRegDirect(ScaledVolts);
+    DBGLN("DAC::setPower(%umV)", milliVolts);
 }
 
 DAC TxDAC;

--- a/src/lib/DAC/DAC.h
+++ b/src/lib/DAC/DAC.h
@@ -19,13 +19,11 @@ public:
     void init();
     void standby();
     void resume();
-    void setVoltageMV(uint32_t voltsMV);
     void setVoltageRegDirect(uint8_t voltReg);
-    void setPower(int16_t milliVolts);
+    void setPower(uint32_t milliVolts);
 
 private:
     DAC_STATE_  m_state;
-    uint32_t    m_currVoltageMV;
     uint8_t     m_currVoltageRegVal;
 };
 

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -32,8 +32,23 @@ const uint8_t SX127x_AllowedSyncwords[105] =
 SX127xDriver::SX127xDriver(): SX12xxDriverCommon()
 {
   instance = this;
-  PayloadLength = 8; // Dummy default value which is overwritten during setup.
-  currFreq = 0; // leave as 0 to ensure that it gets set
+  // default values from datasheet
+  currSyncWord = SX127X_SYNC_WORD;
+  currBW =SX127x_BW_125_00_KHZ;
+  currSF = SX127x_SF_7;
+  currCR = SX127x_CR_4_5;
+  currOpmode = SX127x_OPMODE_SLEEP;
+  ModFSKorLoRa = SX127x_OPMODE_LORA;
+  // Dummy default values which are overwritten during setup
+  currPreambleLen = 0;
+  PayloadLength = 8;
+  currFreq = 0;
+  headerExplMode = false;
+  crcEnabled = false;
+
+  // Force the next power update
+  pwrCurrent = PWRPENDING_NONE;
+  SetOutputPower(0);
 }
 
 bool SX127xDriver::Begin()
@@ -66,6 +81,7 @@ void SX127xDriver::ConfigLoraDefaults()
   hal.writeRegister(SX127X_REG_OP_MODE, ModFSKorLoRa); //must be written in sleep mode
   SetMode(SX127x_OPMODE_STANDBY);
 
+  CommitOutputPower();
   hal.writeRegister(SX127X_REG_PAYLOAD_LENGTH, PayloadLength);
   SetSyncWord(currSyncWord);
   hal.writeRegister(SX127X_REG_FIFO_TX_BASE_ADDR, SX127X_FIFO_TX_BASE_ADDR_MAX);
@@ -154,16 +170,30 @@ void SX127xDriver::SetSyncWord(uint8_t syncWord)
 
 void SX127xDriver::SetOutputPower(uint8_t Power)
 {
-  SetMode(SX127x_OPMODE_STANDBY);
+  uint8_t pwrNew;
   if (OPT_USE_SX1276_RFO_HF)
   {
-    hal.writeRegister(SX127X_REG_PA_CONFIG, SX127X_PA_SELECT_RFO | SX127X_MAX_OUTPUT_POWER_RFO_HF | Power);
+    pwrNew = SX127X_PA_SELECT_RFO | SX127X_MAX_OUTPUT_POWER_RFO_HF | Power;
   }
   else
   {
-    hal.writeRegister(SX127X_REG_PA_CONFIG, SX127X_PA_SELECT_BOOST | SX127X_MAX_OUTPUT_POWER | Power);
+    pwrNew = SX127X_PA_SELECT_BOOST | SX127X_MAX_OUTPUT_POWER | Power;
   }
-  currPWR = Power;
+
+  if (pwrCurrent != pwrNew)
+  {
+    pwrPending = pwrNew;
+  }
+}
+
+void ICACHE_RAM_ATTR SX127xDriver::CommitOutputPower()
+{
+  if (pwrPending != PWRPENDING_NONE)
+  {
+    pwrCurrent = pwrPending;
+    pwrPending = PWRPENDING_NONE;
+    hal.writeRegister(SX127X_REG_PA_CONFIG, pwrCurrent);
+  }
 }
 
 void SX127xDriver::SetPreambleLength(uint8_t PreambleLen)
@@ -301,6 +331,9 @@ void ICACHE_RAM_ATTR SX127xDriver::TXnbISR()
 {
   currOpmode = SX127x_OPMODE_STANDBY; //goes into standby after transmission
   //TXdoneMicros = micros();
+  // The power level must be changed when in SX127x_OPMODE_STANDBY, so this lags power
+  // changes by at most 1 packet, but does not interrupt any pending RX/TX
+  CommitOutputPower();
   TXdoneCallback();
 }
 
@@ -384,7 +417,6 @@ void SX127xDriver::Config(uint8_t bw, uint8_t sf, uint8_t cr, uint32_t freq, uin
   IQinverted = InvertIQ;
   ConfigLoraDefaults();
   SetPreambleLength(preambleLen);
-  SetOutputPower(currPWR);
   SetSpreadingFactor((SX127x_SpreadingFactor)sf);
   SetBandwidthCodingRate((SX127x_Bandwidth)bw, (SX127x_CodingRate)cr);
   SetFrequencyReg(freq);

--- a/src/lib/SX127xDriver/SX127x.h
+++ b/src/lib/SX127xDriver/SX127x.h
@@ -75,7 +75,9 @@ public:
     void RXnb();
 
 private:
-    static const uint8_t PWRPENDING_NONE = 0xff;
+    // constant used for no power change pending
+    // must not be a valid power register value
+    static const uint8_t PWRPENDING_NONE = 0x00;
 
     SX127x_Bandwidth currBW;
     SX127x_SpreadingFactor currSF;
@@ -88,7 +90,7 @@ private:
     uint8_t pwrPending;
 
     static void IsrCallback();
-    void CommitOutputPower();
     void RXnbISR(); // ISR for non-blocking RX routine
     void TXnbISR(); // ISR for non-blocking TX routine
+    void CommitOutputPower();
 };

--- a/src/lib/SX127xDriver/SX127x.h
+++ b/src/lib/SX127xDriver/SX127x.h
@@ -17,8 +17,8 @@ public:
     static SX127xDriver *instance;
 
     ///////////Radio Variables////////
-    bool headerExplMode = false;
-    bool crcEnabled = false;
+    bool headerExplMode;
+    bool crcEnabled;
 
     //// Parameters ////
     uint16_t timeoutSymbols;
@@ -75,16 +75,20 @@ public:
     void RXnb();
 
 private:
-    uint8_t currSyncWord = SX127X_SYNC_WORD;
-    uint8_t currPreambleLen = 0;
-    SX127x_Bandwidth currBW = SX127x_BW_125_00_KHZ; //default values from datasheet
-    SX127x_SpreadingFactor currSF = SX127x_SF_7;
-    SX127x_CodingRate currCR = SX127x_CR_4_5;
-    SX127x_RadioOPmodes currOpmode = SX127x_OPMODE_SLEEP;
-    uint8_t currPWR = 0b0000;
-    SX127x_ModulationModes ModFSKorLoRa = SX127x_OPMODE_LORA;
+    static const uint8_t PWRPENDING_NONE = 0xff;
+
+    SX127x_Bandwidth currBW;
+    SX127x_SpreadingFactor currSF;
+    SX127x_CodingRate currCR;
+    SX127x_RadioOPmodes currOpmode;
+    SX127x_ModulationModes ModFSKorLoRa;
+    uint8_t currSyncWord;
+    uint8_t currPreambleLen;
+    uint8_t pwrCurrent;
+    uint8_t pwrPending;
 
     static void IsrCallback();
+    void CommitOutputPower();
     void RXnbISR(); // ISR for non-blocking RX routine
     void TXnbISR(); // ISR for non-blocking TX routine
 };

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -55,6 +55,9 @@ static uint32_t endTX;
 SX1280Driver::SX1280Driver(): SX12xxDriverCommon()
 {
     instance = this;
+    timeout = 0xffff;
+    currOpmode = SX1280_MODE_SLEEP;
+    lastSuccessfulPacketRadio = SX1280_Radio_1;
 }
 
 void SX1280Driver::End()
@@ -100,6 +103,10 @@ bool SX1280Driver::Begin()
 
     hal.WriteRegister(0x0891, (hal.ReadRegister(0x0891, SX1280_Radio_1) | 0xC0), SX1280_Radio_1);   //default is low power mode, switch to high sensitivity instead
     hal.WriteCommand(SX1280_RADIO_SET_AUTOFS, 0x01, SX1280_Radio_All);                              //Enable auto FS
+    // Force the next power update, and the lowest power
+    pwrCurrent = PWRPENDING_NONE;
+    SetOutputPower(SX1280_POWER_MIN);
+    CommitOutputPower();
 #if defined(USE_SX1280_DCDC)
     if (OPT_USE_SX1280_DCDC)
     {
@@ -158,14 +165,29 @@ void SX1280Driver::SetRxTimeoutUs(uint32_t interval)
     }
 }
 
+/***
+ * @brief: Schedule an output power change after the next transmit
+ ***/
 void SX1280Driver::SetOutputPower(int8_t power)
 {
-    if (power < -18) power = -18;
-    else if (13 < power) power = 13;
-    uint8_t buf[2] = {(uint8_t)(power + 18), (uint8_t)SX1280_RADIO_RAMP_04_US};
+    uint8_t pwrNew = constrain(power, SX1280_POWER_MIN, SX1280_POWER_MAX) + (-SX1280_POWER_MIN);
+
+    if (pwrCurrent != pwrNew)
+    {
+        pwrPending = pwrNew;
+        DBGLN("SetPower: %u", pwrPending);
+    }
+}
+
+void ICACHE_RAM_ATTR SX1280Driver::CommitOutputPower()
+{
+    if (pwrPending == PWRPENDING_NONE)
+        return;
+
+    pwrCurrent = pwrPending;
+    pwrPending = PWRPENDING_NONE;
+    uint8_t buf[2] = { pwrCurrent, (uint8_t)SX1280_RADIO_RAMP_04_US };
     hal.WriteCommand(SX1280_RADIO_SET_TXPARAMS, buf, sizeof(buf), SX1280_Radio_All);
-    DBGLN("SetPower: %d", buf[0]);
-    return;
 }
 
 void SX1280Driver::SetMode(SX1280_RadioOperatingModes_t OPmode, SX1280_Radio_Number_t radioNumber)
@@ -417,6 +439,7 @@ void ICACHE_RAM_ATTR SX1280Driver::TXnbISR()
     endTX = micros();
     DBGLN("TOA: %d", endTX - beginTX);
 #endif
+    CommitOutputPower();
     TXdoneCallback();
 }
 

--- a/src/lib/SX1280Driver/SX1280.h
+++ b/src/lib/SX1280Driver/SX1280.h
@@ -14,7 +14,7 @@ public:
 
 
     ///////////Radio Variables////////
-    uint16_t timeout = 0xFFFF;
+    uint16_t timeout;
 
     ///////////////////////////////////
 
@@ -48,11 +48,17 @@ public:
     void GetLastPacketStats();
 
 private:
-    SX1280_RadioOperatingModes_t currOpmode = SX1280_MODE_SLEEP;
+    // constant used for no power change pending
+    // must not be a valid power register value
+    static const uint8_t PWRPENDING_NONE = 0xff;
+
+    SX1280_RadioOperatingModes_t currOpmode;
     uint8_t packet_mode;
     bool modeSupportsFei;
     SX1280_Radio_Number_t processingPacketRadio;
-    SX1280_Radio_Number_t lastSuccessfulPacketRadio = SX1280_Radio_1;
+    SX1280_Radio_Number_t lastSuccessfulPacketRadio;
+    uint8_t pwrCurrent;
+    uint8_t pwrPending;
 
     void SetMode(SX1280_RadioOperatingModes_t OPmode, SX1280_Radio_Number_t radioNumber);
     void SetFIFOaddr(uint8_t txBaseAddr, uint8_t rxBaseAddr);
@@ -80,4 +86,5 @@ private:
     static void IsrCallback(SX1280_Radio_Number_t radioNumber);
     bool RXnbISR(uint16_t irqStatus, SX1280_Radio_Number_t radioNumber); // ISR for non-blocking RX routine
     void TXnbISR(); // ISR for non-blocking TX routine
+    void CommitOutputPower();
 };

--- a/src/lib/SX1280Driver/SX1280_Regs.h
+++ b/src/lib/SX1280Driver/SX1280_Regs.h
@@ -14,6 +14,9 @@
 #define SX1280_XTAL_FREQ 52000000
 #define FREQ_STEP ((double)(SX1280_XTAL_FREQ / pow(2.0, 18.0)))  // 198.3642578125
 
+#define SX1280_POWER_MIN (-18)
+#define SX1280_POWER_MAX (13)
+
 typedef enum
 {
     SX1280_Radio_1 = 1 << 0,

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -653,8 +653,10 @@ static void UpdateConnectDisconnectStatus()
 {
   // Number of telemetry packets which can be lost in a row before going to disconnected state
   constexpr unsigned RX_LOSS_CNT = 5;
-  // +2 to account for any rounding down and partial millis()
-  const uint32_t msConnectionLostTimeout = (uint32_t)ExpressLRS_currTlmDenom * ExpressLRS_currAirRate_Modparams->interval / (1000U / RX_LOSS_CNT) + 2;
+  // Must be at least 512ms and +2 to account for any rounding down and partial millis()
+  const uint32_t msConnectionLostTimeout = std::max((uint32_t)512U,
+    (uint32_t)ExpressLRS_currTlmDenom * ExpressLRS_currAirRate_Modparams->interval / (1000U / RX_LOSS_CNT)
+    ) + 2U;
   // Capture the last before now so it will always be <= now
   const uint32_t lastTlmMillis = LastTLMpacketRecvMillis;
   const uint32_t now = millis();


### PR DESCRIPTION
The prevents the RF Output Power from being changed at random times, and instead moves it to after TX done. It also changes the minimum amount of time required for the TX to go to disconnected state to 512ms.
Addresses #1691
 
## Details
On Team900 hardware, changing the power level needs to be done in `SX127x_OPMODE_STANDBY`, so the radio code was dutifully performing this action. For the most part this is ok, because the changing power usually occurs after a telemetry packet which is in the dead time between the receive and before the next transmit begins. However, with Dynamic Power on a Switch, this can happen at any time and when the power level is changed any in-process TX or RX operation is cancelled. If this happens during a TX that happens to be the last before an FHSS it can mess up the whole connection and cause it to drop.

Team2.4 seems to be a little safer in this regard, as the command seems to work even mid TX and RX (I forced these to happen frequently to test). It can still be an issue though if a power change is in progress when a TX or RX interrupt occurs.

### When to change?
Ideally, the power change would happen on the next packet, but doing it before transmit means that some packets will be delayed by 10-20us due to the time it takes to send the power change command and add jitter. Therefore I feel it should be done in the TXdone ISR, before calling up the chain (where the radio might be put into RX mode). This causes at most a 1 packet lag, but there's really no other reliable signal that tells us the radio isn't busy.

Note that external DAC-having, dacWrite-using, and Analog-outputting power manager will still possibly change their power mid packet. That definitely could mess with the RX as the power level changes during reception, but it is just a single packet and wouldn't exhibit the sorts of behaviors seen here. I don't want to move all of these into the ISR, there's just too much code given all the various methods.

## Delay before disconnected
When operating at high telemetry rates (1:2, 1:4) combined with high packet rates, it is far too easy to go into and out of `disconnected` state on the TX-- at F1000 1:2 there's just a 12ms window. I was seeing this trigger on 200Hz 1:2 with a marginal signal, the connection going between disconnected and connected a couple times a second. I've added a minimum amount of time required before going to disconnected state, 512ms. That's a ton of telemetry at 1000Hz 1:2 (250 missed telemetry packets instead of the previous 5), but should help keep the link from bouncing into and out of connected state.

The 512ms was chosen somewhat arbitrarily to match the expected LinkStats interval, and might be on the high side?

## Minor Reorg
The radio classes have a constructor... but set some initial values in the class definition? Instead of mixing them, I've made the radio classes now set all their initial values in the constructor, the way Glob intended.

The DAC class also had a function that just called a function so those two were combined into the original function.

## Testing
Dozens of hours of dynamic power on a switch going back and forth to trigger this bug, until after about 20 minutes I just had OpenTX do it for me, flipping the switch a full cycle every 1.9s 
![rssi](https://user-images.githubusercontent.com/677183/182239492-eab9d7fb-d5d7-4409-a2bc-9f8878936e23.gif)

Each of these tested 3-4 hours with no issue
* R9M TX with R9MM RX with Betaflight 4.3.0 full telemetry w/GPS. 100Hz Fullres 1:4 12ch mixed 100mW Dynamic AUX9
* Same except 200Hz 1:2
* Namimno OLED + SX1280 RX, 500Hz 1:4 100mW Dynamic AUX9
* Same except 100Hz Fullres 1:4
* Same except 250Hz Std
* FM30 250Hz Std with EP2
