### PR TITLE
tempFC was wrongly set unsigned

### DIFF
--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -157,7 +157,7 @@ uint8_t TLMBurstMaxForRateRatio(uint16_t const rateHz, uint8_t const ratioDiv)
 uint32_t uidMacSeedGet(void)
 {
     const uint32_t macSeed = ((uint32_t)UID[2] << 24) + ((uint32_t)UID[3] << 16) +
-                             ((uint32_t)UID[4] << 8) + UID[5]^OTA_VERSION_ID;
+                             ((uint32_t)UID[4] << 8) + (UID[5]^OTA_VERSION_ID);
     return macSeed;
 }
 

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -493,9 +493,9 @@ bool ICACHE_RAM_ATTR HandleSendTelemetryResponse()
     return true;
 }
 
-uint32_t ICACHE_RAM_ATTR HandleFreqCorr(bool value)
+int32_t ICACHE_RAM_ATTR HandleFreqCorr(bool value)
 {
-    uint32_t tempFC = FreqCorrection;
+    int32_t tempFC = FreqCorrection;
     if (Radio.GetProcessingPacketRadio() == SX12XX_Radio_2)
     {
         tempFC = FreqCorrection_2;
@@ -1163,7 +1163,7 @@ static void setupSerial()
     {
         sumdSerialOutput = true;
         serialBaud = 115200;
-    }		
+    }
     bool invert = config.GetSerialProtocol() == PROTOCOL_SBUS || config.GetSerialProtocol() == PROTOCOL_INVERTED_CRSF;
 
 #ifdef PLATFORM_STM32


### PR DESCRIPTION
During the `HandleFreqCorr()` the signed `FreqCorrection` was stored and compared against unsigned `tempFC`, which was possibly have caused problems in 900M links

Additionally in `common.cpp`, I made `^` parenthesized in the expression, just to be make sure.