### PR TITLE
Configurable PWM fan speeds

### DIFF
--- a/src/hardware/TX/Radiomaster Boxer.json
+++ b/src/hardware/TX/Radiomaster Boxer.json
@@ -24,5 +24,6 @@
     "debug_backpack_tx": 17,
     "backpack_boot": 15,
     "backpack_en": 25,
-    "misc_fan_en": 2
+    "misc_fan_pwm": 2,
+    "misc_fan_speeds": [165,165,165,165,165,165]
 }

--- a/src/hardware/TX/Radiomaster Ranger.json
+++ b/src/hardware/TX/Radiomaster Ranger.json
@@ -29,6 +29,7 @@
     "ledidx_rgb_status": [2,3,4,5],
     "misc_fan_pwm": 2,
     "misc_fan_tacho": 27,
+    "misc_fan_speeds": [47,63,95,127,191,255,255],
     "gsensor_stk8xxx": true,
     "i2c_scl": 12,
     "i2c_sda": 14,

--- a/src/html/hardware.html
+++ b/src/html/hardware.html
@@ -247,6 +247,7 @@ td img.icon-pwm {
 					<!-- <tr><td></td><td>Buzzer pin</td><td><input size='3' id='misc_buzzer' name='misc_buzzer' type='text'/></td><td>Pin connected to a PWM controlled buzzer</td></tr> -->
 					<tr><td></td><td>Fan enable pin<img class="icon-output"/></td><td><input size='3' id='misc_fan_en' name='misc_fan_en' type='text'/></td><td>Pin used to enable a cooling FAN (active HIGH)</td></tr>
 					<tr><td></td><td>Fan PWM pin<img class="icon-pwm"/></td><td><input size='3' id='misc_fan_pwm' name='misc_fan_pwm' type='text'/></td><td>If the fan is controlled by PWM</td></tr>
+					<tr><td></td><td>Fan PWM output values</td><td><input size='40' id='misc_fan_speeds' name='misc_fan_speeds' type='text' class='array'/></td><td>If the fan is PWM controlled, then this is the list of values for the PWM output for the matching power output levels</td></tr>
 					<tr><td></td><td>Fan TACHO pin<img class="icon-input"/></td><td><input size='3' id='misc_fan_tacho' name='misc_fan_tacho' type='text'/></td><td>If the fan has a "tachometer" interrupt pin</td></tr>
 					<tr><td></td><td>Has STK8xxx G-sensor</td><td><input size='3' id='gsensor_stk8xxx' name='gsensor_stk8xxx' type='checkbox'/></td><td>Checked if there is a STK8xxx g-sensor on the I2C bus</td></tr>
 					<tr><td></td><td>G-sensor interrupt pin<img class="icon-input"/></td><td><input size='3' id='misc_gsensor_int' name='misc_gsensor_int' type='text'/></td><td>Pin connected the STK8xxx g-sensor for interrupts</td></tr>

--- a/src/include/hardware.h
+++ b/src/include/hardware.h
@@ -109,6 +109,8 @@ typedef enum {
     HARDWARE_misc_fan_en,
     HARDWARE_misc_fan_pwm,
     HARDWARE_misc_fan_tacho,
+    HARDWARE_misc_fan_speeds,
+    HARDWARE_misc_fan_speeds_count,
     HARDWARE_gsensor_stk8xxx,
     HARDWARE_thermal_lm75a,
 

--- a/src/include/target/Unified_ESP32_TX.h
+++ b/src/include/target/Unified_ESP32_TX.h
@@ -175,6 +175,8 @@
 #define GPIO_PIN_FAN_EN hardware_pin(HARDWARE_misc_fan_en)
 #define GPIO_PIN_FAN_PWM hardware_pin(HARDWARE_misc_fan_pwm)
 #define GPIO_PIN_FAN_TACHO hardware_pin(HARDWARE_misc_fan_tacho)
+#define GPIO_PIN_FAN_SPEEDS hardware_u16_array(HARDWARE_misc_fan_speeds)
+#define GPIO_PIN_FAN_SPEEDS_COUNT hardware_int(HARDWARE_misc_fan_speeds_count)
 
 #define HAS_GSENSOR
 #define HAS_GSENSOR_STK8xxx

--- a/src/lib/OPTIONS/hardware.cpp
+++ b/src/lib/OPTIONS/hardware.cpp
@@ -107,6 +107,8 @@ static const struct {
     {HARDWARE_misc_fan_en, "misc_fan_en", INT},
     {HARDWARE_misc_fan_pwm, "misc_fan_pwm", INT},
     {HARDWARE_misc_fan_tacho, "misc_fan_tacho", INT},
+    {HARDWARE_misc_fan_speeds, "misc_fan_speeds", ARRAY},
+    {HARDWARE_misc_fan_speeds_count, "misc_fan_speeds", COUNT},
     {HARDWARE_gsensor_stk8xxx, "gsensor_stk8xxx", BOOL},
     {HARDWARE_thermal_lm75a, "thermal_lm75a", BOOL},
     {HARDWARE_pwm_outputs, "pwm_outputs", ARRAY},

--- a/src/lib/THERMAL/devThermal.cpp
+++ b/src/lib/THERMAL/devThermal.cpp
@@ -96,7 +96,18 @@ static void timeoutThermal()
 #if defined(PLATFORM_ESP32)
 static void setFanSpeed()
 {
-    uint32_t speed = GPIO_PIN_FAN_SPEEDS[POWERMGNT::currPower()-POWERMGNT::getMinPower()];
+    const uint8_t defaultFanSpeeds[] = {
+        31,  // 10mW
+        47,  // 25mW
+        63,  // 50mW
+        95,  // 100mW
+        127, // 250mW
+        191, // 500mW
+        255, // 1000mW
+        255  // 2000mW
+    };
+
+    uint32_t speed = GPIO_PIN_FAN_SPEEDS == nullptr ? defaultFanSpeeds[POWERMGNT::currPower()] : GPIO_PIN_FAN_SPEEDS[POWERMGNT::currPower()-POWERMGNT::getMinPower()];
     ledcWrite(fanChannel, speed);
     DBGLN("Fan speed: %d (power) -> %u (pwm)", POWERMGNT::currPower(), speed);
 }

--- a/src/lib/THERMAL/devThermal.cpp
+++ b/src/lib/THERMAL/devThermal.cpp
@@ -96,18 +96,9 @@ static void timeoutThermal()
 #if defined(PLATFORM_ESP32)
 static void setFanSpeed()
 {
-    const uint8_t fanSpeeds[] = {
-        31,  // 10mW
-        47,  // 25mW
-        63,  // 50mW
-        95,  // 100mW
-        127, // 250mW
-        191, // 500mW
-        255, // 1000mW
-        255  // 2000mW
-    };
-    ledcWrite(fanChannel, fanSpeeds[POWERMGNT::currPower()]);
-    DBGLN("Fan speed: %d (power) -> %u (pwm)", POWERMGNT::currPower(), fanSpeeds[POWERMGNT::currPower()]);
+    uint32_t speed = GPIO_PIN_FAN_SPEEDS[POWERMGNT::currPower()-POWERMGNT::getMinPower()];
+    ledcWrite(fanChannel, speed);
+    DBGLN("Fan speed: %d (power) -> %u (pwm)", POWERMGNT::currPower(), speed);
 }
 #endif
 


### PR DESCRIPTION
The fan on the Boxer, although it is a PWM fan, Radiomaster tells us that the speed should always be set to 165.
So the fix in the PR allows us to configure the PWM output speed value for each of the supported power output levels.

Also modified is the Boxer & Ranger json files with the suggested values.