### PR TITLE
Delay sending of VTX Admin if reconnected quickly

### DIFF
--- a/src/lib/VTX/devVTX.cpp
+++ b/src/lib/VTX/devVTX.cpp
@@ -103,7 +103,7 @@ static int event()
 
     if (connectionState == disconnected)
     {
-        // If the VtxSend has completed, wait a before going back to VTXSS_UNKNOWN
+        // If the VtxSend has completed, wait before going back to VTXSS_UNKNOWN
         // to ignore a temporary disconnect after saving EEPROM
         if (VtxSendState == VTXSS_CONFIRMED)
         {

--- a/src/lib/VTX/devVTX.cpp
+++ b/src/lib/VTX/devVTX.cpp
@@ -10,9 +10,14 @@
 #define PITMODE_OFF     0
 #define PITMODE_ON      1
 
+// Delay after disconnect to preserve the VTXSS_CONFIRMED status
+// Needs to be long enough to reconnect, but short enough to
+// reset between the user switching equipment
+#define VTX_DISCONNECT_DEBOUNCE_MS (10 * 1000)
+
 extern CRSF crsf;
 extern Stream *TxBackpack;
-uint8_t pitmodeAuxState = 0;
+static uint8_t pitmodeAuxState = 0;
 
 static enum VtxSendState_e
 {
@@ -97,9 +102,22 @@ static int event()
     }
 
     if (connectionState == disconnected)
+    {
+        // If the VtxSend has completed, wait a before going back to VTXSS_UNKNOWN
+        // to ignore a temporary disconnect after saving EEPROM
+        if (VtxSendState == VTXSS_CONFIRMED)
+        {
+            VtxSendState = VTXSS_CONFIRMED;
+            return VTX_DISCONNECT_DEBOUNCE_MS;
+        }
         VtxSendState = VTXSS_UNKNOWN;
+    }
+    else if (VtxSendState == VTXSS_CONFIRMED && connectionState == connected)
+    {
+        return DURATION_NEVER;
+    }
 
-    return DURATION_NEVER;
+    return DURATION_IGNORE;
 }
 
 static int timeout()
@@ -108,6 +126,13 @@ static int timeout()
     if (config.GetVtxBand() == 0)
     {
         VtxSendState = VTXSS_CONFIRMED;
+        return DURATION_NEVER;
+    }
+
+    // Can only get here in VTXSS_CONFIRMED state if still disconnected
+    if (VtxSendState == VTXSS_CONFIRMED)
+    {
+        VtxSendState = VTXSS_UNKNOWN;
         return DURATION_NEVER;
     }
 


### PR DESCRIPTION
This adds a delay to VTX Admin, where the "CONFIRMED" status will be retained for a short period after disconnecting. The purpose is to prevent continuously sending VTX Admin to SPI receivers, which disconnect when the settings are saved, then reconnect and VTX Admin sends the commands again.

It also fixes a bug where if the VTX Admin send is scheduled / in progress and any other device event occurs, it would cancel sending VTX Admin altogether.

### Background
Current logic looks like this
  1. On "connected" event, or change in "Send VTX" executed, the device schedules sending the VTX info 1 second later
  2. VTX info is sent 3x total
  3. Save EEPROM is sent -- SPI RXes disconnect, because the EEPROM write blocks all tasks
  4. The TX goes to disconnected state
  5. The VTX Admin device resets its state
  6. The SPI receiver reconnects, the cycle begins again at step 1

This change looks to add a new step 5, delaying the state reset for `VTX_DISCONNECT_DEBOUNCE_MS` (10s). If a connection is reestablished before then, the state is not reset and the cycle is broken. If there is no "connected" event before the timeout, the state is reset as before.

### Existing Bug
devVTX's `event()` code always returned `DURATION_NEVER` if the state was in progress. This normally is fine, but _any event_ can be thrown during this procedure, such as a power change, as it does take several seconds to complete. If `DURATION_NEVER` is returned, the process is canceled, and may never even be started.

The code has been changed to return `DURATION_IGNORE` instead by default to prevent the process from being canceled. 

### Proper Duration?
I selected 10s as the debounce duration, as it seemed to always be enough time for even 50Hz 1:2 to reconnect. 5s would never work, so 10s seems OK to me?