### PR TITLE
Change binding to use deferExecution() for the 2s delay.

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1130,10 +1130,11 @@ static void setupConfigAndPocCheck()
         else
         {
             // We haven't reached our binding mode power cycles
-            // and we've been powered on for 2s, reset the power on counter
-            delay(2000);
-            config.SetPowerOnCounter(0);
-            config.Commit();
+            // and we've been powered on for 2s, reset the power on counter.
+            // config.Commit() is done in the loop with CheckConfigChangePending().
+            deferExecution(2000, []() {
+                config.SetPowerOnCounter(0);
+            });
         }
     }
 


### PR DESCRIPTION
Using deferExecution() now allows for devicesInit and the loop to start, which means we can see when the Rx is alive with the LED.  Tested with the esp32, 8285, standard LED and RGB.  Seeing the LED come alive is now a good indication that the Rx should be power cycled.

Down side... CheckConfigChangePending() is called for the config.Commit.  So if a user is on a FLRC mode a connection is made before the 2s delay.  The 'C' in Lua will blink, but I did not experience any tlm lost call outs.  A standard Rx LED will also blink off for a split second, but the RGB LED is ok since it is still performing its hello twinkle. 