### PR TITLE
Add BLE Telemetry device

### DIFF
--- a/src/lib/BLE/devBLETele.cpp
+++ b/src/lib/BLE/devBLETele.cpp
@@ -1,0 +1,146 @@
+#include "devBLE.h"
+
+#if defined(PLATFORM_ESP32)
+
+#include "CRSF.h"
+#include "FHSS.h"
+#include "NimBLEDevice.h"
+#include "POWERMGNT.h"
+#include "common.h"
+#include "hwTimer.h"
+#include "logging.h"
+#include "options.h"
+
+NimBLEServer *pServer;
+NimBLECharacteristic *rcState;
+NimBLECharacteristic *rcCRSF;
+NimBLECharacteristic *rcLink;
+
+NimBLEService *rcTemp;
+NimBLECharacteristic *cTemp;
+
+unsigned short const TELEMETRY_SVC_UUID = 0x1819;
+unsigned short const TELEMETRY_STATE_UUID = 0x2B05;
+unsigned short const TELEMETRY_CRSF_UUID = 0x2A4D;
+unsigned short const TELEMETRY_LINK_UUID = 0x2BBD;
+
+unsigned short const DEVICE_INFO_SVC_UUID = 0x180A;
+unsigned short const MODEL_NUMBER_SVC_UUID = 0x2A24;
+unsigned short const SERIAL_NUMBER_SVC_UUID = 0x2A25;
+unsigned short const SOFTWARE_NUMBER_SVC_UUID = 0x2A28;
+unsigned short const HARDWARE_NUMBER_SVC_UUID = 0x2A27;
+unsigned short const MANUFACTURER_NAME_SVC_UUID = 0x2A29;
+
+unsigned short const TEMP_SVC_UUID = 0x181A;
+unsigned short const TEMP_C_UUID = 0x2A1C;
+
+#ifdef HAS_THERMAL
+#include "thermal.h"
+extern Thermal thermal;
+#endif
+
+extern CRSF crsf;
+
+String getMasterUIDString()
+{
+    char muids[7] = {0};
+    sprintf(muids, "%02X%02X%02X", MasterUID[3], MasterUID[4], MasterUID[5]);
+    return String(muids);
+}
+
+void ICACHE_RAM_ATTR BluetoothTelemetrykUpdateValues(uint8_t *data)
+{
+    rcState->setValue(connectionState);
+    rcState->notify(true);
+
+    if (data != nullptr)
+    {
+        rcCRSF->setValue(data);
+        rcCRSF->notify();
+    }
+
+    cTemp->setValue(thermal.read_temp());
+    cTemp->notify();
+
+    uint8_t linkstats[sizeof(crsfPayloadLinkstatistics_s)];
+    memcpy(linkstats, (byte *)&CRSF::LinkStatistics, sizeof(crsfPayloadLinkstatistics_s));
+    rcLink->setValue(linkstats);
+    rcLink->notify();
+}
+
+void BluetoothTelemetryBegin()
+{
+
+    // bleGamepad is null if it hasn't been started yet
+    if (pServer != nullptr)
+        return;
+
+    NimBLEDevice::init(String(String(device_name) + " " + getMasterUIDString()).c_str());
+
+    /** Set low transmit power, default is 6db */
+    BLEDevice::setPower(ESP_PWR_LVL_P6);
+    pServer = NimBLEDevice::createServer();
+    NimBLEService *rcService = pServer->createService(TELEMETRY_SVC_UUID);
+    rcState = rcService->createCharacteristic(TELEMETRY_STATE_UUID, NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::NOTIFY);
+    rcCRSF = rcService->createCharacteristic(TELEMETRY_CRSF_UUID, NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::NOTIFY, CRSF_MAX_PACKET_LEN);
+    rcLink = rcService->createCharacteristic(TELEMETRY_LINK_UUID, NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::NOTIFY, LinkStatisticsFrameLength);
+    rcService->start();
+
+#ifdef HAS_THERMAL
+    rcTemp = pServer->createService(TEMP_SVC_UUID);
+    cTemp = rcTemp->createCharacteristic(TEMP_C_UUID, NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::NOTIFY);
+    cTemp->setValue(String(thermal.getTempValue()));
+    rcTemp->start();
+#endif
+
+    auto dInfo = pServer->createService(DEVICE_INFO_SVC_UUID);
+    dInfo
+        ->createCharacteristic(MANUFACTURER_NAME_SVC_UUID, NIMBLE_PROPERTY::READ)
+        ->setValue("ExpressLRS");
+    dInfo
+        ->createCharacteristic(MODEL_NUMBER_SVC_UUID, NIMBLE_PROPERTY::READ)
+        ->setValue(String(product_name));
+    dInfo
+        ->createCharacteristic(SERIAL_NUMBER_SVC_UUID, NIMBLE_PROPERTY::READ)
+        ->setValue(String(__TIMESTAMP__) + " - " + getMasterUIDString());
+    dInfo
+        ->createCharacteristic(SOFTWARE_NUMBER_SVC_UUID, NIMBLE_PROPERTY::READ)
+        ->setValue(String(version));
+    dInfo
+        ->createCharacteristic(HARDWARE_NUMBER_SVC_UUID, NIMBLE_PROPERTY::READ)
+        ->setValue(String(getRegulatoryDomain()));
+
+    dInfo->start();
+
+    NimBLEAdvertising *pAdvertising = NimBLEDevice::getAdvertising();
+    pAdvertising->addServiceUUID(rcService->getUUID());
+
+#ifdef HAS_THERMAL
+    pAdvertising->addServiceUUID(rcTemp->getUUID());
+#endif
+
+    pAdvertising->addServiceUUID(dInfo->getUUID());
+    pAdvertising->start();
+
+    INFOLN("Starting BLE Telemetry!");
+}
+
+static int start()
+{
+    BluetoothTelemetryBegin();
+    return DURATION_IMMEDIATELY;
+}
+
+static int timeout()
+{
+    BluetoothTelemetrykUpdateValues(nullptr);
+    return 500;
+}
+
+device_t BLET_device = {
+    .initialize = nullptr,
+    .start = start,
+    .event = nullptr,
+    .timeout = timeout};
+
+#endif

