### PR TITLE
Remove binary file so it's built each time

### DIFF
--- a/src/python/build_env_setup.py
+++ b/src/python/build_env_setup.py
@@ -1,4 +1,5 @@
 Import("env", "projenv")
+import os
 import stlink
 import UARTupload
 import opentx
@@ -133,4 +134,9 @@ if "_WIFI" in target_name:
 if platform != 'native':
     add_target_uploadoption("uploadforce", "Upload even if target mismatch")
 
+# Remove stale binary so the platform is forced to build a new one and attach options/hardware-layout files
+try:
+    os.remove(env['PROJECT_BUILD_DIR'] + '/' + env['PIOENV'] +'/'+ env['PROGNAME'] + '.bin')
+except FileNotFoundError:
+    None
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", UnifiedConfiguration.appendConfiguration)


### PR DESCRIPTION
# Problem
When a user makes option changes in Configurator (e.g. new bind-phrase), the binary file is not reconfigured.

# Root Cause
The underlying cause is that platformio would run the unified configurator when the .bin file changes. The problem is that the software has not changed and so the binary is not re-built and therefore the post-action target is not run (i.e. the unified configuration script).
Not quite sure why this is a problem for Configurator as it actually changes `user_defines.txt`, which causes a full rebuild, so the new json should have been attached, but this fix also works for that too.

# Solution
Remove the binary file before rebuild so it forces a new binary to be built and therefore the new/changed json files attached.

Fixes #1908 