### PR TITLE
The FIFO's actions need to be atomic

### DIFF
--- a/src/lib/FIFO/FIFO.h
+++ b/src/lib/FIFO/FIFO.h
@@ -39,42 +39,45 @@
 class FIFO
 {
 private:
-    uint8_t head;
-    uint8_t tail;
-    uint16_t numElements;
+    volatile uint8_t head;
+    volatile uint8_t tail;
+    volatile uint16_t numElements;
     uint8_t buffer[FIFO_SIZE] = {0};
+#if defined(PLATFORM_ESP32)
+    portMUX_TYPE mux = portMUX_INITIALIZER_UNLOCKED;
+#endif
 
 public:
     FIFO();
     ~FIFO();
 
     // Push a single byte to the FIFO, FIFO is flushed if this byte will not fit and the byte is not pushed
-    void ICACHE_RAM_ATTR push(const uint8_t data);
+    void push(const uint8_t data);
 
     // Push all bytes to FIFO, if all the bytes will not fit then the FIFO is flushed and no bytes are pushed
-    void ICACHE_RAM_ATTR pushBytes(const uint8_t *data, uint8_t len);
+    void pushBytes(const uint8_t *data, uint8_t len);
 
     // Pop a single byte (returns 0 if no bytes left)
-    uint8_t ICACHE_RAM_ATTR pop();
+    uint8_t pop();
 
     // Pops 'len' bytes into the buffer pointed to by 'data'. If there are not enough bytes in the FIFO
     // then the FIFO is flush and the bytes are not read
-    void ICACHE_RAM_ATTR popBytes(uint8_t *data, uint8_t len);
+    void popBytes(uint8_t *data, uint8_t len);
 
     // return the first byte in the FIFO without removing it
-    uint8_t ICACHE_RAM_ATTR peek();
+    uint8_t peek();
 
     // return the number of bytes in the FIFO
-    uint16_t ICACHE_RAM_ATTR size();
+    uint16_t size();
 
     // reset the FIFO back to empty
-    void ICACHE_RAM_ATTR flush();
-    
+    void flush();
+
     // returns true if the number of bytes requested is available in the FIFO
-    bool ICACHE_RAM_ATTR available(uint8_t requiredSize) { return (numElements + requiredSize) < FIFO_SIZE; }
+    bool available(uint8_t requiredSize) { return (numElements + requiredSize) < FIFO_SIZE; }
 
     // Ensure that there is enough room in the FIFO for the requestedSize in bytes.
     // "packets" are popped from the head of the FIFO until there is enough room available.
     // This method assumes that on the FIFO contains length-prefixed data packets.
-    bool ICACHE_RAM_ATTR ensure(uint8_t requiredSize);
+    bool ensure(uint8_t requiredSize);
 };