--- a/src/lib/BLE/devBLETele.h
+++ b/src/lib/BLE/devBLETele.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "device.h"
+
+#if defined(PLATFORM_ESP32)
+extern device_t BLET_device;
+void ICACHE_RAM_ATTR BluetoothTelemetrykUpdateValues(uint8_t *data);
+#define HAS_BLET
+#endif

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -11,7 +11,8 @@
 #include "devLED.h"
 #include "devScreen.h"
 #include "devBuzzer.h"
-#include "devBLE.h"
+//#include "devBLE.h"
+#include "devBLETele.h"
 #include "devLUA.h"
 #include "devWIFI.h"
 #include "devButton.h"
@@ -81,6 +82,9 @@ device_affinity_t ui_devices[] = {
 #endif
 #ifdef HAS_BLE
   {&BLE_device, 1},
+#endif
+#ifdef HAS_BLET
+  {&BLET_device, 1},
 #endif
 #ifdef HAS_BUZZER
   {&Buzzer_device, 1},
@@ -1066,6 +1070,7 @@ void loop()
   if (TelemetryReceiver.HasFinishedData())
   {
       crsf.sendTelemetryToTX(CRSFinBuffer);
+      BluetoothTelemetrykUpdateValues(CRSFinBuffer);
       TelemetryReceiver.Unlock();
   }
 

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -46,7 +46,7 @@ lib_deps =
 	makuna/NeoPixelBus @ 2.6.9
 	ottowinter/ESPAsyncWebServer-esphome @ 2.1.0
 	lemmingdev/ESP32-BLE-Gamepad @ 0.3.4
-	h2zero/NimBLE-Arduino @ 1.3.6
+	h2zero/NimBLE-Arduino @ 1.4.0
 	bblanchon/ArduinoJson @ 6.19.4
 oled_lib_deps =
 	${env_common_esp32.lib_deps}


### PR DESCRIPTION
Hi all! Not sure where to comment on this ... the author of this commit (@dz0ny) seems to have written code for using BLE as a telemetry device. Can somebody take a look at the code and see if they can figure out whether (a) it is intended to send telemetry between ELRS TX and ELRS RX or (b) to _forward_ telemetry from ELRS RX via ELRS TX to a groundstation connected via BLE?