### PR TITLE
Only adjust PFD when a new result is available

### DIFF
--- a/src/lib/PFD/PFD.h
+++ b/src/lib/PFD/PFD.h
@@ -8,7 +8,6 @@ class PFD
 private:
     uint32_t intEventTime = 0;
     uint32_t extEventTime = 0;
-    int32_t result;
     bool gotExtEvent;
     bool gotIntEvent;
 
@@ -31,14 +30,15 @@ public:
         gotIntEvent = false;
     }
 
-    inline void calcResult()
+    int32_t calcResult() const
     {
-        result = (gotExtEvent && gotIntEvent) ? (int32_t)(extEventTime - intEventTime) : 0;
+        // Assumes caller has verified hasResult()
+        return (int32_t)(extEventTime - intEventTime);
     }
 
-    inline int32_t getResult()
+    bool hasResult() const
     {
-        return result;
+        return gotExtEvent && gotIntEvent;
     }
 
     volatile uint32_t getIntEventTime() const { return intEventTime; }

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -432,19 +432,19 @@ void ICACHE_RAM_ATTR HandleFreqCorr(bool value)
 
 void ICACHE_RAM_ATTR updatePhaseLock()
 {
-    if (connectionState != disconnected)
+    if (connectionState != disconnected && PFDloop.hasResult())
     {
-        PFDloop.calcResult();
-        PFDloop.reset();
-
-        int32_t RawOffset = PFDloop.getResult();
+        int32_t RawOffset = PFDloop.calcResult();
         int32_t Offset = LPF_Offset.update(RawOffset);
         int32_t OffsetDx = LPF_OffsetDx.update(RawOffset - PfdPrevRawOffset);
         PfdPrevRawOffset = RawOffset;
 
-        if (RXtimerState == tim_locked && LQCalc.currentIsSet())
+        if (RXtimerState == tim_locked)
         {
-            if (OtaNonce % 8 == 0) //limit rate of freq offset adjustment slightly
+            // limit rate of freq offset adjustment, use slot 1
+            // because telemetry can fall on slot 1 and will
+            // never get here
+            if (OtaNonce % 8 == 1)
             {
                 if (Offset > 0)
                 {
@@ -469,6 +469,8 @@ void ICACHE_RAM_ATTR updatePhaseLock()
         DBGVLN("%d:%d:%d:%d:%d", Offset, RawOffset, OffsetDx, hwTimer.FreqOffset, uplinkLQ);
         UNUSED(OffsetDx); // complier warning if no debug
     }
+
+    PFDloop.reset();
 }
 
 void ICACHE_RAM_ATTR HWtimerCallbackTick() // this is 180 out of phase with the other callback, occurs mid-packet reception


### PR DESCRIPTION
Changes the receiver phase lock to only update the phase lock when it has received a packet, and update freqOffset on a non-telemetry slot.

### Details
Found this one debugging the SPI code, which is broken as well, but our code is double-secret-pro-broken so it actually works.

Our Code:
* Executes `updatePhaseLock()` regardless of if there is data for it to work with, so on a telemetry slot, `0` is added to the offset-- effectively every telemetry packet reduces the freqOffset by a little.
* Adjusts the `hwTimer.incFreqOffset() / hwTimer.decFreqOffset()` on slot 0, but only if a packet has been received according to the LQ counter. For ratios 1:2, 1:4, and 1:8, telemetry ALWAYS occurs on slot 0, making this actually check the previous receive, as the LQ counter does not increment on telemetry slots.

These two issues combine to mean our `LPF_Offset` is a little off, but freqOffset is actually updated. I believe our code is like this because of the whole slot 0 thing was causing the phase lock to possibly never catch up so the code was changed to always execute and boom it just works.

SPI Code:
* Only executes the phase lock code if there is data, but can not, as no new data is ever available on slot 0 due to telemetry.
* Without being able to stretch or contract the timer period, the phase lock is stuck only using 1/4 offset phase shift. This gets it close, but at higher telemetry rates like 1:2, adjusting the phase by offset / 4 every other packet isn't enough and eventually the connection is lost.

This becomes obvious when running `DEBUG_RX_EXPRESSLRS_PHASELOCK` where the 3rd number is the freqOffset, note that it never increases running ratio 1:2, 1:4, and 1:8. However, jumping up to 1:16, the freqOffset will accumulate the proper value and the connection will hold.

[Video showing this debug](https://youtu.be/PeXVua1h2DE)

### Solution
* Do things right. Only execute the phase lock code when a packet has been received and timing data is available.
* incFreqOffset / decFreqOffset on slot 1, as telemetry can never occur on this slot. The choice to only do the adjustment every 8 packets was arbitrary, and doing it on slot 0 was just a round number, but possibly the worst choice possible given how often telemetry happens on it.