### PR TITLE
Add a true-diversity (non-PA) + VTx receiver

### DIFF
--- a/src/hardware/RX/Generic 2400 True Diversity and VTx.json
+++ b/src/hardware/RX/Generic 2400 True Diversity and VTx.json
@@ -1,0 +1,44 @@
+{
+    "serial_rx": 3,
+    "serial_tx": 1,
+
+    "radio_miso": 33,
+    "radio_mosi": 32,
+    "radio_rst": 26,
+    "radio_sck": 25,
+
+    "radio_busy": 36,
+    "radio_dio1": 37,
+    "radio_nss": 27,
+
+    "radio_busy_2": 39,
+    "radio_dio1_2": 34,
+    "radio_nss_2": 13,
+
+    "power_min": 0,
+    "power_high": 0,
+    "power_max": 0,
+    "power_default": 0,
+    "power_control": 0,
+    "power_values": [13],
+
+    "led_rgb": 22,
+    "led_rgb_isgrb": true,
+    "ledidx_rgb_status": [0],
+    "ledidx_rgb_vtx": [1],
+    "ledidx_rgb_boot": [0,1],
+
+    "vtx_nss": 19,
+    "vtx_miso": 23,
+    "vtx_mosi": 18,
+    "vtx_sck": 5,
+
+    "vtx_amp_pwm": 12,
+    "vtx_amp_vpd": 4,
+    "vtx_amp_vref": 2,
+
+    "vtx_amp_vpd_25mW": [1350,1350,1350,1350],
+    "vtx_amp_vpd_100mW": [1600,1600,1600,1600],
+
+    "button": 0
+}

--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -619,10 +619,18 @@
                 "platform": "esp32",
                 "firmware": "Unified_ESP32_2400_RX"
             },
-            "diversity_vtx": {
+            "diversity_pa_vtx": {
                 "product_name": "Generic ESP32 True Diversity PA 2.4Ghz RX and VTx",
                 "lua_name": "Div+VTx 2.4RX",
                 "layout_file": "Generic 2400 True Diversity PA and VTx.json",
+                "upload_methods": ["uart", "wifi", "betaflight"],
+                "platform": "esp32",
+                "firmware": "Unified_ESP32_2400_RX"
+            },
+            "diversity_vtx": {
+                "product_name": "Generic ESP32 True Diversity 2.4Ghz RX and VTx",
+                "lua_name": "Div+VTx 2.4RX",
+                "layout_file": "Generic 2400 True Diversity and VTx.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "platform": "esp32",
                 "firmware": "Unified_ESP32_2400_RX"


### PR DESCRIPTION
As the title says, this adds a new target for a dual non-PA ESP32-based RX.