### PR TITLE
Radiomaster RP2 PWM [WIP]

### DIFF
--- a/src/hardware/RX/Generic 2400 pwm.json
+++ b/src/hardware/RX/Generic 2400 pwm.json
@@ -1,6 +1,5 @@
 {
-    "serial_rx": 3,
-    "serial_tx": 1,
+    "pwm_outputs": [1,3],
     "radio_busy": 5,
     "radio_dio1": 4,
     "radio_miso": 12,

--- a/src/hardware/RX/Generic 2400.json
+++ b/src/hardware/RX/Generic 2400.json
@@ -1,0 +1,19 @@
+{
+    "serial_rx": 3,
+    "serial_tx": 1,
+    "radio_busy": 5,
+    "radio_dio1": 4,
+    "radio_miso": 12,
+    "radio_mosi": 13,
+    "radio_nss": 15,
+    "radio_rst": 2,
+    "radio_sck": 14,
+    "power_min": 0,
+    "power_high": 0,
+    "power_max": 0,
+    "power_default": 0,
+    "power_control": 0,
+    "power_values": [13],
+    "led": 16,
+    "button": 0
+}

--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -1357,6 +1357,14 @@
                 "firmware": "Unified_ESP8285_2400_RX"
             },
             "rp2": {
+                "product_name": "RadioMaster RP2 2.4GHz RX",
+                "lua_name": "RM RP2",
+                "layout_file": "Generic 2400.json",
+                "upload_methods": ["uart", "wifi", "betaflight"],
+                "platform": "esp8285",
+                "firmware": "Unified_ESP8285_2400_RX"
+            },
+            "rp2pwm": {
                 "product_name": "RadioMaster RP2 2.4GHz RX PWM",
                 "lua_name": "RM RP2 PWM",
                 "layout_file": "Generic 2400 pwm.json",

--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -1357,9 +1357,9 @@
                 "firmware": "Unified_ESP8285_2400_RX"
             },
             "rp2": {
-                "product_name": "RadioMaster RP2 2.4GHz RX",
-                "lua_name": "RM RP2",
-                "layout_file": "Generic 2400.json",
+                "product_name": "RadioMaster RP2 2.4GHz RX PWM",
+                "lua_name": "RM RP2 PWM",
+                "layout_file": "Generic 2400 pwm.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "platform": "esp8285",
                 "firmware": "Unified_ESP8285_2400_RX"


### PR DESCRIPTION
unbelievably this works  like a charm and gives two PWM outputs:
- PWM1 instead RX
- PWM2 instead TX
