### PR TITLE
Potential fix for PWM reboot

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -6,6 +6,7 @@
 #include "logging.h"
 #include "helpers.h"
 
+#if defined(CRSF_TX_MODULE)
 #if defined(PLATFORM_ESP32)
 #include <soc/uart_reg.h>
 // UART0 is used since for DupleTX we can connect directly through IO_MUX and not the Matrix
@@ -28,7 +29,7 @@ HardwareSerial CRSF::Port(GPIO_PIN_RCSIGNAL_RX, GPIO_PIN_RCSIGNAL_TX);
 #elif defined(TARGET_NATIVE)
 HardwareSerial CRSF::Port = Serial;
 #endif
-Stream *CRSF::PortSecondary;
+#endif
 
 GENERIC_CRC8 crsf_crc(CRSF_CRC_POLY);
 
@@ -51,6 +52,7 @@ uint8_t CRSF::ParameterUpdateData[3] = {0};
 #if CRSF_TX_MODULE
 #define HANDSET_TELEMETRY_FIFO_SIZE 128 // this is the smallest telemetry FIFO size in ETX with CRSF defined
 
+Stream *CRSF::PortSecondary;
 static FIFO MspWriteFIFO;
 
 void (*CRSF::disconnected)() = nullptr; // called when CRSF stream is lost
@@ -190,6 +192,7 @@ void CRSF::End()
 #endif // CRSF_TX_MODULE
 }
 
+#if CRSF_TX_MODULE
 void CRSF::flush_port_input(void)
 {
     // Make sure there is no garbage on the UART at the start
@@ -199,7 +202,6 @@ void CRSF::flush_port_input(void)
     }
 }
 
-#if CRSF_TX_MODULE
 void ICACHE_RAM_ATTR CRSF::sendLinkStatisticsToTX()
 {
     if (!CRSF::CRSFstate)

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -42,10 +42,6 @@ public:
     #endif
     #endif
 
-
-    static HardwareSerial Port;
-    static Stream *PortSecondary; // A second UART used to mirror telemetry out on the TX, not read from
-
     static uint32_t ChannelData[CRSF_NUM_CHANNELS]; // Current state of channels, CRSF format
 
     /////Variables/////
@@ -54,6 +50,9 @@ public:
     static uint8_t ParameterUpdateData[3];
 
     #ifdef CRSF_TX_MODULE
+    static HardwareSerial Port;
+    static Stream *PortSecondary; // A second UART used to mirror telemetry out on the TX, not read from
+
     static void (*disconnected)();
     static void (*connected)();
 
@@ -126,9 +125,11 @@ public:
     static bool CRSFstate;
 
 private:
-    Stream *_dev;
-
     static inBuffer_U inBuffer;
+
+#if CRSF_RX_MODULE
+    Stream *_dev;
+#endif
 
 #if CRSF_TX_MODULE
     /// OpenTX mixer sync ///
@@ -167,9 +168,8 @@ private:
     static void handleUARTout();
     static bool UARTwdt();
     static uint32_t autobaud();
-#endif
-
     static void flush_port_input(void);
+#endif
 };
 
 extern GENERIC_CRC8 crsf_crc;


### PR DESCRIPTION
We found a couple of things that needed cleaning up in the serial code, which the PWM should not be using but was creating a Serial port object that seems to be causing the problem with the reboot.

I (finally) managed to reproduce the issue described in #1988, and these changes have resolved the problem for me.

Fixes #1988 