### PR TITLE
TX12 Alias Target

### DIFF
--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -1081,6 +1081,15 @@
                 "platform": "esp32",
                 "firmware": "Unified_ESP32_2400_TX",
                 "prior_target_name": "RadioMaster_TX16S_2400_TX"
+            },
+            "tx12": {
+                "product_name": "RadioMaster TX12 Internal 2.4GHz TX",
+                "lua_name": "RadioMstr TX12",
+                "layout_file": "Radiomaster Zorro.json",
+                "upload_methods": ["uart", "wifi", "etx"],
+                "platform": "esp32",
+                "firmware": "Unified_ESP32_2400_TX",
+                "prior_target_name": "RadioMaster_Zorro_2400_TX"
             }
         },
         "rx_2400": {


### PR DESCRIPTION
PR will simply beautify things a bit for the TX12.

Gives it proper Lua and Web Update page names in hopes of lessening user confusion.

Zorro and TX12 modules are interchangeable as they are the same exact module. Currently, TX12 modules use the Zorro Target, and will show up as a Zorro in the Lua Script and in the WiFi Update page.