### PR TITLE
Hide the "unlock higher power" option

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -78,7 +78,7 @@
 							<input size='3' id='fan-runtime' name='fan-runtime' type='text'/>
 							<label>Fan runtime (s)</label>
 						</div>
-						<div class="mui-checkbox">
+						<div id="has-highpower" class="mui-checkbox" style="display: none;">
 							<input id='unlock-higher-power' name='unlock-higher-power' type='checkbox'/>
 							<label>Unlock higher power</label>
 						</div>

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -189,6 +189,7 @@ function updateConfig(data) {
   } else {
     _('button-tab').style.display = 'none';
   }
+  if (data['has-highpower'] === true) _('has-highpower').style.display = 'block';
 @@end
 }
 

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -324,6 +324,7 @@ static void GetConfiguration(AsyncWebServerRequest *request)
   #else
   else json["config"]["uidtype"] = "Not set (using MAC address)";
   #endif
+  json["config"]["has-highpower"] = (MaxPower != HighPower);
 
   AsyncResponseStream *response = request->beginResponseStream("application/json");
   serializeJson(json, *response);


### PR DESCRIPTION
 if MaxPower and HighPower in the hardware settings are the same then hide the unlock higher power option on the main web UI page.