### PR TITLE
Fix HappyModel Dual using wrong target file

### DIFF
--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -535,7 +535,7 @@
                 "platform": "esp32",
                 "firmware": "Unified_ESP32_2400_TR"
             },
-            "diversity": {
+            "true_diversity": {
                 "product_name": "Generic ESP32 True Diversity PA 2.4Ghz RX",
                 "lua_name": "Diversity 2.4RX",
                 "layout_file": "Generic 2400 True Diversity PA.json",

--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -671,7 +671,7 @@
             "ep-dual": {
                 "product_name": "HappyModel EP Dual 2.4GHz RX",
                 "lua_name": "HM EP Dual 2400",
-                "layout_file": "Generic 2400 Diversity.json",
+                "layout_file": "Generic 2400 True Diversity PA.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "platform": "esp32",
                 "firmware": "Unified_ESP32_2400_RX"


### PR DESCRIPTION
After the merge of #1748 the HappyModel Dual RX had the wrong hardware layout file specified and would fail to build.