### PR TITLE
Idle core0 on esp32 platform

### DIFF
--- a/src/include/rxtx_common.h
+++ b/src/include/rxtx_common.h
@@ -16,3 +16,4 @@
 void setupTargetCommon();
 void deferExecution(uint32_t ms, std::function<void()> f);
 void executeDeferredFunction(unsigned long now);
+void throttleMainLoop();

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -1080,11 +1080,12 @@ static void HandleWebUpdate()
     dnsServer.processNextRequest();
     #if defined(PLATFORM_ESP8266)
       MDNS.update();
+      // When in STA mode, a small delay reduces power use from 90mA to 30mA when idle
+      // In AP mode, it doesn't seem to make a measurable difference, but does not hurt
+      // Only done on 8266 as the ESP32 runs a throttled loop()
+      if (!Update.isRunning())
+        delay(1);
     #endif
-    // When in STA mode, a small delay reduces power use from 90mA to 30mA when idle
-    // In AP mode, it doesn't seem to make a measurable difference, but does not hurt
-    if (!Update.isRunning())
-      delay(1);
   }
 }
 

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1533,6 +1533,7 @@ void setup()
 
 void loop()
 {
+    throttleMainLoop();
     unsigned long now = millis();
 
     if (MspReceiver.HasFinishedData())

--- a/src/src/rxtx_common.cpp
+++ b/src/src/rxtx_common.cpp
@@ -1,4 +1,5 @@
 #include "targets.h"
+#include "common.h"
 
 #include <functional>
 
@@ -50,4 +51,15 @@ void executeDeferredFunction(unsigned long now)
         deferredFunction();
         deferredFunction = nullptr;
     }
+}
+
+void throttleMainLoop()
+{
+#if defined(PLATFORM_ESP32)
+    // Throttle the main loop() on ESP32 to allow power saving to kick in
+    // Loop at 1000Hz for 1000Hz rates, Loop at 500Hz for all other rates
+    static TickType_t loopThrottle = 0; // first loop will not delay
+    uint32_t interval_MS = ExpressLRS_currAirRate_Modparams->interval > 1000U ? 2U : 1U;
+    xTaskDelayUntil(&loopThrottle, pdMS_TO_TICKS(interval_MS));
+#endif
 }

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1121,6 +1121,7 @@ void setup()
 
 void loop()
 {
+  throttleMainLoop();
   uint32_t now = millis();
 
   #if defined(USE_BLE_JOYSTICK)


### PR DESCRIPTION
Adds a throttle to the main `loop()` code on ESP32 platform (both TX and RX) to allow core0 to idle and reduce power consumption by roughly 20mA at the 3.3V rail. Did anyone miss my ~~wordy~~ comprehensive PRs?

## Details
ExpressLRS runs all cores on all platforms balls-to-the-wall (except when in wifi mode). This prevents the ESP32 from enabling any power save functionality despite the fact that we don't need to run all our tasks at 100000Hz. Each core's power can be reduced by up to 25mA (50mA total) by simply allowing it to idle. This PR reduces the update frequency of the core0 tasks down to a target of either 500Hz or 1000Hz depending on the packet rate, and makes use of the FreeRTOS function `xTaskDelayUntil()` to idle the remainder of loop duration. Compare this to simply calling `delay()` every loop, which will always delay and possibly greatly reduce the loop frequency under periods of high load-- delayUntil will not delay if the scheduler is already behind.

I've been experimenting with various power save methods for half the year and this seems to meet my requirements for enough savings with what appears to be absolutely no discernable impact to operation. I've tried downclocking, periodic downclocking, straight delays, single-core task aggregation, undervolting, and even a more complicated timeslice scheduler but all of those had disadvantages. I can't find any subsystem that is degraded by the chosen solution.

A 1000Hz loop rate achieves over 90% of the power savings of a 500Hz loop rate, and slower rates didn't appear to show any more power decrease (tested down to ~91Hz / 11ms delay). Therefore, I chose to use a 1000Hz loop for all 1000Hz modes (F1000, D500, D250) and a 500Hz loop for all other packet rates.

## Results
Every ESP32 target I tested showed measurable reduction in power usage. In receivers, there is approximately 20-23mA current reduction (250Hz 10mW) that lowers the load on the LDO, reducing heat generation, and the ESP32 chip itself also runs cooler. The transmitter module current savings are roughly the same, but the amount is less noticeable in the overall handset power usage where 20mA @ 3.3V is only maybe 8mA @ 8V. I found it easiest to test both RX and TX by tying the delay to a switch to be able to turn it on and off (rxtx_common.cpp).
```cpp
#include "devCRSF.h"
void throttleMainLoop()
{
    if (CRSF_to_BIT(CRSF::ChannelData[AUX1])) // disable if AUX1 high
        return;
...
```

* Reduces the power of a True Diversity RX ~20mA from 592mW to 486mW a 21% power reduction (100Hz 10mW Std). Flipping the delay on and off goes from 80-110mA to 100-130mA. We have a weird sinusoidal power draw on the RX that slowly goes up and down over a several minute period which I do not understand but is pre-existing. shrug emoji
* RadioMaster Zorro total system power consumption reduced by ~11mA, a roughly 4% gain in overall battery life (250Hz 10mW Std). This pushed my modded Zorro with 1400mAh 18350s from 5h32m to 5h55m. That's 190mA @ 8.0V, and F500 is just 139mA @ 8.0V.
* HappyModel ES900TX reduction of ~20mA @4.8V from 1.824W to 1.726W (200Hz 10mW Std)
* Jumper T-Lite total system draw reduced from 203mA to 187mA @ 4.0V (250Hz 10mW Std), almost 8% system power decrease. How do they run a whole handset and ExpressLRS TX on 0.748W?! Some magic power BS in that shell.

### Tested
* RadioMaster TX16S internal TX (ESP32)
* RadioMaster Zorro internal TX (ESP32)
* Jumper T-Lite internal TX (ESP32)
* HappyModel ES900TX TX (ESP32)
* HappyModel EP2 RX (ESP8285)
* RadioMaster ER5A PWM RX (ESP8285)
* FrSky R9MM (or is it the R9 mini?) RX (STM32)
* Undisclosed ESP32 True Diversity RX (ESP32)
* Undisclosed ESP32 Vario RX (ESP32)
* Over 25 hours of flight time with PWM fixed wing and Race quads

## Future Work
At some point we need to get core1 away from `while (1) if (Serial.available()) process(Serial.read())` with a DMA-based solution with an interruptible sleep. This can achieve similar power savings as in the testing I did with a bare ESP32-PICO-D4 dev board, each core that runs at 100% utilization draws roughly 25mA extra power over one that loops at 1000Hz.