### PR TITLE
Fix ESP32 RX being labelled as TX in MDNS

### DIFF
--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -754,7 +754,11 @@ static void startMDNS()
     MDNS.addServiceTxt("http", "tcp", "product", (const char *)product_name);
     MDNS.addServiceTxt("http", "tcp", "version", VERSION);
     MDNS.addServiceTxt("http", "tcp", "options", options.c_str());
+  #ifdef TARGET_TX
     MDNS.addServiceTxt("http", "tcp", "type", "tx");
+  #else
+    MDNS.addServiceTxt("http", "tcp", "type", "rx");
+  #endif
   #endif
 }
 


### PR DESCRIPTION
ESP32 RXs were advertising themselves as TXs in MDNS, so just wrap the advertising line in `#ifdef TARGET_TX` and duplicate the line returning the appropriate value.