### PR TITLE
Fix github build warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - id: set-targets
-      run: echo "::set-output name=targets::[$( (grep "\[env:.*UART\]" src/targets/unified.ini ; grep -r "\[env:.*STLINK\]" src/targets/) | sed 's/.*://' | sed s/.$// | egrep "(STLINK|UART)" | grep -v DEPRECATED | tr '\n' ','  | sed 's/,$/"\n/' | sed 's/,/","/'g | sed 's/^/"/')]"
+      run: echo "targets=[$( (grep '\[env:.*UART\]' src/targets/unified.ini ; grep -r '\[env:.*STLINK\]' src/targets/) | sed 's/.*://' | sed s/.$// | egrep "(STLINK|UART)" | grep -v DEPRECATED | tr '\n' ','  | sed 's/,$/"\n/' | sed 's/,/","/'g | sed 's/^/"/')]" >> $GITHUB_OUTPUT
 
   build:
     needs: targets

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,10 @@ jobs:
     steps:
 
     - name: Inject slug/short variables
-      uses: rlespinasse/github-slug-action@v3.x
+      uses: rlespinasse/github-slug-action@v4
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Python
       uses: actions/setup-python@v4
@@ -17,7 +17,7 @@ jobs:
         python-version: '3.10' 
 
     - name: Cache pip
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.target }}
@@ -29,7 +29,7 @@ jobs:
         pip install wheel
 
     - name: Cache PlatformIO
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.platformio
         key: ${{ runner.os }}-platformio
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
@@ -61,7 +61,7 @@ jobs:
       targets: ${{ steps.set-targets.outputs.targets }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - id: set-targets
       run: echo "::set-output name=targets::[$( (grep "\[env:.*UART\]" src/targets/unified.ini ; grep -r "\[env:.*STLINK\]" src/targets/) | sed 's/.*://' | sed s/.$// | egrep "(STLINK|UART)" | grep -v DEPRECATED | tr '\n' ','  | sed 's/,$/"\n/' | sed 's/,/","/'g | sed 's/^/"/')]"
 
@@ -75,10 +75,10 @@ jobs:
     steps:
 
     - name: Inject slug/short variables
-      uses: rlespinasse/github-slug-action@v3.x
+      uses: rlespinasse/github-slug-action@v4
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Python
       uses: actions/setup-python@v4
@@ -86,7 +86,7 @@ jobs:
         python-version: '3.10'
 
     - name: Cache pip
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.target }}
@@ -98,7 +98,7 @@ jobs:
         pip install wheel
 
     - name: Cache PlatformIO
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.platformio
         key: ${{ runner.os }}-platformio
@@ -138,7 +138,7 @@ jobs:
         fi
 
     - name: Store Artifacts
-      uses: actions/upload-artifact@v2-preview
+      uses: actions/upload-artifact@v3
       with:
         name: firmware
         path: ~/artifacts/**/*
@@ -149,7 +149,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get firmware artifacts
         uses: actions/download-artifact@v3
@@ -164,7 +164,7 @@ jobs:
         run: cd src ; find bootloader -name \*.bin -o -name \*.frk | grep -v src/ | cpio -pdm ../dist/firmware
 
       - name: Update firmware artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: firmware
           path: dist/**/*
@@ -177,7 +177,7 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: 3.7
@@ -186,7 +186,7 @@ jobs:
       - run: pip install pyinstaller
       - run: pyinstaller -F src/python/binary_configurator.py -n installer-${{ matrix.os }}
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: installer
           path: dist/*


### PR DESCRIPTION
Github is deprecating node.js v12 and quite a few of the actions we use were developed with that version. They are upgraded to their latest versions to fix this warning.
They are also removing support for `set-output` and `save-state` so our usage has been migrated to use it's replacement using the GITHUB_OUTPUT environment variable form.