### PR TITLE
adds missing stm32 define for crsf.sendRCFrameToFC

### DIFF
--- a/src/lib/CRSF/devCRSF_rx.cpp
+++ b/src/lib/CRSF/devCRSF_rx.cpp
@@ -27,7 +27,7 @@ static int timeout()
 {
     if (connectionState != serialUpdate)
     {
-        #if defined(PLATFORM_ESP32)
+        #if defined(PLATFORM_ESP32) || defined(PLATFORM_STM32)
         if (sendFrame)
         {
             sendFrame = false;


### PR DESCRIPTION
Looks like this addition from here https://github.com/ExpressLRS/ExpressLRS/pull/1874/files was missed during updating master here https://github.com/ExpressLRS/ExpressLRS/pull/1938.

This should be tested asap and 3.1.1 release.