### PR TITLE
Fix rx_main::MspReceiveComplete()

### DIFF
--- a/src/lib/CrsfProtocol/crsf_protocol.h
+++ b/src/lib/CrsfProtocol/crsf_protocol.h
@@ -107,6 +107,7 @@ typedef enum
     CRSF_FRAMETYPE_MSP_WRITE = 0x7C, // write with 8 byte chunked binary (OpenTX outbound telemetry buffer limit)
     // Ardupilot frames
     CRSF_FRAMETYPE_ARDUPILOT_RESP = 0x80,
+    CRSF_FRAMETYPE_ARDUPILOT_LUA = 0x81, // bidirectional telemetry via standard (not extended) CRSF frame
 } crsf_frame_type_e;
 
 typedef enum {

--- a/src/lib/CrsfProtocol/crsf_protocol.h
+++ b/src/lib/CrsfProtocol/crsf_protocol.h
@@ -107,7 +107,6 @@ typedef enum
     CRSF_FRAMETYPE_MSP_WRITE = 0x7C, // write with 8 byte chunked binary (OpenTX outbound telemetry buffer limit)
     // Ardupilot frames
     CRSF_FRAMETYPE_ARDUPILOT_RESP = 0x80,
-    CRSF_FRAMETYPE_ARDUPILOT_LUA = 0x81, // bidirectional telemetry via standard (not extended) CRSF frame
 } crsf_frame_type_e;
 
 typedef enum {

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1089,13 +1089,6 @@ void MspReceiveComplete()
                 luaParamUpdateReq();
             }
             break;
-        case CRSF_FRAMETYPE_ARDUPILOT_LUA:
-            // No MSP data to the FC if no model match
-            if (connectionHasModelMatch)
-            {
-                crsf.sendMSPFrameToFC(MspData);
-            }
-            break;
         default:
             // No MSP data to the FC if no model match
             if (connectionHasModelMatch && (receivedHeader->dest_addr == CRSF_ADDRESS_BROADCAST || receivedHeader->dest_addr == CRSF_ADDRESS_FLIGHT_CONTROLLER))

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1069,7 +1069,7 @@ void MspReceiveComplete()
             {
                 UpdateModelMatch(MspData[9]);
             }
