### PR TITLE
Don't pause Lua loading when in edit mode

### DIFF
--- a/src/lua/elrsV3.lua
+++ b/src/lua/elrsV3.lua
@@ -569,7 +569,7 @@ local function refreshNext()
       crossfireTelemetryPush(0x2D, { deviceId, handsetId, 0x0, 0x0 }) --request linkstat
     end
     linkstatTimeout = time + 100
-  elseif time > fieldTimeout and fields_count ~= 0 and not edit then
+  elseif time > fieldTimeout and fields_count ~= 0 then
     if #loadQ > 0 then
       crossfireTelemetryPush(0x2C, { deviceId, handsetId, loadQ[#loadQ], fieldChunk })
       fieldTimeout = time + 50 -- 0.5s


### PR DESCRIPTION
This removes the behavior of pausing loading the Lua while in edit mode on a field.

This behavior was copied over from Crossfire's Lua and I don't know why it was ever needed. Pausing it mid-load sometimes also seems to hang loading entirely [and leads people to draw the wrong conclusion](https://youtu.be/cyILQqxPpZI?t=704) about the module working.

I didn't tag this for 3.0 but it is against 3.x maint since I think it should be included in 3.0.