### PR TITLE
Defer the config commit when changing via LUA

### DIFF
--- a/src/lib/CONFIG/config.cpp
+++ b/src/lib/CONFIG/config.cpp
@@ -650,6 +650,7 @@ RxConfig::Commit()
     m_eeprom->Put(0, m_config);
     m_eeprom->Commit();
 
+    m_commitTime = 0;
     m_modified = false;
 }
 

--- a/src/lib/CONFIG/config.h
+++ b/src/lib/CONFIG/config.h
@@ -206,12 +206,16 @@ public:
     #endif
     void SetForceTlmOff(bool forceTlmOff);
 
+    void DeferCommit(uint32_t deferMs = 200U) { m_commitTime = millis() + deferMs; }
+    uint32_t GetCommitTime() { return m_commitTime; }
+
 private:
     void UpgradeEepromV4ToV5();
 
     rx_config_t m_config;
     ELRS_EEPROM *m_eeprom;
     bool        m_modified;
+    uint32_t    m_commitTime = 0;
 };
 
 extern RxConfig config;

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -14,6 +14,7 @@
 
 extern void deferExecution(uint32_t ms, std::function<void()> f);
 
+extern unsigned long deferredCommitTime;
 extern bool InLoanBindingMode;
 extern bool returnModelFromLoan;
 
@@ -119,14 +120,18 @@ static void registerLuaParameters()
   if (GPIO_PIN_ANT_CTRL != UNDEF_PIN)
   {
     registerLUAParameter(&luaAntennaMode, [](struct luaPropertiesCommon* item, uint8_t arg){
+      deferredCommitTime = millis() + 1000;
       config.SetAntennaMode(arg);
+      setLuaTextSelectionValue(&luaAntennaMode, arg);
     });
   }
 #ifdef POWER_OUTPUT_VALUES
   luadevGeneratePowerOpts();
   registerLUAParameter(&luaTlmPower, [](struct luaPropertiesCommon* item, uint8_t arg){
-    config.SetPower(arg);
     POWERMGNT::setPower((PowerLevels_e)constrain(arg + MinPower, MinPower, MaxPower));
+    deferredCommitTime = millis() + 1000;
+    config.SetPower(arg);
+    setLuaTextSelectionValue(&luaTlmPower, arg);
   });
 #endif
   registerLUAParameter(&luaLoanModel, [](struct luaPropertiesCommon* item, uint8_t arg){

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -72,6 +72,8 @@ Telemetry telemetry;
 Stream *SerialLogger;
 bool hardwareConfigured = true;
 
+unsigned long deferredCommitTime = 0;
+
 #if defined(PLATFORM_ESP8266) || defined(PLATFORM_ESP32)
 unsigned long rebootTime = 0;
 extern bool webserverPreventAutoStart;
@@ -1331,10 +1333,11 @@ static void updateSwitchMode()
     SwitchModePending = 0;
 }
 
-static void CheckConfigChangePending()
+static void CheckConfigChangePending(unsigned long now)
 {
-    if (config.IsModified() && !InBindingMode)
+    if (config.IsModified() && !InBindingMode && (deferredCommitTime == 0 || now >= deferredCommitTime))
     {
+        deferredCommitTime = 0;
         LostConnection(false);
         config.Commit();
         devicesTriggerEvent();
@@ -1436,7 +1439,7 @@ void loop()
     }
     #endif
 
-    CheckConfigChangePending();
+    CheckConfigChangePending(now);
     executeDeferredFunction(now);
 
     if (connectionState > MODE_STATES)


### PR DESCRIPTION
When changing RX settings via LUA we have to defer the config commit because committing the changes causes the link to drop temporarily and the LUA response needs to make its way to the TX before that happens.
