### PR TITLE
Fixes TFT quirk displaying overwritten text

### DIFF
--- a/src/lib/SCREEN/TFT/tftdisplay.cpp
+++ b/src/lib/SCREEN/TFT/tftdisplay.cpp
@@ -183,19 +183,13 @@ void TFTDisplay::displaySplashScreen()
 
 void TFTDisplay::displayIdleScreen(uint8_t changed, uint8_t rate_index, uint8_t power_index, uint8_t ratio_index, uint8_t motion_index, uint8_t fan_index, bool dynamic, uint8_t running_power_index, uint8_t temperature, message_index_t message_index)
 {
-    if (connectionState == radioFailed || connectionState == noCrossfire)
-    {
-        changed = 0xFF;
-        message_index = MSG_ERROR;
-    }
-
-    if (changed == 0xFF)
+    if (changed == CHANGED_ALL)
     {
         // Everything has changed! So clear the right side
         gfx->fillRect(SCREEN_X/2, 0, SCREEN_X/2, SCREEN_Y, WHITE);
     }
 
-    if (changed & CHANGED_MESSAGE)
+    if (changed & CHANGED_TEMP)
     {
         // Left side logo, version, and temp
         gfx->fillRect(0, 0, SCREEN_X/2, SCREEN_Y, elrs_banner_bgColor[message_index]);

--- a/src/lib/SCREEN/display.h
+++ b/src/lib/SCREEN/display.h
@@ -30,12 +30,13 @@
 #endif
 
 
-#define CHANGED_MESSAGE bit(0)
+#define CHANGED_TEMP bit(0)
 #define CHANGED_RATE bit(1)
 #define CHANGED_POWER bit(2)
 #define CHANGED_TELEMETRY bit(3)
 #define CHANGED_MOTION bit(4)
 #define CHANGED_FAN bit(5)
+#define CHANGED_ALL 0xFF
 
 typedef enum fsm_state_s menu_item_t;
 

--- a/src/lib/SCREEN/menu.cpp
+++ b/src/lib/SCREEN/menu.cpp
@@ -69,14 +69,28 @@ static void displayIdleScreen(bool init)
     }
 #endif
 
-    message_index_t disp_message = CRSF::IsArmed() ? MSG_ARMED : ((connectionState == connected) ? (connectionHasModelMatch ? MSG_CONNECTED : MSG_MISMATCH) : MSG_NONE);
-    uint8_t changed = init ? 0xFF : 0;
+    uint8_t changed = init ? CHANGED_ALL : 0;
+    message_index_t disp_message;
+    if (connectionState == noCrossfire || connectionState > FAILURE_STATES) {
+        disp_message = MSG_ERROR;
+    } else if(CRSF::IsArmed()) {
+        disp_message = MSG_ARMED;
+    } else if(connectionState == connected) {
+        if (connectionHasModelMatch) {
+            disp_message = MSG_CONNECTED;
+        } else {
+            disp_message = MSG_MISMATCH;
+        }
+    } else {
+        disp_message = MSG_NONE;
+    }
+
     // compute log2(ExpressLRS_currTlmDenom) (e.g. 128=7, 64=6, etc)
     uint8_t tlmIdx = __builtin_ffs(ExpressLRS_currTlmDenom) - 1;
     if (changed == 0)
     {
-        changed |= last_message != disp_message ? CHANGED_MESSAGE : 0;
-        changed |= last_temperature != temperature ? CHANGED_MESSAGE : 0;
+        changed |= last_message != disp_message ? CHANGED_ALL : 0;
+        changed |= last_temperature != temperature ? CHANGED_TEMP : 0;
         changed |= last_rate != config.GetRate() ? CHANGED_RATE : 0;
         changed |= last_power != config.GetPower() ? CHANGED_POWER : 0;
         changed |= last_dynamic != config.GetDynamicPower() ? CHANGED_POWER : 0;


### PR DESCRIPTION
# Problem
When debugging a TFT device and using the USB to power it, it will display "NO HANDSET", which is correct.
Connect it to a handset while in this state and the rate etc is displayed over the top of the "NO HANDSET" message without clearing it!

# Solution
Do it properly!

The main problem was that the `CHANGED_MESSAGE` constant was used for temperature change as well as a message display, so that was renamed to `CHANGED_TEMP`. Introduced a `CHANGED_ALL` constant to do a full refresh, which is used if the message is different. Moved the detection of the "error" states out of the TFT code and into the menu code where it belongs, as the "error" states should set the message type and therefore `CHANGED_ALL` is passed down to the display.