### PR TITLE
Failsafe channel mapping to reflect the proper input channel

### DIFF
--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -186,7 +186,7 @@ static void luaparamSetFalisafe(struct luaPropertiesCommon *item, uint8_t arg)
       rx_config_pwm_t newPwmCh;
       newPwmCh.raw = config.GetPwmChannel(ch)->raw;
       // The value must fit into the 10 bit range of the failsafe
-      newPwmCh.val.failsafe = CRSF_to_UINT10(constrain(CRSF::ChannelData[ch], CRSF_CHANNEL_VALUE_MIN, CRSF_CHANNEL_VALUE_MAX));
+      newPwmCh.val.failsafe = CRSF_to_UINT10(constrain(CRSF::ChannelData[config.GetPwmChannel(ch)->val.inputChannel], CRSF_CHANNEL_VALUE_MIN, CRSF_CHANNEL_VALUE_MAX));
       //DBGLN("FSCH(%u) crsf=%u us=%u", ch, CRSF::ChannelData[ch], newPwmCh.val.failsafe+988U);
       config.SetPwmChannelRaw(ch, newPwmCh.raw);
     }


### PR DESCRIPTION
This PR fixes the output channel mismatch that occurs in the following procedure:

1. In the LUA Output Mapping, change Output 1 to Input 2. Then Output 2 to Input 1.
2. Move the gimbals to confirm that now the CH1 output is ELE, and the CH2 output is AIL
3. Hold the Ele stick to the maximum value, then set failsafe
4. Turn off the remote control
5. In theory, CH1 is now ELE, and the servo of CH1 needs to be switched to the maximum value ( as per failsafe), but CH2 is switched to the maximum value during the actual test. 