### PR TITLE
Platform lib upgrade

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
         esac
         # copy the common ESP32 files
         if [[ ${{matrix.target}} == *ESP32* ]] ; then
-          cp ~/.platformio/packages/framework-arduinoespressif32/tools/sdk/bin/bootloader_dio_40m.bin ~/artifacts/firmware/
+          cp ~/.platformio/packages/framework-arduinoespressif32/tools/sdk/esp32/bin/bootloader_dio_40m.bin ~/artifacts/firmware/
           cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin ~/artifacts/firmware/
           mv .pio/build/${{ matrix.target }}/partitions.bin ~/artifacts/firmware/
         fi

--- a/src/lib/BLE/devBLE.cpp
+++ b/src/lib/BLE/devBLE.cpp
@@ -36,7 +36,7 @@ void BluetoothJoystickUpdateValues()
 
         for (uint8_t i = 0; i < 8; i++)
         {
-            data[i] = map(CRSF::ChannelData[i], CRSF_CHANNEL_VALUE_MIN - 1, CRSF_CHANNEL_VALUE_MAX + 1, -32768, 32768);
+            data[i] = map(CRSF::ChannelData[i], CRSF_CHANNEL_VALUE_MIN, CRSF_CHANNEL_VALUE_MAX, 0, 32767);
         }
 
         bleGamepad->setX(data[0]);
@@ -60,8 +60,6 @@ void BluetoothJoystickBegin()
 
     // construct the BLE immediately to prevent reentry from events/timeout
     bleGamepad = new BleGamepad("ExpressLRS Joystick", "ELRS", 100);
-    bleGamepad->setAutoReport(false);
-    bleGamepad->setControllerType(CONTROLLER_TYPE_GAMEPAD);
 
     hwTimer::updateInterval(5000);
     CRSF::setSyncParams(5000); // 200hz
@@ -70,8 +68,15 @@ void BluetoothJoystickBegin()
     Radio.End();
     CRSF::RCdataCallback = BluetoothJoystickUpdateValues;
 
+    BleGamepadConfiguration *gamepadConfig = new BleGamepadConfiguration();
+    gamepadConfig->setAutoReport(false);
+    gamepadConfig->setButtonCount(0);
+    gamepadConfig->setHatSwitchCount(0);
+    gamepadConfig->setWhichAxes(enableX, enableY, enableZ, enableRX, enableRY, enableRZ, enableSlider1, enableSlider2);
+    gamepadConfig->setWhichSimulationControls(enableRudder, enableThrottle, enableAccelerator, enableBrake, enableSteering);
+
     DBGLN("Starting BLE Joystick!");
-    bleGamepad->begin(numOfButtons, numOfHatSwitches, enableX, enableY, enableZ, enableRZ, enableRX, enableRY, enableSlider1, enableSlider2, enableRudder, enableThrottle, enableAccelerator, enableBrake, enableSteering);
+    bleGamepad->begin(gamepadConfig);
 }
 
 static int timeout()

--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -7,6 +7,7 @@
 #include "helpers.h"
 
 #if defined(PLATFORM_ESP32)
+#include <soc/uart_reg.h>
 // UART0 is used since for DupleTX we can connect directly through IO_MUX and not the Matrix
 // for better performance, and on other targets (mostly using pin 13), it always uses Matrix
 HardwareSerial CRSF::Port(0);

--- a/src/lib/VTXSPI/devVTXSPI.cpp
+++ b/src/lib/VTXSPI/devVTXSPI.cpp
@@ -8,7 +8,7 @@
 #include "logging.h"
 #include <SPI.h>
 #if defined(PLATFORM_ESP32)
-#include <analogWrite.h>
+#include <pwmWrite.h>
 #endif
 
 #define SYNTHESIZER_REGISTER_A                  0x00
@@ -25,15 +25,13 @@
 
 #define POWER_AMP_ON                            0b00000100111110111111
 #define POWER_AMP_OFF                           0x00
-#if defined(PLATFORM_ESP32)
-// ESP32 DAC pins are 0-4095
-#define MIN_PWM                                 1 // Testing required.
-#define MAX_PWM                                 250 // Absolute max is 4095.  But above 250 does nothing.
-#else
-// ESP8285 PWM is 0-4095
+// ESP32 DAC pins are 0-255
+#define MIN_DAC                                 1 // Testing required.
+#define MAX_DAC                                 250 // Absolute max is 255.  But above 250 does nothing.
+// PWM is 0-4095
 #define MIN_PWM                                 1000 // Testing required.
 #define MAX_PWM                                 3600 // Absolute max is 4095.  But above 3500 does nothing.
-#endif
+
 #define VPD_BUFFER                              5
 
 #define READ_BIT                                0x00
