### PR TITLE
Put "important" tasks on core 1 (loop core)

### DIFF
--- a/src/lib/Backpack/devBackpack.cpp
+++ b/src/lib/Backpack/devBackpack.cpp
@@ -84,9 +84,11 @@ void startPassthrough()
         CRSF::Port.write(buf, r);
     }
 }
+#endif
 
 void checkBackpackUpdate()
 {
+#if defined(GPIO_PIN_BACKPACK_EN)
     if (GPIO_PIN_BACKPACK_EN != UNDEF_PIN)
     {
         if (!digitalRead(0))
@@ -94,8 +96,8 @@ void checkBackpackUpdate()
             startPassthrough();
         }
     }
-}
 #endif
+}
 
 static void BackpackWiFiToMSPOut(uint16_t command)
 {

--- a/src/lib/Backpack/devBackpack.cpp
+++ b/src/lib/Backpack/devBackpack.cpp
@@ -84,6 +84,17 @@ void startPassthrough()
         CRSF::Port.write(buf, r);
     }
 }
+
+void checkBackpackUpdate()
+{
+    if (GPIO_PIN_BACKPACK_EN != UNDEF_PIN)
+    {
+        if (!digitalRead(0))
+        {
+            startPassthrough();
+        }
+    }
+}
 #endif
 
 static void BackpackWiFiToMSPOut(uint16_t command)
@@ -211,17 +222,6 @@ static int timeout()
         VRxBackpackWiFiReadyToSend = false;
         BackpackWiFiToMSPOut(MSP_ELRS_SET_VRX_BACKPACK_WIFI_MODE);
     }
-
-#ifdef GPIO_PIN_BACKPACK_EN
-    if (GPIO_PIN_BACKPACK_EN != UNDEF_PIN)
-    {
-        if (!digitalRead(0))
-        {
-            startPassthrough();
-            return DURATION_NEVER;
-        }
-    }
-#endif
     return BACKPACK_TIMEOUT;
 }
 

--- a/src/lib/Backpack/devBackpack.h
+++ b/src/lib/Backpack/devBackpack.h
@@ -2,4 +2,6 @@
 
 #include "device.h"
 
+void checkBackpackUpdate();
+
 extern device_t Backpack_device;

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -68,28 +68,28 @@ StubbornSender MspSender;
 uint8_t CRSFinBuffer[CRSF_MAX_PACKET_LEN+1];
 
 device_affinity_t ui_devices[] = {
-  {&CRSF_device, 0},
+  {&CRSF_device, 1},
 #ifdef HAS_LED
-  {&LED_device, 1},
+  {&LED_device, 0},
 #endif
 #ifdef HAS_RGB
-  {&RGB_device, 1},
+  {&RGB_device, 0},
 #endif
   {&LUA_device, 1},
 #if defined(USE_TX_BACKPACK)
-  {&Backpack_device, 1},
+  {&Backpack_device, 0},
 #endif
 #ifdef HAS_BLE
-  {&BLE_device, 1},
+  {&BLE_device, 0},
 #endif
 #ifdef HAS_BUZZER
-  {&Buzzer_device, 1},
+  {&Buzzer_device, 0},
 #endif
 #ifdef HAS_WIFI
-  {&WIFI_device, 1},
+  {&WIFI_device, 0},
 #endif
 #ifdef HAS_BUTTON
-  {&Button_device, 1},
+  {&Button_device, 0},
 #endif
 #ifdef HAS_SCREEN
   {&Screen_device, 0},
@@ -101,9 +101,9 @@ device_affinity_t ui_devices[] = {
   {&Thermal_device, 0},
 #endif
 #if defined(GPIO_PIN_PA_PDET)
-  {&PDET_device, 1},
+  {&PDET_device, 0},
 #endif
-  {&VTX_device, 1}
+  {&VTX_device, 0}
 };
 
 #if defined(GPIO_PIN_ANT_CTRL)

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1028,6 +1028,9 @@ void loop()
   // Update UI devices
   devicesUpdate(now);
 
+  // Not a device because it must be run on the loop core
+  checkBackpackUpdate();
+
   #if defined(PLATFORM_ESP8266) || defined(PLATFORM_ESP32)
     // If the reboot time is set and the current time is past the reboot time then reboot.
     if (rebootTime != 0 && now > rebootTime) {


### PR DESCRIPTION
Move the "important" tasks to core 1 (the loop core).
These would be the CRSF, and Lua tasks. Putting them on the loop core, with the main codepath and radio handling ensures that if any of the other devices fail at least the radio continues to work. Also has the benefit that there is a more stable CRSF servicing time. I've noticed that this also increases the reliability of the BLE joystick! 