### PR TITLE
sx1276 errata - Receiver Spurious Reception of a LoRa Signal

### DIFF
--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -146,10 +146,17 @@ void SX127xDriver::SetBandwidthCodingRate(SX127x_Bandwidth bw, SX127x_CodingRate
         //data-sheet errata recommendation http://caxapa.ru/thumbs/972894/SX1276_77_8_ErrataNote_1.1_STD.pdf
         hal.writeRegister(0x36, 0x02, SX12XX_Radio_All);
         hal.writeRegister(0x3a, lowFrequencyMode ? 0x7F : 0x64, SX12XX_Radio_All);
+
+        // 2.3 Receiver Spurious Reception of a LoRa Signal
+        hal.writeRegisterBits(0x31, 0x80, 0x80, SX12XX_Radio_All);
       }
       else
       {
         hal.writeRegister(0x36, 0x03, SX12XX_Radio_All);
+
+        // 2.3 Receiver Spurious Reception of a LoRa Signal
+        // !!! Note - Registers 0x2F and 0x30 also need to be corrected if ELRS every uses other BW.  Check errata. !!!
+        hal.writeRegisterBits(0x31, 0x00, 0x80, SX12XX_Radio_All);
       }
     #endif
 

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -143,20 +143,22 @@ void SX127xDriver::SetBandwidthCodingRate(SX127x_Bandwidth bw, SX127x_CodingRate
     #if !defined(RADIO_SX1272) //does not apply to SX1272
       if (bw == SX127x_BW_500_00_KHZ)
       {
-        //data-sheet errata recommendation http://caxapa.ru/thumbs/972894/SX1276_77_8_ErrataNote_1.1_STD.pdf
+        // Errata 2.1 Sensitivity Optimization with a 500 kHz Bandwidth https://www.semtech.com/products/wireless-rf/lora-connect/sx1276
         hal.writeRegister(0x36, 0x02, SX12XX_Radio_All);
         hal.writeRegister(0x3a, lowFrequencyMode ? 0x7F : 0x64, SX12XX_Radio_All);
 
-        // 2.3 Receiver Spurious Reception of a LoRa Signal
-        hal.writeRegisterBits(0x31, 0x80, 0x80, SX12XX_Radio_All);
+
+        // Errata 2.3 Receiver Spurious Reception of a LoRa Signal - https://www.semtech.com/products/wireless-rf/lora-connect/sx1276
+        hal.writeRegisterBits(SX127X_REG_DETECT_OPTIMIZE, 0x80, 0x80, SX12XX_Radio_All);
       }
       else
       {
+        // Errata 2.1 Sensitivity Optimization with a 500 kHz Bandwidth https://www.semtech.com/products/wireless-rf/lora-connect/sx1276
         hal.writeRegister(0x36, 0x03, SX12XX_Radio_All);
 
-        // 2.3 Receiver Spurious Reception of a LoRa Signal
+        // Errata 2.3 Receiver Spurious Reception of a LoRa Signal - https://www.semtech.com/products/wireless-rf/lora-connect/sx1276
         // !!! Note - Registers 0x2F and 0x30 also need to be corrected if ELRS every uses other BW.  Check errata. !!!
-        hal.writeRegisterBits(0x31, 0x00, 0x80, SX12XX_Radio_All);
+        hal.writeRegisterBits(SX127X_REG_DETECT_OPTIMIZE, 0x00, 0x80, SX12XX_Radio_All);
       }
     #endif
 


### PR DESCRIPTION
While testing it was found bit 7 was not set as default ☹️ 

This could be classed as a bug for maintenance, but should really have some more testing as part of the v3.3 release.

![image](https://user-images.githubusercontent.com/14170229/226147474-8699753e-86fe-4ee3-8132-23c167ff52ea.png)
