### PR TITLE
Fix attenuation for some ESP32 pins

### DIFF
--- a/src/lib/AnalogVbat/devAnalogVbat.cpp
+++ b/src/lib/AnalogVbat/devAnalogVbat.cpp
@@ -32,6 +32,10 @@ static int start()
         return DURATION_NEVER;
     }
     vbatUpdateScale = 1;
+#if defined(PLATFORM_ESP32)
+    analogSetPinAttenuation(GPIO_ANALOG_VBAT, ADC_0db);
+    analogSetWidth(12);
+#endif
     return VBAT_SAMPLE_INTERVAL;
 }
 
@@ -40,7 +44,7 @@ static void reportVbat()
     uint32_t adc = vbatSmooth.calc_scaled();
     uint16_t vbat;
     // For negative offsets, anything between abs(OFFSET)*CNT and 0 is considered 0
-    if (ANALOG_VBAT_OFFSET < 0 && adc <= (ANALOG_VBAT_OFFSET * -VBAT_SMOOTH_CNT))
+    if (ANALOG_VBAT_OFFSET < 0 && adc <= (ANALOG_VBAT_OFFSET * -vbatSmooth.scale()))
         vbat = 0;
     else
         vbat = adc * 100U / (ANALOG_VBAT_SCALE * vbatSmooth.scale());


### PR DESCRIPTION
During the testing of a new target, it was found that some ADC pins are not using the 0dB attenuation that we have set our code up for, so this always sets the attenuation to 0dB for ADC pins used for VBAT measurement on ESP32 devices.

Also whilst testing said new target, it was found that at low voltages (1S i.e. 3.8V) the VBAT code was setting it to zero. This was simply a bug using the wrong scale value for the cutoff calculation. As the median calculator discards the min/max values from it's calculation so the sum is actually based on the MedianAvgFilter's scale NOT the configured number of elements in the moving average window.
