### PR TITLE
Fix OLED change packet rate

### DIFF
--- a/src/lib/SCREEN/menu.cpp
+++ b/src/lib/SCREEN/menu.cpp
@@ -24,6 +24,7 @@ extern bool VRxBackpackWiFiReadyToSend;
 extern void VtxTriggerSend();
 extern void ResetPower();
 extern void setWifiUpdateMode();
+extern void SetSyncSpam();
 
 extern Display *display;
 
@@ -209,9 +210,11 @@ static void saveValueIndex(bool init)
     {
         case STATE_PACKET:
             config.SetRate(values_index);
+            SetSyncSpam();
             break;
         case STATE_TELEMETRY:
             config.SetTlm(values_index);
+            SetSyncSpam();
             break;
         case STATE_POWERSAVE:
             config.SetMotionMode(values_index);


### PR DESCRIPTION
When changing packet rate via the OLED when connected, the RX would not reconnect because it was locked on.
When we change the rate, we need to call `SetSyncSpam()` like the Lua does.