### PR TITLE
Fixes loop throttle & no-layout wifi mode

### DIFF
--- a/src/include/rxtx_common.h
+++ b/src/include/rxtx_common.h
@@ -17,4 +17,3 @@
 void setupTargetCommon();
 void deferExecution(uint32_t ms, std::function<void()> f);
 void executeDeferredFunction(unsigned long now);
-void throttleMainLoop();

--- a/src/lib/DEVICE/device.cpp
+++ b/src/lib/DEVICE/device.cpp
@@ -107,9 +107,13 @@ void devicesTriggerEvent()
 {
     eventFired[0] = true;
     eventFired[1] = true;
+    #if defined(PLATFORM_ESP32)
+    // Release teh semaphore so the tasks on core 0 run now
+    xSemaphoreGive(taskSemaphore);
+    #endif
 }
 
-void devicesUpdate(unsigned long now)
+int devicesUpdate(unsigned long now)
 {
     int32_t core = CURRENT_CORE;
 
@@ -132,6 +136,7 @@ void devicesUpdate(unsigned long now)
         }
     }
 
+    int smallest_delay = DURATION_NEVER;
     for(size_t i=0 ; i<deviceCount ; i++)
     {
         if (uiDevices[i].core == core || core == -1) {
@@ -139,9 +144,14 @@ void devicesUpdate(unsigned long now)
             {
                 int delay = (uiDevices[i].device->timeout)();
                 deviceTimeout[i] = delay == DURATION_NEVER ? 0xFFFFFFFF : now + delay;
+                if (delay != DURATION_NEVER)
+                {
+                    smallest_delay = (smallest_delay == DURATION_NEVER) ? delay : std::min(smallest_delay, (int)(deviceTimeout[i]-now));
+                }
             }
         }
     }
+    return smallest_delay;
 }
 
 #if defined(PLATFORM_ESP32)
@@ -155,7 +165,9 @@ static void deviceTask(void *pvArgs)
     xSemaphoreGive(completeSemaphore);
     for (;;)
     {
-        devicesUpdate(millis());
+        int delay = devicesUpdate(millis());
+        // sleep the core until the desired time or it's awakened by an event
+        xSemaphoreTake(taskSemaphore, delay == DURATION_NEVER ? portMAX_DELAY : pdMS_TO_TICKS(delay));
     }
 }
 #endif

