### PR TITLE
Move uart writes from ISR on STM32

### DIFF
--- a/src/lib/CRSF/devCRSF_rx.cpp
+++ b/src/lib/CRSF/devCRSF_rx.cpp
@@ -9,7 +9,7 @@ extern void HandleUARTin();
 
 void ICACHE_RAM_ATTR crsfRCFrameAvailable()
 {
-    #if defined(PLATFORM_ESP32)
+    #if defined(PLATFORM_ESP32) || defined(PLATFORM_STM32)
     sendFrame = true;
     #else
     crsf.sendRCFrameToFC();
@@ -23,7 +23,7 @@ static int start()
 
 static int timeout()
 {
-    #if defined(PLATFORM_ESP32)
+    #if defined(PLATFORM_ESP32) || defined(PLATFORM_STM32)
     if (sendFrame)
     {
         sendFrame = false;


### PR DESCRIPTION
EDIT: related issue #1873  

OK, here's a draft PR - I'm still testing, so at this point unsure if the issue is actually fixed.

The alternative workaround is increasing Arduino tx buffer to 128 bytes using -DSERIAL_TX_BUFFER_SIZE=128