### PR TITLE
Telemetry fix

### DIFF
--- a/src/lib/Telemetry/telemetry.cpp
+++ b/src/lib/Telemetry/telemetry.cpp
@@ -74,16 +74,8 @@ bool Telemetry::GetNextPayload(uint8_t* nextPayloadSize, uint8_t **payloadData)
         payloadTypes[currentPayloadIndex].locked = true;
 
         realLength = CRSF_FRAME_SIZE(payloadTypes[currentPayloadIndex].data[CRSF_TELEMETRY_LENGTH_INDEX]);
-        // search for non zero data from the end
-        while (realLength > 0 && payloadTypes[currentPayloadIndex].data[realLength - 1] == 0)
-        {
-            realLength--;
-        }
-
         if (realLength > 0)
         {
-            // store real length in frame
-            payloadTypes[currentPayloadIndex].data[CRSF_TELEMETRY_LENGTH_INDEX] = realLength - CRSF_FRAME_NOT_COUNTED_BYTES;
             *nextPayloadSize = realLength;
             *payloadData = payloadTypes[currentPayloadIndex].data;
             return true;

--- a/src/test/test_telemetry/test_telemetry.cpp
+++ b/src/test/test_telemetry/test_telemetry.cpp
@@ -204,6 +204,36 @@ void test_function_uart_in(void)
     TEST_ASSERT_EQUAL(true, telemetry.RXhandleUARTin(0xEC));
 }
 
+void test_function_add_type_with_zero_crc(void)
+{
+    telemetry.ResetState();
+    uint8_t sequence[] = {
+        0xee,                   // device addr
+        32,                     // frame size
+        0x29,                   // frame type
+        0xee,                   // dest addr
+        0xec,                   // source addr
+        'R','a','d','i','o','M','s','t','r',' ','R','P','3', 0, // device name (nul terminated string)
+        'E', 'L', 'R', 'S',     // serial no.
+        0x00, 0x00, 0x00, 0x00, // hardware version
+        0x00, 0x30, 0x00, 0x00, // software version
+        0x07,                   // field count
+        0x00,                   // parameter version
+        0x00                    // CRC
+    };
+
+    telemetry.AppendTelemetryPackage(sequence);
+
+    uint8_t* data;
+    uint8_t receivedLength;
+    telemetry.GetNextPayload(&receivedLength, &data);
+    TEST_ASSERT_NOT_EQUAL(0, data);
+    for (int i = 0; i < sizeof(sequence); i++)
+    {
+        TEST_ASSERT_EQUAL(sequence[i], data[i]);
+    }
+}
+
 // Unity setup/teardown
 void setUp() {}
 void tearDown() {}
@@ -221,6 +251,7 @@ int main(int argc, char **argv)
     RUN_TEST(test_function_store_unknown_type);
     RUN_TEST(test_function_store_unknown_type_two_slots);
     RUN_TEST(test_function_store_ardupilot_status_text);
+    RUN_TEST(test_function_add_type_with_zero_crc);
     UNITY_END();
 
     return 0;


### PR DESCRIPTION
This actually fixes the problem with some devices RX Lua failing unexpectedly with a syntax error.

The problem is that the telemetry class was removing zeros from the end of the packet (assuming a larger buffer was passed in). Problem is that the CRC8 byte is the final byte and it is perfectly valid to have a zero CRC! So the telemetry class just happily threw all the zeros away, then forwarded the corrupt packet to the TX over the air, which then promptly dropped the bad packet. This manifested on some devices as the device information Lua response packet happened to have a 0 CRC i.e. for 'RadioMstr RP3' and some others which caused the packet to get lost and the Lua script to fail.

I noticed during debugging that added an extra item to the Lua menu on the RX would "fix" the problem, because it changed the device information packet (which contains the number of items) and hence the CRC changed.