### PR TITLE
Copy the configured bootloader binary to the firmware artefact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,9 +132,9 @@ jobs:
         esac
         # copy the common ESP32 files
         if [[ ${{matrix.target}} == *ESP32* ]] ; then
-          cp ~/.platformio/packages/framework-arduinoespressif32/tools/sdk/esp32/bin/bootloader_dio_40m.bin ~/artifacts/firmware/
           cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin ~/artifacts/firmware/
           mv .pio/build/${{ matrix.target }}/partitions.bin ~/artifacts/firmware/
+          mv .pio/build/${{ matrix.target }}/bootloader.bin ~/artifacts/firmware/bootloader_dio_40m.bin
         fi
 
     - name: Store Artifacts


### PR DESCRIPTION
This fixes the problem that that the un-configured bootloader for ESP32 devices was copied to firmware.zip artefact during the github build. This happened because of the changes in platformio, which was causing issues with the web-flasher, which just uses the build artefacts from github.