### PR TITLE
Remove usage of IsArmed from receivers

### DIFF
--- a/src/lib/BUTTON/button.h
+++ b/src/lib/BUTTON/button.h
@@ -1,9 +1,6 @@
 #pragma once
 
 #include <functional>
-#include "CRSF.h"
-
-extern CRSF crsf;
 
 class Button
 {
@@ -51,9 +48,6 @@ public:
     // Call this in loop()
     int update()
     {
-        if (crsf.IsArmed())
-            return MS_DEBOUNCE;
-
         const uint32_t now = millis();
 
         // Reset press count if it has been too long since last rising edge

--- a/src/lib/BUTTON/devButton.cpp
+++ b/src/lib/BUTTON/devButton.cpp
@@ -11,8 +11,13 @@ static Button button;
 #define GPIO_BUTTON_INVERTED false
 #endif
 
+// only check every second if the device is in-use, i.e. RX conencted, or TX is armed
+static constexpr int MS_IN_USE = 1000;
+
 #if defined(TARGET_TX)
+#include "CRSF.h"
 #include "POWERMGNT.h"
+
 void EnterBindingMode();
 
 static void enterBindMode3Click()
@@ -109,6 +114,14 @@ static int timeout()
     {
         return DURATION_NEVER;
     }
+#if defined(TARGET_TX)
+    if (CRSF::IsArmed())
+        return MS_IN_USE;
+#else
+    if (connectionState == connected)
+        return MS_IN_USE;
+#endif
+
     return button.update();
 }
 

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -80,9 +80,9 @@ public:
     static void SetHeaderAndCrc(uint8_t *frame, uint8_t frameType, uint8_t frameSize, uint8_t destAddr);
     static void SetExtendedHeaderAndCrc(uint8_t *frame, uint8_t frameType, uint8_t frameSize, uint8_t senderAddr, uint8_t destAddr);
     static uint32_t VersionStrToU32(const char *verStr);
-    static bool IsArmed() { return CRSF_to_BIT(ChannelData[4]); } // AUX1
 
     #ifdef CRSF_TX_MODULE
+    static bool IsArmed() { return CRSF_to_BIT(ChannelData[4]); } // AUX1
     static void ICACHE_RAM_ATTR sendLinkStatisticsToTX();
     static void ICACHE_RAM_ATTR sendTelemetryToTX(uint8_t *data);
 

--- a/src/lib/VTXSPI/devVTXSPI.cpp
+++ b/src/lib/VTXSPI/devVTXSPI.cpp
@@ -45,8 +45,6 @@
 
 #define BUF_PACKET_SIZE                         4 // 25b packet in 4 bytes
 
-extern bool ICACHE_RAM_ATTR IsArmed();
-
 uint8_t vtxSPIBandChannelIdx = 255;
 static uint8_t vtxSPIBandChannelIdxCurrent = 255;
 uint8_t vtxSPIPowerIdx = 0;
@@ -306,11 +304,6 @@ static int event()
     if (GPIO_PIN_SPI_VTX_NSS == UNDEF_PIN)
     {
         return DURATION_NEVER;
-    }
-
-    if (CRSF::IsArmed())
-    {
-        vtxSPIBandChannelIdx = vtxSPIBandChannelIdxCurrent; // Do not allow frequency changed while armed.
     }
 
     if (vtxSPIBandChannelIdxCurrent != vtxSPIBandChannelIdx)

--- a/src/lib/VTXSPI/devVTXSPI.h
+++ b/src/lib/VTXSPI/devVTXSPI.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "device.h"
-#include "CRSF.h"
 
 extern device_t VTxSPI_device;
 


### PR DESCRIPTION
## Remove usage of `IsArmed` from receivers.

In the case of the button, we can disable its use if the receiver is connected to a TX by using the connected state.

For the SPI VTX, the TX is already checking `IsArmed` and not sending the MSP packet, so it's safe to remove the double-check on the receiver.

I also moved the `IsArmed` definition in the CRSF header file into the TX only section, so new calls cannot be introduced in the RX. Hopefully giving anyone trying to do it pause for concern...