### PR TITLE
Fix QuadKoptersNano 2400 RX referencing Generic 900 target

### DIFF
--- a/src/targets/quadkopters_2400.ini
+++ b/src/targets/quadkopters_2400.ini
@@ -15,7 +15,7 @@ extends = env:QuadKopters_JR_2400_TX_via_UART
 # ********************************
 
 [env:QuadKopters_NANO_RX_via_UART]
-extends = env:Unified_ESP8285_900_RX_via_UART
+extends = env:Unified_ESP8285_2400_RX_via_UART
 board_config = quadkopters.rx_2400.nano
 
 [env:QuadKopters_NANO_RX_via_BetaflightPassthrough]


### PR DESCRIPTION
Discord user shikhs (shikhs#1180) pointed out the issue shown on the attached error message:
![error](https://cdn.discordapp.com/attachments/798006228450017290/1036239749662396447/unknown.png)