### PR TITLE
Correct 900 rx power settings

### DIFF
--- a/src/hardware/RX/Generic 900 PWMP.json
+++ b/src/hardware/RX/Generic 900 PWMP.json
@@ -6,11 +6,11 @@
     "radio_rst": 2,
     "radio_sck": 14,
     "power_min": 0,
-    "power_high": 0,
-    "power_max": 0,
-    "power_default": 0,
+    "power_high": 2,
+    "power_max": 2,
+    "power_default": 2,
     "power_control": 0,
-    "power_values": [15],
+    "power_values": [8,12,15],
     "led": 16,
     "pwm_outputs": [0,1,3,5,9,10]
 }

--- a/src/hardware/RX/Generic 900.json
+++ b/src/hardware/RX/Generic 900.json
@@ -9,11 +9,11 @@
     "radio_rst": 2,
     "radio_sck": 14,
     "power_min": 0,
-    "power_high": 0,
-    "power_max": 0,
-    "power_default": 0,
+    "power_high": 2,
+    "power_max": 2,
+    "power_default": 2,
     "power_control": 0,
-    "power_values": [15],
+    "power_values": [8,12,15],
     "led": 16,
     "button": 0
 }

--- a/src/hardware/RX/Namimno VOYAGER 900.json
+++ b/src/hardware/RX/Namimno VOYAGER 900.json
@@ -9,11 +9,11 @@
     "radio_rst": 2,
     "radio_sck": 14,
     "power_min": 0,
-    "power_high": 0,
-    "power_max": 0,
-    "power_default": 0,
+    "power_high": 2,
+    "power_max": 2,
+    "power_default": 2,
     "power_control": 0,
-    "power_values": [15],
+    "power_values": [8,12,15],
     "button": 0,
     "led": 16
 }


### PR DESCRIPTION
These receivers were set to a output power of 50mW (max) but the Lua options only displayed 10mW.  This PR restores all of the options, 10, 25, 50mW.