### PR TITLE
Fix power on boot being default power

### DIFF
--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -184,7 +184,7 @@ void SX127xDriver::SetOutputPower(uint8_t Power)
     pwrNew = SX127X_PA_SELECT_BOOST | SX127X_MAX_OUTPUT_POWER | Power;
   }
 
-  if (pwrCurrent != pwrNew)
+  if ((pwrPending == PWRPENDING_NONE && pwrCurrent != pwrNew) || pwrPending != pwrNew)
   {
     pwrPending = pwrNew;
   }

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -184,7 +184,7 @@ void SX1280Driver::SetOutputPower(int8_t power)
 {
     uint8_t pwrNew = constrain(power, SX1280_POWER_MIN, SX1280_POWER_MAX) + (-SX1280_POWER_MIN);
 
-    if (pwrCurrent != pwrNew)
+    if ((pwrPending == PWRPENDING_NONE && pwrCurrent != pwrNew) || pwrPending != pwrNew)
     {
         pwrPending = pwrNew;
         DBGLN("SetPower: %u", pwrPending);


### PR DESCRIPTION
Fixes #1877 

# Problem
If configured power is set to MIN_POWER, when the TX module is started it would select the default power level.

The problem was that the drivers would only check `pwrCurrent != pwrNew`, and set `pwrPending`.

1. On boot `pwrCurrent` is `SX12xx_MIN_POWER` set in the constructor and committed.
2. `POWERMGNT::init` sets power to default (not committed yet).
3. `ChangeRadioParams` calls `SetOutputPower` (with configured MIN_POWER) and the value is ignored because `pwrCurrent` == `pwrNew`!

Later the commit happens and sets the power to default (in step 2 above.)