### PR TITLE
Foxeer RX target

### DIFF
--- a/src/hardware/RX/Generic 2400 PA RGB.json
+++ b/src/hardware/RX/Generic 2400 PA RGB.json
@@ -1,0 +1,23 @@
+{
+    "serial_rx": 3,
+    "serial_tx": 1,
+    "radio_busy": 5,
+    "radio_dio1": 4,
+    "radio_miso": 12,
+    "radio_mosi": 13,
+    "radio_nss": 15,
+    "radio_rst": 16,
+    "radio_sck": 14,
+    "radio_dcdc": true,
+    "power_rxen": 9,
+    "power_txen": 10,
+    "power_min": 0,
+    "power_high": 3,
+    "power_max": 3,
+    "power_default": 3,
+    "power_control": 0,
+    "power_values": [-10,-6,-3,1],
+    "button": 0,
+    "led_rgb": 2,
+    "led_rgb_isgrb": 1
+}

--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -440,6 +440,14 @@
                 "platform": "esp8285",
                 "firmware": "Unified_ESP8285_2400_RX"
             },
+            "pa-rgb": {
+                "product_name": "Generic ESP8285 RGB + PA 2.4Ghz RX",
+                "lua_name": "ELRS+RGB 2400RX",
+                "layout_file": "Generic 2400 PA RGB.json",
+                "upload_methods": ["uart", "wifi", "betaflight"],
+                "platform": "esp8285",
+                "firmware": "Unified_ESP8285_2400_RX"
+            },
             "diversity": {
                 "product_name": "Generic ESP8285 + Diversity PA 2.4Ghz RX",
                 "lua_name": "ELRS+D 2400RX",

--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -246,6 +246,22 @@
             }
         }
     },
+    "foxeer": {
+        "name": "Foxeer",
+        "rx_2400": {
+            "pa-rgb": {
+                "product_name": "Foxeer 2.4Ghz RX",
+                "lua_name": "Foxeer 2400 RX",
+                "layout_file": "Generic 2400 PA RGB.json",
+                "overlay": {
+                    "radio_dcdc": true
+                },
+                "upload_methods": ["uart", "wifi", "betaflight"],
+                "platform": "esp8285",
+                "firmware": "Unified_ESP8285_2400_RX"
+            }
+        }
+    },
     "frsky": {
         "name": "Frsky",
         "tx_900": {

--- a/src/targets/diy_2400.ini
+++ b/src/targets/diy_2400.ini
@@ -59,6 +59,19 @@ upload_command = ${env_common_esp82xx.bf_upload_command}
 [env:DIY_2400_RX_ESP8285_SX1280_via_WIFI]
 extends = env:DIY_2400_RX_ESP8285_SX1280_via_UART
 
+[env:DIY_2400_PA_RGB_RX_via_UART]
+extends = env:Unified_ESP8285_2400_RX_via_UART
+board_config = generic.rx_2400.pa-rgb
+
+[env:DIY_2400_PA_RGB_RX_via_BetaflightPassthrough]
+extends = env:DIY_2400_PA_RGB_RX_via_UART
+upload_protocol = custom
+upload_speed = 420000
+upload_command = ${env_common_esp82xx.bf_upload_command}
+
+[env:DIY_2400_PA_RGB_RX_via_WIFI]
+extends = env:DIY_2400_PA_RGB_RX_via_UART
+
 [env:DIY_2400_RX_PWMP_via_UART]
 extends = env:Unified_ESP8285_2400_RX_via_UART
 board_config = generic.rx_2400.pwm5

--- a/src/targets/foxeer_2400.ini
+++ b/src/targets/foxeer_2400.ini
@@ -1,0 +1,21 @@
+
+# ********************************
+# Transmitter targets
+# ********************************
+
+# ********************************
+# Receiver targets
+# ********************************
+
+[env:Foxeer_2400_RX_via_UART]
+extends = env:Unified_ESP8285_2400_RX_via_UART
+board_config = Foxeer.rx_2400.pa-rgb
+
+[env:Foxeer_2400_RX_via_BetaflightPassthrough]
+extends = env:Foxeer_2400_RX_via_UART
+upload_protocol = custom
+upload_speed = 420000
+upload_command = ${env_common_esp82xx.bf_upload_command}
+
+[env:Foxeer_2400_RX_via_WIFI]
+extends = env:Foxeer_2400_RX_via_UART


### PR DESCRIPTION
This PR builds on top of #1665 and adds the Foxeer RX target, which is a 8285 based RX with a PA/LNA and RGB LED.