### PR TITLE
Use 250hz default rate for 2.4, 50hz for 868/900

### DIFF
--- a/src/lib/CONFIG/config.cpp
+++ b/src/lib/CONFIG/config.cpp
@@ -527,11 +527,14 @@ TxConfig::SetDefaults(bool commit)
     m_config.powerFanThreshold = PWR_250mW;
     m_modified = ALL_CHANGED;
 
-    expresslrs_mod_settings_s *const modParams = get_elrs_airRateConfig(RATE_DEFAULT);
     for (unsigned i=0; i<64; i++)
     {
         SetModelId(i);
-        SetRate(modParams->index);
+        #if defined(RADIO_SX127X)
+            SetRate(enumRatetoIndex(RATE_LORA_50HZ));
+        #elif defined(RADIO_SX128X)
+            SetRate(enumRatetoIndex(RATE_LORA_250HZ));
+        #endif
         SetPower(POWERMGNT::getDefaultPower());
 #if defined(PLATFORM_ESP32)
         // ESP32 nvs needs to commit every model

--- a/src/lib/CONFIG/config.cpp
+++ b/src/lib/CONFIG/config.cpp
@@ -531,7 +531,7 @@ TxConfig::SetDefaults(bool commit)
     {
         SetModelId(i);
         #if defined(RADIO_SX127X)
-            SetRate(enumRatetoIndex(RATE_LORA_50HZ));
+            SetRate(enumRatetoIndex(RATE_LORA_200HZ));
         #elif defined(RADIO_SX128X)
             SetRate(enumRatetoIndex(RATE_LORA_250HZ));
         #endif


### PR DESCRIPTION
There is an existing defect where:
- TX is flashed with default EEPROM config values
- Default packet rate is 1000hz for 2.4
- TX module is inserted into a handset with 400k UART baud rate
- 1000hz is not compatible with 400k baud, so LUA breaks when entering wifi, among other mismatches.

This PR sets the default packet rates to 250hz for 2.4, and 50hz for 900mhz