--- a/src/lib/DEVICE/device.cpp
+++ b/src/lib/DEVICE/device.cpp
@@ -139,15 +139,17 @@ int devicesUpdate(unsigned long now)
     int smallest_delay = DURATION_NEVER;
     for(size_t i=0 ; i<deviceCount ; i++)
     {
-        if (uiDevices[i].core == core || core == -1) {
-            if (uiDevices[i].device->timeout && now >= deviceTimeout[i])
+        if ((uiDevices[i].core == core || core == -1) && uiDevices[i].device->timeout)
+        {
+            int delay = deviceTimeout[i] == 0xFFFFFFFF ? DURATION_NEVER : (int)(deviceTimeout[i]-now);
+            if (now >= deviceTimeout[i])
             {
-                int delay = (uiDevices[i].device->timeout)();
+                delay = (uiDevices[i].device->timeout)();
                 deviceTimeout[i] = delay == DURATION_NEVER ? 0xFFFFFFFF : now + delay;
-                if (delay != DURATION_NEVER)
-                {
-                    smallest_delay = (smallest_delay == DURATION_NEVER) ? delay : std::min(smallest_delay, (int)(deviceTimeout[i]-now));
-                }
+            }
+            if (delay != DURATION_NEVER)
+            {
+                smallest_delay = (smallest_delay == DURATION_NEVER) ? delay : std::min(smallest_delay, delay);
             }
         }
     }

--- a/src/lib/DEVICE/device.h
+++ b/src/lib/DEVICE/device.h
@@ -26,6 +26,6 @@ typedef struct {
 void devicesRegister(device_affinity_t *devices, uint8_t count);
 void devicesInit();
 void devicesStart();
-void devicesUpdate(unsigned long now);
+int devicesUpdate(unsigned long now);
 void devicesTriggerEvent();
 void devicesStop();

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -317,7 +317,10 @@ static int event()
 static int timeout()
 {
   luaHandleUpdateParameter();
-  return DURATION_IMMEDIATELY;
+  // Receivers can only `UpdateParamReq == true` every 4th packet due to the transmitter cadence in 1:2
+  // Channels, Downlink Telem Slot, Uplink Telem (the write command), Downlink Telem Slot...
+  // (interval * 4 / 1000) or 1 second if not connected
+  return (connectionState == connected) ? ExpressLRS_currAirRate_Modparams->interval / 250 : 1000;
 }
 
 static int start()

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -1147,12 +1147,12 @@ static int timeout()
     HandleWebUpdate();
     HandleMSP2WIFI();
 #if defined(PLATFORM_ESP8266)
-      // When in STA mode, a small delay reduces power use from 90mA to 30mA when idle
-      // In AP mode, it doesn't seem to make a measurable difference, but does not hurt
-      // Only done on 8266 as the ESP32 runs a throttled task
-      if (!Update.isRunning())
-        delay(1);
-      return DURATION_IMMEDIATELY
+    // When in STA mode, a small delay reduces power use from 90mA to 30mA when idle
+    // In AP mode, it doesn't seem to make a measurable difference, but does not hurt
+    // Only done on 8266 as the ESP32 runs a throttled task
+    if (!Update.isRunning())
+      delay(1);
+      return DURATION_IMMEDIATELY;
 #else
     // All the web traffic is async apart from changing modes and MSP2WIFI
     // No need to run balls-to-the-wall; the wifi runs on this core too (0)

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -1152,7 +1152,7 @@ static int timeout()
     // Only done on 8266 as the ESP32 runs a throttled task
     if (!Update.isRunning())
       delay(1);
-      return DURATION_IMMEDIATELY;
+    return DURATION_IMMEDIATELY;
 #else
     // All the web traffic is async apart from changing modes and MSP2WIFI
     // No need to run balls-to-the-wall; the wifi runs on this core too (0)

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -1084,11 +1084,6 @@ static void HandleWebUpdate()
     dnsServer.processNextRequest();
     #if defined(PLATFORM_ESP8266)
       MDNS.update();
-      // When in STA mode, a small delay reduces power use from 90mA to 30mA when idle
-      // In AP mode, it doesn't seem to make a measurable difference, but does not hurt
-      // Only done on 8266 as the ESP32 runs a throttled loop()
-      if (!Update.isRunning())
-        delay(1);
     #endif
   }
 }
@@ -1151,7 +1146,18 @@ static int timeout()
   {
     HandleWebUpdate();
     HandleMSP2WIFI();
-    return DURATION_IMMEDIATELY;
+#if defined(PLATFORM_ESP8266)
+      // When in STA mode, a small delay reduces power use from 90mA to 30mA when idle
+      // In AP mode, it doesn't seem to make a measurable difference, but does not hurt
+      // Only done on 8266 as the ESP32 runs a throttled task
+      if (!Update.isRunning())
+        delay(1);
+      return DURATION_IMMEDIATELY
+#else
+    // All the web traffic is async apart from changing modes and MSP2WIFI
+    // No need to run balls-to-the-wall; the wifi runs on this core too (0)
+    return 2;
+#endif
   }
 
   #if defined(TARGET_TX)

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -342,7 +342,7 @@ bool ICACHE_RAM_ATTR HandleFHSS()
     alreadyFHSS = true;
 
     if (geminiMode)
