### PR TITLE
Fix ETX passthrough flashing

### DIFF
--- a/src/python/build_env_setup.py
+++ b/src/python/build_env_setup.py
@@ -110,7 +110,10 @@ elif platform in ['espressif32']:
             UPLOAD_SPEED=460800
         )
     if "_ETX" in target_name:
-        env.Replace(UPLOADER="$PROJECT_DIR/python/external/esptool/esptool.py")
+        env.Replace(
+            UPLOADER="$PROJECT_DIR/python/external/esptool/esptool.py",
+            UPLOAD_SPEED=230400
+        )
         env.AddPreAction("upload", ETXinitPassthrough.init_passthrough)
     elif "_BETAFLIGHTPASSTHROUGH" in target_name:
         env.Replace(


### PR DESCRIPTION
Fix EdgeTX passthrough flashing after the upgrade to the esptool and ESP32 RX flashing code broke it by being a b it too aggressive with the upload speed for ETX flashing 😭  

This slows it back down to 230400 from 460800.

EDIT: This seems to be an EdgeTX 2.8 thing sadly.