### PR TITLE
Add DIY900 TTGO LoRa32 RXes

### DIFF
--- a/src/hardware/RX/DIY 900 TTGO V1.json
+++ b/src/hardware/RX/DIY 900 TTGO V1.json
@@ -1,0 +1,17 @@
+{
+    "serial_rx": 3,
+    "serial_tx": 1,
+    "radio_dio0": 26,
+    "radio_miso": 19,
+    "radio_mosi": 27,
+    "radio_nss": 18,
+    "radio_rst": 14,
+    "radio_sck": 5,
+    "power_min": 0,
+    "power_high": 2,
+    "power_max": 2,
+    "power_default": 2,
+    "power_control": 0,
+    "power_values": [8,12,15],
+    "led": 2
+}

--- a/src/hardware/RX/DIY 900 TTGO V2.json
+++ b/src/hardware/RX/DIY 900 TTGO V2.json
@@ -1,0 +1,17 @@
+{
+    "serial_rx": 3,
+    "serial_tx": 1,
+    "radio_dio0": 26,
+    "radio_miso": 19,
+    "radio_mosi": 27,
+    "radio_nss": 18,
+    "radio_rst": 12,
+    "radio_sck": 5,
+    "power_min": 0,
+    "power_high": 2,
+    "power_max": 2,
+    "power_default": 2,
+    "power_control": 0,
+    "power_values": [8,12,15],
+    "led": 2
+}

--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -192,6 +192,22 @@
             }
         },
         "rx_900": {
+            "ttgov1": {
+                "product_name": "DIY TTGO V1 900MHz RX",
+                "lua_name": "DIY900 TTGO V1RX",
+                "layout_file": "DIY 900 TTGO V1.json",
+                "upload_methods": ["uart", "wifi"],
+                "platform": "esp32",
+                "firmware": "Unified_ESP32_900_RX"
+            },
+            "ttgov2": {
+                "product_name": "DIY TTGO V2 900MHz RX",
+                "lua_name": "DIY900 TTGO V2RX",
+                "layout_file": "DIY 900 TTGO V2.json",
+                "upload_methods": ["uart", "wifi"],
+                "platform": "esp32",
+                "firmware": "Unified_ESP32_900_RX"
+            },
             "huzzah": {
                 "product_name": "DIY Huzzah RFM95 900MHz TX",
                 "lua_name": "ELRS RFM95 900RX",

--- a/src/targets/diy_900.ini
+++ b/src/targets/diy_900.ini
@@ -36,6 +36,26 @@ extends = env:DIY_900_TX_ESP32_SX127x_RFM95_via_UART
 # Receiver targets
 # ********************************
 
+[env:DIY_900_RX_TTGO_V1_SX127x_via_UART]
+extends = env:Unified_ESP32_900_RX_via_UART
+board_config = diy.rx_900.ttgov1
+
+[env:DIY_900_RX_TTGO_V1_SX127x_via_BetaflightPassthrough]
+extends = env:DIY_900_RX_TTGO_V1_SX127x_via_UART
+
+[env:DIY_900_RX_TTGO_V1_SX127x_via_WIFI]
+extends = env:DIY_900_RX_TTGO_V1_SX127x_via_UART
+
+[env:DIY_900_RX_TTGO_V2_SX127x_via_UART]
+extends = env:Unified_ESP32_900_RX_via_UART
+board_config = diy.rx_900.ttgov2
+
+[env:DIY_900_RX_TTGO_V2_SX127x_via_BetaflightPassthrough]
+extends = env:DIY_900_RX_TTGO_V2_SX127x_via_UART
+
+[env:DIY_900_RX_TTGO_V2_SX127x_via_WIFI]
+extends = env:DIY_900_RX_TTGO_V2_SX127x_via_UART
+
 [env:DIY_900_RX_ESP8285_SX127x_via_UART]
 extends = env:Unified_ESP8285_900_RX_via_UART
 board_config = generic.rx_900.plain


### PR DESCRIPTION
Adds TTGO LoRa32 boards as DIY RXes and not just TXes. This makes it easy to get both ends of a 433MHz link going without having to build your own from scratch.

Tested on my TTGO LoRa32 V2s and some new LilyGo "T3_V1.6.1", both of which seem to work well.