### PR TITLE
Scale PWM failsafe timeout with packet rate

### DIFF
--- a/src/include/rxtx_intf.h
+++ b/src/include/rxtx_intf.h
@@ -1,0 +1,19 @@
+/***
+ * This file defines the interface from device units to functions in either rx_main or tx_main
+ * Use this instead of drectly declaring externs in your unit
+ ***/
+
+#include "common.h"
+
+/***
+ * TX interface
+ ***/
+#if defined(TARGET_TX)
+#endif
+
+/***
+ * RX interface
+ ***/
+#if defined(TARGET_RX)
+uint8_t getLq();
+#endif

--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -18,7 +18,7 @@ expresslrs_rf_pref_params_s ExpressLRS_AirRateRFperf[RATE_MAX] = {
     {1, RATE_LORA_100HZ_8CH, -112,  6690, 3500, 2500, 600, 5000, SNR_SCALE( 1), SNR_SCALE(3.0)},
     {2, RATE_LORA_100HZ,     -117,  8770, 3500, 2500, 600, 5000, SNR_SCALE( 1), SNR_SCALE(2.5)},
     {3, RATE_LORA_50HZ,      -120, 18560, 4000, 2500, 600, 5000, SNR_SCALE(-1), SNR_SCALE(1.5)},
-    {4, RATE_LORA_25HZ,      -123, 29950, 6000, 4000,   0, 9000, SNR_SCALE(-3), SNR_SCALE(0.5)}};
+    {4, RATE_LORA_25HZ,      -123, 29950, 6000, 4000,   0, 5000, SNR_SCALE(-3), SNR_SCALE(0.5)}};
 #endif
 
 #if defined(RADIO_SX128X)

--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -18,7 +18,7 @@ expresslrs_rf_pref_params_s ExpressLRS_AirRateRFperf[RATE_MAX] = {
     {1, RATE_LORA_100HZ_8CH, -112,  6690, 3500, 2500, 600, 5000, SNR_SCALE( 1), SNR_SCALE(3.0)},
     {2, RATE_LORA_100HZ,     -117,  8770, 3500, 2500, 600, 5000, SNR_SCALE( 1), SNR_SCALE(2.5)},
     {3, RATE_LORA_50HZ,      -120, 18560, 4000, 2500, 600, 5000, SNR_SCALE(-1), SNR_SCALE(1.5)},
-    {4, RATE_LORA_25HZ,      -123, 29950, 6000, 4000,   0, 5000, SNR_SCALE(-3), SNR_SCALE(0.5)}};
+    {4, RATE_LORA_25HZ,      -123, 29950, 6000, 4000,   0, 9000, SNR_SCALE(-3), SNR_SCALE(0.5)}};
 #endif
 
 #if defined(RADIO_SX128X)

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -201,6 +201,11 @@ void ExitBindingMode();
 void OnELRSBindMSP(uint8_t* packet);
 extern void setWifiUpdateMode();
 
+uint8_t getLq()
+{
+    return LQCalc.getLQ();
+}
+
 static uint8_t minLqForChaos()
 {
     // Determine the most number of CRC-passing packets we could receive on
@@ -627,7 +632,7 @@ void ICACHE_RAM_ATTR HWtimerCallbackTock()
     }
 
     if (!didFHSS) didFHSS = HandleFHSS();
-    
+
     updateDiversity();
     bool tlmSent = HandleSendTelemetryResponse();
 


### PR DESCRIPTION
Changes the PWM failsafe duration to be preferentially-based on the packet rate instead of using a fixed 1 second timeout. PWM failsafe will occur when LQ hits 0, *or* a maximum of 1s.

### Purpose
The current PWM output (devServoOutput) uses a fixed 1 second timeout to determine failsafe-- if no channels update comes in 1000ms, then the outputs are set to the configured failsafe us positions. This timeout was chosen arbitrarily (by me) to be similar to older systems, however ExpressLRS can run at much higher packet rates than those older systems so the timeout isn't appropriate for all rates. There has been a complaint about the 1 second being too long and it does make sense. It does seem inappropriate to just have a duration when we know the state of the link.

Instead, this PR changes the timeout to be based on packet rate: if 100 uplink packets in a row are missed, then failsafe is activated. This corresponds to LQ == 0 and accounts for the selected telemetry ratio as well. Some examples:

| Packet Rate | Telemetry Ratio | Old Timeout (ms) | New Timeout (ms) |
|---|---|---|---|
| F1000 | 1:128 | 1000 | 100.7 |
| 500Hz | 1:128 | 1000 | 201.5 |
| 333Hz Fullres | 1:128 | 1000 | 302.6 |
| 100Hz Fullres | 1:64 | 1000 | 1015.8 - >1000 |
| 50Hz | 1:8 | 1000 | 2285.7 -> 1000 |
| 50Hz | 1:2 | 1000 | 4000 -> 1000 |
| 25Hz | 1:2 | 1000 | 8000 -> 1000 |

Note: This does not affect systems that use flight controllers, as the flight controller has its own failsafe procedure. This is only for PWM output receivers.

### For Discussion - INCLUDED
For people running insanely low uplink rates, such as 25Hz 1:2 or even 50Hz 1:2, it can take a long time before the PWM goes to failsafe. I can't imagine being out of control for 8 seconds before the failsafe kicks in. I also can't imagine running 25Hz 1:2 though so these people have different brains than I do.

~~Question: Should the new system have an absolute limit as well, such as a 1500ms hard cutoff? If you feel that a hard cutoff should be included, specify what the duration should be. This is pretty simple to implement but I was on the fence about if having two timeouts (one calculated, one fixed) would be too much for people's brains.~~

An absolute timeout of 1000ms has been included

### Other changes
* PWM Failsafe wasn't working for outputs set to "On/Off" mode, they would start outputting PWM when they failsafe. This has been remedied.
* ~~The disconnect timeout for Team900 25Hz has been extended from 5s to 9s to allow at least 100 packets before disconnect event, even at 1:2 ratio.~~