### PR TITLE
Use common packet rate naming

### DIFF
--- a/src/lib/LUA/rxtx_devLua.cpp
+++ b/src/lib/LUA/rxtx_devLua.cpp
@@ -8,7 +8,7 @@ const char STR_LUA_PACKETRATES[] =
     "L25(-123);L50(-120);L100(-117);L100F(-112);L200(-112)";
 #elif defined(RADIO_SX128X)
     "L50(-115);L100F(-112);L150(-112);L250(-108);L333F(-105);L500(-105);"
-    "D250(-104);D500(-104);F500(-104);F1000(-104)";
+    "F250D(-104);F500D(-104);F500(-104);F1000(-104)";
 #else
     #error Invalid radio configuration!
 #endif

--- a/src/lib/LUA/rxtx_devLua.cpp
+++ b/src/lib/LUA/rxtx_devLua.cpp
@@ -5,10 +5,10 @@ char strPowerLevels[] = "10;25;50;100;250;500;1000;2000";
 const char STR_EMPTYSPACE[] = { 0 };
 const char STR_LUA_PACKETRATES[] =
 #if defined(RADIO_SX127X)
-    "L25(-123dBm);L50(-120dBm);L100(-117dBm);L100F(-112dBm);L200(-112dBm)";
+    "L25(-123);L50(-120);L100(-117);L100F(-112);L200(-112)";
 #elif defined(RADIO_SX128X)
-    "L50(-115dBm);L100F(-112dBm);L150(-112dBm);L250(-108dBm);L333F(-105dBm);L500(-105dBm);"
-    "D250(-104dBm);D500(-104dBm);F500(-104dBm);F1000(-104dBm)";
+    "L50(-115);L100F(-112);L150(-112);L250(-108);L333F(-105);L500(-105);"
+    "D250(-104);D500(-104);F500(-104);F1000(-104)";
 #else
     #error Invalid radio configuration!
 #endif

--- a/src/lib/LUA/rxtx_devLua.cpp
+++ b/src/lib/LUA/rxtx_devLua.cpp
@@ -5,9 +5,9 @@ char strPowerLevels[] = "10;25;50;100;250;500;1000;2000";
 const char STR_EMPTYSPACE[] = { 0 };
 const char STR_LUA_PACKETRATES[] =
 #if defined(RADIO_SX127X)
-    "25Hz(-123dBm);50Hz(-120dBm);100Hz(-117dBm);100Hz Full(-112dBm);200Hz(-112dBm)";
+    "L25(-123dBm);L50(-120dBm);L100(-117dBm);L100F(-112dBm);L200(-112dBm)";
 #elif defined(RADIO_SX128X)
-    "50Hz(-115dBm);100Hz Full(-112dBm);150Hz(-112dBm);250Hz(-108dBm);333Hz Full(-105dBm);500Hz(-105dBm);"
+    "L50(-115dBm);L100F(-112dBm);L150(-112dBm);L250(-108dBm);L333F(-105dBm);L500(-105dBm);"
     "D250(-104dBm);D500(-104dBm);F500(-104dBm);F1000(-104dBm)";
 #else
     #error Invalid radio configuration!


### PR DESCRIPTION
Currently packet rates are inconsistently named, also on B/W 128x64 radios sensitivity is not visible for "full" modes.

Standard Lora modes are (for 2G4):
`50Hz, 100Hz Full, 150Hz, 250Hz, 333Hz Full, 500Hz`
FLRC rates use first letter to describe mode details, but no unit (Hz).
`D250, D500, F500, F1000`.

Idea is to use common pattern for both FLRC and Lora, so Lora modes could become:
`L50, L100F, L150, L250, L333F, L500`

and FLRC, as suggested by @froqstar:
`F250D, F500D, F500, F1000`.

`[A][B][C]` where:

`[A]` is L: Lora, F: FLRC,
`[B]` is actual packet rate,
`[C]` optional: F: full channel mode, "D": Déjà Vu Diversity Aid.

This way we gain:
* consistent naming pattern,
* visible sensitivity on B/W radios,