### PR TITLE
Fix 8285 RX as TX

### DIFF
--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -376,12 +376,12 @@
                 "prior_target_name": "DIY_2400_TX_DUPLETX"
             },
             "dupletxesp": {
-                "product_name": "Generic ESP8285 Full-duplex 2.4GHz TX",
+                "product_name": "Generic ESP8285 Full-duplex 2.4GHz RX as TX",
                 "lua_name": "DupleTX ESP",
                 "layout_file": "DIY 2400 DupleTX ESP.json",
                 "upload_methods": ["uart", "wifi"],
-                "platform": "esp32",
-                "firmware": "Unified_ESP32_2400_TX",
+                "platform": "esp8285",
+                "firmware": "Unified_ESP8285_2400_TX",
                 "prior_target_name": "DIY_2400_TX_DUPLETX_ESP"
             }
         },

--- a/src/lib/CRSF/devCRSF_tx.cpp
+++ b/src/lib/CRSF/devCRSF_tx.cpp
@@ -7,7 +7,14 @@ static int start()
     CRSF::Begin();
 #if defined(DEBUG_TX_FREERUN)
     CRSF::CRSFstate = true;
-    CRSF::connected();
+    if (CRSF::connected)
+    {
+        CRSF::connected();
+    }
+    else
+    {
+        ERRLN("CRSF::connteced has not been initialised");
+    }
 #endif
     return DURATION_IMMEDIATELY;
 }

--- a/src/lib/CRSF/devCRSF_tx.cpp
+++ b/src/lib/CRSF/devCRSF_tx.cpp
@@ -7,8 +7,7 @@ static int start()
     CRSF::Begin();
 #if defined(DEBUG_TX_FREERUN)
     CRSF::CRSFstate = true;
-    extern void UARTconnected();
-    UARTconnected();
+    CRSF::connected();
 #endif
     return DURATION_IMMEDIATELY;
 }


### PR DESCRIPTION
Whilst doing to testing of RGB I noticed that the 8285 RX as TX was broken not only in the `targets.json` file, but also trying to access a static method from `tx_main.cpp`

This could be back-ported to 3.x.x but because it's really only used for testing I don't think it's necessary.