### PR TITLE
Fix race condition in Telemetry and improve throughput

### DIFF
--- a/src/lib/Telemetry/telemetry.h
+++ b/src/lib/Telemetry/telemetry.h
@@ -61,7 +61,7 @@ public:
     bool GetNextPayload(uint8_t* nextPayloadSize, uint8_t **payloadData);
     uint8_t UpdatedPayloadCount();
     uint8_t ReceivedPackagesCount();
-    bool AppendTelemetryPackage(uint8_t *package);
+    void AppendTelemetryPackage(uint8_t *package);
 private:
     void AppendToPackage(volatile crsf_telemetry_package_t *current);
     uint8_t CRSFinBuffer[CRSF_MAX_PACKET_LEN];


### PR DESCRIPTION
This PR fixes a race condition and improves the telemetry throughput of extended header crsf packets.

## Current Situation

9 slots are defined for holding incoming crsf packets. 7 slots are used for specific standard header crsf packets, two are used for extended crsf packets. The RXhandleUARTin() method writes packets to these slots, a slot locked and then transmitted OTA.

However, the extended header slots are never locked. This creates a race condition when RXhandleUARTin() is writing to a slot while the OTA handler is reading from the same slot.

## Pull Request

Modify AppendTelemetryPackage() as follows:

 - Always check the locked flag before writing data to a slot.

 - Currently the slots are effectively 1 position LIFO buffers with overwrite. This is fine for standard crsf telemetry packets, where we are interested in the latest packet only. However, for extended packets we are interested in all packets. Make the 2 extended slots act as a 2 positon FIFO buffer without overwrite. By double buffering, we can receive the next packet in the buffer whilst the previous packet is transmitted OTA.

- Refactor code: first handle non-OTA, then OTA for standard crsf, then OTA for anything not handled yet.

- Remove the return value of the method, it is never used.

## Test Results

Tested by tormenting the ELRS receiver by firing 100 extended crsf packages per second at it. Each crsf packet is 20 bytes long.

Maximum possible throughput with Telemetry ratio 1:2
```
Mode crsf/s  byte/s 
500    62     1250
333F   83     1665
100F   25      500
 50    12      250

crsf/s = number of 20 byte crsf packets OTA per second
byte/s = number of OTA bytes per second
```
Results with ELRS 3.2.0:
```
Mode crsf/s  byte/s    telemetry lost
500    21     420      YES
333F   37     740      NO
100F    0       0      YES
 50     0       0      YES
```
Results after this PR:
```
Mode crsf/s  byte/s     telemetry lost
500     52    1040      NO
333F    60    1200      NO
100F    18     360      NO
 50      5     100      NO
```
## Tools

The Python script was used to enulate a FC and send crsf packets to the ELRS receiver. The Lua script was used to analyse the received data on an EdgeTX radio.
https://github.com/qqqlab/ExpressLRS/blob/pr_attachments/CRSF-Telem.py
https://github.com/qqqlab/ExpressLRS/blob/pr_attachments/CRSF-Debug.lua