### PR TITLE
Power level 0 is malfunctioning on Team900 HWs

### DIFF
--- a/src/lib/SX127xDriver/SX127x.h
+++ b/src/lib/SX127xDriver/SX127x.h
@@ -77,7 +77,7 @@ public:
 private:
     // constant used for no power change pending
     // must not be a valid power register value
-    static const uint8_t PWRPENDING_NONE = 0x00;
+    static const uint8_t PWRPENDING_NONE = SX127X_MAX_OUTPUT_POWER_INVALID;
 
     SX127x_Bandwidth currBW;
     SX127x_SpreadingFactor currSF;

--- a/src/lib/SX127xDriver/SX127xRegs.h
+++ b/src/lib/SX127xDriver/SX127xRegs.h
@@ -106,7 +106,7 @@ typedef enum
 #define SX127X_OUTPUT_POWER 0b00001111     //  3     0     output power: P_out = 17 - (15 - OUTPUT_POWER) [dBm] for PA_SELECT_BOOST
 #define SX127X_MAX_OUTPUT_POWER_RFO_HF 0b00000000 //       Max output power when using RFO_HF
 #define SX127X_MAX_OUTPUT_POWER 0b01110000 //              Enable max output power
-#define SX127X_MAX_OUTPUT_POWER_INVALID 0b00010000 //              Enable max output power
+#define SX127X_MAX_OUTPUT_POWER_INVALID 0b00010000 //      A value for the MaxPower field that is not used by ExpressLRS
 // SX127X_REG_OCP
 #define SX127X_OCP_OFF 0b00000000   //  5     5     PA overload current protection disabled
 #define SX127X_OCP_ON 0b00100000    //  5     5     PA overload current protection enabled

--- a/src/lib/SX127xDriver/SX127xRegs.h
+++ b/src/lib/SX127xDriver/SX127xRegs.h
@@ -106,6 +106,7 @@ typedef enum
 #define SX127X_OUTPUT_POWER 0b00001111     //  3     0     output power: P_out = 17 - (15 - OUTPUT_POWER) [dBm] for PA_SELECT_BOOST
 #define SX127X_MAX_OUTPUT_POWER_RFO_HF 0b00000000 //       Max output power when using RFO_HF
 #define SX127X_MAX_OUTPUT_POWER 0b01110000 //              Enable max output power
+#define SX127X_MAX_OUTPUT_POWER_INVALID 0b00010000 //              Enable max output power
 // SX127X_REG_OCP
 #define SX127X_OCP_OFF 0b00000000   //  5     5     PA overload current protection disabled
 #define SX127X_OCP_ON 0b00100000    //  5     5     PA overload current protection enabled


### PR DESCRIPTION
`PWRPENDING_NONE` was set `0x00`, which prevents proper power change when try to set the power level `0`. 

This PR defines `SX127X_MAX_OUTPUT_POWER_INVALID` which is not expected to appear in normal operation in ELRS

(Special thanks to CapnBry, and auge103 for the bug report!)