### PR TITLE
LNA + RGB Receivers via BFPassthrough Failing due to missing env scripts

### DIFF
--- a/src/targets/diy_2400.ini
+++ b/src/targets/diy_2400.ini
@@ -62,9 +62,6 @@ board_config = generic.rx_2400.pa-rgb
 
 [env:DIY_2400_PA_RGB_RX_via_BetaflightPassthrough]
 extends = env:DIY_2400_PA_RGB_RX_via_UART
-upload_protocol = custom
-upload_speed = 420000
-upload_command = ${env_common_esp82xx.bf_upload_command}
 
 [env:DIY_2400_PA_RGB_RX_via_WIFI]
 extends = env:DIY_2400_PA_RGB_RX_via_UART

--- a/src/targets/foxeer_2400.ini
+++ b/src/targets/foxeer_2400.ini
@@ -13,9 +13,6 @@ board_config = foxeer.rx_2400.pa-rgb
 
 [env:Foxeer_2400_RX_via_BetaflightPassthrough]
 extends = env:Foxeer_2400_RX_via_UART
-upload_protocol = custom
-upload_speed = 420000
-upload_command = ${env_common_esp82xx.bf_upload_command}
 
 [env:Foxeer_2400_RX_via_WIFI]
 extends = env:Foxeer_2400_RX_via_UART

--- a/src/targets/unified.ini
+++ b/src/targets/unified.ini
@@ -128,9 +128,6 @@ build_src_filter = ${env_common_esp32rx.build_src_filter} -<tx_*.cpp>
 
 [env:Unified_ESP32_900_RX_via_BetaflightPassthrough]
 extends = env:Unified_ESP32_900_RX_via_UART
-upload_protocol = custom
-upload_speed = 420000
-upload_command = ${env_common_esp82xx.bf_upload_command}
 
 [env:Unified_ESP32_900_RX_via_WIFI]
 extends = env:Unified_ESP32_900_RX_via_UART


### PR DESCRIPTION
the line
`upload_command = ${env_common_esp82xx.bf_upload_command}`
would fail because it wasn't in the common.ini parameters.

> Error: Invalid 'C:\Users\d3ad1ock\AppData\Roaming\ExpressLRS Configurator\firmwares\github\ExpressLRS\src\platformio.ini' (project configuration file): 'No option 'bf_upload_command' in section: 'env_common_esp82xx''

Removing the extra lines allow the flash to go through. Other via Passthrough environments doesn't have these extra lines.