### PR TITLE
Lock NeoPixelBus to 2.6.7 as 2.7.2 won't compile for ELRS v2.x

### DIFF
--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -44,7 +44,7 @@ build_flags =
 	-I ${PROJECTSRC_DIR}/hal
 build_src_filter = ${common_env_data.build_src_filter} -<ESP8266*.*> -<STM32*.*>
 lib_deps =
-	makuna/NeoPixelBus @ ^2.6.7
+	makuna/NeoPixelBus @ 2.6.7
 	ottowinter/ESPAsyncWebServer-esphome @ ^2.1.0
 	lemmingdev/ESP32-BLE-Gamepad @ ^0.3.3
 	h2zero/NimBLE-Arduino @ ^1.3.6


### PR DESCRIPTION
### Issue
ExpressLRS 2.5.1 won't build ESP32 targets that use RGB LED any more, as the NeoPixelBus library version 2.7.2 throws more build errors than you can even see in the build window. I'm not sure what the actual error is because the errors I can see are just fallout from whatever the first thing gcc didn't like was.

### Solution
Lock NeoPixelBus to the version that was around at the time, instead of using the "compatible" (`^`) identifier. Maybe NeoPixelBus 2.7.2 is compatible with NeoPixelBus 2.6.7, but it sure ain't compatible with the gcc from the older esp32 platform.

### New 2.x.x release
I thing this requires us to put out a new 2.x.x ExpressLRS release, as nobody can build 2.5.1 now. A lot of dumb users (and dumb developers helping test things for other projects) go back and forth between versions, and this issue means nobody with Betaflight 4.3.x SPI RX can use them if they don't already have the older ExpressLRS version installed.