### PR TITLE
Remove redundant code post maint merge

### DIFF
--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -390,11 +390,6 @@ void ICACHE_RAM_ATTR SX127xDriver::TXnb(uint8_t * data, uint8_t size, SX12XX_Rad
   // }
   SetMode(SX127x_OPMODE_STANDBY, SX12XX_Radio_All);
 
-  if (radioNumber == SX12XX_Radio_NONE)
-  {
-      radioNumber = lastSuccessfulPacketRadio;
-  }
-
   RFAMP.TXenable(radioNumber);
   hal.writeRegister(SX127X_REG_FIFO_ADDR_PTR, SX127X_FIFO_TX_BASE_ADDR_MAX, radioNumber);
   hal.writeRegister(SX127X_REG_FIFO, data, size, radioNumber);


### PR DESCRIPTION
With the change to using `SX12XX_Radio_NONE` it means `TXnb` isnt called when no radio is set to transmit. 