### PR TITLE
Update tag for "closing" stale issues.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           days-before-issue-stale: -1
           days-before-issue-close: 12
-          stale-issue-label: "closing"
+          stale-issue-label: "closing :door:"
           close-issue-message: "This issue was closed because it has been inactive for 12 days since being marked as closing."
           days-before-pr-stale: -1
           days-before-pr-close: -1


### PR DESCRIPTION
Fix the workflow for closing stale tickets. This was broken because of the icons in the label names.