### PR TITLE
Fix Skystars SS24D target layout

### DIFF
--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -1423,7 +1423,7 @@
             "ss24d": {
                 "product_name": "Skystars SS24D 2.4GHz RX",
                 "lua_name": "Skystars SS24D",
-                "layout_file": "Generic 2400 PA.json",
+                "layout_file": "Generic 2400 Diversity PA.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "platform": "esp8285",
                 "firmware": "Unified_ESP8285_2400_RX",


### PR DESCRIPTION
p.i.engineer on the Discord reported that the antenna diversity options were missing from the ELRS lua for the Skystars SS24D receiver. It appears the correct target layout should be `Generic 2400 Diversity PA.json`, not `Generic 2400 Diversity PA.json`. 
Tested and confirmed working: https://discord.com/channels/596350022191415318/596350022191415320/1074187363938484295