### PR TITLE
Adds some missing targets

### DIFF
--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -128,6 +128,17 @@
                 "platform": "esp8285",
                 "firmware": "Unified_ESP8285_2400_RX",
                 "prior_target_name": "DIY_2400_RX_PWMP"
+            },
+            "superd": {
+                "product_name": "BETAFPV 2.4GHz SuperD RX",
+                "lua_name": "BFPV SuperD 2G4",
+                "layout_file": "Generic 2400 True Diversity PA.json",
+                "overlay": {
+                    "radio_dcdc": true
+                },
+                "upload_methods": ["uart", "wifi", "betaflight"],
+                "platform": "esp32",
+                "firmware": "Unified_ESP32_2400_RX"
             }
         }
     },

--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -99,6 +99,15 @@
             }
         },
         "rx_2400": {
+            "aio": {
+                "product_name": "BETAFPV 2.4GHz AIO RX",
+                "lua_name": "BFPV AIO 2G4RX",
+                "layout_file": "Generic 2400.json",
+                "upload_methods": ["uart", "wifi", "betaflight"],
+                "platform": "esp8285",
+                "firmware": "Unified_ESP8285_2400_RX",
+                "prior_target_name": "DIY_2400_RX_ESP8285_SX1280"
+            },
             "lite": {
                 "product_name": "BETAFPV 2.4GHz Lite RX",
                 "lua_name": "BFPV Lite 2G4RX",
@@ -703,6 +712,16 @@
                 "platform": "esp32",
                 "firmware": "Unified_ESP32_2400_TX",
                 "prior_target_name": "HappyModel_ES24TX_Pro_Series_2400_TX"
+            },
+            "es24slimpro": {
+                "product_name": "HappyModel ES24 Slim Pro 2.4GHz TX",
+                "lua_name": "HM ES24 SlimPro",
+                "layout_file": "HappyModel ES24 Pro.json",
+                "features": ["fan"],
+                "upload_methods": ["uart", "wifi"],
+                "platform": "esp32",
+                "firmware": "Unified_ESP32_2400_TX",
+                "prior_target_name": "HappyModel_ES24TX_Pro_Series_2400_TX"
             }
         },
         "rx_2400": {
@@ -1188,6 +1207,15 @@
                 "platform": "esp32",
                 "firmware": "Unified_ESP32_2400_TX",
                 "prior_target_name": "QuadKopters_JR_2400_TX"
+            },
+            "slim": {
+                "product_name": "QuadKopters Slim 2.4GHz TX",
+                "lua_name": "QuadKopters 2G4",
+                "layout_file": "QuadKopters JR 2400.json",
+                "upload_methods": ["uart", "wifi"],
+                "platform": "esp32",
+                "firmware": "Unified_ESP32_2400_TX",
+                "prior_target_name": "QuadKopters_SLIM_2400_TX"
             }
         },
         "rx_2400": {

--- a/src/targets/betafpv_2400.ini
+++ b/src/targets/betafpv_2400.ini
@@ -47,3 +47,13 @@ extends = env:BETAFPV_Nano_2400_RX_via_UART
 
 [env:BETAFPV_Nano_2400_RX_via_WIFI]
 extends = env:BETAFPV_Nano_2400_RX_via_UART
+
+[env:BETAFPV_SuperD_2400_RX_via_UART]
+extends = env:Unified_ESP32_2400_RX_via_UART
+board_config = betafpv.rx_2400.superd
+
+[env:BETAFPV_SuperD_2400_RX_via_BetaflightPassthrough]
+extends = env:BETAFPV_SuperD_2400_RX_via_UART
+
+[env:BETAFPV_SuperD_2400_RX_via_WIFI]
+extends = env:BETAFPV_SuperD_2400_RX_via_UART


### PR DESCRIPTION
Add missing targets to the `targets.json` file for the web and binary flasher.
- Foxeer Lite
- BETAFPV SuperD
