### PR TITLE
Add missing lastSuccessfulPacketRadio

### DIFF
--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -49,6 +49,7 @@ SX127xDriver::SX127xDriver(): SX12xxDriverCommon()
   headerExplMode = false;
   crcEnabled = false;
   lowFrequencyMode = SX1278_HIGH_FREQ;
+  lastSuccessfulPacketRadio = SX12XX_Radio_1;
 }
 
 bool SX127xDriver::Begin()


### PR DESCRIPTION
Fixes 900M on master for single radio modules (non diversity/gemini).