### PR TITLE
Hide 'Reset Runtime Options' in webui if not customized

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -96,8 +96,8 @@
 						</div>
 @@end
 						<button id='submit-options' class="mui-btn mui-btn--primary">Save & Reboot</button>
-						<div>
-							<a id="reset-options" class="mui-btn mui-btn--small mui-btn--danger">Reset runtime options to defaults</a>
+						<div id="reset-options" style="display: none;">
+							<a class="mui-btn mui-btn--small mui-btn--danger">Reset runtime options to defaults</a>
 						</div>
 					</form>
 				</div>

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -41,7 +41,6 @@
 						<label for="phrase">Binding Phrase</label>
 					</div>
 					<form id='upload_options' method='POST' action="/options">
-						<input type="hidden" id="customised" name="customised" value="true"/>
 						<input type="hidden" id="wifi-ssid" name="wifi-ssid"/>
 						<input type="hidden" id='wifi-password' name='wifi-password'/>
 						<div class="mui-textfield">

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -549,7 +549,7 @@ function updateOptions(data) {
   }
   if (data['wifi-ssid']) _('homenet').textContent = data['wifi-ssid'];
   else _('connect').style.display = 'none';
-  _('reset-options').style.display = data['customised'] ? 'block' : 'none';
+  if (data['customised']) _('reset-options').style.display = 'block';
 }
 
 @@if isTX:

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -470,6 +470,8 @@ function submitOptions(e) {
   const formObject = Object.fromEntries(new FormData(formElem));
   // Add in all the unchecked checkboxes which will be absent from a FormData object
   formElem.querySelectorAll('input[type=checkbox]:not(:checked)').forEach((k) => formObject[k.name] = false);
+  // Force customised to true as this is now customising it
+  formObject['customised'] = true;
 
   // Serialize and send the formObject
   xhr.send(JSON.stringify(formObject, function(k, v) {

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -552,7 +552,6 @@ function updateOptions(data) {
   if (data['wifi-ssid']) _('homenet').textContent = data['wifi-ssid'];
   else _('connect').style.display = 'none';
   if (data['customised']) _('reset-options').style.display = 'block';
-  _('customised').value = true; // overwrite the value from the module, if we save then it's customised
 }
 
 @@if isTX:

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -485,6 +485,8 @@ function submitOptions(e) {
       return arr.length == 0 ? undefined : arr;
     }
     if (typeof v === 'boolean') return v;
+    if (v == 'true') return true;
+    if (v == 'false') return false;
     return isNaN(v) ? v : +v;
   }));
 
@@ -550,6 +552,7 @@ function updateOptions(data) {
   if (data['wifi-ssid']) _('homenet').textContent = data['wifi-ssid'];
   else _('connect').style.display = 'none';
   if (data['customised']) _('reset-options').style.display = 'block';
+  _('customised').value = true; // overwrite the value from the module, if we save then it's customised
 }
 
 @@if isTX:

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -549,7 +549,7 @@ function updateOptions(data) {
   }
   if (data['wifi-ssid']) _('homenet').textContent = data['wifi-ssid'];
   else _('connect').style.display = 'none';
-  if (data['customised']) _('reset-options').style.display = 'block';
+  _('reset-options').style.display = data['customised'] ? 'block' : 'none';
 }
 
 @@if isTX:

--- a/src/lib/OPTIONS/options.cpp
+++ b/src/lib/OPTIONS/options.cpp
@@ -194,7 +194,7 @@ String& getOptions()
     return builtinOptions;
 }
 
-void saveOptions(Stream &stream)
+void saveOptions(Stream &stream, boolean customised)
 {
     DynamicJsonDocument doc(1024);
 
@@ -220,6 +220,7 @@ void saveOptions(Stream &stream)
     doc["lock-on-first-connection"] = firmwareOptions.lock_on_first_connection;
     #endif
     doc["domain"] = firmwareOptions.domain;
+    doc["customised"] = customised;
 
     serializeJson(doc, stream);
 }
@@ -227,7 +228,7 @@ void saveOptions(Stream &stream)
 void saveOptions()
 {
     File options = SPIFFS.open("/options.json", "w");
-    saveOptions(options);
+    saveOptions(options, true);
     options.close();
 }
 
@@ -318,7 +319,7 @@ bool options_init()
     firmwareOptions.domain = doc["domain"] | 0;
 
     builtinOptions.clear();
-    saveOptions(builtinOptions);
+    saveOptions(builtinOptions, doc["customised"] | false);
 
     debugFreeInitLogger();
 

--- a/src/lib/OPTIONS/options.cpp
+++ b/src/lib/OPTIONS/options.cpp
@@ -194,7 +194,7 @@ String& getOptions()
     return builtinOptions;
 }
 
-void saveOptions(Stream &stream, boolean customised)
+void saveOptions(Stream &stream, bool customised)
 {
     DynamicJsonDocument doc(1024);
 


### PR DESCRIPTION
This button appears to be always visible, even though it is designed to not be?
![image](https://user-images.githubusercontent.com/677183/213554522-b2746253-d764-4e1e-a41f-a28ecdf90767.png)

The code would set it to visible if the `customized` option was true. However, the block's initial state is visible (there is no CSS rule to hide it), and the code only set it to visible, not hide it. It has always been like this (always visible) since the functionality was added, but now that it is **RED** I noticed that there was code to toggle its visibility but not in the right way.

Alternatively the original code could just be flipped to set it to 'none' if !customized, but let's go crazy!