### PR TITLE
Power detection fix for TX modules with SKY85321

### DIFF
--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -98,25 +98,25 @@ PowerLevels_e POWERMGNT::decPower()
     return CurrentPower;
 }
 
-void POWERMGNT::incSX1280Ouput()
+void POWERMGNT::incSX1280Output()
 {
-    if (CurrentSX1280Power < 13)
+    if (CurrentSX1280Power < 13 && CurrentSX1280Power < powerValues[CurrentPower] + 2)
     {
         CurrentSX1280Power++;
         Radio.SetOutputPower(CurrentSX1280Power);
     }
 }
 
-void POWERMGNT::decSX1280Ouput()
+void POWERMGNT::decSX1280Output()
 {
-    if (CurrentSX1280Power > -18)
+    if (CurrentSX1280Power > -18 && CurrentSX1280Power > powerValues[CurrentPower] - 2)
     {
         CurrentSX1280Power--;
         Radio.SetOutputPower(CurrentSX1280Power);
     }
 }
 
-int8_t POWERMGNT::currentSX1280Ouput()
+int8_t POWERMGNT::currentSX1280Output()
 {
     return CurrentSX1280Power;
 }

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -100,7 +100,8 @@ PowerLevels_e POWERMGNT::decPower()
 
 void POWERMGNT::incSX1280Output()
 {
-    if (CurrentSX1280Power < 13 && CurrentSX1280Power < powerValues[CurrentPower] + 2)
+    // Power adjustment is capped to within +-3dB of the target power level to prevent power run-away
+    if (CurrentSX1280Power < 13 && CurrentSX1280Power < powerValues[CurrentPower] + 3)
     {
         CurrentSX1280Power++;
         Radio.SetOutputPower(CurrentSX1280Power);
@@ -109,7 +110,8 @@ void POWERMGNT::incSX1280Output()
 
 void POWERMGNT::decSX1280Output()
 {
-    if (CurrentSX1280Power > -18 && CurrentSX1280Power > powerValues[CurrentPower] - 2)
+    // Power adjustment is capped to within +-3dB of the target power level to prevent power run-away
+    if (CurrentSX1280Power > -18 && CurrentSX1280Power > powerValues[CurrentPower] - 3)
     {
         CurrentSX1280Power--;
         Radio.SetOutputPower(CurrentSX1280Power);

--- a/src/lib/POWERMGNT/POWERMGNT.h
+++ b/src/lib/POWERMGNT/POWERMGNT.h
@@ -62,18 +62,55 @@ class POWERMGNT : public PowerLevelContainer
 private:
     static int8_t CurrentSX1280Power;
     static PowerLevels_e FanEnableThreshold;
-    static void updateFan();
 #if defined(PLATFORM_ESP32)
     static nvs_handle  handle;
 #endif
     static void LoadCalibration();
 
 public:
+    /**
+     * @brief Set the power level, constrained to MinPower..MaxPower
+     * 
+     * @param Power the power level to set
+     */
     static void setPower(PowerLevels_e Power);
+
+    /**
+     * @brief Increment to the next higher power level, capped at MaxPower
+     * 
+     * @return PowerLevels_e the new power level
+     */
     static PowerLevels_e incPower();
+
+    /**
+     * @brief Decrement to the next lower power level, capped at MinPower
+     * 
+     * @return PowerLevels_e the new power level
+     */
     static PowerLevels_e decPower();
+
+    /**
+     * @brief Get the currently selected power level
+     * 
+     * @return PowerLevels_e the currently selected power level
+     */
     static PowerLevels_e currPower() { return CurrentPower; }
+
+    /**
+     * @brief Get the MinPower level supported by this device
+     * 
+     * @return PowerLevels_e the minimum power level supported
+     */
     static PowerLevels_e getMinPower() { return MinPower; }
+
+    /**
+     * @brief Get the MaxPower level supported by this device.
+     * For devices that support the HighPower override, i.e. R9M with the fan hack,
+     * the MaxPower is normally HighPower unless the 'unlock_higher_power' option
+     * is set at compile time.
+     * 
+     * @return PowerLevels_e the maximum power level supported
+     */
     static PowerLevels_e getMaxPower() {
         #if defined(TARGET_RX)
             return MaxPower;
@@ -81,13 +118,53 @@ public:
             return firmwareOptions.unlock_higher_power ? MaxPower : HighPower;
         #endif
     }
-    static void incSX1280Ouput();
-    static void decSX1280Ouput();
-    static int8_t currentSX1280Ouput();
+
+    /**
+     * @brief Get the Default power level for this device
+     * 
+     * @return PowerLevels_e the default power level
+     */
     static PowerLevels_e getDefaultPower();
-    static uint8_t getPowerIndBm();
+
+    /**
+     * @brief Set the output power to the default power level
+     */
     static void setDefaultPower();
+
+    /**
+     * @brief Get the currently configured power level in dBm
+     * 
+     * @return uint8_t the dBm for the current power level
+     */
+    static uint8_t getPowerIndBm();
+
+    /**
+     * @brief increment the SX1280 power level by 1 dBm, capped to 3dBm above the selected power level
+     */
+    static void incSX1280Output();
+
+    /**
+     * @brief decrement the SX1280 power level by 1 dBm, capped to 3dBm below the selected power level
+     */
+    static void decSX1280Output();
+
+    /**
+     * @brief Get the current value given to the SX1280 for it's output power.
+     * This value may have been adjusted up/dowm from nominal by the PDET routine, if supported
+     * by the device (i.e. modules with SKY85321 PA/LNA)
+     * 
+     * @return int8_t the current (adjusted) SX1280 power level
+     */
+    static int8_t currentSX1280Output();
+
+    /**
+     * @brief Initialise the power management subsystem.
+     * Configures PWM ouptut pins, DACs, loads power calibration settings
+     * and sets output power to the default power level as appropriate for the
+     * device
+     */
     static void init();
+
     static void SetPowerCaliValues(int8_t *values, size_t size);
     static void GetPowerCaliValues(int8_t *values, size_t size);
 };

--- a/src/lib/POWER_DETECT/devPDET.cpp
+++ b/src/lib/POWER_DETECT/devPDET.cpp
@@ -39,11 +39,11 @@ static int start()
 
 /**
  * @brief Event callback for PDET device.
- * 
+ *
  * If the module is running in the "normal" mode, i.e. with the radio outputting RF,
  * then set the initial duration to immediately call the 'timeout' function.
- * Otherwise set the diration to never call the power detection/adjustment 'timeout' function.
- * 
+ * Otherwise set the duration to never call the power detection/adjustment 'timeout' function.
+ *
  * @return int duration in ms to call the 'timeout' function
  */
 static int event()

--- a/src/lib/POWER_DETECT/devPDET.cpp
+++ b/src/lib/POWER_DETECT/devPDET.cpp
@@ -1,4 +1,5 @@
 #include "targets.h"
+#include "common.h"
 #include "device.h"
 #include "logging.h"
 #include "POWERMGNT.h"
@@ -36,9 +37,27 @@ static int start()
     return DURATION_NEVER;
 }
 
+/**
+ * @brief Event callback for PDET device.
+ * 
+ * If the module is running in the "normal" mode, i.e. with the radio outputting RF,
+ * then set the initial duration to immediately call the 'timeout' function.
+ * Otherwise set the diration to never call the power detection/adjustment 'timeout' function.
+ * 
+ * @return int duration in ms to call the 'timeout' function
+ */
+static int event()
+{
+    if (GPIO_PIN_PA_PDET == UNDEF_PIN || connectionState > connectionState_e::MODE_STATES)
+    {
+        return DURATION_NEVER;
+    }
+    return DURATION_IMMEDIATELY;
+}
+
 static int timeout()
 {
-    if (!busyTransmitting) return PDET_BUSY_PERIODMS;
+    if (!busyTransmitting) return DURATION_IMMEDIATELY;
 
     pdet_storage_t newPdetScaled = PDET_MV_SCALE(analogReadMilliVolts(GPIO_PIN_PA_PDET));
 
@@ -59,14 +78,14 @@ static int timeout()
     pdet_storage_t targetPowerDbmScaled = PDET_DBM_SCALE(targetPowerDbm);
     DBGVLN("PdetMv=%u dBm=%u", PdetMvScaled, dBmScaled);
 
-    if (dBmScaled < (targetPowerDbmScaled - PDET_HYSTERESIS_DBMSCALED) && POWERMGNT::currentSX1280Ouput() < SKY85321_MAX_DBM_INPUT)
+    if (dBmScaled < (targetPowerDbmScaled - PDET_HYSTERESIS_DBMSCALED) && POWERMGNT::currentSX1280Output() < SKY85321_MAX_DBM_INPUT)
     {
-        POWERMGNT::incSX1280Ouput();
+        POWERMGNT::incSX1280Output();
         PdetMvScaled = 0;
     }
     else if (dBmScaled > (targetPowerDbmScaled + PDET_HYSTERESIS_DBMSCALED))
     {
-        POWERMGNT::decSX1280Ouput();
+        POWERMGNT::decSX1280Output();
         PdetMvScaled = 0;
     }
 
@@ -76,7 +95,7 @@ static int timeout()
 device_t PDET_device = {
     .initialize = NULL,
     .start = start,
-    .event = NULL,
+    .event = event,
     .timeout = timeout
 };
 #endif


### PR DESCRIPTION
# Problem
On FLRC you could see the power every now and then, bump up by 1dB

There are actually a couple of problems with the PDET device:
1. There was no limit to the increment (other than max power) so even starting at 10mW the device would eventually go to max power.
2. The timing was set up so that a device would likely not be transmitting when the detection started and we would decide to wait. The problem is that at 1000Hz we have a 1ms window and the delay is specified in units of 1ms so we would be unlikely to converge on a time were both start and end of reading the ADC was lined up.

# Solution
1. put a 3dB limit on inc/dec for the power level from their configured level.
2. When we are looking for a time to start reading ADC if the radio is not transmitting, return `DURATION_IMMEDIATE` so the PDET function would converge as fast as possible.