### PR TITLE
Fix for RX not showing UID and other options

### DIFF
--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -470,7 +470,7 @@ function submitOptions(e) {
 
 _('submit-options').addEventListener('click', submitOptions);
 
-
+@@if isTX:
 function submitButtonActions(e) {
   e.stopPropagation();
   e.preventDefault();
@@ -492,8 +492,8 @@ function submitButtonActions(e) {
     }
   };
 }
-
 _('submit-actions').addEventListener('click', submitButtonActions);
+@@end
 
 function updateOptions(data) {
   for (const [key, value] of Object.entries(data)) {


### PR DESCRIPTION
# Problem
On RX wifi I can't see the options!

# Solution
The RX wifi page does not have the button action HTML and so this part needed to be templated out of the RX scan.j also.
With the action code still on the scan.ja page it would cause an error during load and would then no longer load the json files for the current options.