### PR TITLE
Avoid updating the thermal device if no change

### DIFF
--- a/src/lib/THERMAL/thermal.cpp
+++ b/src/lib/THERMAL/thermal.cpp
@@ -58,6 +58,12 @@ uint8_t Thermal::read_temp()
 
 void Thermal::update_threshold(int index)
 {
+    static int prevIndex = -1;
+    if (index == prevIndex)
+    {
+        return;
+    }
+    prevIndex = index;
     if(thermal_status != THERMAL_STATUS_NORMAL)
     {
         ERRLN("thermal not ready!");


### PR DESCRIPTION
On the Axis module the thermal device (LM75A) was being updated every second even if the fan-mode had not changed!
This was causing lockups during boot of some users Axis modules.