### PR TITLE
Fix BETAFPV Nano `prior_target_name`

### DIFF
--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -118,7 +118,7 @@
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "platform": "esp8285",
                 "firmware": "Unified_ESP8285_2400_RX",
-                "prior_target_name": "BETAFPV_Nano_2400_RX"
+                "prior_target_name": "BETAFPV_2400_RX"
             },
             "pwmp": {
                 "product_name": "BETAFPV PWM 2.4GHz RX",


### PR DESCRIPTION
The wrong `prior_target_name` was in the `targets.json` file so when a user upgraded to 3.x it would still say that it's a target mismatch and they would have to force flash.
This just puts the correct prior target name so it won't ask them to force flash.