### PR TITLE
PWM fan support

### DIFF
--- a/src/html/hardware.html
+++ b/src/html/hardware.html
@@ -244,6 +244,8 @@ td img.icon-pwm {
 					<tr><td></td><td>SDA pin<img class="icon-input"/><img class="icon-output"/></td><td><input size='3' id='i2c_sda' name='i2c_sda' type='text'/></td><td>I2C data pin used to communicate with I2C devices (may be the same as OLED I2C)</td></tr>
 					<!-- <tr><td></td><td>Buzzer pin</td><td><input size='3' id='misc_buzzer' name='misc_buzzer' type='text'/></td><td>Pin connected to a PWM controlled buzzer</td></tr> -->
 					<tr><td></td><td>Fan enable pin<img class="icon-output"/></td><td><input size='3' id='misc_fan_en' name='misc_fan_en' type='text'/></td><td>Pin used to enable a cooling FAN (active HIGH)</td></tr>
+					<tr><td></td><td>Fan PWM pin<img class="icon-pwm"/></td><td><input size='3' id='misc_fan_pwm' name='misc_fan_pwm' type='text'/></td><td>If the fan is controlled by PWM</td></tr>
+					<tr><td></td><td>Fan TACHO pin<img class="icon-input"/></td><td><input size='3' id='misc_fan_tacho' name='misc_fan_tacho' type='text'/></td><td>If the fan has a "tachometer" interrupt pin</td></tr>
 					<tr><td></td><td>Has STK8xxx G-sensor</td><td><input size='3' id='gsensor_stk8xxx' name='gsensor_stk8xxx' type='checkbox'/></td><td>Checked if there is a STK8xxx g-sensor on the I2C bus</td></tr>
 					<tr><td></td><td>G-sensor interrupt pin<img class="icon-input"/></td><td><input size='3' id='misc_gsensor_int' name='misc_gsensor_int' type='text'/></td><td>Pin connected the STK8xxx g-sensor for interrupts</td></tr>
 					<tr><td></td><td>Has LM75A Thermal sensor</td><td><input size='3' id='thermal_lm75a' name='thermal_lm75a' type='checkbox'/></td><td>Checked if there is a LM75A thermal sensor on the I2C bus</td></tr>

--- a/src/include/hardware.h
+++ b/src/include/hardware.h
@@ -104,6 +104,8 @@ typedef enum {
     HARDWARE_misc_gsensor_int,
     HARDWARE_misc_buzzer,  // stm32 only
     HARDWARE_misc_fan_en,
+    HARDWARE_misc_fan_pwm,
+    HARDWARE_misc_fan_tacho,
     HARDWARE_gsensor_stk8xxx,
     HARDWARE_thermal_lm75a,
 

--- a/src/include/target/Unified_ESP32_TX.h
+++ b/src/include/target/Unified_ESP32_TX.h
@@ -166,7 +166,10 @@
 // Misc sensors & things
 #define GPIO_PIN_GSENSOR_INT hardware_pin(HARDWARE_misc_gsensor_int)
 // #define GPIO_PIN_BUZZER hardware_pin(HARDWARE_misc_buzzer)  // stm32 only
+#define define HAS_FAN
 #define GPIO_PIN_FAN_EN hardware_pin(HARDWARE_misc_fan_en)
+#define GPIO_PIN_FAN_PWM hardware_pin(HARDWARE_misc_fan_pwm)
+#define GPIO_PIN_FAN_TACHO hardware_pin(HARDWARE_misc_fan_tacho)
 
 #define HAS_GSENSOR
 #define HAS_GSENSOR_STK8xxx

--- a/src/include/targets.h
+++ b/src/include/targets.h
@@ -143,6 +143,12 @@
 #ifndef GPIO_PIN_FAN_EN
 #define GPIO_PIN_FAN_EN UNDEF_PIN
 #endif
+#ifndef GPIO_PIN_FAN_PWM
+#define GPIO_PIN_FAN_PWM UNDEF_PIN
+#endif
+#ifndef GPIO_PIN_FAN_TACHO
+#define GPIO_PIN_FAN_TACHO UNDEF_PIN
+#endif
 #ifndef GPIO_PIN_OLED_MOSI
 #define GPIO_PIN_OLED_MOSI UNDEF_PIN
 #endif

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -65,7 +65,7 @@ static struct luaItem_selection luaDynamicPower = {
     emptySpace
 };
 
-#if defined(GPIO_PIN_FAN_EN)
+#if defined(GPIO_PIN_FAN_EN) || defined(GPIO_PIN_FAN_PWM)
 static struct luaItem_selection luaFanThreshold = {
     {"Fan Thresh", CRSF_TEXT_SELECTION},
     0, // value
@@ -608,7 +608,7 @@ static void registerLuaParameters()
       config.SetBoostChannel((arg - 1) > 0 ? arg - 1 : 0);
     }, luaPowerFolder.common.id);
   }
