### PR TITLE
Reporting both RSSIs & antenna at better reception in telemetry for a Dual sx1280 RX

### DIFF
--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -580,13 +580,13 @@ void ICACHE_RAM_ATTR SX1280Driver::GetLastPacketStats()
     if (radio2)
     {
         LastPacketRSSI2 = -(int8_t)(status2[0] / 2);
-        SNR2 = -(int8_t)(status[0] / 2);
+        SNR2 = (int8_t)status2[1];
 
         negOffset = (SNR2 < 0) ? (SNR2 / RADIO_SNR_SCALE) : 0;
+        
         LastPacketRSSI2 += negOffset;
-
-        (SNR < SNR2)? LastPacketSNRRaw = SNR : LastPacketSNRRaw = SNR2;
-    }    
+        (SNR > SNR2)? LastPacketSNRRaw = SNR : LastPacketSNRRaw = SNR2;
+    }
 }
 
 void ICACHE_RAM_ATTR SX1280Driver::IsrCallback_1()

--- a/src/lib/SX12xxDriverCommon/SX12xxDriverCommon.h
+++ b/src/lib/SX12xxDriverCommon/SX12xxDriverCommon.h
@@ -36,6 +36,7 @@ public:
 
     /////////////Packet Stats//////////
     int8_t LastPacketRSSI;
+    int8_t LastPacketRSSI2;
     int8_t LastPacketSNRRaw; // in RADIO_SNR_SCALE units
 
 protected:

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -219,6 +219,7 @@ void ICACHE_RAM_ATTR getRFlinkInfo()
         // BetaFlight/iNav expect positive values for -dBm (e.g. -80dBm -> sent as 80)
         crsf.LinkStatistics.uplink_RSSI_1 = -rssiDBM;
         crsf.LinkStatistics.uplink_RSSI_2 = -rssiDBM2;
+        (rssiDBM > rssiDBM2)? antenna=0: antenna=1; // report a better antenna for the reception
     }
     else if (antenna == 0)
     {

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -205,7 +205,22 @@ static uint8_t minLqForChaos()
 void ICACHE_RAM_ATTR getRFlinkInfo()
 {
     int32_t rssiDBM = Radio.LastPacketRSSI;
-    if (antenna == 0)
+
+    if (GPIO_PIN_NSS_2 != UNDEF_PIN) {
+        int32_t rssiDBM2 = Radio.LastPacketRSSI2;
+
+        #if !defined(DEBUG_RCVR_LINKSTATS)
+        rssiDBM = LPF_UplinkRSSI0.update(rssiDBM);
+        rssiDBM2 = LPF_UplinkRSSI1.update(rssiDBM2);
+        #endif
+        if (rssiDBM > 0) rssiDBM = 0;
+        if (rssiDBM2 > 0) rssiDBM2 = 0;
+
+        // BetaFlight/iNav expect positive values for -dBm (e.g. -80dBm -> sent as 80)
+        crsf.LinkStatistics.uplink_RSSI_1 = -rssiDBM;
+        crsf.LinkStatistics.uplink_RSSI_2 = -rssiDBM2;
+    }
+    else if (antenna == 0)
     {
         #if !defined(DEBUG_RCVR_LINKSTATS)
         rssiDBM = LPF_UplinkRSSI0.update(rssiDBM);


### PR DESCRIPTION
# The problem
Current dual sx1280 RX reports just one RSSI of the first-come packet. However, reporting the RSSI of both radio is required because of:
* the reception state from two antennas should be transparent to a user
* Having the two RSSIs will help better analysis of posthoc log analysis
* Dynamic power on FLRC modes relies on RSSI values & selected antenna

# Solution in this PR
* When reading the link stat (`GetLastPacketStats()`) read the values from the two radios instead of just from a last-used radio, and save the values separately. 
* The RSSI values may be behind several packets due to the timing or packet loss, but I assume it's not the critical thing (they'll be delayed in LPF also anyway)

# Possible problem
* When a radio fails to receive any packet from a bad antenna for a long time, the reported RSSI value of that radio could be hugely outdated... however I think it's acceptable, I expect at least one or two packets/100 packets will reach even with the bad antenna side.