### PR TITLE
Pin define `ant_ctrl` typo on Namimno 2.4g Diversity target

### DIFF
--- a/src/hardware/RX/Namimno FLASH 2400 PA.json
+++ b/src/hardware/RX/Namimno FLASH 2400 PA.json
@@ -8,7 +8,7 @@
     "radio_nss": 15,
     "radio_rst": 2,
     "radio_sck": 14,
-    "ant_select": 0,
+    "ant_ctrl": 0,
     "power_txen": 9,
     "power_min": 0,
     "power_high": 3,


### PR DESCRIPTION
`ant_ctrl` pin was defined using old name `ant_select` which prevented the proper diversity operation of the RX.