### PR TITLE
Python 3.11 support. AST node column out of range.

### DIFF
--- a/src/python/external/wheezy/template/engine.py
+++ b/src/python/external/wheezy/template/engine.py
@@ -44,7 +44,7 @@ class Engine(object):
         self.global_vars = {"_r": self.render, "_i": self.import_name}
         self.loader = loader
         self.template_class = template_class or Template
-        self.compiler = Compiler(self.global_vars, -2)
+        self.compiler = Compiler(self.global_vars, 0)
         self.lexer = Lexer(**lexer_scan(extensions))
         self.parser = Parser(**parser_scan(extensions))
         self.builder = SourceBuilder(**builder_scan(extensions))


### PR DESCRIPTION
ast node column range (0, 22) for line range (-1, 283) is not valid

Not sure why this changed from python 3.10 to python 3.11 but the value `-2` used in our code breaks python3.11. 

@pkendall64 