-             else if (OPT_HAS_VTX_SPI && MspData[7] == MSP_SET_VTX_CONFIG)
+            else if (OPT_HAS_VTX_SPI && MspData[7] == MSP_SET_VTX_CONFIG)
             {
                 vtxSPIBandChannelIdx = MspData[8];
                 if (MspData[6] >= 4) // If packet has 4 bytes it also contains power idx and pitmode.

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1012,7 +1012,8 @@ void UpdateModelMatch(uint8_t model)
  **/
 void MspReceiveComplete()
 {
-    switch (MspData[0]) {
+    switch (MspData[0]) 
+    {
     case MSP_ELRS_SET_RX_WIFI_MODE: //0x0E
 #if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
         // The MSP packet needs to be ACKed so the TX doesn't
@@ -1029,7 +1030,8 @@ void MspReceiveComplete()
     default:
         //handle received CRSF package
         crsf_ext_header_t *receivedHeader = (crsf_ext_header_t *) MspData;
-        switch (receivedHeader->type) {
+        switch (receivedHeader->type) 
+        {
         case CRSF_FRAMETYPE_MSP_WRITE: //encapsulated MSP payload
             if (MspData[7] == MSP_SET_RX_CONFIG && MspData[8] == MSP_ELRS_MODEL_ID)
             {

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1013,16 +1013,16 @@ void UpdateModelMatch(uint8_t model)
 void MspReceiveComplete()
 {
     /* Possible data types received in a MSP frame:
-     *    MSP_ELRS command bytes: 
+     *    MSP_ELRS command bytes:
      *        0: command
      *        1..n: payload
-     *    crsf_header_t bytes: 
+     *    crsf_header_t bytes:
      *        0: device_addr
      *        1: frame_size
      *        2: type
      *        3..n-1: payload
-     *        n: crc     
-     *    crsf_ext_header_t bytes: 
+     *        n: crc
+     *    crsf_ext_header_t bytes:
      *        0: device_addr
      *        1: frame_size
      *        2: type
@@ -1030,7 +1030,7 @@ void MspReceiveComplete()
      *        4: orig_addr
      *        5..n-1: payload
      *        n: crc
-     *    crsf_ext_header_t with encapsulated MSP sent with CRSF::AddMspMessage(mspPacket_t* packet): 
+     *    crsf_ext_header_t with encapsulated MSP sent with CRSF::AddMspMessage(mspPacket_t* packet):
      *        // CRSF extended frame header
      *        0: device_addr = CRSF_ADDRESS_BROADCAST = 0x00
      *        1: frame_size
@@ -1045,9 +1045,9 @@ void MspReceiveComplete()
      *        n-1: mspCrc
      *        // CRSF crc
      *        n: crc
-    /*
-    crsf_ext_header_t *receivedHeader = (crsf_ext_header_t *) MspData; 
-    
+     */
+    crsf_ext_header_t *receivedHeader = (crsf_ext_header_t *) MspData;
+
     switch(receivedHeader->device_addr) {
     case MSP_ELRS_SET_RX_WIFI_MODE: //0x0E
 #if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
@@ -1061,7 +1061,7 @@ void MspReceiveComplete()
     case MSP_ELRS_SET_RX_LOAN_MODE: //0x0F
         loanBindTimeout = LOAN_BIND_TIMEOUT_MSP;
         InLoanBindingMode = true;
-        break;           
+        break;
     default:
         switch(receivedHeader->type) {
         case CRSF_FRAMETYPE_MSP_WRITE: //encapsulated MSP payload
@@ -1078,7 +1078,7 @@ void MspReceiveComplete()
                     vtxSPIPitmode = MspData[11];
                 }
                 devicesTriggerEvent();
-            }           
+            }
             break;
         case CRSF_FRAMETYPE_PARAMETER_SETTINGS_ENTRY:
             if ((receivedHeader->dest_addr == CRSF_ADDRESS_BROADCAST || receivedHeader->dest_addr == CRSF_ADDRESS_CRSF_RECEIVER))
@@ -1087,7 +1087,7 @@ void MspReceiveComplete()
                 crsf.ParameterUpdateData[1] = MspData[CRSF_TELEMETRY_FIELD_ID_INDEX];
                 crsf.ParameterUpdateData[2] = MspData[CRSF_TELEMETRY_FIELD_CHUNK_INDEX];
                 luaParamUpdateReq();
-            }      
+            }
             break;
         case CRSF_FRAMETYPE_ARDUPILOT_LUA:
             // No MSP data to the FC if no model match
@@ -1096,7 +1096,7 @@ void MspReceiveComplete()
                 crsf.sendMSPFrameToFC(MspData);
             }
             break;
-        default: 
+        default:
             // No MSP data to the FC if no model match
             if (connectionHasModelMatch && (receivedHeader->dest_addr == CRSF_ADDRESS_BROADCAST || receivedHeader->dest_addr == CRSF_ADDRESS_FLIGHT_CONTROLLER))
             {

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1012,12 +1012,44 @@ void UpdateModelMatch(uint8_t model)
  **/
 void MspReceiveComplete()
 {
-    if (MspData[7] == MSP_SET_RX_CONFIG && MspData[8] == MSP_ELRS_MODEL_ID)
-    {
-        UpdateModelMatch(MspData[9]);
-    }
-    else if (MspData[0] == MSP_ELRS_SET_RX_WIFI_MODE)
-    {
+    /* Possible data types received in a MSP frame:
+     *    MSP_ELRS command bytes: 
+     *        0: command
+     *        1..n: payload
+     *    crsf_header_t bytes: 
+     *        0: device_addr
+     *        1: frame_size
+     *        2: type
+     *        3..n-1: payload
+     *        n: crc     
+     *    crsf_ext_header_t bytes: 
+     *        0: device_addr
+     *        1: frame_size
+     *        2: type
+     *        3: dest_addr
+     *        4: orig_addr
+     *        5..n-1: payload
+     *        n: crc
+     *    crsf_ext_header_t with encapsulated MSP sent with CRSF::AddMspMessage(mspPacket_t* packet): 
+     *        // CRSF extended frame header
+     *        0: device_addr = CRSF_ADDRESS_BROADCAST = 0x00
+     *        1: frame_size
+     *        2: type = CRSF_FRAMETYPE_MSP_WRITE
+     *        3: dest_addr = CRSF_ADDRESS_FLIGHT_CONTROLLER
+     *        4: orig_addr = CRSF_ADDRESS_RADIO_TRANSMITTER
+     *        // Encapsulated MSP payload
+     *        5: mspHeader = 0x30
+     *        6: mspPayloadSize
+     *        7: mspFunction
+     *        8..n-2: mspPayload
+     *        n-1: mspCrc
+     *        // CRSF crc
+     *        n: crc
+    /*
+    crsf_ext_header_t *receivedHeader = (crsf_ext_header_t *) MspData; 
+    
+    switch(receivedHeader->device_addr) {
+    case MSP_ELRS_SET_RX_WIFI_MODE: //0x0E
 #if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
         // The MSP packet needs to be ACKed so the TX doesn't
         // keep sending it, so defer the switch to wifi
@@ -1025,38 +1057,51 @@ void MspReceiveComplete()
             setWifiUpdateMode();
         });
 #endif
-    }
-    else if (MspData[0] == MSP_ELRS_SET_RX_LOAN_MODE)
-    {
+        break;
+    case MSP_ELRS_SET_RX_LOAN_MODE: //0x0F
         loanBindTimeout = LOAN_BIND_TIMEOUT_MSP;
         InLoanBindingMode = true;
-    }
-    else if (OPT_HAS_VTX_SPI && MspData[7] == MSP_SET_VTX_CONFIG)
-    {
-        vtxSPIBandChannelIdx = MspData[8];
-        if (MspData[6] >= 4) // If packet has 4 bytes it also contains power idx and pitmode.
-        {
-            vtxSPIPowerIdx = MspData[10];
-            vtxSPIPitmode = MspData[11];
-        }
-        devicesTriggerEvent();
-    }
-    else
-    {
-        crsf_ext_header_t *receivedHeader = (crsf_ext_header_t *) MspData;
-
-        // No MSP data to the FC if no model match
-        if (connectionHasModelMatch && (receivedHeader->dest_addr == CRSF_ADDRESS_BROADCAST || receivedHeader->dest_addr == CRSF_ADDRESS_FLIGHT_CONTROLLER))
-        {
-            crsf.sendMSPFrameToFC(MspData);
-        }
-
-        if ((receivedHeader->dest_addr == CRSF_ADDRESS_BROADCAST || receivedHeader->dest_addr == CRSF_ADDRESS_CRSF_RECEIVER))
-        {
-            crsf.ParameterUpdateData[0] = MspData[CRSF_TELEMETRY_TYPE_INDEX];
-            crsf.ParameterUpdateData[1] = MspData[CRSF_TELEMETRY_FIELD_ID_INDEX];
-            crsf.ParameterUpdateData[2] = MspData[CRSF_TELEMETRY_FIELD_CHUNK_INDEX];
-            luaParamUpdateReq();
+        break;           
+    default:
+        switch(receivedHeader->type) {
+        case CRSF_FRAMETYPE_MSP_WRITE: //encapsulated MSP payload
+            if (MspData[7] == MSP_SET_RX_CONFIG && MspData[8] == MSP_ELRS_MODEL_ID)
+            {
+                UpdateModelMatch(MspData[9]);
+            }
+             else if (OPT_HAS_VTX_SPI && MspData[7] == MSP_SET_VTX_CONFIG)
+            {
+                vtxSPIBandChannelIdx = MspData[8];
+                if (MspData[6] >= 4) // If packet has 4 bytes it also contains power idx and pitmode.
+                {
+                    vtxSPIPowerIdx = MspData[10];
+                    vtxSPIPitmode = MspData[11];
+                }
+                devicesTriggerEvent();
+            }           
+            break;
+        case CRSF_FRAMETYPE_PARAMETER_SETTINGS_ENTRY:
+            if ((receivedHeader->dest_addr == CRSF_ADDRESS_BROADCAST || receivedHeader->dest_addr == CRSF_ADDRESS_CRSF_RECEIVER))
+            {
+                crsf.ParameterUpdateData[0] = MspData[CRSF_TELEMETRY_TYPE_INDEX];
+                crsf.ParameterUpdateData[1] = MspData[CRSF_TELEMETRY_FIELD_ID_INDEX];
+                crsf.ParameterUpdateData[2] = MspData[CRSF_TELEMETRY_FIELD_CHUNK_INDEX];
+                luaParamUpdateReq();
+            }      
+            break;
+        case CRSF_FRAMETYPE_ARDUPILOT_LUA:
+            // No MSP data to the FC if no model match
+            if (connectionHasModelMatch)
+            {
+                crsf.sendMSPFrameToFC(MspData);
+            }
+            break;
+        default: 
+            // No MSP data to the FC if no model match
+            if (connectionHasModelMatch && (receivedHeader->dest_addr == CRSF_ADDRESS_BROADCAST || receivedHeader->dest_addr == CRSF_ADDRESS_FLIGHT_CONTROLLER))
+            {
+                crsf.sendMSPFrameToFC(MspData);
+            }
         }
     }
 


### PR DESCRIPTION
Currently MspReceiveComplete() checks various positions in MspData[] to determine the action to be taken, this could lead to unintended behaviour.

For example:
1) LUA on transmitter executes: crossfireTelemetryPush(0x80, {0,4,5,6,45,0x0A,99}) to push some telemetry data to the flight controller.

2) This is transmitted/received as MspData[] = {0xEE,length,0x80,0,4,5,6,45,0x0A,99}

3) On the receiver rx_main::MspReceiveComplete() does not execute crsf.sendMSPFrameToFC(MspData) as intended, but executes UpdateModelMatch(99) instead. 

This is because the received MspData[] matches the first if() statement in rx_main::MspReceiveComplete():

```
#define MSP_SET_RX_CONFIG   45
#define MSP_ELRS_MODEL_ID   0x0A
...
void MspReceiveComplete()
{
    if (MspData[7] == MSP_SET_RX_CONFIG && MspData[8] == MSP_ELRS_MODEL_ID)
    {
        UpdateModelMatch(MspData[9]);
    }
```

Fix this by using switch statements in rx_main::MspReceiveComplete(), first decoding the ELRS command in MspData[0], and then decoding the CRSF type in MspData[2]

In addition add new CRSF frame type CRSF_FRAMETYPE_ARDUPILOT_LUA to allow for bidirectional telemetry data. See https://github.com/ArduPilot/ardupilot/pull/22768