### PR TITLE
Add condition to prevent config commit from main loop while in wifi update mode

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -448,7 +448,7 @@ bool ICACHE_RAM_ATTR HandleSendTelemetryResponse()
 
     OtaGeneratePacketCrc(&otaPkt);
 
-    SX12XX_Radio_Number_t transmittingRadio = geminiMode ? SX12XX_Radio_All : SX12XX_Radio_Default;    
+    SX12XX_Radio_Number_t transmittingRadio = geminiMode ? SX12XX_Radio_All : SX12XX_Radio_Default;
     SX12XX_Radio_Number_t clearChannelsMask = SX12XX_Radio_All;
 #if defined(Regulatory_Domain_EU_CE_2400)
     clearChannelsMask = ChannelIsClear(transmittingRadio);
@@ -1426,7 +1426,7 @@ static void updateSwitchMode()
 
 static void CheckConfigChangePending()
 {
-    if (config.IsModified() && !InBindingMode)
+    if (config.IsModified() && !InBindingMode && connectionState != wifiUpdate)
     {
         LostConnection(false);
         config.Commit();


### PR DESCRIPTION
Without this condition calls to config.Commit() from devWIFI did change the wifi mode from station to AP on eps32 with the log output

```Setting model match id 6
lost conn fc=0 fo=0
Stopping Radio
Begin Webupdater
WiFi status 255
Connection failed 255
Changing to AP mode
```

CheckConfigChangePending is called 9 times while the request in devWIFI is handled.