### PR TITLE
Only do compression for wifi

### DIFF
--- a/src/python/build_env_setup.py
+++ b/src/python/build_env_setup.py
@@ -133,5 +133,5 @@ try:
 except FileNotFoundError:
     None
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", UnifiedConfiguration.appendConfiguration)
-if platform in ['espressif8266']:
+if platform in ['espressif8266'] and "_WIFI" in target_name:
     env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", esp_compress.compressFirmware)


### PR DESCRIPTION
Well I'm a dumb ass!
The previous gzip PR gzipped the binary, so when uploading via UART it uploaded the gzipped binary! That ain't gonna work.
This fixes that PR by only compressing the binary when building an ESP8285 wifi target.