### PR TITLE
Fix error in initial network setting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,9 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10' 
 
     - name: Cache pip
       uses: actions/cache@v2
@@ -45,7 +47,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
     - name: Validate target files
       run: |
         cd src
@@ -77,7 +81,9 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
 
     - name: Cache pip
       uses: actions/cache@v2
@@ -172,7 +178,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
 

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -351,7 +351,7 @@ _('upload_form').addEventListener('submit', (e) => {
 
 // =========================================================
 
-function callback(title, msg, url, getdata) {
+function callback(title, msg, url, getdata, success) {
   return function(e) {
     e.stopPropagation();
     e.preventDefault();
@@ -359,6 +359,7 @@ function callback(title, msg, url, getdata) {
     xmlhttp.onreadystatechange = function() {
       if (this.readyState == 4) {
         if (this.status == 200) {
+          if (success) success();
           cuteAlert({
             type: 'info',
             title: title,
@@ -384,6 +385,9 @@ function setupNetwork(event) {
   if (_('nt0').checked) {
     callback('Set Home Network', 'An error occurred setting the home network', '/sethome?save', function() {
       return new FormData(_('sethome'));
+    }, function() {
+      _('wifi-ssid').value = _('network').value;
+      _('wifi-password').value = _('password').value;
     })(event);
   }
   if (_('nt1').checked) {

--- a/src/python/serve_html.py
+++ b/src/python/serve_html.py
@@ -22,7 +22,6 @@ sx127x = False
 config = {
         "options": {
             'uid': [1,2,3,4,5,6],
-            'wifi-on-interval': 60,
             "tlm-interval": 240,
             "fan-runtime": 30,
             "no-sync-on-arm": False,
@@ -31,10 +30,13 @@ config = {
             "rcvr-uart-baud": 400000,
             "rcvr-invert-tx": False,
             "lock-on-first-connection": True,
-            "domain": 1
+            "domain": 1,
+            "wifi-on-interval": 60,
+            "wifi-password": "w1f1-pAssw0rd",
+            "wifi-ssid": "network-ssid"
         },
         "config": {
-            "ssid":"ConnectedNetwork",
+            "ssid":"network-ssid",
             "mode":"STA",
             "modelid":255,
             "pwm":[512,1536,2048,3584,4608],
@@ -135,6 +137,11 @@ def options():
 def update_config():
     if (request.json['button-actions'] is not None):
         config['config']['button-actions'] = request.json['button-actions']
+
+@route('/sethome', method='POST')
+def options():
+    response.content_type = 'application/json; charset=latin9'
+    return "Connecting to network '" + request.forms.get('network') + "', connect to http://elrs_tx.local from a browser on that network"
 
 @route('/networks.json')
 def mode():


### PR DESCRIPTION
# Problem
Wifi network configuration is not saved!

1. Use AP mode to set SSID network and PW.
2. SSID connects right way, nav to http://elrs_tx.local/ works fine
3. Click "SAVE & REBOOT" on OPTIONS tab
4. Module reboots
5. Enter wifi mode again and wait for SSID mode to time out to AP mode.
6. Back to step 1.

# Root Cause
The actual error is that in step 1, the new network information is not in the retrieved options (local to the browser), which means that when step 3 happens they are erased again!

# Solution
When a network is connected to successfully in step 1; copy the credentials to the options form just in case someone decides to hit "save & reboot" on that form.

# Unrelated Changes
Fix the broken build on github because the default python is now 3.11, which broke our build, so I've pinned the version to 3.10 in the meantime.