### PR TITLE
Add ETX passthrough target for T-Lite V2 and T-Pro

### DIFF
--- a/src/targets/Jumper_2400.ini
+++ b/src/targets/Jumper_2400.ini
@@ -18,7 +18,7 @@ upload_speed = 460800
 lib_deps =
 	${env_common_esp32.lib_deps}
 
-[env:Jumper_AION_2400_T-Lite_TX_via_WIFI]
+[env:Jumper_AION_2400_T-Lite_TX_via_ETX]
 extends = env_common_esp32, radio_2400
 board = pico32
 build_flags =
@@ -32,6 +32,9 @@ build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp>
 upload_speed = 460800
 lib_deps =
 	${env_common_esp32.lib_deps}
+
+[env:Jumper_AION_2400_T-Lite_TX_via_WIFI]
+extends = Jumper_AION_2400_T-Lite_TX_via_ETX
 
 [env:Jumper_AION_NANO_2400_TX_via_UART]
 extends = env_common_esp32, radio_2400

--- a/src/targets/Jumper_2400.ini
+++ b/src/targets/Jumper_2400.ini
@@ -18,7 +18,10 @@ upload_speed = 460800
 lib_deps =
 	${env_common_esp32.lib_deps}
 
-[env:Jumper_AION_2400_T-Lite_TX_via_ETX]
+[env:Jumper_AION_2400_T-Pro_TX_via_ETX]
+extends = env:Jumper_AION_2400_T-Pro_TX_via_WIFI
+
+[env:Jumper_AION_2400_T-Lite_TX_via_WIFI]
 extends = env_common_esp32, radio_2400
 board = pico32
 build_flags =
@@ -33,8 +36,8 @@ upload_speed = 460800
 lib_deps =
 	${env_common_esp32.lib_deps}
 
-[env:Jumper_AION_2400_T-Lite_TX_via_WIFI]
-extends = Jumper_AION_2400_T-Lite_TX_via_ETX
+[env:Jumper_AION_2400_T-Lite_TX_via_ETX]
+extends = env:Jumper_AION_2400_T-Lite_TX_via_WIFI
 
 [env:Jumper_AION_NANO_2400_TX_via_UART]
 extends = env_common_esp32, radio_2400