--- a/src/lib/FIFO/FIFO.h
+++ b/src/lib/FIFO/FIFO.h
@@ -39,9 +39,9 @@
 class FIFO
 {
 private:
-    volatile uint8_t head;
-    volatile uint8_t tail;
-    volatile uint16_t numElements;
+    uint8_t head;
+    uint8_t tail;
+    uint16_t numElements;
     uint8_t buffer[FIFO_SIZE] = {0};
 #if defined(PLATFORM_ESP32)
     portMUX_TYPE mux = portMUX_INITIALIZER_UNLOCKED;

--- a/src/lib/FIFO_GENERIC/FIFO_GENERIC.h
+++ b/src/lib/FIFO_GENERIC/FIFO_GENERIC.h
@@ -37,9 +37,9 @@ template <uint32_t FIFO_SIZE>
 class FIFO_GENERIC
 {
 private:
-    volatile uint32_t head;
-    volatile uint32_t tail;
-    volatile uint32_t numElements;
+    uint32_t head;
+    uint32_t tail;
+    uint32_t numElements;
     uint8_t buffer[FIFO_SIZE] = {0};
 #if defined(PLATFORM_ESP32)
     portMUX_TYPE mux = portMUX_INITIALIZER_UNLOCKED;

--- a/src/lib/FIFO_GENERIC/FIFO_GENERIC.h
+++ b/src/lib/FIFO_GENERIC/FIFO_GENERIC.h
@@ -37,10 +37,24 @@ template <uint32_t FIFO_SIZE>
 class FIFO_GENERIC
 {
 private:
-    uint32_t head;
-    uint32_t tail;
-    uint32_t numElements;
+    volatile uint32_t head;
+    volatile uint32_t tail;
+    volatile uint32_t numElements;
     uint8_t buffer[FIFO_SIZE] = {0};
+#if defined(PLATFORM_ESP32)
+    portMUX_TYPE mux = portMUX_INITIALIZER_UNLOCKED;
+#define ENTER_CRITICAL  portENTER_CRITICAL(&mux)
+#define EXIT_CRITICAL   portEXIT_CRITICAL(&mux)
+#elif defined(PLATFORM_ESP8266)
+#define ENTER_CRITICAL  noInterrupts()
+#define EXIT_CRITICAL   interrupts()
+#elif defined(PLATFORM_STM32)
+#define ENTER_CRITICAL  noInterrupts()
+#define EXIT_CRITICAL   interrupts()
+#else
+#define ENTER_CRITICAL
+#define EXIT_CRITICAL
+#endif
 
 public:
     FIFO_GENERIC()
@@ -59,12 +73,11 @@ public:
             flush();
             return;
         }
-        else
-        {
-            numElements++;
-            buffer[tail] = data;
-            tail = (tail + 1) % FIFO_SIZE;
-        }
+        ENTER_CRITICAL;
+        buffer[tail] = data;
+        tail = (tail + 1) % FIFO_SIZE;
+        numElements++;
+        EXIT_CRITICAL;
     }
 
     void pushBytes(const uint8_t *data, uint32_t len)
@@ -75,12 +88,14 @@ public:
             flush();
             return;
         }
+        ENTER_CRITICAL;
         for (uint32_t i = 0; i < len; i++)
         {
             buffer[tail] = data[i];
             tail = (tail + 1) % FIFO_SIZE;
         }
         numElements += len;
+        EXIT_CRITICAL;
     }
 
     uint8_t pop()
@@ -90,13 +105,12 @@ public:
             // DBGLN(F("Buffer empty"));
             return 0;
         }
-        else
-        {
-            numElements--;
-            uint8_t data = buffer[head];
-            head = (head + 1) % FIFO_SIZE;
-            return data;
-        }
+        ENTER_CRITICAL;
+        uint8_t data = buffer[head];
+        head = (head + 1) % FIFO_SIZE;
+        numElements--;
+        EXIT_CRITICAL;
+        return data;
     }
 
     void popBytes(uint8_t *data, uint32_t len)
@@ -105,16 +119,16 @@ public:
         {
             // DBGLN(F("Buffer underrun"));
             flush();
+            return;
         }
-        else
+        ENTER_CRITICAL;
+        for (uint32_t i = 0; i < len; i++)
         {
-            numElements -= len;
-            for (uint32_t i = 0; i < len; i++)
-            {
-                data[i] = buffer[head];
-                head = (head + 1) % FIFO_SIZE;
-            }
+            data[i] = buffer[head];
+            head = (head + 1) % FIFO_SIZE;
         }
+        numElements -= len;
+        EXIT_CRITICAL;
     }
 
     uint8_t peek()
@@ -167,8 +181,10 @@ public:
 
     void flush()
     {
+        ENTER_CRITICAL;
         head = 0;
         tail = 0;
         numElements = 0;
+        EXIT_CRITICAL;
     }
 };


### PR DESCRIPTION
# Problem
Whilst helping @wvarty with his Airport code, we were having problems with the order of data on the remote serial line.

# Root Cause
The FIFO's used in the code were not atomic in nature, so as a byte was being pushed or popped, an ISR could fire and adjust the number of elements, only to have the original code continue and overwrite the number elements with a wrong value.

# Solution
The actions in the FIFOs need to be atomic, so for ESP32, wrap the functions in `portENTER_CRITICAL`/`portEXIT_CRITICAL` and for ESP8266/STM32 use `noInterrupt`/`interrupt` calls.

# Testing
I have tested this on ESP8285, and ESP32 devices with and without the LBT code merged.
Will test on STM32 and update later.