### PR TITLE
Max rate of external module on 115k baud is 150Hz

### DIFF
--- a/src/include/common.h
+++ b/src/include/common.h
@@ -142,7 +142,7 @@ typedef struct expresslrs_mod_settings_s
     uint8_t cr;
     expresslrs_tlm_ratio_e TLMinterval;        // every X packets is a response TLM packet, should be a power of 2
     uint8_t FHSShopInterval;    // every X packets we hop to a new frequency. Max value of 16 since only 4 bits have been assigned in the sync package.
-    uint32_t interval;          // interval in us seconds that corresponds to that frequency
+    int32_t interval;           // interval in us seconds that corresponds to that frequency
     uint8_t PreambleLen;
     uint8_t PayloadLength;      // Number of OTA bytes to be sent.
     uint8_t numOfSends;         // Number of packets to send.

--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -65,7 +65,7 @@ bool CRSF::elrsLUAmode = false;
 
 /// OpenTX mixer sync ///
 uint32_t CRSF::OpenTXsyncLastSent = 0;
-uint32_t CRSF::RequestedRCpacketInterval = 5000; // default to 200hz as per 'normal'
+int32_t CRSF::RequestedRCpacketInterval = 5000; // default to 200hz as per 'normal'
 volatile uint32_t CRSF::RCdataLastRecv = 0;
 volatile int32_t CRSF::OpenTXsyncOffset = 0;
 volatile int32_t CRSF::OpenTXsyncWindow = 0;
@@ -284,7 +284,7 @@ void ICACHE_RAM_ATTR CRSF::sendTelemetryToTX(uint8_t *data)
     }
 }
 
-void ICACHE_RAM_ATTR CRSF::setSyncParams(uint32_t PacketInterval)
+void ICACHE_RAM_ATTR CRSF::setSyncParams(int32_t PacketInterval)
 {
     CRSF::RequestedRCpacketInterval = PacketInterval;
     CRSF::OpenTXsyncOffset = 0;
@@ -340,7 +340,7 @@ void ICACHE_RAM_ATTR CRSF::sendSyncPacketToTX() // in values in us.
     uint32_t now = millis();
     if (CRSF::CRSFstate && (now - OpenTXsyncLastSent) >= OpenTXsyncPacketInterval)
     {
-        uint32_t packetRate = CRSF::RequestedRCpacketInterval * 10; //convert from us to right format
+        int32_t packetRate = CRSF::RequestedRCpacketInterval * 10; //convert from us to right format
         int32_t offset = CRSF::OpenTXsyncOffset - CRSF::OpenTXsyncOffsetSafeMargin; // offset so that opentx always has some headroom
 #ifdef DEBUG_OPENTX_SYNC
         DBGLN("Offset %d", offset); // in 10ths of us (OpenTX sync unit)

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -70,7 +70,7 @@ public:
 
     ///// Variables for OpenTX Syncing //////////////////////////
     #define OpenTXsyncPacketInterval 200 // in ms
-    static void ICACHE_RAM_ATTR setSyncParams(uint32_t PacketInterval);
+    static void ICACHE_RAM_ATTR setSyncParams(int32_t PacketInterval);
     static void ICACHE_RAM_ATTR JustSentRFpacket();
     static void ICACHE_RAM_ATTR sendSyncPacketToTX();
     static void disableOpentxSync();
@@ -101,7 +101,7 @@ private:
 
 #if CRSF_TX_MODULE
     /// OpenTX mixer sync ///
-    static uint32_t RequestedRCpacketInterval;
+    static int32_t RequestedRCpacketInterval;
     static volatile uint32_t RCdataLastRecv;
     static volatile uint32_t dataLastRecv;
     static volatile int32_t OpenTXsyncOffset;

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -320,7 +320,11 @@ void ICACHE_RAM_ATTR GenerateSyncPacketData(OTA_Sync_s * const syncPtr)
 uint8_t adjustPacketRateForBaud(uint8_t rateIndex)
 {
   #if defined(RADIO_SX128X)
-    if (crsf.GetCurrentBaudRate() == 115200) // Packet rate limited to 250Hz if we are on 115k baud
+    if (crsf.GetCurrentBaudRate() == 115200 && GPIO_PIN_RCSIGNAL_RX == GPIO_PIN_RCSIGNAL_TX) // Packet rate limited to 150Hz if we are on 115k baud on external module
+    {
+      rateIndex = get_elrs_HandsetRate_max(rateIndex, 6666);
+    }
+    else if (crsf.GetCurrentBaudRate() == 115200) // Packet rate limited to 250Hz if we are on 115k baud (on internal module)
     {
       rateIndex = get_elrs_HandsetRate_max(rateIndex, 4000);
     }
@@ -538,14 +542,14 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
     }
   }
 
-#if defined(Regulatory_Domain_EU_CE_2400) 
+#if defined(Regulatory_Domain_EU_CE_2400)
   transmittingRadio &= ChannelIsClear(transmittingRadio);   // weed out the radio(s) if channel in use
-  
+
 	if (transmittingRadio == SX12XX_Radio_NONE)               // don't send packet if no radio available
   {                                                         // but do status update (issue #2028)
 		Radio.TXdoneCallback();
   }
-	else		
+	else
 #endif
   {
     Radio.TXnb((uint8_t*)&otaPkt, ExpressLRS_currAirRate_Modparams->PayloadLength, transmittingRadio);


### PR DESCRIPTION
From 3.1.0 115k baud external modules no longer support 250Hz, so we've reduced the max air rate for them to 150Hz.
Also fix signed-ness calculations for OpenTX sync offset.

Fixes #2010
