### PR TITLE
Disable TX diversity on FM30

### DIFF
--- a/src/include/target/FM30_TX.h
+++ b/src/include/target/FM30_TX.h
@@ -15,7 +15,7 @@
 #define GPIO_PIN_SCK            PB13
 #define GPIO_PIN_RST            PB3
 #define GPIO_PIN_TX_ENABLE      PB9 // CTX on SE2431L
-#define GPIO_PIN_ANT_CTRL       PB4 // Low for left (stock), high for right (empty)
+#define GPIO_PIN_ANT_CTRL_FIXED PB4 // Low for left (stock), high for right (empty). Named _FIXED to prevent auto-switching
 #define GPIO_PIN_RCSIGNAL_RX    PA10 // UART1
 #define GPIO_PIN_RCSIGNAL_TX    PA9  // UART1
 #define GPIO_PIN_BUFFER_OE      PB7

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -909,8 +909,8 @@ static void setupTarget()
   digitalWrite(GPIO_PIN_BLUETOOTH_EN, HIGH);
   pinMode(GPIO_PIN_UART1RX_INVERT, OUTPUT); // RX1 inverter (TX handled in CRSF)
   digitalWrite(GPIO_PIN_UART1RX_INVERT, HIGH);
-  pinMode(GPIO_PIN_ANT_CTRL, OUTPUT);
-  digitalWrite(GPIO_PIN_ANT_CTRL, LOW); // LEFT antenna
+  pinMode(GPIO_PIN_ANT_CTRL_FIXED, OUTPUT);
+  digitalWrite(GPIO_PIN_ANT_CTRL_FIXED, LOW); // LEFT antenna
   HardwareSerial *uart2 = new HardwareSerial(USART2);
   uart2->begin(57600);
   CRSF::PortSecondary = uart2;


### PR DESCRIPTION
This disables diversity switching on the TX on SIYI FM30 hardware, which is causing major issues by transmitting half the packets to a disconnected antenna u.FL.

### Details
The PR which unified the ANT_CTRL defines enables TX diversity on any TX target that has this set. However, the FM30 has this set but only has one physical antenna attached so this started sending 50% of the packets out the second, disconnected antenna.

I did not notice this because I have added a second internal antenna to my FM30 so it was not obvious in testing as the RSSI reported is smoothed and will just show a lower average.

### Target Branch
I dunno what is supposed to go on what branch, but this is a bug fix for 3.0.1 so it is against 3.x.x-maint. It should also apply cleanly to master if I should need to rebase it, or just flippin retype the 20 characters this patch is.