### PR TITLE
Fix wifi auto on interval when not entered/selected in configurator

### DIFF
--- a/src/lib/OPTIONS/options.cpp
+++ b/src/lib/OPTIONS/options.cpp
@@ -301,7 +301,8 @@ bool options_init()
     {
         firmwareOptions.hasUID = false;
     }
-    firmwareOptions.wifi_auto_on_interval = (doc["wifi-on-interval"] | 60) * 1000;
+    int32_t wifiInterval = doc["wifi-on-interval"] | -1;
+    firmwareOptions.wifi_auto_on_interval = wifiInterval == -1 ? -1 : wifiInterval * 1000;
     strlcpy(firmwareOptions.home_wifi_ssid, doc["wifi-ssid"] | "", sizeof(firmwareOptions.home_wifi_ssid));
     strlcpy(firmwareOptions.home_wifi_password, doc["wifi-password"] | "", sizeof(firmwareOptions.home_wifi_password));
     #if defined(TARGET_UNIFIED_TX)


### PR DESCRIPTION
This PR should fix #1797 
Where the default was being set at 60 like we have in `user_defines.txt` as a default, but from configurator if not set then the firmware was using -1 (i.e. disabled).