### PR TITLE
Lowering upload speed

### DIFF
--- a/src/python/build_env_setup.py
+++ b/src/python/build_env_setup.py
@@ -83,7 +83,7 @@ elif platform in ['espressif8266']:
     elif "_UART" in target_name:
         env.Replace(
             UPLOADER="$PROJECT_DIR/python/external/esptool/esptool.py",
-            UPLOAD_SPEED=921600,
+            UPLOAD_SPEED=460800,
             UPLOADERFLAGS=[
                 "-b", "$UPLOAD_SPEED", "-p", "$UPLOAD_PORT",
                 "-c", "esp8266", "--before", "default_reset", "--after", "soft_reset", "write_flash"
@@ -107,7 +107,7 @@ elif platform in ['espressif32']:
     elif "_UART" in target_name:
         env.Replace(
             UPLOADER="$PROJECT_DIR/python/external/esptool/esptool.py",
-            UPLOAD_SPEED=921600
+            UPLOAD_SPEED=460800
         )
     if "_ETX" in target_name:
         env.Replace(UPLOADER="$PROJECT_DIR/python/external/esptool/esptool.py")


### PR DESCRIPTION
Some modules (ex: Vantac 2.4G TX) fail to upload the firmware via UART.
Lowering the upload speed is safer to use here.