### PR TITLE
Add telemetryStatus bit to MSP+SYNC OTA packets

### DIFF
--- a/src/lib/OTA/OTA.h
+++ b/src/lib/OTA/OTA.h
@@ -55,7 +55,7 @@ typedef struct {
         /** PACKET_TYPE_RCDATA **/
         struct {
             OTA_Channels_4x10 ch;
-            uint8_t switches:7,
+            uint8_t switches:7, // note: contains telemetryStatus bit
                     ch4:1;
         } rc;
         struct {
@@ -64,7 +64,9 @@ typedef struct {
         } PACKED dbg_linkstats;
         /** PACKET_TYPE_MSP **/
         struct {
-            uint8_t packageIndex;
+            uint8_t packageIndex:4, // values: 0-13:packageIndex, 14=ELRS_MSP_MAX_PACKAGES:resync, 15:unused, 1:payload is bind info (in bind mode)
+                    telemetryStatus:1,
+                    zero: 3; // future expansion, set to 0
             uint8_t payload[ELRS4_MSP_BYTES_PER_CALL];
         } msp_ul;
         /** PACKET_TYPE_SYNC **/
@@ -113,13 +115,17 @@ typedef struct {
         } PACKED dbg_linkstats;
         /** PACKET_TYPE_MSP **/
         struct {
-            uint8_t packetType: 2,
-                    packageIndex: 6;
+            uint8_t packetType: 2, // PACKET_TYPE_MSPDATA 0b01
+                    packageIndex: 4, // values: 0-13:packageIndex, 14=ELRS_MSP_MAX_PACKAGES:resync, 15:unused, 1:payload is bind info (in bind mode)
+                    telemetryStatus:1,
+                    zero: 1; // reserved for future expansion, set to 0
             uint8_t payload[ELRS8_MSP_BYTES_PER_CALL];
         } msp_ul;
         /** PACKET_TYPE_SYNC **/
         struct {
-            uint8_t packetType; // only low 2 bits
+            uint8_t packetType: 2, // PACKET_TYPE_SYNC 0b10 (low 2 bits)
+                    telemetryStatus:1,
+                    zero: 5; // reserved for future expansion, set to 0
             OTA_Sync_s sync;
             uint8_t free[4];
         } PACKED sync;


### PR DESCRIPTION
Add telemetryStatus bit to MSP and SYNC OTA packets to improve bi-directional telemetry throughput.

Telemetry OTA messages need an acknowledgement from the radio, which is transmitted as the telemetryStatus bit in the RCDATA OTA packet. MSP and SYNC messages do not have this status bit. When using MSP messages to send uplink telemetry from the radio to the flight controller, the telemetryStatus is not sent and the downlink telemetry throughput is reduced all the way down to zero in worst case.

This PR adds a telemetryStatus bit to the MSP and SYNC packets to improve throughput for bi-directional telemetry.

I'm not 100% sure the bit for the SYNC message is needed/helping. It can only be added to the "full" packets without changing the OTA packet format. I did not see measurable improvement in throughput after adding it, but left it in this PR.

Below my throughput measurements before and after this PR.

`ul/dl`  uplink/downlink:  ***stable*** throughput in packets/second when sending MSP messages from the Radio Controller to the FC and simultaneously sending TELEM messages from the FC to the Radio Controller

`dlo` downlink only: ***stable*** throughput in packets/second when sending TELEM messages from the FC to the Radio Controller (no MSP messages)

`CRSF` is the CRSF packet as sent over-the-air, including 5 bytes CRSF headers: sync length type destination and crc

`payload` is the netto telemetry payload inside the CRSF message.

```
ExpressLRS 3.1.2 telemetry rate 1:2 :

CRSF:10 bytes    20 bytes     best B/s   best B/s
payl: 5 bytes    15 bytes       CRSF     payload
Mode ul/dl dlo   ul/dl dlo     ul/dl      ul/dl
 50   5/ 3   5    3/ 1   2     60/ 20     45/ 15
100F 13/ 9  12   11/ 0  10    130/ 90     65/ 45
333F 42/28  45   30/ 0  36    420/280    210/140
500  63/35  61   31/14  33    630/350    465/210

After PR MSP:

 50   6/ 3   4    2/ 2   2     60/ 30     30/ 30
100F 12/12  12    8/ 8   9    160/160    120/120
333F 42/28  45   31/31  35    620/620    465/465
500  63/43  60   30/16  32    630/430    450/240

After PR MSP+SYNC:

 50   6/ 3   4    2/ 2   2     60/ 30     30/ 30
100F 12/10  10    8/ 6   9    160/120    120/ 60
333F 42/40  40   31/31  35    620/620    465/465
500  63/43  60   30/16  32    630/430    450/240

Theoretical CRSF B/s ul/dl: (assuming alternating RCDATA/MSP on uplink)

 50   62/ 125
100F 250/ 500
333F 833/1666
500  625/1250
```

The uplink rates match the theoretical expectations.

The PR improves the downlink throughput for longer packages in full modes. But, the downlink throughput is still less than half of what I was hoping for. What is going on? Is every TELEM packet sent twice ota? Link stats or sync every second downlink packet? I did not investigate further. Any ideas on this?

I used the attached Lua scripts on EdgeTX and Ardupilot to do the measurements:
https://github.com/qqqlab/ardupilot/blob/pr/csrf_pop/libraries/AP_Scripting/applets/CRSF/CRSF-Rate-E.lua
https://github.com/qqqlab/ardupilot/blob/pr/csrf_pop/libraries/AP_Scripting/applets/CRSF/CRSF-Rate-A.lua
