### PR TITLE
Put the correct UID (the one being used) into the json response

### DIFF
--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -334,7 +334,7 @@ static void GetConfiguration(AsyncWebServerRequest *request)
   }
 #endif
   JsonArray uid = json["config"].createNestedArray("uid");
-  copyArray(firmwareOptions.uid, sizeof(firmwareOptions.uid), uid);
+  copyArray(UID, sizeof(UID), uid);
   if (!exportMode)
   {
     json["config"]["ssid"] = station_ssid;


### PR DESCRIPTION
Silly bug that caused the web UI to display the firmware flashed UID rather than the UID being used!
So in the case of receivers flashed without a bind-phrase (i.e. those that come directly from manufacturers) it would display 0,0,0,0,0,0 when it was bound using traditional binding.