### PR TITLE
Fix popup touch events, remove from B&W

### DIFF
--- a/src/lua/elrsV3.lua
+++ b/src/lua/elrsV3.lua
@@ -50,7 +50,7 @@ local maxLineIndex
 local textXoffset
 local textYoffset
 local textSize
-local symbolChars
+local byteToStr
 
 local function allocateFields()
   fields = {}
@@ -97,11 +97,6 @@ local function constrain(x, low, high)
     return high
   end
   return x
-end
-
-local function byteToStr(b)
-  -- Translate b into a string from symbolChars if available, else use string.char
-  return symbolChars and symbolChars[b] or string.char(b)
 end
 
 -- Change display attribute to current field
@@ -830,9 +825,15 @@ local function loadSymbolChars()
   -- On firmwares that have constants defined for the arrow chars, use them in place of
   -- the \xc0 \xc1 chars (which are OpenTX-en)
   if __opentx then
-    symbolChars = {}
-    symbolChars[192] = __opentx.CHAR_UP
-    symbolChars[193] = __opentx.CHAR_DOWN
+    byteToStr = function (b)
+      -- Use the table to convert the char, else use string.char if not in the table
+      return ({
+        [192] = __opentx.CHAR_UP,
+        [193] = __opentx.CHAR_DOWN
+      })[b] or string.char(b)
+    end
+  else
+    byteToStr = string.char
   end
 end
 

--- a/src/lua/elrsV3.lua
+++ b/src/lua/elrsV3.lua
@@ -836,6 +836,18 @@ local function loadSymbolChars()
   end
 end
 
+local function touch2evt(event, touchState)
+  -- Convert swipe events to normal events Left/Right/Up/Down -> EXIT/ENTER/PREV/NEXT
+  -- PREV/NEXT are swapped if editing
+  -- TAP is converted to ENTER
+  touchState = touchState or {}
+  return (touchState.swipeLeft and EVT_VIRTUAL_EXIT)
+    or (touchState.swipeRight  and EVT_VIRTUAL_ENTER)
+    or (touchState.swipeUp     and (edit and EVT_VIRTUAL_NEXT or EVT_VIRTUAL_PREV))
+    or (touchState.swipeDown   and (edit and EVT_VIRTUAL_PREV or EVT_VIRTUAL_NEXT))
+    or (event == EVT_TOUCH_TAP and EVT_VIRTUAL_ENTER)
+end
+
 local function setLCDvar()
   -- Set the title function depending on if LCD is color, and free the other function and
   -- set textselection unit function, use GetLastPost or sizeText
@@ -845,6 +857,7 @@ local function setLCDvar()
   else
     lcd_title = lcd_title_bw
     functions[10].display=fieldTextSelectionDisplay_bw
+    touch2evt = nil
   end
   lcd_title_color = nil
   lcd_title_bw = nil
@@ -916,17 +929,7 @@ local function run(event, touchState)
     return 2
   end
 
-  -- Convert swipe events to normal events Left/Right/Up/Down -> EXIT/ENTER/PREV/NEXT
-  -- PREV/NEXT are swapped if editing
-  -- TAP is converted to ENTER
-  touchState = touchState or {}
-  event = (touchState.swipeLeft and EVT_VIRTUAL_EXIT)
-    or (touchState.swipeRight   and EVT_VIRTUAL_ENTER)
-    or (touchState.swipeUp      and (edit and EVT_VIRTUAL_NEXT or EVT_VIRTUAL_PREV))
-    or (touchState.swipeDown    and (edit and EVT_VIRTUAL_PREV or EVT_VIRTUAL_NEXT))
-    or (event == EVT_TOUCH_TAP  and EVT_VIRTUAL_ENTER)
-    or event
-
+  event = (touch2evt and touch2evt(event, touchState)) or event
   if fieldPopup ~= nil then
     runPopupPage(event)
   else


### PR DESCRIPTION
This refactors the touch events slightly and fixes the issue of no way to exit a popup with touch events. It also reduces the Lua compiled code size on all platforms, and 904 bytes on B&W.

### Details
I started this cleanup to fix #1733, but once I cleaned it up, I found that the bug is on the EdgeTX side. Considering this reduces Lua memory usage on all platforms, and fixes the bug of not being able to exit a popup, I'mma put it on ya, gurl.

* There was no way to exit a popup message with touch, as all the events were translated inline for every instance. I've modified this so they are translated once at the top level and all the event code stays the same. (see `touch2evt`)
* Because this is now handled at the top level, it can be removed from B&W (which does not have touch) on load, and removing this code saves 904 bytes of Lua memory which these platforms dearly need.
* byteToStr fixed to have less overhead, reduces memory by 20 bytes, or 80 bytes by eliminating the function altogether on targets which do not need to do any conversion.