### PR TITLE
Set BLE to max power

### DIFF
--- a/src/lib/BLE/devBLE.cpp
+++ b/src/lib/BLE/devBLE.cpp
@@ -9,6 +9,7 @@
 #include "logging.h"
 
 #include <BleGamepad.h>
+#include <NimBLEDevice.h>
 
 #define numOfButtons 0
 #define numOfHatSwitches 0
@@ -26,7 +27,18 @@
 #define enableBrake false
 #define enableSteering false
 
-static BleGamepad *bleGamepad;
+
+class ELRSGamepad : public BleGamepad {
+    public:
+        ELRSGamepad() : BleGamepad("ExpressLRS Joystick", "ELRS", 100) {};
+
+    protected:
+        void onStarted(NimBLEServer *pServer) {
+            NimBLEDevice::setPower(ESP_PWR_LVL_P9);
+        }
+};
+
+static ELRSGamepad *bleGamepad;
 
 void BluetoothJoystickUpdateValues()
 {
@@ -59,7 +71,7 @@ void BluetoothJoystickBegin()
         return;
 
     // construct the BLE immediately to prevent reentry from events/timeout
-    bleGamepad = new BleGamepad("ExpressLRS Joystick", "ELRS", 100);
+    bleGamepad = new ELRSGamepad();
 
     hwTimer::updateInterval(5000);
     CRSF::setSyncParams(5000); // 200hz

--- a/src/lib/BLE/devBLE.cpp
+++ b/src/lib/BLE/devBLE.cpp
@@ -73,9 +73,9 @@ void BluetoothJoystickBegin()
     // construct the BLE immediately to prevent reentry from events/timeout
     bleGamepad = new ELRSGamepad();
 
-    hwTimer::updateInterval(5000);
-    CRSF::setSyncParams(5000); // 200hz
-    CRSF::disableOpentxSync();
+    hwTimer::updateInterval(10000);
+    CRSF::setSyncParams(10000); // 100hz
+    // CRSF::disableOpentxSync();
     POWERMGNT::setPower(MinPower);
     Radio.End();
     CRSF::RCdataCallback = BluetoothJoystickUpdateValues;


### PR DESCRIPTION
After the platform upgrade, this allows us to set the BLE power level.
This sets it to MAX power level 9, which means it can operate at a better distance.
Also, adjusted the update rate down from 200Hz to 100Hz as at the higher rate it causes a build-up lag which then ends up with the joystick being unusable. Also, after doing a lot of research online it looks to be that most BLE based joysticks are limited to 100Hz as MacOS has that limitation as well.

After this PR I can actually win races in Liftoff whereas before I could not unless I was using USB.
USB is still far superior, but this at least makes BLE more usable.