@@ -54,6 +52,8 @@ static uint8_t vtxSPIPowerIdxCurrent = 0;
 uint8_t vtxSPIPitmode = 1;
 static uint8_t RfAmpVrefState = 0;
 static uint16_t vtxSPIPWM = MAX_PWM;
+static uint16_t vtxMinPWM = MAX_PWM;
+static uint16_t vtxMaxPWM = MIN_PWM;
 static uint16_t VpdSetPoint = 0;
 static uint16_t Vpd = 0;
 
@@ -79,6 +79,9 @@ static const uint16_t freqTable[48] = {
     5333, 5373, 5413, 5453, 5493, 5533, 5573, 5613  // L
 };
 
+#if defined(PLATFORM_ESP32)
+static Pwm pwm;
+#endif
 static SPIClass *vtxSPI;
 static void rtc6705WriteRegister(uint32_t regData)
 {
@@ -149,24 +152,40 @@ static void RfAmpVrefOff()
     RfAmpVrefState = 0;
 }
 
+static void setPWM()
+{
+#if defined(PLATFORM_ESP32)
+    if (GPIO_PIN_RF_AMP_PWM == 25 || GPIO_PIN_RF_AMP_PWM == 26)
+    {
+        dacWrite(GPIO_PIN_RF_AMP_PWM, vtxSPIPWM >> 4);
+    }
+    else
+    {
+        pwm.write(GPIO_PIN_RF_AMP_PWM, vtxSPIPWM);
+    }
+#else
+    analogWrite(GPIO_PIN_RF_AMP_PWM, vtxSPIPWM);
+#endif
+}
+
 void VTxOutputMinimum()
 {
     RfAmpVrefOff();
 
-    vtxSPIPWM = MAX_PWM;
-    analogWrite(GPIO_PIN_RF_AMP_PWM, vtxSPIPWM);
+    vtxSPIPWM = vtxMaxPWM;
+    setPWM();
 }
 
 static void VTxOutputIncrease()
 {
-    if (vtxSPIPWM > MIN_PWM) vtxSPIPWM -= 1;
-    analogWrite(GPIO_PIN_RF_AMP_PWM, vtxSPIPWM);
+    if (vtxSPIPWM > vtxMinPWM) vtxSPIPWM -= 1;
+    setPWM();
 }
 
 static void VTxOutputDecrease()
 {
-    if (vtxSPIPWM < MAX_PWM) vtxSPIPWM += 1;
-    analogWrite(GPIO_PIN_RF_AMP_PWM, vtxSPIPWM);
+    if (vtxSPIPWM < vtxMaxPWM) vtxSPIPWM += 1;
+    setPWM();
 }
 
 static uint16_t LinearInterpVpdSetPointArray(const uint16_t VpdSetPointArray[])
@@ -277,11 +296,22 @@ static void initialize()
         #if defined(PLATFORM_ESP8266)
             pinMode(GPIO_PIN_RF_AMP_PWM, OUTPUT);
             analogWriteFreq(10000); // 10kHz
+            analogWriteResolution(12); // 0 - 4095
         #else
-            analogWriteFrequency(GPIO_PIN_RF_AMP_PWM, 10000); // 10kHz
+            // If using a DAC pin then adjust min/max and initial value
+            if (GPIO_PIN_RF_AMP_PWM == 25 || GPIO_PIN_RF_AMP_PWM == 26)
+            {
+                vtxMinPWM = MIN_DAC;
+                vtxMaxPWM = MAX_DAC;
+                vtxSPIPWM = vtxMaxPWM;
+            }
+            else
+            {
+                pwm.writeFrequency(GPIO_PIN_RF_AMP_PWM, 10000); // 10kHz
+                pwm.writeResolution(12); // 0 - 4095
+            }
         #endif
-        analogWriteResolution(12); // 0 - 4095
-        analogWrite(GPIO_PIN_RF_AMP_PWM, vtxSPIPWM);
+        setPWM();
 
         delay(RTC6705_BOOT_DELAY);
     }

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -865,7 +865,13 @@ static void HandleWebUpdate()
         DBGLN("Changing to AP mode");
         WiFi.disconnect();
         wifiMode = WIFI_AP;
+        #if defined(PLATFORM_ESP32)
+        WiFi.setHostname(wifi_hostname); // hostname must be set before the mode is set to STA
+        #endif
         WiFi.mode(wifiMode);
+        #if defined(PLATFORM_ESP8266)
+        WiFi.setHostname(wifi_hostname); // hostname must be set before the mode is set to STA
+        #endif
         changeTime = now;
         WiFi.softAPConfig(ipAddress, ipAddress, netMsk);
         WiFi.softAP(wifi_ap_ssid, wifi_ap_password);
@@ -874,8 +880,13 @@ static void HandleWebUpdate()
       case WIFI_STA:
         DBGLN("Connecting to network '%s'", station_ssid);
         wifiMode = WIFI_STA;