### PR DESCRIPTION
Please correct me if I'm wrong, but I think this is all that is needed to also allow for ETX passthrough support in Configurator for this handset (in addition to the WiFi support that was added in #1709)? ~~I'm hoping I can find out for myself once this PR is created~~ (Derp... didn't notice before pushing that pointing to a local folder is a configurator option). So anyway, confirmed that ETX passthrough worked on T-Lite V2 with this change.

<details>
  <summary>Configurator Upload Log</summary>
  
```
Processing Jumper_AION_2400_T-Lite_TX_via_ETX (board: pico32; platform: espressif32@3.3.2; framework: arduino)
--------------------------------------------------------------------------------
Library Manager: Installing makuna/NeoPixelBus @ ^2.6.7
Downloading 0% 10% 20% 30% 40% 50% 60% 70% 80% 90% 100%
Unpacking
Library Manager: NeoPixelBus@2.7.0 has been installed!
Library Manager: Resolving dependencies...
Library Manager: Installing ottowinter/ESPAsyncWebServer-esphome @ ^2.1.0
Unpacking
Library Manager: ESPAsyncWebServer-esphome@2.1.0 has been installed!
Library Manager: Resolving dependencies...
Library Manager: Installing esphome/AsyncTCP-esphome
Unpacking
Library Manager: AsyncTCP-esphome@2.0.0 has been installed!
Library Manager: Installing lemmingdev/ESP32-BLE-Gamepad @ ^0.3.3
Unpacking
Library Manager: ESP32-BLE-Gamepad@0.3.4 has been installed!
Library Manager: Resolving dependencies...
Library Manager: Installing NimBLE-Arduino
Unpacking
Library Manager: NimBLE-Arduino@1.4.0 has been installed!
Verbose mode can be enabled via `-v, --verbose` option
UID bytes: 169,118,139,153,77,191
***CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/pico32.html
PLATFORM: Espressif 32 (3.3.2) > ESP32 Pico Kit
HARDWARE: ESP32 240MHz, 320KB RAM, 4MB Flash
DEBUG: Current (esp-prog) External (esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
PACKAGES: 
 - framework-arduinoespressif32 @ 3.10006.210326 (1.0.6) 
 - tool-esptoolpy @ 1.30100.210531 (3.1.0) 
 - tool-mkspiffs @ 2.230.0 (2.30) 
 - toolchain-xtensa32 @ 2.50200.97 (5.2.0)
LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
LDF Modes: Finder ~ chain, Compatibility ~ soft
Found 68 compatible libraries
Scanning dependencies...
Dependency Graph
|-- NeoPixelBus @ 2.7.0
|   |-- SPI @ 1.0
|-- ESPAsyncWebServer-esphome @ 2.1.0
|   |-- AsyncTCP-esphome @ 2.0.0
|   |-- FS @ 1.0
|   |-- WiFi @ 1.0
|-- ESP32-BLE-Gamepad @ 0.3.4
|   |-- NimBLE-Arduino @ 1.4.0
|-- NimBLE-Arduino @ 1.4.0
|-- SX1280Driver
|   |-- logging
|   |-- SPI @ 1.0
|-- CONFIG
|   |-- EEPROM
|   |   |-- logging
|   |   |-- EEPROM @ 1.0.3
|   |   |-- Wire @ 1.0.1
|   |-- logging
|   |-- OTA
|   |   |-- CRSF
|   |   |   |-- CRC
|   |   |   |-- CrsfProtocol
|   |   |   |   |-- CRC
|   |   |   |-- MSP
|   |   |   |   |-- logging
|   |   |   |-- TelemetryProtocol
|   |   |   |-- DEVICE
|   |   |   |   |-- helpers
|   |   |   |   |-- logging
|   |   |   |   |-- SX1280Driver
|   |   |   |   |   |-- logging
|   |   |   |   |   |-- SPI @ 1.0
|   |   |   |-- FIFO
|   |   |   |   |-- logging
|   |   |   |-- helpers
|   |   |   |-- logging
|   |-- POWERMGNT
|   |   |-- DAC
|   |   |   |-- Wire @ 1.0.1
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |-- DEVICE
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |   |-- SX1280Driver
|   |   |   |   |-- logging
|   |   |   |   |-- SPI @ 1.0
|   |   |-- SX1280Driver
|   |   |   |-- logging
|   |   |   |-- SPI @ 1.0
|   |   |-- helpers
|-- CRSF
|   |-- CRC
|   |-- CrsfProtocol
|   |   |-- CRC
|   |-- MSP
|   |   |-- logging
|   |-- TelemetryProtocol
|   |-- DEVICE
|   |   |-- helpers
|   |   |-- logging
|   |   |-- SX1280Driver
|   |   |   |-- logging
|   |   |   |-- SPI @ 1.0
|   |-- FIFO
|   |   |-- logging
|   |-- helpers
|   |-- logging
|-- Backpack
|   |-- DEVICE
|   |   |-- helpers
|   |   |-- logging
|   |   |-- SX1280Driver
|   |   |   |-- logging
|   |   |   |-- SPI @ 1.0
|   |-- CONFIG
|   |   |-- EEPROM
|   |   |   |-- logging
|   |   |   |-- EEPROM @ 1.0.3
|   |   |   |-- Wire @ 1.0.1
|   |   |-- logging
|   |   |-- OTA
|   |   |   |-- CRSF
|   |   |   |   |-- CRC
|   |   |   |   |-- CrsfProtocol
|   |   |   |   |   |-- CRC
|   |   |   |   |-- MSP
|   |   |   |   |   |-- logging
|   |   |   |   |-- TelemetryProtocol
|   |   |   |   |-- DEVICE
|   |   |   |   |   |-- helpers
|   |   |   |   |   |-- logging
|   |   |   |   |   |-- SX1280Driver
|   |   |   |   |   |   |-- logging
|   |   |   |   |   |   |-- SPI @ 1.0
|   |   |   |   |-- FIFO
|   |   |   |   |   |-- logging
|   |   |   |   |-- helpers
|   |   |   |   |-- logging
|   |   |-- POWERMGNT
|   |   |   |-- DAC
|   |   |   |   |-- Wire @ 1.0.1
|   |   |   |   |-- helpers
|   |   |   |   |-- logging
|   |   |   |-- DEVICE
|   |   |   |   |-- helpers
|   |   |   |   |-- logging
|   |   |   |   |-- SX1280Driver
|   |   |   |   |   |-- logging
|   |   |   |   |   |-- SPI @ 1.0
|   |   |   |-- SX1280Driver
|   |   |   |   |-- logging
|   |   |   |   |-- SPI @ 1.0
|   |   |   |-- helpers
|   |-- CRSF
|   |   |-- CRC
|   |   |-- CrsfProtocol
|   |   |   |-- CRC
|   |   |-- MSP
|   |   |   |-- logging
|   |   |-- TelemetryProtocol
|   |   |-- DEVICE
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |   |-- SX1280Driver
|   |   |   |   |-- logging
|   |   |   |   |-- SPI @ 1.0
|   |   |-- FIFO
|   |   |   |-- logging
|   |   |-- helpers
|   |   |-- logging
|   |-- HWTIMER
|   |   |-- logging
|   |-- MSP
|   |   |-- logging
|   |-- SX1280Driver
|   |   |-- logging
|   |   |-- SPI @ 1.0
|-- BLE
|   |-- DEVICE
|   |   |-- helpers
|   |   |-- logging
|   |   |-- SX1280Driver
|   |   |   |-- logging
|   |   |   |-- SPI @ 1.0
|   |-- CRSF
|   |   |-- CRC
|   |   |-- CrsfProtocol
|   |   |   |-- CRC
|   |   |-- MSP
|   |   |   |-- logging
|   |   |-- TelemetryProtocol
|   |   |-- DEVICE
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |   |-- SX1280Driver
|   |   |   |   |-- logging
|   |   |   |   |-- SPI @ 1.0
|   |   |-- FIFO
|   |   |   |-- logging
|   |   |-- helpers
|   |   |-- logging
|   |-- HWTIMER
|   |   |-- logging
|   |-- logging
|   |-- POWERMGNT
|   |   |-- DAC
|   |   |   |-- Wire @ 1.0.1
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |-- DEVICE
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |   |-- SX1280Driver
|   |   |   |   |-- logging
|   |   |   |   |-- SPI @ 1.0
|   |   |-- SX1280Driver
|   |   |   |-- logging
|   |   |   |-- SPI @ 1.0
|   |   |-- helpers
|   |-- ESP32-BLE-Gamepad @ 0.3.4
|   |   |-- NimBLE-Arduino @ 1.4.0
|-- BUTTON
|   |-- DEVICE
|   |   |-- helpers
|   |   |-- logging
|   |   |-- SX1280Driver
|   |   |   |-- logging
|   |   |   |-- SPI @ 1.0
|   |-- logging
|   |-- POWERMGNT
|   |   |-- DAC
|   |   |   |-- Wire @ 1.0.1
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |-- DEVICE
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |   |-- SX1280Driver
|   |   |   |   |-- logging
|   |   |   |   |-- SPI @ 1.0
|   |   |-- SX1280Driver
|   |   |   |-- logging
|   |   |   |-- SPI @ 1.0
|   |   |-- helpers
|-- BUZZER
|   |-- DEVICE
|   |   |-- helpers
|   |   |-- logging
|   |   |-- SX1280Driver
|   |   |   |-- logging
|   |   |   |-- SPI @ 1.0
|   |-- helpers
|   |-- logging
|   |-- POWERMGNT
|   |   |-- DAC
|   |   |   |-- Wire @ 1.0.1
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |-- DEVICE
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |   |-- SX1280Driver
|   |   |   |   |-- logging
|   |   |   |   |-- SPI @ 1.0
|   |   |-- SX1280Driver
|   |   |   |-- logging
|   |   |   |-- SPI @ 1.0
|   |   |-- helpers
|-- GSENSOR
|   |-- DEVICE
|   |   |-- helpers
|   |   |-- logging
|   |   |-- SX1280Driver
|   |   |   |-- logging
|   |   |   |-- SPI @ 1.0
|   |-- CONFIG
|   |   |-- EEPROM
|   |   |   |-- logging
|   |   |   |-- EEPROM @ 1.0.3
|   |   |   |-- Wire @ 1.0.1
|   |   |-- logging
|   |   |-- OTA
|   |   |   |-- CRSF
|   |   |   |   |-- CRC
|   |   |   |   |-- CrsfProtocol
|   |   |   |   |   |-- CRC
|   |   |   |   |-- MSP
|   |   |   |   |   |-- logging
|   |   |   |   |-- TelemetryProtocol
|   |   |   |   |-- DEVICE
|   |   |   |   |   |-- helpers
|   |   |   |   |   |-- logging
|   |   |   |   |   |-- SX1280Driver
|   |   |   |   |   |   |-- logging
|   |   |   |   |   |   |-- SPI @ 1.0
|   |   |   |   |-- FIFO
|   |   |   |   |   |-- logging
|   |   |   |   |-- helpers
|   |   |   |   |-- logging
|   |   |-- POWERMGNT
|   |   |   |-- DAC
|   |   |   |   |-- Wire @ 1.0.1
|   |   |   |   |-- helpers
|   |   |   |   |-- logging
|   |   |   |-- DEVICE
|   |   |   |   |-- helpers
|   |   |   |   |-- logging
|   |   |   |   |-- SX1280Driver
|   |   |   |   |   |-- logging
|   |   |   |   |   |-- SPI @ 1.0
|   |   |   |-- SX1280Driver
|   |   |   |   |-- logging
|   |   |   |   |-- SPI @ 1.0
|   |   |   |-- helpers
|   |-- logging
|   |-- Wire @ 1.0.1
|   |-- POWERMGNT
|   |   |-- DAC
|   |   |   |-- Wire @ 1.0.1
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |-- DEVICE
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |   |-- SX1280Driver
|   |   |   |   |-- logging
|   |   |   |   |-- SPI @ 1.0
|   |   |-- SX1280Driver
|   |   |   |-- logging
|   |   |   |-- SPI @ 1.0
|   |   |-- helpers
|-- LED
|   |-- DEVICE
|   |   |-- helpers
|   |   |-- logging
|   |   |-- SX1280Driver
|   |   |   |-- logging
|   |   |   |-- SPI @ 1.0
|   |-- CrsfProtocol
|   |   |-- CRC
|   |-- POWERMGNT
|   |   |-- DAC
|   |   |   |-- Wire @ 1.0.1
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |-- DEVICE
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |   |-- SX1280Driver
|   |   |   |   |-- logging
|   |   |   |   |-- SPI @ 1.0
|   |   |-- SX1280Driver
|   |   |   |-- logging
|   |   |   |-- SPI @ 1.0
|   |   |-- helpers
|   |-- logging
|   |-- NeoPixelBus @ 2.7.0
|   |   |-- SPI @ 1.0
|-- LUA
|   |-- DEVICE
|   |   |-- helpers
|   |   |-- logging
|   |   |-- SX1280Driver
|   |   |   |-- logging
|   |   |   |-- SPI @ 1.0
|   |-- CONFIG
|   |   |-- EEPROM
|   |   |   |-- logging
|   |   |   |-- EEPROM @ 1.0.3
|   |   |   |-- Wire @ 1.0.1
|   |   |-- logging
|   |   |-- OTA
|   |   |   |-- CRSF
|   |   |   |   |-- CRC
|   |   |   |   |-- CrsfProtocol
|   |   |   |   |   |-- CRC
|   |   |   |   |-- MSP
|   |   |   |   |   |-- logging
|   |   |   |   |-- TelemetryProtocol
|   |   |   |   |-- DEVICE
|   |   |   |   |   |-- helpers
|   |   |   |   |   |-- logging
|   |   |   |   |   |-- SX1280Driver
|   |   |   |   |   |   |-- logging
|   |   |   |   |   |   |-- SPI @ 1.0
|   |   |   |   |-- FIFO
|   |   |   |   |   |-- logging
|   |   |   |   |-- helpers
|   |   |   |   |-- logging
|   |   |-- POWERMGNT
|   |   |   |-- DAC
|   |   |   |   |-- Wire @ 1.0.1
|   |   |   |   |-- helpers
|   |   |   |   |-- logging
|   |   |   |-- DEVICE
|   |   |   |   |-- helpers
|   |   |   |   |-- logging
|   |   |   |   |-- SX1280Driver
|   |   |   |   |   |-- logging
|   |   |   |   |   |-- SPI @ 1.0
|   |   |   |-- SX1280Driver
|   |   |   |   |-- logging
|   |   |   |   |-- SPI @ 1.0
|   |   |   |-- helpers
|   |-- CRSF
|   |   |-- CRC
|   |   |-- CrsfProtocol
|   |   |   |-- CRC
|   |   |-- MSP
|   |   |   |-- logging
|   |   |-- TelemetryProtocol
|   |   |-- DEVICE
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |   |-- SX1280Driver
|   |   |   |   |-- logging
|   |   |   |   |-- SPI @ 1.0
|   |   |-- FIFO
|   |   |   |-- logging
|   |   |-- helpers
|   |   |-- logging
|   |-- HWTIMER
|   |   |-- logging
|   |-- logging
|   |-- OTA
|   |   |-- CRSF
|   |   |   |-- CRC
|   |   |   |-- CrsfProtocol
|   |   |   |   |-- CRC
|   |   |   |-- MSP
|   |   |   |   |-- logging
|   |   |   |-- TelemetryProtocol
|   |   |   |-- DEVICE
|   |   |   |   |-- helpers
|   |   |   |   |-- logging
|   |   |   |   |-- SX1280Driver
|   |   |   |   |   |-- logging
|   |   |   |   |   |-- SPI @ 1.0
|   |   |   |-- FIFO
|   |   |   |   |-- logging
|   |   |   |-- helpers
|   |   |   |-- logging
|   |-- POWERMGNT
|   |   |-- DAC
|   |   |   |-- Wire @ 1.0.1
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |-- DEVICE
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |   |-- SX1280Driver
|   |   |   |   |-- logging
|   |   |   |   |-- SPI @ 1.0
|   |   |-- SX1280Driver
|   |   |   |-- logging
|   |   |   |-- SPI @ 1.0
|   |   |-- helpers
|   |-- SX1280Driver
|   |   |-- logging
|   |   |-- SPI @ 1.0
|   |-- CrsfProtocol
|   |   |-- CRC
|-- POWER_DETECT
|   |-- DEVICE
|   |   |-- helpers
|   |   |-- logging
|   |   |-- SX1280Driver
|   |   |   |-- logging
|   |   |   |-- SPI @ 1.0
|   |-- logging
|   |-- POWERMGNT
|   |   |-- DAC
|   |   |   |-- Wire @ 1.0.1
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |-- DEVICE
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |   |-- SX1280Driver
|   |   |   |   |-- logging
|   |   |   |   |-- SPI @ 1.0
|   |   |-- SX1280Driver
|   |   |   |-- logging
|   |   |   |-- SPI @ 1.0
|   |   |-- helpers
|-- SCREEN
|   |-- DEVICE
|   |   |-- helpers
|   |   |-- logging
|   |   |-- SX1280Driver
|   |   |   |-- logging
|   |   |   |-- SPI @ 1.0
|   |-- CONFIG
|   |   |-- EEPROM
|   |   |   |-- logging
|   |   |   |-- EEPROM @ 1.0.3
|   |   |   |-- Wire @ 1.0.1
|   |   |-- logging
|   |   |-- OTA
|   |   |   |-- CRSF
|   |   |   |   |-- CRC
|   |   |   |   |-- CrsfProtocol
|   |   |   |   |   |-- CRC
|   |   |   |   |-- MSP
|   |   |   |   |   |-- logging
|   |   |   |   |-- TelemetryProtocol
|   |   |   |   |-- DEVICE
|   |   |   |   |   |-- helpers
|   |   |   |   |   |-- logging
|   |   |   |   |   |-- SX1280Driver
|   |   |   |   |   |   |-- logging
|   |   |   |   |   |   |-- SPI @ 1.0
|   |   |   |   |-- FIFO
|   |   |   |   |   |-- logging
|   |   |   |   |-- helpers
|   |   |   |   |-- logging
|   |   |-- POWERMGNT
|   |   |   |-- DAC
|   |   |   |   |-- Wire @ 1.0.1
|   |   |   |   |-- helpers
|   |   |   |   |-- logging
|   |   |   |-- DEVICE
|   |   |   |   |-- helpers
|   |   |   |   |-- logging
|   |   |   |   |-- SX1280Driver
|   |   |   |   |   |-- logging
|   |   |   |   |   |-- SPI @ 1.0
|   |   |   |-- SX1280Driver
|   |   |   |   |-- logging
|   |   |   |   |-- SPI @ 1.0
|   |   |   |-- helpers
|   |-- POWERMGNT
|   |   |-- DAC
|   |   |   |-- Wire @ 1.0.1
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |-- DEVICE
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |   |-- SX1280Driver
|   |   |   |   |-- logging
|   |   |   |   |-- SPI @ 1.0
|   |   |-- SX1280Driver
|   |   |   |-- logging
|   |   |   |-- SPI @ 1.0
|   |   |-- helpers
|   |-- GSENSOR
|   |   |-- DEVICE
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |   |-- SX1280Driver
|   |   |   |   |-- logging
|   |   |   |   |-- SPI @ 1.0
|   |   |-- CONFIG
|   |   |   |-- EEPROM
|   |   |   |   |-- logging
|   |   |   |   |-- EEPROM @ 1.0.3
|   |   |   |   |-- Wire @ 1.0.1
|   |   |   |-- logging
|   |   |   |-- OTA
|   |   |   |   |-- CRSF
|   |   |   |   |   |-- CRC
|   |   |   |   |   |-- CrsfProtocol
|   |   |   |   |   |   |-- CRC
|   |   |   |   |   |-- MSP
|   |   |   |   |   |   |-- logging
|   |   |   |   |   |-- TelemetryProtocol
|   |   |   |   |   |-- DEVICE
|   |   |   |   |   |   |-- helpers
|   |   |   |   |   |   |-- logging
|   |   |   |   |   |   |-- SX1280Driver
|   |   |   |   |   |   |   |-- logging
|   |   |   |   |   |   |   |-- SPI @ 1.0
|   |   |   |   |   |-- FIFO
|   |   |   |   |   |   |-- logging
|   |   |   |   |   |-- helpers
|   |   |   |   |   |-- logging
|   |   |   |-- POWERMGNT
|   |   |   |   |-- DAC
|   |   |   |   |   |-- Wire @ 1.0.1
|   |   |   |   |   |-- helpers
|   |   |   |   |   |-- logging
|   |   |   |   |-- DEVICE
|   |   |   |   |   |-- helpers
|   |   |   |   |   |-- logging
|   |   |   |   |   |-- SX1280Driver
|   |   |   |   |   |   |-- logging
|   |   |   |   |   |   |-- SPI @ 1.0
|   |   |   |   |-- SX1280Driver
|   |   |   |   |   |-- logging
|   |   |   |   |   |-- SPI @ 1.0
|   |   |   |   |-- helpers
|   |   |-- logging
|   |   |-- Wire @ 1.0.1
|   |   |-- POWERMGNT
|   |   |   |-- DAC
|   |   |   |   |-- Wire @ 1.0.1
|   |   |   |   |-- helpers
|   |   |   |   |-- logging
|   |   |   |-- DEVICE
|   |   |   |   |-- helpers
|   |   |   |   |-- logging
|   |   |   |   |-- SX1280Driver
|   |   |   |   |   |-- logging
|   |   |   |   |   |-- SPI @ 1.0
|   |   |   |-- SX1280Driver
|   |   |   |   |-- logging
|   |   |   |   |-- SPI @ 1.0
|   |   |   |-- helpers
|   |-- HWTIMER
|   |   |-- logging
|   |-- logging
|   |-- THERMAL
|   |   |-- Wire @ 1.0.1
|   |   |-- logging
|   |   |-- DEVICE
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |   |-- SX1280Driver
|   |   |   |   |-- logging
|   |   |   |   |-- SPI @ 1.0
|   |   |-- CONFIG
|   |   |   |-- EEPROM
|   |   |   |   |-- logging
|   |   |   |   |-- EEPROM @ 1.0.3
|   |   |   |   |-- Wire @ 1.0.1
|   |   |   |-- logging
|   |   |   |-- OTA
|   |   |   |   |-- CRSF
|   |   |   |   |   |-- CRC
|   |   |   |   |   |-- CrsfProtocol
|   |   |   |   |   |   |-- CRC
|   |   |   |   |   |-- MSP
|   |   |   |   |   |   |-- logging
|   |   |   |   |   |-- TelemetryProtocol
|   |   |   |   |   |-- DEVICE
|   |   |   |   |   |   |-- helpers
|   |   |   |   |   |   |-- logging
|   |   |   |   |   |   |-- SX1280Driver
|   |   |   |   |   |   |   |-- logging
|   |   |   |   |   |   |   |-- SPI @ 1.0
|   |   |   |   |   |-- FIFO
|   |   |   |   |   |   |-- logging
|   |   |   |   |   |-- helpers
|   |   |   |   |   |-- logging
|   |   |   |-- POWERMGNT
|   |   |   |   |-- DAC
|   |   |   |   |   |-- Wire @ 1.0.1
|   |   |   |   |   |-- helpers
|   |   |   |   |   |-- logging
|   |   |   |   |-- DEVICE
|   |   |   |   |   |-- helpers
|   |   |   |   |   |-- logging
|   |   |   |   |   |-- SX1280Driver
|   |   |   |   |   |   |-- logging
|   |   |   |   |   |   |-- SPI @ 1.0
|   |   |   |   |-- SX1280Driver
|   |   |   |   |   |-- logging
|   |   |   |   |   |-- SPI @ 1.0
|   |   |   |   |-- helpers
|   |   |-- POWERMGNT
|   |   |   |-- DAC
|   |   |   |   |-- Wire @ 1.0.1
|   |   |   |   |-- helpers
|   |   |   |   |-- logging
|   |   |   |-- DEVICE
|   |   |   |   |-- helpers
|   |   |   |   |-- logging
|   |   |   |   |-- SX1280Driver
|   |   |   |   |   |-- logging
|   |   |   |   |   |-- SPI @ 1.0
|   |   |   |-- SX1280Driver
|   |   |   |   |-- logging
|   |   |   |   |-- SPI @ 1.0
|   |   |   |-- helpers
|   |-- Wire @ 1.0.1
|   |-- SPI @ 1.0
|-- THERMAL
|   |-- Wire @ 1.0.1
|   |-- logging
|   |-- DEVICE
|   |   |-- helpers
|   |   |-- logging
|   |   |-- SX1280Driver
|   |   |   |-- logging
|   |   |   |-- SPI @ 1.0
|   |-- CONFIG
|   |   |-- EEPROM
|   |   |   |-- logging
|   |   |   |-- EEPROM @ 1.0.3
|   |   |   |-- Wire @ 1.0.1
|   |   |-- logging
|   |   |-- OTA
|   |   |   |-- CRSF
|   |   |   |   |-- CRC
|   |   |   |   |-- CrsfProtocol
|   |   |   |   |   |-- CRC
|   |   |   |   |-- MSP
|   |   |   |   |   |-- logging
|   |   |   |   |-- TelemetryProtocol
|   |   |   |   |-- DEVICE
|   |   |   |   |   |-- helpers
|   |   |   |   |   |-- logging
|   |   |   |   |   |-- SX1280Driver
|   |   |   |   |   |   |-- logging
|   |   |   |   |   |   |-- SPI @ 1.0
|   |   |   |   |-- FIFO
|   |   |   |   |   |-- logging
|   |   |   |   |-- helpers
|   |   |   |   |-- logging
|   |   |-- POWERMGNT
|   |   |   |-- DAC
|   |   |   |   |-- Wire @ 1.0.1
|   |   |   |   |-- helpers
|   |   |   |   |-- logging
|   |   |   |-- DEVICE
|   |   |   |   |-- helpers
|   |   |   |   |-- logging
|   |   |   |   |-- SX1280Driver
|   |   |   |   |   |-- logging
|   |   |   |   |   |-- SPI @ 1.0
|   |   |   |-- SX1280Driver
|   |   |   |   |-- logging
|   |   |   |   |-- SPI @ 1.0
|   |   |   |-- helpers
|   |-- POWERMGNT
|   |   |-- DAC
|   |   |   |-- Wire @ 1.0.1
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |-- DEVICE
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |   |-- SX1280Driver
|   |   |   |   |-- logging
|   |   |   |   |-- SPI @ 1.0
|   |   |-- SX1280Driver
|   |   |   |-- logging
|   |   |   |-- SPI @ 1.0
|   |   |-- helpers
|-- VTX
|   |-- DEVICE
|   |   |-- helpers
|   |   |-- logging
|   |   |-- SX1280Driver
|   |   |   |-- logging
|   |   |   |-- SPI @ 1.0
|   |-- CONFIG
|   |   |-- EEPROM
|   |   |   |-- logging
|   |   |   |-- EEPROM @ 1.0.3
|   |   |   |-- Wire @ 1.0.1
|   |   |-- logging
|   |   |-- OTA
|   |   |   |-- CRSF
|   |   |   |   |-- CRC
|   |   |   |   |-- CrsfProtocol
|   |   |   |   |   |-- CRC
|   |   |   |   |-- MSP
|   |   |   |   |   |-- logging
|   |   |   |   |-- TelemetryProtocol
|   |   |   |   |-- DEVICE
|   |   |   |   |   |-- helpers
|   |   |   |   |   |-- logging
|   |   |   |   |   |-- SX1280Driver
|   |   |   |   |   |   |-- logging
|   |   |   |   |   |   |-- SPI @ 1.0
|   |   |   |   |-- FIFO
|   |   |   |   |   |-- logging
|   |   |   |   |-- helpers
|   |   |   |   |-- logging
|   |   |-- POWERMGNT
|   |   |   |-- DAC
|   |   |   |   |-- Wire @ 1.0.1
|   |   |   |   |-- helpers
|   |   |   |   |-- logging
|   |   |   |-- DEVICE
|   |   |   |   |-- helpers
|   |   |   |   |-- logging
|   |   |   |   |-- SX1280Driver
|   |   |   |   |   |-- logging
|   |   |   |   |   |-- SPI @ 1.0
|   |   |   |-- SX1280Driver
|   |   |   |   |-- logging
|   |   |   |   |-- SPI @ 1.0
|   |   |   |-- helpers
|   |-- CRSF
|   |   |-- CRC
|   |   |-- CrsfProtocol
|   |   |   |-- CRC
|   |   |-- MSP
|   |   |   |-- logging
|   |   |-- TelemetryProtocol
|   |   |-- DEVICE
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |   |-- SX1280Driver
|   |   |   |   |-- logging
|   |   |   |   |-- SPI @ 1.0
|   |   |-- FIFO
|   |   |   |-- logging
|   |   |-- helpers
|   |   |-- logging
|   |-- logging
|   |-- MSP
|   |   |-- logging
|-- WIFI
|   |-- DEVICE
|   |   |-- helpers
|   |   |-- logging
|   |   |-- SX1280Driver
|   |   |   |-- logging
|   |   |   |-- SPI @ 1.0
|   |-- CONFIG
|   |   |-- EEPROM
|   |   |   |-- logging
|   |   |   |-- EEPROM @ 1.0.3
|   |   |   |-- Wire @ 1.0.1
|   |   |-- logging
|   |   |-- OTA
|   |   |   |-- CRSF
|   |   |   |   |-- CRC
|   |   |   |   |-- CrsfProtocol
|   |   |   |   |   |-- CRC
|   |   |   |   |-- MSP
|   |   |   |   |   |-- logging
|   |   |   |   |-- TelemetryProtocol
|   |   |   |   |-- DEVICE
|   |   |   |   |   |-- helpers
|   |   |   |   |   |-- logging
|   |   |   |   |   |-- SX1280Driver
|   |   |   |   |   |   |-- logging
|   |   |   |   |   |   |-- SPI @ 1.0
|   |   |   |   |-- FIFO
|   |   |   |   |   |-- logging
|   |   |   |   |-- helpers
|   |   |   |   |-- logging
|   |   |-- POWERMGNT
|   |   |   |-- DAC
|   |   |   |   |-- Wire @ 1.0.1
|   |   |   |   |-- helpers
|   |   |   |   |-- logging
|   |   |   |-- DEVICE
|   |   |   |   |-- helpers
|   |   |   |   |-- logging
|   |   |   |   |-- SX1280Driver
|   |   |   |   |   |-- logging
|   |   |   |   |   |-- SPI @ 1.0
|   |   |   |-- SX1280Driver
|   |   |   |   |-- logging
|   |   |   |   |-- SPI @ 1.0
|   |   |   |-- helpers
|   |-- helpers
|   |-- HWTIMER
|   |   |-- logging
|   |-- logging
|   |-- POWERMGNT
|   |   |-- DAC
|   |   |   |-- Wire @ 1.0.1
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |-- DEVICE
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |   |-- SX1280Driver
|   |   |   |   |-- logging
|   |   |   |   |-- SPI @ 1.0
|   |   |-- SX1280Driver
|   |   |   |-- logging
|   |   |   |-- SPI @ 1.0
|   |   |-- helpers
|   |-- SX1280Driver
|   |   |-- logging
|   |   |-- SPI @ 1.0
|   |-- DNSServer @ 1.1.0
|   |   |-- WiFi @ 1.0
|   |-- ESPAsyncWebServer-esphome @ 2.1.0
|   |   |-- AsyncTCP-esphome @ 2.0.0
|   |   |-- FS @ 1.0
|   |   |-- WiFi @ 1.0
|   |-- ESPmDNS @ 1.0
|   |   |-- WiFi @ 1.0
|   |-- Update @ 1.0
|   |-- WiFi @ 1.0
|-- FHSS
|   |-- SX1280Driver
|   |   |-- logging
|   |   |-- SPI @ 1.0
|   |-- logging
|-- helpers
|-- HWTIMER
|   |-- logging
|-- logging
|-- LQCALC
|-- MSP
|   |-- logging
|-- POWERMGNT
|   |-- DAC
|   |   |-- Wire @ 1.0.1
|   |   |-- helpers
|   |   |-- logging
|   |-- DEVICE
|   |   |-- helpers
|   |   |-- logging
|   |   |-- SX1280Driver
|   |   |   |-- logging
|   |   |   |-- SPI @ 1.0
|   |-- SX1280Driver
|   |   |-- logging
|   |   |-- SPI @ 1.0
|   |-- helpers
|-- StubbornReceiver
|-- StubbornSender
|-- TelemetryProtocol
|-- OTA
|   |-- CRSF
|   |   |-- CRC
|   |   |-- CrsfProtocol
|   |   |   |-- CRC
|   |   |-- MSP
|   |   |   |-- logging
|   |   |-- TelemetryProtocol
|   |   |-- DEVICE
|   |   |   |-- helpers
|   |   |   |-- logging
|   |   |   |-- SX1280Driver
|   |   |   |   |-- logging
|   |   |   |   |-- SPI @ 1.0
|   |   |-- FIFO
|   |   |   |-- logging
|   |   |-- helpers
|   |   |-- logging
Building in release mode
PLATFORM : 'espressif32'
BUILD ENV: 'JUMPER_AION_2400_T-LITE_TX_VIA_ETX'
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\src\common.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\src\hal\hal_stm32.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\src\options.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\src\tx_main.cpp.o
Generating partitions .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\partitions.bin
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libade\SPI\SPI.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib007\NeoPixelBus\internal\Esp32_i2s.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib007\NeoPixelBus\internal\HsbColor.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib007\NeoPixelBus\internal\HslColor.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib007\NeoPixelBus\internal\HtmlColor.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib007\NeoPixelBus\internal\HtmlColorNameStrings.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib007\NeoPixelBus\internal\HtmlColorNames.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib007\NeoPixelBus\internal\HtmlColorShortNames.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib007\NeoPixelBus\internal\NeoEsp32RmtMethod.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib007\NeoPixelBus\internal\NeoEsp8266I2sMethodCore.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib007\NeoPixelBus\internal\NeoEsp8266UartMethod.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib007\NeoPixelBus\internal\NeoEspBitBangMethod.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib007\NeoPixelBus\internal\NeoGamma.cpp.o
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libade\libSPI.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib007\NeoPixelBus\internal\NeoPixelAnimator.cpp.o
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libade\libSPI.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib007\NeoPixelBus\internal\NeoPixelAvr.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib007\NeoPixelBus\internal\Rgb48Color.cpp.o
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoEsp32RmtMethod.cpp:33:0:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoEsp32RmtMethod.h:600:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib007\NeoPixelBus\internal\RgbColor.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib007\NeoPixelBus\internal\RgbColorBase.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib007\NeoPixelBus\internal\Rgbw64Color.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib007\NeoPixelBus\internal\RgbwColor.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib007\NeoPixelBus\internal\SegmentDigit.cpp.o
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:68:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:282:57: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:282:88: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                        ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:68:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:282:137: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:286:54: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:286:85: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                     ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:291:66: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                  ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:291:97: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                                 ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:303:57: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:303:88: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                        ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:303:137: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:307:54: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:307:85: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                     ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:312:66: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                  ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:312:97: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                                 ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:324:57: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:324:88: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                        ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:324:137: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:328:54: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:328:85: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                     ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:333:66: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                  ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:333:97: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                                 ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:345:57: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:345:88: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                        ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:345:137: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:349:54: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:349:85: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                     ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:354:66: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                  ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:354:97: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                                 ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:69:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoTm1814ColorFeatures.h:63:57: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoTm1814ColorFeatures.h:63:88: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                        ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:69:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoTm1814ColorFeatures.h:63:137: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoTm1814ColorFeatures.h:83:54: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoTm1814ColorFeatures.h:83:85: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                     ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoTm1814ColorFeatures.h:89:66: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                  ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoTm1814ColorFeatures.h:89:97: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                                 ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:70:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoTm1914ColorFeatures.h:53:57: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoTm1914ColorFeatures.h:53:88: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                        ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:70:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoTm1914ColorFeatures.h:53:137: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoTm1914ColorFeatures.h:88:54: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoTm1914ColorFeatures.h:88:85: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                     ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoTm1914ColorFeatures.h:94:66: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                  ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoTm1914ColorFeatures.h:94:97: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                                 ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:71:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSm168xxColorFeatures.h:208:57: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSm168xxColorFeatures.h:208:88: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                        ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:71:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSm168xxColorFeatures.h:208:137: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSm168xxColorFeatures.h:216:54: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSm168xxColorFeatures.h:216:85: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                     ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSm168xxColorFeatures.h:221:66: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                  ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSm168xxColorFeatures.h:221:97: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                                 ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSm168xxColorFeatures.h:269:57: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSm168xxColorFeatures.h:269:88: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                        ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSm168xxColorFeatures.h:269:137: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSm168xxColorFeatures.h:277:54: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSm168xxColorFeatures.h:277:85: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                     ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSm168xxColorFeatures.h:282:66: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                  ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSm168xxColorFeatures.h:282:97: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                                 ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:72:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarColorFeatures.h:170:57: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarColorFeatures.h:170:88: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                        ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:72:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarColorFeatures.h:170:137: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarColorFeatures.h:174:54: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarColorFeatures.h:174:85: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                     ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarColorFeatures.h:179:66: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                  ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarColorFeatures.h:179:97: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                                 ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarColorFeatures.h:191:57: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarColorFeatures.h:191:88: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                        ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarColorFeatures.h:191:137: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarColorFeatures.h:195:54: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarColorFeatures.h:195:85: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                     ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarColorFeatures.h:200:66: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                  ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarColorFeatures.h:200:97: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                                 ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:73:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd8806ColorFeatures.h:35:57: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd8806ColorFeatures.h:35:88: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                        ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:73:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd8806ColorFeatures.h:35:137: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd8806ColorFeatures.h:39:54: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd8806ColorFeatures.h:39:85: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                     ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd8806ColorFeatures.h:44:66: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                  ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd8806ColorFeatures.h:44:97: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                                 ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:74:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd6803ColorFeatures.h:35:57: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd6803ColorFeatures.h:35:88: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                        ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:74:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd6803ColorFeatures.h:35:137: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd6803ColorFeatures.h:39:54: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd6803ColorFeatures.h:39:85: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                     ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd6803ColorFeatures.h:44:66: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                  ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd6803ColorFeatures.h:44:97: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                                 ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:75:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/P9813ColorFeatures.h:102:57: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/P9813ColorFeatures.h:102:88: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                        ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:75:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/P9813ColorFeatures.h:102:137: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/P9813ColorFeatures.h:106:54: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/P9813ColorFeatures.h:106:85: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                     ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/P9813ColorFeatures.h:111:66: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                  ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/P9813ColorFeatures.h:111:97: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                                 ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:76:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSegmentFeatures.h:93:57: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSegmentFeatures.h:93:88: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                        ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:76:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSegmentFeatures.h:93:137: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSegmentFeatures.h:97:54: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSegmentFeatures.h:97:85: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                     ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSegmentFeatures.h:102:66: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                  ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSegmentFeatures.h:102:97: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                                 ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarGenericMethod.h:33:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:96,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\TwoWireBitBangImple.h:91:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:96:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarGenericMethod.h:117:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarGenericMethod.h:133:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:96,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\TwoWireSpiImple.h:37:70: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] const SettingsObject& settings) {}
                                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\TwoWireSpiImple.h:48:70: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] const SettingsObject& settings) {}
                                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\TwoWireSpiImple.h:59:70: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] const SettingsObject& settings) {}
                                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\TwoWireSpiImple.h:70:70: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] const SettingsObject& settings) {}
                                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\TwoWireSpiImple.h:81:70: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] const SettingsObject& settings) {}
                                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\TwoWireSpiImple.h:92:70: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] const SettingsObject& settings) {}
                                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\TwoWireSpiImple.h:103:70: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] const SettingsObject& settings) {}
                                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\TwoWireSpiImple.h:114:70: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] const SettingsObject& settings) {}
                                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\TwoWireSpiImple.h:125:70: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] const SettingsObject& settings) {}
                                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\TwoWireSpiImple.h:149:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\TwoWireSpiImple.h:218:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarGenericMethod.h:159:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:96,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\TwoWireHspiImple.h:84:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:97:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd8806GenericMethod.h:113:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:98:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd6803GenericMethod.h:113:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:99:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Ws2801GenericMethod.h:115:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:100:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/P9813GenericMethod.h:109:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:101:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Tlc5947GenericMethod.h:177:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:112:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoEsp32I2sMethod.h:220:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:113:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoEsp32RmtMethod.h:600:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:114:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoEspBitBangMethod.h:321:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:115:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoGamma.cpp:28:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarEsp32DmaSpiMethod.h:227:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:68:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:282:57: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:282:88: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                        ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:68:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:282:137: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:286:54: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:286:85: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                     ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:291:66: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                  ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:291:97: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                                 ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:303:57: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:303:88: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                        ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:303:137: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:307:54: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:307:85: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                     ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:312:66: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                  ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:312:97: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                                 ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:324:57: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:324:88: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                        ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:324:137: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:328:54: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:328:85: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                     ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:333:66: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                  ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:333:97: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                                 ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:345:57: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:345:88: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                        ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:345:137: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:349:54: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:349:85: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                     ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:354:66: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                  ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoColorFeatures.h:354:97: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                                 ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:69:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoTm1814ColorFeatures.h:63:57: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoTm1814ColorFeatures.h:63:88: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                        ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:69:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoTm1814ColorFeatures.h:63:137: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoTm1814ColorFeatures.h:83:54: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoTm1814ColorFeatures.h:83:85: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                     ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoTm1814ColorFeatures.h:89:66: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                  ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoTm1814ColorFeatures.h:89:97: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                                 ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:70:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoTm1914ColorFeatures.h:53:57: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoTm1914ColorFeatures.h:53:88: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                        ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:70:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoTm1914ColorFeatures.h:53:137: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoTm1914ColorFeatures.h:88:54: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoTm1914ColorFeatures.h:88:85: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                     ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoTm1914ColorFeatures.h:94:66: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                  ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoTm1914ColorFeatures.h:94:97: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                                 ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:71:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSm168xxColorFeatures.h:208:57: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSm168xxColorFeatures.h:208:88: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                        ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:71:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSm168xxColorFeatures.h:208:137: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSm168xxColorFeatures.h:216:54: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSm168xxColorFeatures.h:216:85: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                     ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSm168xxColorFeatures.h:221:66: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                  ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSm168xxColorFeatures.h:221:97: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                                 ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSm168xxColorFeatures.h:269:57: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSm168xxColorFeatures.h:269:88: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                        ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSm168xxColorFeatures.h:269:137: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSm168xxColorFeatures.h:277:54: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSm168xxColorFeatures.h:277:85: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                     ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSm168xxColorFeatures.h:282:66: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                  ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSm168xxColorFeatures.h:282:97: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                                 ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:72:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarColorFeatures.h:170:57: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarColorFeatures.h:170:88: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                        ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:72:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarColorFeatures.h:170:137: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarColorFeatures.h:174:54: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarColorFeatures.h:174:85: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                     ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarColorFeatures.h:179:66: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                  ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarColorFeatures.h:179:97: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                                 ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarColorFeatures.h:191:57: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarColorFeatures.h:191:88: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                        ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarColorFeatures.h:191:137: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarColorFeatures.h:195:54: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarColorFeatures.h:195:85: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                     ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarColorFeatures.h:200:66: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                  ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarColorFeatures.h:200:97: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                                 ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:73:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd8806ColorFeatures.h:35:57: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd8806ColorFeatures.h:35:88: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                        ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:73:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd8806ColorFeatures.h:35:137: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd8806ColorFeatures.h:39:54: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd8806ColorFeatures.h:39:85: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                     ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd8806ColorFeatures.h:44:66: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                  ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd8806ColorFeatures.h:44:97: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                                 ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:74:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd6803ColorFeatures.h:35:57: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd6803ColorFeatures.h:35:88: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                        ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:74:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd6803ColorFeatures.h:35:137: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd6803ColorFeatures.h:39:54: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd6803ColorFeatures.h:39:85: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                     ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd6803ColorFeatures.h:44:66: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                  ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd6803ColorFeatures.h:44:97: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                                 ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:75:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/P9813ColorFeatures.h:102:57: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/P9813ColorFeatures.h:102:88: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                        ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:75:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/P9813ColorFeatures.h:102:137: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/P9813ColorFeatures.h:106:54: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/P9813ColorFeatures.h:106:85: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                     ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/P9813ColorFeatures.h:111:66: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                  ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/P9813ColorFeatures.h:111:97: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                                 ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:76:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSegmentFeatures.h:93:57: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSegmentFeatures.h:93:88: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                        ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:76:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSegmentFeatures.h:93:137: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData, [[maybe_unused]] const SettingsObject& settings)
                                                                                                                                         ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSegmentFeatures.h:97:54: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSegmentFeatures.h:97:85: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static uint8_t* pixels([[maybe_unused]] uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                     ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSegmentFeatures.h:102:66: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                  ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoSegmentFeatures.h:102:97: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static const uint8_t* pixels([[maybe_unused]] const uint8_t* pData, [[maybe_unused]] size_t sizeData)
                                                                                                 ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarGenericMethod.h:33:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:96,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\TwoWireBitBangImple.h:91:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:96:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarGenericMethod.h:117:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarGenericMethod.h:133:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:96,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\TwoWireSpiImple.h:37:70: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] const SettingsObject& settings) {}
                                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\TwoWireSpiImple.h:48:70: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] const SettingsObject& settings) {}
                                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\TwoWireSpiImple.h:59:70: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] const SettingsObject& settings) {}
                                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\TwoWireSpiImple.h:70:70: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] const SettingsObject& settings) {}
                                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\TwoWireSpiImple.h:81:70: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] const SettingsObject& settings) {}
                                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\TwoWireSpiImple.h:92:70: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] const SettingsObject& settings) {}
                                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\TwoWireSpiImple.h:103:70: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] const SettingsObject& settings) {}
                                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\TwoWireSpiImple.h:114:70: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] const SettingsObject& settings) {}
                                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\TwoWireSpiImple.h:125:70: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     static void applySettings([[maybe_unused]] const SettingsObject& settings) {}
                                                                      ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\TwoWireSpiImple.h:149:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\TwoWireSpiImple.h:218:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarGenericMethod.h:159:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:96,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\TwoWireHspiImple.h:84:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:97:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd8806GenericMethod.h:113:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:98:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Lpd6803GenericMethod.h:113:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:99:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Ws2801GenericMethod.h:115:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:100:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/P9813GenericMethod.h:109:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:101:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/Tlc5947GenericMethod.h:177:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:112:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoEsp32I2sMethod.h:220:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:113:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoEsp32RmtMethod.h:600:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:114:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/NeoEspBitBangMethod.h:321:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
In file included from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/NeoPixelBus.h:115:0,
                 from .pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src\internal\NeoPixelAnimator.cpp:27:
.pio\libdeps\Jumper_AION_2400_T-Lite_TX_via_ETX\NeoPixelBus\src/internal/DotStarEsp32DmaSpiMethod.h:227:63: warning: 'maybe_unused' attribute directive ignored [-Wattributes]
     void applySettings([[maybe_unused]] const SettingsObject& settings)
                                                               ^
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib951\AsyncTCP-esphome\AsyncTCP.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libaa7\FS\FS.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libaa7\FS\vfs_api.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libe7b\WiFi\ETH.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libe7b\WiFi\WiFi.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libe7b\WiFi\WiFiAP.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libe7b\WiFi\WiFiClient.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libe7b\WiFi\WiFiGeneric.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libe7b\WiFi\WiFiMulti.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libe7b\WiFi\WiFiSTA.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libe7b\WiFi\WiFiScan.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libe7b\WiFi\WiFiServer.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libe7b\WiFi\WiFiUdp.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib917\ESPAsyncWebServer-esphome\AsyncEventSource.cpp.o
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib007\libNeoPixelBus.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib917\ESPAsyncWebServer-esphome\AsyncWebSocket.cpp.o
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib007\libNeoPixelBus.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib917\ESPAsyncWebServer-esphome\WebAuthentication.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib917\ESPAsyncWebServer-esphome\WebHandlers.cpp.o
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libaa7\libFS.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib917\ESPAsyncWebServer-esphome\WebRequest.cpp.o
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib951\libAsyncTCP-esphome.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libaa7\libFS.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib917\ESPAsyncWebServer-esphome\WebResponses.cpp.o
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib951\libAsyncTCP-esphome.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib917\ESPAsyncWebServer-esphome\WebServer.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\NimBLE2904.cpp.o
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libe7b\libWiFi.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\NimBLEAddress.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\NimBLEAdvertisedDevice.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\NimBLEAdvertising.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\NimBLEBeacon.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\NimBLECharacteristic.cpp.o
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libe7b\libWiFi.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\NimBLEClient.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\NimBLEDescriptor.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\NimBLEDevice.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\NimBLEEddystoneTLM.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\NimBLEEddystoneURL.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\NimBLEExtAdvertising.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\NimBLEHIDDevice.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\NimBLERemoteCharacteristic.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\NimBLERemoteDescriptor.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\NimBLERemoteService.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\NimBLEScan.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\NimBLESecurity.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\NimBLEServer.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\NimBLEService.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\NimBLEUUID.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\NimBLEUtils.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\esp_port\esp-hci\src\esp_nimble_hci.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\esp_port\port\src\esp_nimble_mem.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\ext\tinycrypt\src\aes_decrypt.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\ext\tinycrypt\src\aes_encrypt.c.o
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib917\libESPAsyncWebServer-esphome.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\ext\tinycrypt\src\cbc_mode.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\ext\tinycrypt\src\ccm_mode.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\ext\tinycrypt\src\cmac_mode.c.o
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib917\libESPAsyncWebServer-esphome.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\ext\tinycrypt\src\ctr_mode.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\ext\tinycrypt\src\ctr_prng.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\ext\tinycrypt\src\ecc.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\ext\tinycrypt\src\ecc_dh.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\ext\tinycrypt\src\ecc_dsa.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\ext\tinycrypt\src\ecc_platform_specific.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\ext\tinycrypt\src\hmac.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\ext\tinycrypt\src\hmac_prng.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\ext\tinycrypt\src\sha256.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\ext\tinycrypt\src\utils.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\controller\src\ble_ll.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\controller\src\ble_ll_adv.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\controller\src\ble_ll_conn.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\controller\src\ble_ll_conn_hci.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\controller\src\ble_ll_ctrl.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\controller\src\ble_ll_dtm.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\controller\src\ble_ll_hci.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\controller\src\ble_ll_hci_ev.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\controller\src\ble_ll_iso.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\controller\src\ble_ll_rand.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\controller\src\ble_ll_resolv.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\controller\src\ble_ll_rfmgmt.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\controller\src\ble_ll_scan.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\controller\src\ble_ll_sched.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\controller\src\ble_ll_supp_cmd.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\controller\src\ble_ll_sync.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\controller\src\ble_ll_trace.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\controller\src\ble_ll_utils.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\controller\src\ble_ll_whitelist.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\drivers\nrf51\src\ble_hw.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\drivers\nrf51\src\ble_phy.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\drivers\nrf52\src\ble_hw.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\drivers\nrf52\src\ble_phy.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\drivers\nrf52\src\ble_phy_trace.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\access.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\adv.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\aes-ccm.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\app_keys.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\beacon.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\cdb.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\cfg.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\cfg_cli.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\cfg_srv.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\crypto.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\friend.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\glue.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\health_cli.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\health_srv.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\heartbeat.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\light_model.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\lpn.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\mesh.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\model_cli.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\model_srv.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\net.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\nodes.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\pb_adv.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\pb_gatt.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\prov.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\prov_device.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\provisioner.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\proxy.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\rpl.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\settings.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\shell.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\subnet.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\mesh\src\transport.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\services\ans\src\ble_svc_ans.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\services\bas\src\ble_svc_bas.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\services\dis\src\ble_svc_dis.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\services\gap\src\ble_svc_gap.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\services\gatt\src\ble_svc_gatt.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\services\ias\src\ble_svc_ias.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\services\ipss\src\ble_svc_ipss.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\services\lls\src\ble_svc_lls.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_att.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_att_clt.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_att_cmd.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_att_svr.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_eddystone.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_gap.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_gattc.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_gatts.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_gatts_lcl.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_hs.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_hs_adv.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_hs_atomic.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_hs_cfg.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_hs_conn.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_hs_flow.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_hs_hci.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_hs_hci_cmd.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_hs_hci_evt.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_hs_hci_util.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_hs_id.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_hs_log.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_hs_mbuf.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_hs_misc.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_hs_mqueue.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_hs_periodic_sync.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_hs_pvcy.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_hs_resolv.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_hs_shutdown.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_hs_startup.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_hs_stop.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_ibeacon.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_l2cap.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_l2cap_coc.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_l2cap_sig.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_l2cap_sig_cmd.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_monitor.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_sm.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_sm_alg.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_sm_cmd.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_sm_lgcy.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_sm_sc.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_store.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_store_util.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\src\ble_uuid.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\store\config\src\ble_store_config.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\store\config\src\ble_store_config_conf.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\store\config\src\ble_store_nvs.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\host\util\src\addr.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\nimble\transport\ram\src\ble_hci_ram.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\porting\nimble\src\endian.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\porting\nimble\src\hal_timer.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\porting\nimble\src\hal_uart.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\porting\nimble\src\mem.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\porting\nimble\src\nimble_port.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\porting\nimble\src\os_cputime.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\porting\nimble\src\os_cputime_pwr2.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\porting\nimble\src\os_mbuf.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\porting\nimble\src\os_mempool.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\porting\nimble\src\os_msys_init.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\porting\npl\freertos\src\nimble_port_freertos.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\NimBLE-Arduino\nimble\porting\npl\freertos\src\npl_os_freertos.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib46c\ESP32-BLE-Gamepad\BleConnectionStatus.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib46c\ESP32-BLE-Gamepad\BleGamepad.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib1db\logging\logging.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib549\SX1280Driver\SX1280.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib549\SX1280Driver\SX1280_hal.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\liba7c\EEPROM\EEPROM.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib957\Wire\Wire.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libebe\EEPROM\elrs_eeprom.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib900\CRC\crc.cpp.o
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\libNimBLE-Arduino.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib96f\CrsfProtocol\dummy.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib0b8\MSP\msp.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib59d\TelemetryProtocol\dummy.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib940\helpers\dummy.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libe83\DEVICE\device.cpp.o
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib176\libNimBLE-Arduino.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib6df\FIFO\FIFO.cpp.o
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib549\libSX1280Driver.a
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib940\libhelpers.a
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib59d\libTelemetryProtocol.a
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib1db\liblogging.a
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib96f\libCrsfProtocol.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib940\libhelpers.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib1db\liblogging.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib549\libSX1280Driver.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib96f\libCrsfProtocol.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib59d\libTelemetryProtocol.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib35b\CRSF\CRSF.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib35b\CRSF\devCRSF.cpp.o
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib957\libWire.a
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib46c\libESP32-BLE-Gamepad.a
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\liba7c\libEEPROM.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib957\libWire.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib46c\libESP32-BLE-Gamepad.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libadb\OTA\OTA.cpp.o
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\liba7c\libEEPROM.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib75c\DAC\DAC.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libb74\POWERMGNT\POWERMGNT.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libc5e\CONFIG\config.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libdb9\HWTIMER\ESP32_hwTimer.cpp.o
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib6df\libFIFO.a
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libe83\libDEVICE.a
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib0b8\libMSP.a
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib900\libCRC.a
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libebe\libEEPROM.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libdb9\HWTIMER\ESP8266_hwTimer.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libdb9\HWTIMER\STM32_hwTimer.cpp.o
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libe83\libDEVICE.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libebe\libEEPROM.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib6df\libFIFO.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib0b8\libMSP.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib900\libCRC.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib645\Backpack\devBackpack.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib1f0\BLE\devBLE.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libfed\BUTTON\devButton.cpp.o
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libdb9\libHWTIMER.a
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libb74\libPOWERMGNT.a
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libadb\libOTA.a
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib75c\libDAC.a
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib35b\libCRSF.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libb74\libPOWERMGNT.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib75c\libDAC.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libadb\libOTA.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib35b\libCRSF.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libdb9\libHWTIMER.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib2f9\BUZZER\devBuzzer.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib359\GSENSOR\devGsensor.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib359\GSENSOR\gsensor.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib359\GSENSOR\stk8baxx.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib523\LED\devLED.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib523\LED\devRGB.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib9a9\LUA\devLUA.cpp.o
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libfed\libBUTTON.a
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib645\libBackpack.a
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libc5e\libCONFIG.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib9a9\LUA\lua.cpp.o
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libfed\libBUTTON.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib645\libBackpack.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libc5e\libCONFIG.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib2d7\POWER_DETECT\devPDET.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib5ba\THERMAL\devThermal.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib5ba\THERMAL\lm75a.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib5ba\THERMAL\thermal.cpp.o
lib\LED\devLED.cpp:42:17: warning: 'uint16_t flashLED(uint8_t, uint8_t, const uint8_t*, uint8_t)' defined but not used [-Wunused-function]
 static uint16_t flashLED(uint8_t pin, uint8_t pin_inverted, const uint8_t durations[], uint8_t count)
                 ^
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib94f\SCREEN\FiveWayButton\FiveWayButton.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib94f\SCREEN\OLED\oledscreen.cpp.o
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib5ba\libTHERMAL.a
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib359\libGSENSOR.a
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib1f0\libBLE.a
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib2f9\libBUZZER.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib94f\SCREEN\TFT\tftscreen.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib94f\SCREEN\devScreen.cpp.o
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib5ba\libTHERMAL.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib1f0\libBLE.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib359\libGSENSOR.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib2f9\libBUZZER.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib94f\SCREEN\screen.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib45d\VTX\devVTX.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib6df\DNSServer\DNSServer.cpp.o
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib523\libLED.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib523\libLED.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libb15\ESPmDNS\ESPmDNS.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libf1a\Update\HttpsOTAUpdate.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libf1a\Update\Updater.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib3d5\WIFI\devWIFI.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib0a4\FHSS\FHSS.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib0a4\FHSS\random.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libb81\StubbornReceiver\stubborn_receiver.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib8ce\StubbornSender\stubborn_sender.cpp.o
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib94f\libSCREEN.a
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib9a9\libLUA.a
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib2d7\libPOWER_DETECT.a
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libFrameworkArduinoVariant.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib94f\libSCREEN.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib2d7\libPOWER_DETECT.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib9a9\libLUA.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libFrameworkArduinoVariant.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\Esp.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\FunctionalInterrupt.cpp.o
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib45d\libVTX.a
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib8ce\libStubbornSender.a
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libb81\libStubbornReceiver.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\HardwareSerial.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\IPAddress.cpp.o
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib45d\libVTX.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\IPv6Address.cpp.o
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib8ce\libStubbornSender.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\MD5Builder.cpp.o
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libb81\libStubbornReceiver.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\Print.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\Stream.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\StreamString.cpp.o
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib6df\libDNSServer.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\WMath.cpp.o
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib6df\libDNSServer.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\WString.cpp.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\base64.cpp.o
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libf1a\libUpdate.a
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libb15\libESPmDNS.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libf1a\libUpdate.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\cbuf.cpp.o
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libb15\libESPmDNS.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\esp32-hal-adc.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\esp32-hal-bt.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\esp32-hal-cpu.c.o
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib0a4\libFHSS.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib0a4\libFHSS.a
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\esp32-hal-dac.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\esp32-hal-gpio.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\esp32-hal-i2c.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\esp32-hal-ledc.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\esp32-hal-log.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\esp32-hal-matrix.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\esp32-hal-misc.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\esp32-hal-psram.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\esp32-hal-rmt.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\esp32-hal-sigmadelta.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\esp32-hal-spi.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\esp32-hal-time.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\esp32-hal-timer.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\esp32-hal-touch.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\esp32-hal-uart.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\libb64\cdecode.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\libb64\cencode.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\main.cpp.o
C:\Users\pfeer\.platformio\packages\framework-arduinoespressif32\cores\esp32\esp32-hal-spi.c: In function 'spiTransferBytesNL':
C:\Users\pfeer\.platformio\packages\framework-arduinoespressif32\cores\esp32\esp32-hal-spi.c:922:39: warning: initialization from incompatible pointer type [-Wincompatible-pointer-types]
                 uint8_t * last_out8 = &result[c_longs-1];
                                       ^
C:\Users\pfeer\.platformio\packages\framework-arduinoespressif32\cores\esp32\esp32-hal-spi.c:923:40: warning: initialization from incompatible pointer type [-Wincompatible-pointer-types]
                 uint8_t * last_data8 = &last_data;
                                        ^
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\stdlib_noniso.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\wiring_pulse.c.o
Compiling .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\FrameworkArduino\wiring_shift.c.o
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib3d5\libWIFI.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\lib3d5\libWIFI.a
Archiving .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libFrameworkArduino.a
Indexing .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\libFrameworkArduino.a
Linking .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\firmware.elf
Retrieving maximum program size .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\firmware.elf
Checking size .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\firmware.elf
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [==        ]  16.6% (used 54484 bytes from 327680 bytes)
Flash: [======    ]  56.4% (used 1107901 bytes from 1966080 bytes)
Building .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\firmware.bin
esptool.py v3.1
Merged 1 ELF section
init_passthrough(["upload"], [".pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\firmware.bin"])
Using manually specified: COM7
======== PASSTHROUGH INIT ========
  Trying to initialize COM7 @ 460800
Enabling serial passthrough...
  CMD: 'serialpassthrough rfmod 0 460800'
======== PASSTHROUGH DONE ========
Configuring upload protocol...
AVAILABLE: esp-prog, espota, esptool, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa
CURRENT: upload_protocol = esptool
Looking for upload port...
Using manually specified: COM7
Uploading .pio\build\Jumper_AION_2400_T-Lite_TX_via_ETX\firmware.bin
esptool.py v3.1
Serial port COM7
Connecting......
Chip is ESP32-PICO-D4 (revision 1)
Features: WiFi, BT, Dual Core, 240MHz, Embedded Flash, VRef calibration in efuse, Coding Scheme None
Crystal is 40MHz
MAC: 4c:75:25:98:97:58
Uploading stub...
Running stub...
Stub running...
Changing baud rate to 460800
Changed.
Configuring flash size...
Auto-detected Flash size: 4MB
Flash will be erased from 0x00001000 to 0x00005fff...
Flash will be erased from 0x00008000 to 0x00008fff...
Flash will be erased from 0x0000e000 to 0x0000ffff...
Flash will be erased from 0x00010000 to 0x0011efff...
Compressed 17104 bytes to 11191...
Writing at 0x00001000... (100 %)
Wrote 17104 bytes (11191 compressed) at 0x00001000 in 0.5 seconds (effective 260.4 kbit/s)...
Hash of data verified.
Compressed 3072 bytes to 129...
Writing at 0x00008000... (100 %)
Wrote 3072 bytes (129 compressed) at 0x00008000 in 0.1 seconds (effective 438.0 kbit/s)...
Hash of data verified.
Compressed 8192 bytes to 47...
Writing at 0x0000e000... (100 %)
Wrote 8192 bytes (47 compressed) at 0x0000e000 in 0.1 seconds (effective 596.7 kbit/s)...
Hash of data verified.
Compressed 1108016 bytes to 655627...
Writing at 0x00010000... (2 %)
Writing at 0x00015ec5... (4 %)
Writing at 0x0002288f... (7 %)
Writing at 0x0002fb85... (9 %)
Writing at 0x00044850... (12 %)
Writing at 0x00051cf0... (14 %)
Writing at 0x000579e9... (17 %)
Writing at 0x0005cf7e... (19 %)
Writing at 0x00065bc6... (21 %)
Writing at 0x0006c673... (24 %)
Writing at 0x00071ef5... (26 %)
Writing at 0x00077d88... (29 %)
Writing at 0x0007dacd... (31 %)
Writing at 0x00083d81... (34 %)
Writing at 0x00089e36... (36 %)
Writing at 0x0008fe60... (39 %)
Writing at 0x00095cf1... (41 %)
Writing at 0x0009ba0d... (43 %)
Writing at 0x000a0b2e... (46 %)
Writing at 0x000a5ed0... (48 %)
Writing at 0x000ab2f1... (51 %)
Writing at 0x000b08a1... (53 %)
Writing at 0x000b6547... (56 %)
Writing at 0x000bbcfc... (58 %)
Writing at 0x000c1386... (60 %)
Writing at 0x000c7457... (63 %)
Writing at 0x000ccf15... (65 %)
Writing at 0x000d2529... (68 %)
Writing at 0x000d8406... (70 %)
Writing at 0x000ddf10... (73 %)
Writing at 0x000e3cf1... (75 %)
Writing at 0x000e9cc9... (78 %)
Writing at 0x000ef93f... (80 %)
Writing at 0x000f50b5... (82 %)
Writing at 0x000fa714... (85 %)
Writing at 0x001004c2... (87 %)
Writing at 0x001074bb... (90 %)
Writing at 0x0010ce85... (92 %)
Writing at 0x0011273f... (95 %)
Writing at 0x00118410... (97 %)
Writing at 0x0011e5d7... (100 %)
Wrote 1108016 bytes (655627 compressed) at 0x00010000 in 16.5 seconds (effective 536.6 kbit/s)...
Hash of data verified.

Leaving...
Hard resetting via RTS pin...
========================= [SUCCESS] Took 71.56 seconds =========================

Environment                         Status    Duration
----------------------------------  --------  ------------
Jumper_AION_2400_T-Lite_TX_via_ETX  SUCCESS   00:01:11.558
========================= 1 succeeded in 00:01:11.558 =========================
```
</details>