### PR TITLE
esp32 rx - allow non uart0 pins for serial setup

### DIFF
--- a/src/include/targets.h
+++ b/src/include/targets.h
@@ -226,7 +226,7 @@
 #ifndef GPIO_PIN_RCSIGNAL_RX_SBUS
 #define GPIO_PIN_RCSIGNAL_RX_SBUS UNDEF_PIN
 #endif
-#if defined(PLATFORM_ESP8266) || defined(PLATFORM_ESP32)
+#if defined(PLATFORM_ESP8266)
 #ifndef GPIO_PIN_DEBUG_RX
 #define GPIO_PIN_DEBUG_RX       3
 #endif

--- a/src/include/targets.h
+++ b/src/include/targets.h
@@ -226,7 +226,7 @@
 #ifndef GPIO_PIN_RCSIGNAL_RX_SBUS
 #define GPIO_PIN_RCSIGNAL_RX_SBUS UNDEF_PIN
 #endif
-#if defined(PLATFORM_ESP8266)
+#if defined(PLATFORM_ESP8266) || defined(PLATFORM_ESP32)
 #ifndef GPIO_PIN_DEBUG_RX
 #define GPIO_PIN_DEBUG_RX       3
 #endif

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1246,7 +1246,7 @@ static void setupSerial()
     Serial.begin(serialBaud, config, mode, -1, invert);
 #elif defined(PLATFORM_ESP32)
     uint32_t config = sbusSerialOutput ? SERIAL_8E2 : SERIAL_8N1;
-    Serial.begin(serialBaud, config, -1, -1, invert);
+    Serial.begin(serialBaud, config, GPIO_PIN_DEBUG_RX, GPIO_PIN_DEBUG_TX, invert);
 #endif
 
     if (firmwareOptions.is_airport)

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1246,7 +1246,7 @@ static void setupSerial()
     Serial.begin(serialBaud, config, mode, -1, invert);
 #elif defined(PLATFORM_ESP32)
     uint32_t config = sbusSerialOutput ? SERIAL_8E2 : SERIAL_8N1;
-    Serial.begin(serialBaud, config, GPIO_PIN_DEBUG_RX, GPIO_PIN_DEBUG_TX, invert);
+    Serial.begin(serialBaud, config, GPIO_PIN_RCSIGNAL_RX, GPIO_PIN_RCSIGNAL_TX, invert);
 #endif
 
     if (firmwareOptions.is_airport)


### PR DESCRIPTION
When the rx and tx pins are changed via the hardware UI, they now actually change.