### PR TITLE
Fix overflow on F1000 TLM 1:2

### DIFF
--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -10,7 +10,7 @@ static char version_domain[20+1+6+1];
 char pwrFolderDynamicName[] = "TX Power (1000 Dynamic)";
 char vtxFolderDynamicName[] = "VTX Admin (OFF:C:1 Aux11 )";
 static char modelMatchUnit[] = " (ID: 00)";
-static char tlmBandwidth[] = " (xxxxbps)";
+static char tlmBandwidth[] = " (xxxxxbps)";
 static const char folderNameSeparator[2] = {' ',':'};
 static const char switchmodeOpts4ch[] = "Wide;Hybrid";
 static const char switchmodeOpts8ch[] = "8ch;16ch Rate/2;12ch Mixed";
@@ -703,6 +703,7 @@ static int event()
 #if defined(TARGET_TX_FM30)
   setLuaTextSelectionValue(&luaBluetoothTelem, !digitalRead(GPIO_PIN_BLUETOOTH_EN));
 #endif
+  luadevUpdateFolderNames();
   return DURATION_IMMEDIATELY;
 }
 
@@ -727,7 +728,6 @@ static int start()
   setLuaStringValue(&luaInfo, luaBadGoodString);
   luaRegisterDevicePingCallback(&luadevUpdateBadGood);
 
-  luadevUpdateFolderNames();
   event();
   return DURATION_IMMEDIATELY;
 }


### PR DESCRIPTION
Whilst running through the test suite, I noticed that at F1000 TLM 1:2 the bandwidth is `19221bps`, clearly bigger than the 4 digits we allowed in the template string!
I also noticed that when I set the TLM to 1:2 and powered off/on the radio it would startup displaying `9921bps` which is the rate for F500, this was because the update call was happening too early in the start function, I moved it to the end of the event function so when changes are made in the TX code and an event fired it will re-calculate the folder strings.