### PR TITLE
Fullres power level reports 0mW for 50mW

### DIFF
--- a/src/lib/CRSF/devCRSF_tx.cpp
+++ b/src/lib/CRSF/devCRSF_tx.cpp
@@ -19,25 +19,6 @@ static int timeout()
     return DURATION_IMMEDIATELY;
 }
 
-static uint8_t powerToCrsfPower(PowerLevels_e Power)
-{
-    // Crossfire's power levels as defined in opentx:radio/src/telemetry/crossfire.cpp
-    //static const int32_t power_values[] = { 0, 10, 25, 100, 500, 1000, 2000, 250, 50 };
-    switch (Power)
-    {
-    case PWR_10mW: return 1;
-    case PWR_25mW: return 2;
-    case PWR_50mW: return 8;
-    case PWR_100mW: return 3;
-    case PWR_250mW: return 7;
-    case PWR_500mW: return 4;
-    case PWR_1000mW: return 5;
-    case PWR_2000mW: return 6;
-    default:
-        return 0;
-    }
-}
-
 static int event()
 {
     // An event should be generated every time the TX power changes

--- a/src/lib/OTA/OTA.cpp
+++ b/src/lib/OTA/OTA.cpp
@@ -229,7 +229,8 @@ static void ICACHE_RAM_ATTR GenerateChannelData8ch12ch(OTA_Packet8_s * const ota
     // All channel data is 10 bit apart from AUX1 which is 1 bit
     ota8->rc.packetType = PACKET_TYPE_RCDATA;
     ota8->rc.telemetryStatus = TelemetryStatus;
-    ota8->rc.uplinkPower = crsf->LinkStatistics.uplink_TX_Power;
+    // uplinkPower has 8 items but only 3 bits, but 0 is 0 power which we never use, shift 1-8 -> 0-7
+    ota8->rc.uplinkPower = constrain(crsf->LinkStatistics.uplink_TX_Power, 1, 8) - 1;
     ota8->rc.isHighAux = isHighAux;
     ota8->rc.ch4 = CRSF_to_BIT(crsf->ChannelData[4]);
 #if defined(DEBUG_RCVR_LINKSTATS)
@@ -475,7 +476,8 @@ bool ICACHE_RAM_ATTR UnpackChannelData8ch(OTA_Packet_s const * const otaPktPtr, 
     UnpackChannels4x10ToUInt11(&ota8->rc.chLow, &crsf->ChannelData[chDstLow]);
     UnpackChannels4x10ToUInt11(&ota8->rc.chHigh, &crsf->ChannelData[chDstHigh]);
 #endif
-    crsf->LinkStatistics.uplink_TX_Power = ota8->rc.uplinkPower;
+    // Restore the uplink_TX_Power range 0-7 -> 1-8
+    crsf->LinkStatistics.uplink_TX_Power = ota8->rc.uplinkPower + 1;
     return ota8->rc.telemetryStatus;
 }
 #endif

--- a/src/lib/OTA/OTA.h
+++ b/src/lib/OTA/OTA.h
@@ -92,7 +92,7 @@ typedef struct {
         struct {
             uint8_t packetType: 2,
                     telemetryStatus: 1,
-                    uplinkPower: 3, // PowerLevels_e - 1 (1-8 is 0-7 in the air)
+                    uplinkPower: 3, // CRSF_power_level - 1 (1-8 is 0-7 in the air)
                     isHighAux: 1, // true if chHigh are AUX6-9
                     ch4: 1;   // AUX1, included up here so ch0 starts on a byte boundary
             OTA_Channels_4x10 chLow;  // CH0-CH3

--- a/src/lib/OTA/OTA.h
+++ b/src/lib/OTA/OTA.h
@@ -92,7 +92,7 @@ typedef struct {
         struct {
             uint8_t packetType: 2,
                     telemetryStatus: 1,
-                    uplinkPower: 3, // PowerLevels_e
+                    uplinkPower: 3, // PowerLevels_e - 1 (1-8 is 0-7 in the air)
                     isHighAux: 1, // true if chHigh are AUX6-9
                     ch4: 1;   // AUX1, included up here so ch0 starts on a byte boundary
             OTA_Channels_4x10 chLow;  // CH0-CH3

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -1,8 +1,29 @@
-#ifndef UNIT_TEST
 #include "targets.h"
+#include "POWERMGNT.h"
+
+uint8_t powerToCrsfPower(PowerLevels_e Power)
+{
+    // Crossfire's power levels as defined in opentx:radio/src/telemetry/crossfire.cpp
+    //static const int32_t power_values[] = { 0, 10, 25, 100, 500, 1000, 2000, 250, 50 };
+    switch (Power)
+    {
+    case PWR_10mW: return 1;
+    case PWR_25mW: return 2;
+    case PWR_50mW: return 8;
+    case PWR_100mW: return 3;
+    case PWR_250mW: return 7;
+    case PWR_500mW: return 4;
+    case PWR_1000mW: return 5;
+    case PWR_2000mW: return 6;
+    default:
+        return 0;
+    }
+}
+
+#ifndef UNIT_TEST
+
 #include "common.h"
 #include "device.h"
-#include "POWERMGNT.h"
 #include "DAC.h"
 #include "helpers.h"
 

--- a/src/lib/POWERMGNT/POWERMGNT.h
+++ b/src/lib/POWERMGNT/POWERMGNT.h
@@ -44,6 +44,8 @@ typedef enum
     PWR_COUNT = 8
 } PowerLevels_e;
 
+uint8_t powerToCrsfPower(PowerLevels_e Power);
+
 class PowerLevelContainer
 {
 protected:


### PR DESCRIPTION
This fixes the oversight in the fullres OTA which tries to stuff 9 power levels into 3 bits. This resulted in 50mW being displayed at 0mW. This removes 0mW (CRSF power 0) from our possibilities to make room for 50mW (CRSF power 8).

### Details
Only was a problem on FullRes, which only has 3 bits for the power level. Wide switch mode has 6/7 bits, and Hybrid doesn't send it at all.

### Solution
constrain the uplink power to 3 bits 1-8 instead of 0-7, this means that 0mW will be displayed as 10mW, but we never switch to 0mW mode even when the radio is disabled (it is below MinPower). Not sure if the constrain is needed, since we can't be at 0 power, but I included it for safety. I can remove it if we think that's a waste.