-    {   
+    {
         if (((OtaNonce + 1)/ExpressLRS_currAirRate_Modparams->FHSShopInterval) % 2 == 0)
         {
             Radio.SetFrequencyReg(FHSSgetNextFreq(), SX12XX_Radio_1);
@@ -1554,6 +1554,10 @@ void resetConfigAndReboot()
 void setup()
 {
     #if defined(TARGET_UNIFIED_RX)
+    // Setup default logging in case of failure, or no layout
+    Serial.begin(115200);
+    SerialLogger = &Serial;
+
     hardwareConfigured = options_init();
     if (!hardwareConfigured)
     {

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1618,7 +1618,6 @@ void setup()
 
 void loop()
 {
-    throttleMainLoop();
     unsigned long now = millis();
 
     if (MspReceiver.HasFinishedData())

--- a/src/src/rxtx_common.cpp
+++ b/src/src/rxtx_common.cpp
@@ -52,22 +52,3 @@ void executeDeferredFunction(unsigned long now)
         deferredFunction = nullptr;
     }
 }
-
-void throttleMainLoop()
-{
-#if defined(PLATFORM_ESP32)
-    // Throttle the main loop() on ESP32 to allow power saving to kick in
-    // Loop at 1000Hz for 1000Hz rates, Loop at 500Hz for all other rates
-    static TickType_t loopThrottle = 0; // first loop will not delay
-    uint32_t interval_MS = 2U;
-    if (ExpressLRS_currAirRate_Modparams != nullptr)
-    {
-        auto interval = ExpressLRS_currAirRate_Modparams->interval;
-        interval_MS = interval > 2000U ? 2U : (interval > 1000U ? 1U : 0U);
-    }
-    if (interval_MS)
-    {
-        xTaskDelayUntil(&loopThrottle, pdMS_TO_TICKS(interval_MS));
-    }
-#endif
-}

--- a/src/src/rxtx_common.cpp
+++ b/src/src/rxtx_common.cpp
@@ -59,7 +59,15 @@ void throttleMainLoop()
     // Throttle the main loop() on ESP32 to allow power saving to kick in
     // Loop at 1000Hz for 1000Hz rates, Loop at 500Hz for all other rates
     static TickType_t loopThrottle = 0; // first loop will not delay
-    uint32_t interval_MS = ExpressLRS_currAirRate_Modparams->interval > 1000U ? 2U : 1U;
-    xTaskDelayUntil(&loopThrottle, pdMS_TO_TICKS(interval_MS));
+    uint32_t interval_MS = 2U;
+    if (ExpressLRS_currAirRate_Modparams != nullptr)
+    {
+        auto interval = ExpressLRS_currAirRate_Modparams->interval;
+        interval_MS = interval > 2000U ? 2U : (interval > 1000U ? 1U : 0U);
+    }
+    if (interval_MS)
+    {
+        xTaskDelayUntil(&loopThrottle, pdMS_TO_TICKS(interval_MS));
+    }
 #endif
 }

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1107,6 +1107,10 @@ static void setupTarget()
 bool setupHardwareFromOptions()
 {
 #if defined(TARGET_UNIFIED_TX)
+  // Setup default logging in case of failure, or no layout
+  Serial.begin(115200);
+  TxBackpack = &Serial;
+
   if (!options_init())
   {
     // Register the WiFi with the framework
@@ -1261,12 +1265,9 @@ void loop()
 
   executeDeferredFunction(now);
 
-  if (TxUSB->available())
+  if (firmwareOptions.is_airport && apInputBuffer.size() < AP_MAX_BUF_LEN && connectionState == connected && TxUSB->available())
   {
-    if (firmwareOptions.is_airport && apInputBuffer.size() < AP_MAX_BUF_LEN && connectionState == connected)
-    {
-      apInputBuffer.push(TxUSB->read());
-    }
+    apInputBuffer.push(TxUSB->read());
   }
 
   if (TxBackpack->available())

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1233,7 +1233,6 @@ void setup()
 
 void loop()
 {
-  throttleMainLoop();
   uint32_t now = millis();
 
   HandleUARTout(); // Only used for non-CRSF output


### PR DESCRIPTION
When doing some testing it was noticed that the Unified targets weren't working when no layout was provided.
Also as part of the fix for that I also fixed the problem where the main loop throttle was over zealous in throttling causing missed packet processing between the radio and the TX module.

EDIT: Removed the throttling as it was on the wrong core anyway!

EDIT2: Changed the throttling for core 0 (the non-main loop core) to dynamically sleep based on the requested delays from the device timeout functions.