### PR TITLE
Fix binary configurator for targets with `-`

### DIFF
--- a/src/python/binary_configurator.py
+++ b/src/python/binary_configurator.py
@@ -257,7 +257,7 @@ def ask_for_firmware(args):
         products = []
         if args.target is not None:
             target = args.target
-            config = jmespath.search(f'{target}', targets)
+            config = jmespath.search('.'.join(map(lambda s: f'"{s}"', args.target.split('.'))), targets)
         else:
             i = 0
             for k in jmespath.search(f'*.["{moduletype}_2400","{moduletype}_900"][].*[]', targets):


### PR DESCRIPTION
There are quite a few devices that have a `-` in the name so I thought it more prudent to fix the issue in our code rather than rename them all in the targets file.

fixes #2105 