### PR TITLE
Correct RateEnumToHz

### DIFF
--- a/src/include/common.h
+++ b/src/include/common.h
@@ -208,7 +208,6 @@ uint8_t get_elrs_HandsetRate_max(uint8_t rateIndex, uint32_t minInterval);
 
 uint8_t TLMratioEnumToValue(expresslrs_tlm_ratio_e const enumval);
 uint8_t TLMBurstMaxForRateRatio(uint16_t const rateHz, uint8_t const ratioDiv);
-uint16_t RateEnumToHz(expresslrs_RFrates_e const eRate);
 uint8_t enumRatetoIndex(expresslrs_RFrates_e const eRate);
 
 extern uint8_t ExpressLRS_currTlmDenom;

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -294,7 +294,7 @@ static void luadevUpdateTlmBandwidth()
   {
     tlmBandwidth[0] = ' ';
 
-    uint16_t hz = RateEnumToHz(ExpressLRS_currAirRate_Modparams->enum_rate);
+    uint16_t hz = 1000000 / ExpressLRS_currAirRate_Modparams->interval;
     uint8_t ratiodiv = TLMratioEnumToValue(eRatio);
     uint8_t burst = TLMBurstMaxForRateRatio(hz, ratiodiv);
     uint8_t bytesPerCall = OtaIsFullRes ? ELRS8_TELEMETRY_BYTES_PER_CALL : ELRS4_TELEMETRY_BYTES_PER_CALL;

--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -154,15 +154,16 @@ uint8_t TLMBurstMaxForRateRatio(uint16_t const rateHz, uint8_t const ratioDiv)
     return retVal;
 }
 
-
+// The below Hz is the OTA rate.  Not the RC packet rate.  Which will be different for DVDA modes and can be calculated with numOfSends.
 uint16_t RateEnumToHz(expresslrs_RFrates_e const eRate)
 {
     switch(eRate)
     {
     case RATE_FLRC_1000HZ: return 1000;
     case RATE_FLRC_500HZ: return 500;
-    case RATE_DVDA_500HZ: return 500;
-    case RATE_DVDA_250HZ: return 250;
+    case RATE_DVDA_500HZ: return 1000;
+    case RATE_DVDA_250HZ: return 1000;
+    case RATE_DVDA_50HZ: return 200;
     case RATE_LORA_500HZ: return 500;
     case RATE_LORA_333HZ_8CH: return 333;
     case RATE_LORA_250HZ: return 250;

--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -154,30 +154,6 @@ uint8_t TLMBurstMaxForRateRatio(uint16_t const rateHz, uint8_t const ratioDiv)
     return retVal;
 }
 
-// The below Hz is the OTA rate.  Not the RC packet rate.  Which will be different for DVDA modes and can be calculated with numOfSends.
-uint16_t RateEnumToHz(expresslrs_RFrates_e const eRate)
-{
-    switch(eRate)
-    {
-    case RATE_FLRC_1000HZ: return 1000;
-    case RATE_FLRC_500HZ: return 500;
-    case RATE_DVDA_500HZ: return 1000;
-    case RATE_DVDA_250HZ: return 1000;
-    case RATE_DVDA_50HZ: return 200;
-    case RATE_LORA_500HZ: return 500;
-    case RATE_LORA_333HZ_8CH: return 333;
-    case RATE_LORA_250HZ: return 250;
-    case RATE_LORA_200HZ: return 200;
-    case RATE_LORA_150HZ: return 150;
-    case RATE_LORA_100HZ: return 100;
-    case RATE_LORA_100HZ_8CH: return 100;
-    case RATE_LORA_50HZ: return 50;
-    case RATE_LORA_25HZ: return 25;
-    case RATE_LORA_4HZ: return 4;
-    default: return 1;
-    }
-}
-
 uint32_t uidMacSeedGet(void)
 {
     const uint32_t macSeed = ((uint32_t)UID[2] << 24) + ((uint32_t)UID[3] << 16) +

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1368,7 +1368,7 @@ static void updateTelemetryBurst()
         return;
     telemBurstValid = true;
 
-    uint32_t hz = RateEnumToHz(ExpressLRS_currAirRate_Modparams->enum_rate);
+    uint16_t hz = 1000000 / ExpressLRS_currAirRate_Modparams->interval;
     telemetryBurstMax = TLMBurstMaxForRateRatio(hz, ExpressLRS_currTlmDenom);
 
     // Notify the sender to adjust its expected throughput


### PR DESCRIPTION
This PR corrects the OTA rate for DVDA modes.  The rate is used for tlm bps and was being under reported.

It also adds the DVDA 50 mode for Team900.