### PR TITLE
Fix windows build

### DIFF
--- a/src/lib/OTA/OTA.h
+++ b/src/lib/OTA/OTA.h
@@ -2,6 +2,7 @@
 #define H_OTA
 
 #include <functional>
+#include <cstddef>
 #include "crc.h"
 #include "devCRSF.h"
 

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -32,7 +32,7 @@ lib_ignore = SX127xDriver
 # bootloader first!
 
 [env_common_esp32]
-platform = espressif32@5.1.1
+platform = espressif32@5.2.0
 board = esp32dev
 board_build.partitions = min_spiffs.csv
 upload_speed = 460800
@@ -63,7 +63,7 @@ tft_lib_deps =
 	moononournation/GFX Library for Arduino @ 1.2.8
 
 [env_common_esp32rx]
-platform = espressif32@5.1.1
+platform = espressif32@5.2.0
 board = esp32dev
 board_build.partitions = min_spiffs.csv
 upload_speed = 460800


### PR DESCRIPTION
This PR fixes the problem where on windows the install of 3.1 caused some TX modules to go into hardware layout mode.
The problem is that, somehow, the flash was in a mode where the firmware could not read the attached layout file so it thought it was running in "bare" mode.
An upgrade in the base platform fixes the problem.