### PR TITLE
WIP: Expose CSRF stream over Bluetooth Serial for ESP32

### DIFF
--- a/src/lib/BTS/devBTS.cpp
+++ b/src/lib/BTS/devBTS.cpp
@@ -1,0 +1,49 @@
+#include "devBTS.h"
+
+#if defined(PLATFORM_ESP32)
+
+#include "common.h"
+#include "CRSF.h"
+#include "logging.h"
+#include "BluetoothSerial.h"
+#include "config.h"
+
+extern TxConfig config;
+
+BluetoothSerial SerialBT;
+bool started = false;
+
+static int event()
+{
+    // Shutdown if not enabled, ignore if in init mode
+    if ( (config.GetBTSerial() == false) || (connectionState == bleJoystick) )
+    {
+        CRSF::PortSecondary = nullptr;
+        SerialBT.end();
+        started = false;
+        DBGLN("Shutting down BT Serial!");
+        return DURATION_NEVER;
+    }
+
+    // Start BT stack if not started yet and service is enabled via LUA
+    if (config.GetBTSerial() == true && !started)
+    {
+        started = true;
+        SerialBT.begin("ELRS Telemetry");
+        CRSF::PortSecondary = &SerialBT;
+
+        DBGLN("Starting BT Serial!");
+        return DURATION_NEVER;
+    }
+
+    return DURATION_NEVER;
+}
+
+device_t BTS_device = {
+  .initialize = NULL,
+  .start = NULL,
+  .event = event,
+  .timeout = NULL
+};
+
+#endif

--- a/src/lib/BTS/devBTS.h
+++ b/src/lib/BTS/devBTS.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "device.h"
+
+#if defined(PLATFORM_ESP32)
+extern device_t BTS_device;
+#define HAS_BTS
+#endif

--- a/src/lib/CONFIG/config.cpp
+++ b/src/lib/CONFIG/config.cpp
@@ -374,6 +374,16 @@ TxConfig::SetTlm(uint8_t tlm)
 }
 
 void
+TxConfig::SetBTSerial(bool btSerial)
+{
+    if (GetBTSerial() != btSerial)
+    {
+        m_model->btSerial = btSerial;
+        m_modified |= MODEL_CHANGED;
+    }
+}
+
+void
 TxConfig::SetPower(uint8_t power)
 {
     if (GetPower() != power)

--- a/src/lib/CONFIG/config.h
+++ b/src/lib/CONFIG/config.h
@@ -28,6 +28,7 @@ typedef struct {
     uint8_t     dynamicPower:1,
                 modelMatch:1,
                 txAntenna:2;    // FUTURE: Which TX antenna to use, 0=Auto
+    uint8_t     btSerial:1;
 } model_config_t;
 
 typedef struct {
@@ -91,6 +92,7 @@ public:
     uint8_t  GetDvrAux() const { return m_config.dvrAux; }
     uint8_t  GetDvrStartDelay() const { return m_config.dvrStartDelay; }
     uint8_t  GetDvrStopDelay() const { return m_config.dvrStopDelay; }
+    bool GetBTSerial() const { return m_model->btSerial; }
     tx_button_color_t const *GetButtonActions(uint8_t button) const { return &m_config.buttonColors[button]; }
     model_config_t const &GetModelConfig(uint8_t model) const { return m_config.model_config[model]; }
 
@@ -115,6 +117,7 @@ public:
     void SetDvrAux(uint8_t dvrAux);
     void SetDvrStartDelay(uint8_t dvrStartDelay);
     void SetDvrStopDelay(uint8_t dvrStopDelay);
+    void SetBTSerial(bool btSerial);
     void SetButtonActions(uint8_t button, tx_button_color_t actions[2]);
 
     // State setters

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -203,6 +203,15 @@ struct luaItem_selection luaBluetoothTelem = {
 };
 #endif
 
+#if defined(PLATFORM_ESP32)
+static struct luaItem_selection luaBTSerial = {
+    {"BT Telemetry", CRSF_TEXT_SELECTION},
+    0, // value
+    "Off;On",
+    STR_EMPTYSPACE
+};
+#endif
+
 //---------------------------- BACKPACK ------------------
 static struct luaItem_folder luaBackpackFolder = {
     {"Backpack", CRSF_FOLDER},
@@ -536,6 +545,14 @@ static void registerLuaParameters()
       devicesTriggerEvent();
     });
     #endif
+
+    #if defined(PLATFORM_ESP32)
+    registerLUAParameter(&luaBTSerial, [](struct luaPropertiesCommon *item, uint8_t arg) {
+      bool newBTSerial = arg;
+      config.SetBTSerial(newBTSerial);
+    });
+    #endif
+
     if (!firmwareOptions.is_airport)
     {
       registerLUAParameter(&luaSwitch, [](struct luaPropertiesCommon *item, uint8_t arg) {
@@ -709,6 +726,9 @@ static int event()
   }
 #if defined(TARGET_TX_FM30)
   setLuaTextSelectionValue(&luaBluetoothTelem, !digitalRead(GPIO_PIN_BLUETOOTH_EN));
+#endif
+#if defined(PLATFORM_ESP32)
+  setLuaTextSelectionValue(&luaBTSerial, (uint8_t)config.GetBTSerial());
 #endif
   return DURATION_IMMEDIATELY;
 }

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -11,7 +11,8 @@
 #include "devLED.h"
 #include "devScreen.h"
 #include "devBuzzer.h"
-#include "devBLE.h"
+// #include "devBLE.h"
+#include "devBTS.h"
 #include "devLUA.h"
 #include "devWIFI.h"
 #include "devButton.h"
@@ -86,6 +87,9 @@ device_affinity_t ui_devices[] = {
 #endif
 #ifdef HAS_BLE
   {&BLE_device, 0},
+#endif
+#ifdef HAS_BTS
+  {&BTS_device, 0},
 #endif
 #ifdef HAS_BUZZER
   {&Buzzer_device, 0},


### PR DESCRIPTION
 Experimental CSRF telemetry output via classic Bluetooth serial connection.

Does not fit with default ESP32 target
```shell
Error: The program size (2028409 bytes) is greater than maximum allowed (1966080 bytes)
*** [checkprogsize] Explicit exit, status 1
RAM:   [==        ]  24.5% (used 80244 bytes from 327680 bytes)
Flash: [==========]  103.2% (used 2028409 bytes from 1966080 bytes)
```

just barely with BLE disabled.

```shell
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [==        ]  22.7% (used 74532 bytes from 327680 bytes)
Flash: [==========]  98.0% (used 1925789 bytes from 1966080 bytes)
```