### PR TITLE
Add backpack command to request version

### DIFF
--- a/src/lib/Backpack/devBackpack.cpp
+++ b/src/lib/Backpack/devBackpack.cpp
@@ -5,11 +5,13 @@
 #include "msptypes.h"
 #include "CRSF.h"
 #include "config.h"
+#include "logging.h"
 
 #define BACKPACK_TIMEOUT 20    // How often to check for backpack commands
 
 extern bool InBindingMode;
 extern Stream *TxBackpack;
+extern char backpackVersion[];
 
 bool TxBackpackWiFiReadyToSend = false;
 bool VRxBackpackWiFiReadyToSend = false;
@@ -206,10 +208,24 @@ static int start()
 
 static int timeout()
 {
+    static uint8_t versionRequestTries = 0;
+    static uint32_t lastVersionTryTime = 0;
+
     if (InBindingMode)
     {
         BackpackBinding();
         return 1000;        // don't check for another second so we don't spam too hard :-)
+    }
+
+    if (versionRequestTries < 10 && strlen(backpackVersion) == 0 && (lastVersionTryTime == 0 || lastVersionTryTime+1000 < millis())) {
+        lastVersionTryTime = millis();
+        versionRequestTries++;
+        mspPacket_t out;
+        out.reset();
+        out.makeCommand();
+        out.function = MSP_ELRS_GET_BACKPACK_VERSION;
+        MSP::sendPacket(&out, TxBackpack);
+        DBGLN("Sending get backpack version command");
     }
 
     if (TxBackpackWiFiReadyToSend && connectionState < MODE_STATES)

--- a/src/lib/Backpack/devBackpack.cpp
+++ b/src/lib/Backpack/devBackpack.cpp
@@ -217,7 +217,7 @@ static int timeout()
         return 1000;        // don't check for another second so we don't spam too hard :-)
     }
 
-    if (versionRequestTries < 10 && strlen(backpackVersion) == 0 && (lastVersionTryTime == 0 || lastVersionTryTime+1000 < millis())) {
+    if (versionRequestTries < 10 && strlen(backpackVersion) == 0 && (lastVersionTryTime == 0 || millis() - lastVersionTryTime > 1000)) {
         lastVersionTryTime = millis();
         versionRequestTries++;
         mspPacket_t out;

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -6,6 +6,8 @@
 #include "OTA.h"
 #include "FHSS.h"
 
+extern char backpackVersion[];
+
 static char version_domain[20+1+6+1];
 char pwrFolderDynamicName[] = "TX Power (1000 Dynamic)";
 char vtxFolderDynamicName[] = "VTX Admin (OFF:C:1 Aux11 )";
@@ -225,6 +227,10 @@ static struct luaItem_selection luaDvrStopDelay = {
     0, // value
     "0s;5s;15s;30s;45s;1min;2min",
     STR_EMPTYSPACE};
+
+static struct luaItem_string luaBackpackVersion = {
+    {"Version", CRSF_INFO},
+    backpackVersion};
 
 //---------------------------- BACKPACK ------------------
 
@@ -647,6 +653,7 @@ static void registerLuaParameters()
               config.SetDvrStopDelay(arg);
           },
           luaBackpackFolder.common.id);
+      registerLUAParameter(&luaBackpackVersion, nullptr, luaBackpackFolder.common.id);
     }
   }
 
@@ -706,6 +713,7 @@ static int event()
     setLuaTextSelectionValue(&luaDvrAux, config.GetDvrAux());
     setLuaTextSelectionValue(&luaDvrStartDelay, config.GetDvrStartDelay());
     setLuaTextSelectionValue(&luaDvrStopDelay, config.GetDvrStopDelay());
+    setLuaStringValue(&luaBackpackVersion, backpackVersion);
   }
 #if defined(TARGET_TX_FM30)
   setLuaTextSelectionValue(&luaBluetoothTelem, !digitalRead(GPIO_PIN_BLUETOOTH_EN));

--- a/src/lib/MSP/msp.cpp
+++ b/src/lib/MSP/msp.cpp
@@ -93,7 +93,10 @@ MSP::processReceivedByte(uint8_t c)
                 m_packet.flags = header->flags;
                 // reset the offset iterator for re-use in payload below
                 m_offset = 0;
