### PR TITLE
Fix wifi led when in binding mode

### DIFF
--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -699,7 +699,10 @@ static void initialize()
   #if defined(PLATFORM_ESP8266)
   WiFi.forceSleepBegin();
   #endif
-  registerButtonFunction(ACTION_START_WIFI, [](){ connectionState = wifiUpdate; });
+  registerButtonFunction(ACTION_START_WIFI, [](){
+    setWifiUpdateMode();
+    devicesTriggerEvent();
+  });
 }
 
 static void startWiFi(unsigned long now)


### PR DESCRIPTION
When in binding mode, and then using the button to enter wifi mode, the button action code did not trigger the event to the device system.

Fixes #1880 