### PR TITLE
Fix for `/config` on 8285 based devices

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -105,12 +105,12 @@
 					<h2>Import/Export</h2>
 					<br/>
 					<div>
-						<a href="/config?export" download="models.json" target="_blank" class="mui-btn mui-btn--small mui-btn--dark">Download model configurations</a>
+						<a href="/config?export" download="models.json" target="_blank" class="mui-btn mui-btn--small mui-btn--dark">Download model configuration file</a>
 					</div>
 					<div>
 						<form action="" method="POST" enctype="multipart/form-data">
 							<div>
-								<label for="fileselect">Select a models configuration JSON file to upload</label>
+								<label for="fileselect">Select a model configuration file to upload</label>
 								<input type="file" id="fileselect" name="fileselect[]" />
 							</div>
 						</form>

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -270,7 +270,11 @@ static void HandleReset(AsyncWebServerRequest *request)
 
 static void GetConfiguration(AsyncWebServerRequest *request)
 {
+#if defined(PLATFORM_ESP32)
   DynamicJsonDocument json(32768);
+#else
+  DynamicJsonDocument json(2048);
+#endif
 
   bool exportMode = request->hasArg("export");
 


### PR DESCRIPTION
8285 devices don't have enough memory (RAM) to allocate a 32k JSON object! And we don't need that much on an RX anyway.