-                m_inputState = MSP_PAYLOAD_V2_NATIVE;
+				if (m_packet.payloadSize == 0)
+                	m_inputState = MSP_CHECKSUM_V2_NATIVE;
+				else
+                	m_inputState = MSP_PAYLOAD_V2_NATIVE;
             }
             break;
 

--- a/src/lib/MSP/msp.h
+++ b/src/lib/MSP/msp.h
@@ -4,9 +4,9 @@
 
 // TODO: MSP_PORT_INBUF_SIZE should be changed to
 // dynamically allocate array length based on the payload size
-// Hardcoding payload size to 8 bytes for now, since MSP is
-// limited to a 4 byte payload on the BF side
-#define MSP_PORT_INBUF_SIZE 8
+// Hardcoding payload size to 32 bytes for now, to cover a version
+// number from the backpack
+#define MSP_PORT_INBUF_SIZE 32
 
 #define CHECK_PACKET_PARSING() \
   if (packet->readError) {\

--- a/src/lib/MSP/msptypes.h
+++ b/src/lib/MSP/msptypes.h
@@ -18,6 +18,7 @@
 #define MSP_ELRS_SET_VRX_BACKPACK_WIFI_MODE 0x0D
 #define MSP_ELRS_SET_RX_WIFI_MODE           0x0E
 #define MSP_ELRS_SET_RX_LOAN_MODE           0x0F
+#define MSP_ELRS_GET_BACKPACK_VERSION       0x10
 
 #define MSP_ELRS_POWER_CALI_GET             0x20
 #define MSP_ELRS_POWER_CALI_SET             0x21

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -964,7 +964,7 @@ void ProcessMSPPacket(mspPacket_t *packet)
   if (packet->function == MSP_ELRS_GET_BACKPACK_VERSION)
   {
     memset(backpackVersion, 0, sizeof(backpackVersion));
-    memcpy(backpackVersion, packet->payload, packet->payloadSize > sizeof(backpackVersion)-1 ? sizeof(backpackVersion)-1 : packet->payloadSize);
+    memcpy(backpackVersion, packet->payload, min((size_t)packet->payloadSize, sizeof(backpackVersion)-1));
   }
 }
 

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -44,6 +44,7 @@ extern bool webserverPreventAutoStart;
 #endif
 //// MSP Data Handling ///////
 bool NextPacketIsMspData = false;  // if true the next packet will contain the msp data
+char backpackVersion[32] = "";
 
 ////////////SYNC PACKET/////////
 /// sync packet spamming on mode change vars ///
@@ -960,6 +961,11 @@ void ProcessMSPPacket(mspPacket_t *packet)
     VtxTriggerSend();
   }
 #endif
+  if (packet->function == MSP_ELRS_GET_BACKPACK_VERSION)
+  {
+    memset(backpackVersion, 0, sizeof(backpackVersion));
+    memcpy(backpackVersion, packet->payload, packet->payloadSize > sizeof(backpackVersion)-1 ? sizeof(backpackVersion)-1 : packet->payloadSize);
+  }
 }
 
 static void HandleUARTout()

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1260,16 +1260,6 @@ void loop()
 
   executeDeferredFunction(now);
 
-  if (connectionState > MODE_STATES)
-  {
-    return;
-  }
-
-  CheckReadyToSend();
-  CheckConfigChangePending();
-  DynamicPower_Update(now);
-  VtxPitmodeSwitchUpdate();
-
   if (TxUSB->available())
   {
     if (firmwareOptions.is_airport && apInputBuffer.size() < AP_MAX_BUF_LEN && connectionState == connected)
@@ -1287,6 +1277,16 @@ void loop()
       msp.markPacketReceived();
     }
   }
+
+  if (connectionState > MODE_STATES)
+  {
+    return;
+  }
+
+  CheckReadyToSend();
+  CheckConfigChangePending();
+  DynamicPower_Update(now);
+  VtxPitmodeSwitchUpdate();
 
   /* Send TLM updates to handset if connected + reporting period
    * is elapsed. This keeps handset happy dispite of the telemetry ratio */


### PR DESCRIPTION
Adds a command to request the backpack firmware version from the backpack. The command is sent on startup 10 time with 1 second between each (so as not to spam a backpack without the support for this command).

The version is then displayed as an INFO item in the Backpack Lua folder.

This PR goes along with https://github.com/ExpressLRS/Backpack/pull/75