+        #if defined(PLATFORM_ESP32)
+        WiFi.setHostname(wifi_hostname); // hostname must be set before the mode is set to STA
+        #endif
         WiFi.mode(wifiMode);
+        #if defined(PLATFORM_ESP8266)
         WiFi.setHostname(wifi_hostname); // hostname must be set after the mode is set to STA
+        #endif
         changeTime = now;
         WiFi.begin(station_ssid, station_password);
         startServices();

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -82,7 +82,7 @@ lib_deps =
 
 # ------------------------- COMMON ESP82xx DEFINITIONS -----------------
 [env_common_esp82xx]
-platform = espressif8266@3.2.0
+platform = espressif8266@4.0.1
 board = esp8285-8285
 build_flags =
 	-D PLATFORM_ESP8266=1
@@ -100,8 +100,8 @@ extra_scripts =
 	${env.extra_scripts}
 	pre:python/build_html.py
 lib_deps =
-	makuna/NeoPixelBus @ 2.6.9
-	ottowinter/ESPAsyncWebServer-esphome @ 2.1.0
+	makuna/NeoPixelBus @ 2.7.0
+	ottowinter/ESPAsyncWebServer-esphome @ 3.0.0
 	bblanchon/ArduinoJson @ 6.19.4
 upload_speed = 460800
 monitor_speed = 420000

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -25,8 +25,14 @@ build_flags = -DRADIO_SX128X=1
 lib_ignore = SX127xDriver
 
 # ------------------------- COMMON ESP32 DEFINITIONS -----------------
+
+# platform 5.1.0 uses arduino core 2.0.4 which has a "major" problem with
+# requiring the QIO bootloader on PICO devices, so upgrading older firmware
+# will be problem using OTA, unless we have a mechanism for uploading a new
+# bootloader first!
+
 [env_common_esp32]
-platform = espressif32@3.4.0
+platform = espressif32@5.1.1
 board = esp32dev
 board_build.partitions = min_spiffs.csv
 upload_speed = 460800
@@ -43,20 +49,20 @@ build_flags =
 	-I ${PROJECTSRC_DIR}/hal
 build_src_filter = ${common_env_data.build_src_filter} -<ESP8266*.*> -<STM32*.*>
 lib_deps =
-	makuna/NeoPixelBus @ 2.6.9
-	ottowinter/ESPAsyncWebServer-esphome @ 2.1.0
-	lemmingdev/ESP32-BLE-Gamepad @ 0.3.4
-	h2zero/NimBLE-Arduino @ 1.3.6
+	makuna/NeoPixelBus @ 2.7.0
+	ottowinter/ESPAsyncWebServer-esphome @ 3.0.0
+	lemmingdev/ESP32-BLE-Gamepad @ 0.5.1
+	h2zero/NimBLE-Arduino @ 1.4.0
 	bblanchon/ArduinoJson @ 6.19.4
 oled_lib_deps =
 	${env_common_esp32.lib_deps}
-	olikraus/U8g2 @ 2.32.10
+	olikraus/U8g2 @ 2.33.15
 tft_lib_deps =
 	${env_common_esp32.lib_deps}
-	moononournation/GFX Library for Arduino @ 1.2.1
+	moononournation/GFX Library for Arduino @ 1.2.8
 
 [env_common_esp32rx]
-platform = espressif32@3.4.0
+platform = espressif32@5.1.1
 board = esp32dev
 board_build.partitions = min_spiffs.csv
 upload_speed = 460800
@@ -74,11 +80,11 @@ build_flags =
 	-I ${PROJECTSRC_DIR}/hal
 build_src_filter = ${common_env_data.build_src_filter} -<ESP8266*.*> -<STM32*.*>
 lib_deps =
-	makuna/NeoPixelBus @ 2.6.9
-	ottowinter/ESPAsyncWebServer-esphome @ 2.1.0
+	makuna/NeoPixelBus @ 2.7.0
+	ottowinter/ESPAsyncWebServer-esphome @ 3.0.0
 	bblanchon/ArduinoJson @ 6.19.4
 	roboticsbrno/ServoESP32 @ 1.0.3
-	dlloydev/ESP32 ESP32S2 AnalogWrite @ 2.0.9
+	dlloydev/ESP32 ESP32S2 AnalogWrite @ 3.0.3
 
 # ------------------------- COMMON ESP82xx DEFINITIONS -----------------
 [env_common_esp82xx]


### PR DESCRIPTION
## Upgrade  ESP platforms and arduino libraries
- Upgrade the platform from 3.4.0 to 5.1.1.
- Also upgrade libraries to latest versions.
- Make adjustments to code to match upgraded libraries

This fixes the problem we were seeing in V3.0 to do with i2c devices sometimes locking up.