### PR TITLE
Fix RF power-creep on TTGOv2 TX

### DIFF
--- a/src/hardware/TX/DIY 900 TTGO V2.json
+++ b/src/hardware/TX/DIY 900 TTGO V2.json
@@ -13,7 +13,6 @@
     "power_default": 2,
     "power_control": 0,
     "power_values": [8,12,15],
-    "button": 39,
     "screen_sck": 22,
     "screen_sda": 21,
     "screen_type": 1,


### PR DESCRIPTION
When using a TTGOv2 dev board as a TX, the RF power slowly increases of it's own accord, as if dynamic power is turned on, even though it is not.
This is a result of a define in the target file for the `button` pin, which is typically connected to the 5way selector on a module that has a screen.
The unused `button` pin was floating, and thus triggering random false "presses", which I assume is changing settings and cause power to increase.
Removing the define in the TX target for TTGO has fixed the problem in my testing.
![Screenshot_7](https://user-images.githubusercontent.com/59873510/232044501-8b8d4b7c-bf97-4626-9085-ed2cd81dea7d.png)
