### PR TITLE
Move HandleUARTIn to devCRSF timeout function

### DIFF
--- a/src/lib/CRSF/devCRSF_rx.cpp
+++ b/src/lib/CRSF/devCRSF_rx.cpp
@@ -5,6 +5,7 @@
 extern CRSF crsf;
 
 static volatile bool sendFrame = false;
+extern void HandleUARTin();
 
 void ICACHE_RAM_ATTR crsfRCFrameAvailable()
 {
@@ -30,6 +31,8 @@ static int timeout()
     }
     #endif
     crsf.RXhandleUARTout();
+    HandleUARTin();
+
     return DURATION_IMMEDIATELY;
 }
 

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1423,7 +1423,6 @@ void loop()
 {
     unsigned long now = millis();
 
-    HandleUARTin();
     if (MspReceiver.HasFinishedData())
     {
         MspReceiveComplete();


### PR DESCRIPTION
This move the call to `HandleUARTin` into the same codepath (core) as the code that writes to the UART, `crsf.RXhandleUARTout`. With them being done in different cores it would cause intermittent crashes on ESP32 PICO based RXes.