### PR TITLE
Build and flash gzipped binary on ESP8285

### DIFF
--- a/src/python/build_env_setup.py
+++ b/src/python/build_env_setup.py
@@ -71,13 +71,6 @@ if stm and "$UPLOADER $UPLOADERFLAGS" in env.get('UPLOADCMD', '$UPLOADER $UPLOAD
         env.Replace(UPLOADCMD=stlink.on_upload)
 
 elif platform in ['espressif8266']:
-    env.AddPostAction("buildprog", esp_compress.compressFirmware)
-    env.AddPreAction("${BUILD_DIR}/spiffs.bin",
-                     [esp_compress.compress_files])
-    env.AddPreAction("${BUILD_DIR}/${ESP8266_FS_IMAGE_NAME}.bin",
-                     [esp_compress.compress_files])
-    env.AddPostAction("${BUILD_DIR}/${ESP8266_FS_IMAGE_NAME}.bin",
-                     [esp_compress.compress_fs_bin])
     if "_WIFI" in target_name:
         env.Replace(UPLOAD_PROTOCOL="custom")
         env.Replace(UPLOADCMD=upload_via_esp8266_backpack.on_upload)
@@ -140,3 +133,5 @@ try:
 except FileNotFoundError:
     None
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", UnifiedConfiguration.appendConfiguration)
+if platform in ['espressif8266']:
+    env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", esp_compress.compressFirmware)

--- a/src/python/esp_compress.py
+++ b/src/python/esp_compress.py
@@ -51,6 +51,8 @@ def compressFirmware(source, target, env):
         source_file = os.path.join(build_dir, image_name + ".bin")
         target_file = source_file + ".gz"
         binary_compress(target_file, source_file)
+        os.remove(source_file)
+        os.rename(target_file, source_file)
 
 
 def compress_files(source, target, env):

--- a/src/python/upload_via_esp8266_backpack.py
+++ b/src/python/upload_via_esp8266_backpack.py
@@ -116,9 +116,11 @@ def on_upload(source, target, env):
     upload_addr = ['elrs_tx', 'elrs_tx.local']
     elrs_bin_target = os.path.join(bin_path, 'firmware.elrs')
     if not os.path.exists(elrs_bin_target):
-        elrs_bin_target = os.path.join(bin_path, 'firmware.bin')
+        elrs_bin_target = os.path.join(bin_path, 'firmware.bin.gz')
         if not os.path.exists(elrs_bin_target):
-            raise Exception("No valid binary found!")
+            elrs_bin_target = os.path.join(bin_path, 'firmware.bin')
+            if not os.path.exists(elrs_bin_target):
+                raise Exception("No valid binary found!")
 
     pio_target = target[0].name
     isstm = env.get('PIOPLATFORM', '') in ['ststm32']


### PR DESCRIPTION
When performing wifi build/flash on ESP8285 based devices, we now gzip the firmware and flash that instead as theres not a lot of free space in the flash with the latest firmwares.
fixes #2014