### PR TITLE
EU CE Regulatory Domain display text

### DIFF
--- a/src/lib/FHSS/FHSS.cpp
+++ b/src/lib/FHSS/FHSS.cpp
@@ -18,7 +18,11 @@ const fhss_config_t domains[] = {
 #include "SX1280Driver.h"
 
 const fhss_config_t domains[] = {
-    {"ISM2G4", FREQ_HZ_TO_REG_VAL(2400400000), FREQ_HZ_TO_REG_VAL(2479400000), 80}
+    #if defined(Regulatory_Domain_EU_CE_2400)
+        {"CE_LBT", FREQ_HZ_TO_REG_VAL(2400400000), FREQ_HZ_TO_REG_VAL(2479400000), 80}
+    #elif defined(Regulatory_Domain_ISM_2400)
+        {"ISM2G4", FREQ_HZ_TO_REG_VAL(2400400000), FREQ_HZ_TO_REG_VAL(2479400000), 80}
+    #endif
 };
 #endif
 

--- a/src/lib/FHSS/FHSS.cpp
+++ b/src/lib/FHSS/FHSS.cpp
@@ -18,11 +18,13 @@ const fhss_config_t domains[] = {
 #include "SX1280Driver.h"
 
 const fhss_config_t domains[] = {
+    {    
     #if defined(Regulatory_Domain_EU_CE_2400)
-        {"CE_LBT", FREQ_HZ_TO_REG_VAL(2400400000), FREQ_HZ_TO_REG_VAL(2479400000), 80}
+        "CE_LBT",
     #elif defined(Regulatory_Domain_ISM_2400)
-        {"ISM2G4", FREQ_HZ_TO_REG_VAL(2400400000), FREQ_HZ_TO_REG_VAL(2479400000), 80}
+        "ISM2G4",
     #endif
+    FREQ_HZ_TO_REG_VAL(2400400000), FREQ_HZ_TO_REG_VAL(2479400000), 80}
 };
 #endif
 


### PR DESCRIPTION
Context:
https://discord.com/channels/596350022191415318/798006228450017290/1004732867324149890

EU CE regulatory domain would still show ISM2G4 on Lua Script and on the Web interface. 
However, if you'd check the TX Power folder in the Lua Script, the 100mW CE LIMIT item is there, indicating that it is indeed got applied (the build flag).
https://discord.com/channels/596350022191415318/798006228450017290/1004745968194957472

I have tested this on my TX16S and on the Commando, both via a Configurator Build/Flash as well as in PIO.

The "fix" in this PR is a simple one, and could very well be a band-aid solution.
This PR is only to provide a visual feedback that user has indeed flashed using the EU_CE regulatory domain.