-  if (GPIO_PIN_FAN_EN != UNDEF_PIN) {
+  if (GPIO_PIN_FAN_EN != UNDEF_PIN || GPIO_PIN_FAN_PWM != UNDEF_PIN) {
     registerLUAParameter(&luaFanThreshold, [](struct luaPropertiesCommon *item, uint8_t arg){
       config.SetPowerFanThreshold(arg);
     }, luaPowerFolder.common.id);
@@ -706,7 +706,7 @@ static int event()
   luadevUpdateModelID();
   setLuaTextSelectionValue(&luaModelMatch, (uint8_t)config.GetModelMatch());
   setLuaTextSelectionValue(&luaPower, config.GetPower() - MinPower);
-  if (GPIO_PIN_FAN_EN != UNDEF_PIN)
+  if (GPIO_PIN_FAN_EN != UNDEF_PIN || GPIO_PIN_FAN_PWM != UNDEF_PIN)
   {
     setLuaTextSelectionValue(&luaFanThreshold, config.GetPowerFanThreshold());
   }

--- a/src/lib/OPTIONS/hardware.cpp
+++ b/src/lib/OPTIONS/hardware.cpp
@@ -101,6 +101,8 @@ static const struct {
     {HARDWARE_misc_gsensor_int, "misc_gsensor_int", INT},
     {HARDWARE_misc_buzzer, "misc_buzzer", INT},
     {HARDWARE_misc_fan_en, "misc_fan_en", INT},
+    {HARDWARE_misc_fan_pwm, "misc_fan_pwm", INT},
+    {HARDWARE_misc_fan_tacho, "misc_fan_tacho", INT},
     {HARDWARE_gsensor_stk8xxx, "gsensor_stk8xxx", BOOL},
     {HARDWARE_thermal_lm75a, "thermal_lm75a", BOOL},
     {HARDWARE_pwm_outputs, "pwm_outputs", ARRAY},

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -200,10 +200,6 @@ void POWERMGNT::init()
     analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095 2.7V
     analogWrite(GPIO_PIN_RFamp_APC2, 950);
 #endif
-    if (GPIO_PIN_FAN_EN != UNDEF_PIN)
-    {
-        pinMode(GPIO_PIN_FAN_EN, OUTPUT);
-    }
     LoadCalibration();
     setDefaultPower();
 }

--- a/src/lib/THERMAL/devThermal.cpp
+++ b/src/lib/THERMAL/devThermal.cpp
@@ -124,6 +124,7 @@ static void timeoutFan()
     static uint8_t fanStateDuration;
     static bool fanIsOn;
     bool fanShouldBeOn = POWERMGNT::currPower() >= (PowerLevels_e)config.GetPowerFanThreshold();
+    static PowerLevels_e lastPower = MinPower;
 
     if (fanIsOn)
     {
@@ -132,7 +133,6 @@ static void timeoutFan()
 #if defined(PLATFORM_ESP32)
             if (GPIO_PIN_FAN_PWM != UNDEF_PIN)
             {
-                static PowerLevels_e lastPower = MinPower;
                 if (fanStateDuration < FAN_MIN_CHANGETIME)
                 {
                     ++fanStateDuration;
@@ -193,6 +193,7 @@ static void timeoutFan()
                 // the PWM level is not sufficient to get it moving
                 ledcWrite(fanChannel, 192);
                 fanStateDuration = FAN_MIN_CHANGETIME;
+                lastPower = (PowerLevels_e)(MaxPower + 1);
             }
 #endif
             fanIsOn = true;

--- a/src/lib/THERMAL/devThermal.cpp
+++ b/src/lib/THERMAL/devThermal.cpp
@@ -124,7 +124,6 @@ static void timeoutFan()
     static uint8_t fanStateDuration;
     static bool fanIsOn;
     bool fanShouldBeOn = POWERMGNT::currPower() >= (PowerLevels_e)config.GetPowerFanThreshold();
-    static PowerLevels_e lastPower = MinPower;
 
     if (fanIsOn)
     {
@@ -133,11 +132,12 @@ static void timeoutFan()
 #if defined(PLATFORM_ESP32)
             if (GPIO_PIN_FAN_PWM != UNDEF_PIN)
             {
-                if (fanStateDuration < FAN_MIN_CHANGETIME)
+                static PowerLevels_e lastPower = MinPower;
+                if (POWERMGNT::currPower() < lastPower && fanStateDuration < FAN_MIN_CHANGETIME)
                 {
                     ++fanStateDuration;
                 }
-                if (POWERMGNT::currPower() > lastPower || (POWERMGNT::currPower() < lastPower && fanStateDuration >= FAN_MIN_CHANGETIME))
+                if (POWERMGNT::currPower() > lastPower || fanStateDuration >= FAN_MIN_CHANGETIME)
                 {
                     setFanSpeed();
                     lastPower = POWERMGNT::currPower();
@@ -193,7 +193,6 @@ static void timeoutFan()
                 // the PWM level is not sufficient to get it moving
                 ledcWrite(fanChannel, 192);
                 fanStateDuration = FAN_MIN_CHANGETIME;
-                lastPower = (PowerLevels_e)(MaxPower + 1);
             }
 #endif
             fanIsOn = true;

--- a/src/lib/THERMAL/devThermal.cpp
+++ b/src/lib/THERMAL/devThermal.cpp
@@ -82,7 +82,7 @@ static void initialize()
 #if defined(HAS_THERMAL)
 static void timeoutThermal()
 {
-    if(OPT_HAS_THERMAL_LM75A && !CRSF::IsArmed() && connectionState != wifiUpdate)
+    if(OPT_HAS_THERMAL_LM75A)
     {
         thermal.handle();
 #ifdef HAS_SMART_FAN
@@ -141,12 +141,10 @@ static void timeoutFan()
                 }
             }
             else
+#endif
             {
                 fanStateDuration = 0; // reset the timeout
             }
-#else
-            fanStateDuration = 0; // reset the timeout
-#endif
         }
         else if (fanStateDuration < firmwareOptions.fan_min_runtime)
         {

--- a/src/lib/THERMAL/rpm.cpp
+++ b/src/lib/THERMAL/rpm.cpp
@@ -1,0 +1,58 @@
+#include "targets.h"
+
+#if defined(PLATFORM_ESP32)
+#include "logging.h"
+#include <driver/pcnt.h>
+#include <soc/pcnt_struct.h>
+
+static volatile int overflow = 0;
+static uint32_t lastTime = 0;
+
+static void IRAM_ATTR pcnt_overflow(void *arg)
+{
+    overflow++;
+    PCNT.int_clr.val = BIT(PCNT_UNIT_0);
+    pcnt_counter_clear(PCNT_UNIT_0);
+}
+
+void init_rpm_counter(int pin)
+{
+    pcnt_config_t pcnt_config = {};
+    pcnt_config.pulse_gpio_num = pin;
+    pcnt_config.ctrl_gpio_num = PCNT_PIN_NOT_USED;
+    // What to do on the positive / negative edge of pulse input?
+    pcnt_config.pos_mode = PCNT_COUNT_INC;   // Count up on the positive edge
+    pcnt_config.neg_mode = PCNT_COUNT_DIS;   // Keep the counter value on the negative edge
+    // Set the maximum and minimum limit values to watch
+    pcnt_config.counter_h_lim = 30000;
+    pcnt_config.counter_l_lim = -1;
+    pcnt_config.unit = PCNT_UNIT_0;
+    pcnt_config.channel = PCNT_CHANNEL_0;
+
+    /* Initialize PCNT unit */
+    pcnt_unit_config(&pcnt_config);
+    /* Configure and enable the input filter */
+    pcnt_set_filter_value(PCNT_UNIT_0, 100);
+    pcnt_filter_enable(PCNT_UNIT_0);
+    /* Enable interrupt on overflow */
+    pcnt_event_enable(PCNT_UNIT_0, PCNT_EVT_H_LIM);
+    pcnt_isr_register(pcnt_overflow, NULL, 0, NULL);
+    pcnt_intr_enable(PCNT_UNIT_0);
+    /* Initialize PCNT's counter */
+    pcnt_counter_pause(PCNT_UNIT_0);
+    pcnt_counter_clear(PCNT_UNIT_0);
+    /* Everything is set up, now go to counting */
+    pcnt_counter_resume(PCNT_UNIT_0);
+}
+
+uint32_t get_rpm()
+{
+    int16_t counter;
+    pcnt_get_counter_value(PCNT_UNIT_0, &counter);
+    pcnt_counter_clear(PCNT_UNIT_0);
+    uint32_t now = millis();
+    uint32_t rpm = ((overflow * 30000) + counter) * 60000 / 4 / (now - lastTime);
+    lastTime = now;
+    return rpm;
+}
+#endif

--- a/src/lib/THERMAL/rpm.cpp
+++ b/src/lib/THERMAL/rpm.cpp
@@ -52,6 +52,7 @@ uint32_t get_rpm()
     pcnt_counter_clear(PCNT_UNIT_0);
     uint32_t now = millis();
     uint32_t rpm = ((overflow * 30000) + counter) * 60000 / 4 / (now - lastTime);
+    overflow = 0;
     lastTime = now;
     return rpm;
 }


### PR DESCRIPTION
Adds support for PWM fan with a 'tachometer' pin as well.

Currently the PWM/speed of the fan is hard-coded based on the power output of the module and the reading of the tachometer is just printed as debug messages.

In future we could detect the speed of the fan and if it's not within  some range of expected speed, then downgrade the power and have a warning on the module (in LUA, OLED, RGB etc).