### PR TITLE
Build fails with the latest NeoPixel version. Lock to version 2.7.0

### DIFF
--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -44,7 +44,7 @@ build_flags =
 	-I ${PROJECTSRC_DIR}/hal
 build_src_filter = ${common_env_data.build_src_filter} -<ESP8266*.*> -<STM32*.*>
 lib_deps =
-	makuna/NeoPixelBus @ ^2.6.7
+	makuna/NeoPixelBus @ 2.7.0
 	ottowinter/ESPAsyncWebServer-esphome @ ^2.1.0
 	lemmingdev/ESP32-BLE-Gamepad @ ^0.3.3
 	h2zero/NimBLE-Arduino @ ^1.3.6


### PR DESCRIPTION
With the latest NeoPixel 2.7.2 build fails:
```
.pio/libdeps/HappyModel_TX_ES900TX_via_UART/NeoPixelBus/src/internal/DotStarEsp32DmaSpiMethod.h:305:38: error: template argument 1 is invalid
 typedef Esp32SpiBus<SPI3_HOST, WIDTH4> Esp32Spi34BitBus;
```
Lock to 2.7.0 which is also used in master branch.