### PR TITLE
Reduce screen update frequency when running Lua

### DIFF
--- a/src/lua/elrsV3.lua
+++ b/src/lua/elrsV3.lua
@@ -500,6 +500,11 @@ local function parseParameterInfoMessage(data)
     if #loadQ == 0 then
       createDeviceFields()
     end
+
+    -- Return value is if the screen should be updated
+    -- If deviceId is TX module, then the Bad/Good drives the update; for other
+    -- devices update each new item. and always update when the queue empties
+    return deviceId ~= 0xEE or #loadQ == 0
   end
 end
 
@@ -537,21 +542,27 @@ local function parseElrsV1Message(data)
 end
 
 local function refreshNext()
-  local command, data = crossfireTelemetryPop()
-  if command == 0x29 then
-    parseDeviceInfoMessage(data)
-  elseif command == 0x2B then
-    parseParameterInfoMessage(data)
-    if #loadQ > 0 then
-      fieldTimeout = 0 -- request next chunk immediately
-    elseif fieldPopup then
-      fieldTimeout = getTime() + fieldPopup.timeout
+  local command, data, forceRedraw
+  repeat
+    command, data = crossfireTelemetryPop()
+    if command == 0x29 then
+      parseDeviceInfoMessage(data)
+    elseif command == 0x2B then
+      if parseParameterInfoMessage(data) then
+        forceRedraw = true
+      end
+      if #loadQ > 0 then
+        fieldTimeout = 0 -- request next chunk immediately
+      elseif fieldPopup then
+        fieldTimeout = getTime() + fieldPopup.timeout
+      end
+    elseif command == 0x2D then
+      parseElrsV1Message(data)
+    elseif command == 0x2E then
+      parseElrsInfoMessage(data)
+      forceRedraw = true
     end
-  elseif command == 0x2D then
-    parseElrsV1Message(data)
-  elseif command == 0x2E then
-    parseElrsInfoMessage(data)
-  end
+  until command == nil
 
   local time = getTime()
   if fieldPopup then
@@ -559,7 +570,8 @@ local function refreshNext()
       crossfireTelemetryPush(0x2D, { deviceId, handsetId, fieldPopup.id, 6 }) -- lcsQuery
       fieldTimeout = time + fieldPopup.timeout
     end
-  elseif time > devicesRefreshTimeout and fields_count < 1  then
+  elseif time > devicesRefreshTimeout and fields_count < 1 then
+    forceRedraw = true -- handles initial screen draw
     devicesRefreshTimeout = time + 100 -- 1s
     crossfireTelemetryPush(0x28, { 0x00, 0xEA })
   elseif time > linkstatTimeout then
@@ -580,7 +592,10 @@ local function refreshNext()
     -- if elrsFlags bit set is bit higher than bit 0 and bit 1, it is warning flags
     titleShowWarn = (elrsFlags > 3 and not titleShowWarn) or nil
     titleShowWarnTimeout = time + 100
+    forceRedraw = true
   end
+
+  return forceRedraw
 end
 
 local lcd_title -- holds function that is color/bw version
@@ -699,7 +714,7 @@ local function handleDevicePageEvent(event)
   if event == EVT_VIRTUAL_EXIT then -- Cancel edit / go up a folder / reload all
     if edit then
       edit = nil
-      reloadCurField(0)
+      reloadCurField()
     else
       if folderAccess == nil and #loadQ == 0 then -- only do reload if we're in the root folder and finished loading
         if deviceId ~= 0xEE then
@@ -930,14 +945,14 @@ local function run(event, touchState)
     return 2
   end
 
+  local forceRedraw = refreshNext()
+
   event = (touch2evt and touch2evt(event, touchState)) or event
   if fieldPopup ~= nil then
     runPopupPage(event)
-  else
+  elseif event ~= 0 or forceRedraw or edit then
     runDevicePage(event)
   end
-
-  refreshNext()
 
   return exitscript
 end

--- a/src/lua/elrsV3.lua
+++ b/src/lua/elrsV3.lua
@@ -622,7 +622,6 @@ local function lcd_title_color()
   lcd.setColor(CUSTOM_COLOR, BLACK)
   if titleShowWarn then
     lcd.drawText(textXoffset + 1, 4, elrsFlagsInfo, CUSTOM_COLOR)
-    lcd.drawText(LCD_W - textSize - 5, 4, tostring(elrsFlags), RIGHT + BOLD + CUSTOM_COLOR)
   else
     local title = fields_count > 0 and deviceName or "Loading..."
     lcd.drawText(textXoffset + 1, 4, title, CUSTOM_COLOR)

--- a/src/lua/elrsV3.lua
+++ b/src/lua/elrsV3.lua
@@ -641,9 +641,7 @@ local function lcd_title_bw()
   lcd.clear()
   -- B&W screen
   local barHeight = 9
-  if titleShowWarn then
-    lcd.drawText(LCD_W, 1, tostring(elrsFlags), RIGHT)
-  else
+  if not titleShowWarn then
     lcd.drawText(LCD_W - 1, 1, goodBadPkt, RIGHT)
     lcd.drawLine(LCD_W - 10, 0, LCD_W - 10, barHeight-1, SOLID, INVERS)
   end


### PR DESCRIPTION
This reduces the redraw frequency when running the Lua script. Currently we redraw the whole thing every call, and it takes so long on colorlcd that it nearly doubles the amount of time it takes for the screen to fully load (since EdgeTX 2.8) and it sucks. The screen will be updated:
* Every time the bad/good counter is updated (every second)
* If there is an input event to react to
* While in edit mode (so the field can blink properly)
* When loading completes
* When the title bar needs to switch between normal and warning modes (!!ARMED!! or Model Mismatch)
* When each remote config item fully loads

For discussion because: Which do we want, twice as fast or the progress bar to go more smoothly?

### Details
Drawing the screen on colorlcd takes about 60ms, which is a ton of missed telemetry intervals that could have been used to actually transfer data. Load times for B&W screens are in the neighborhood of 3-3.5s because drawing text happen an order of magnitude faster, compared to around 6s on colorlcd. Ideally we would only update the portions of the screen that have changed, but that's pretty complex and we can not add much to the Lua as it is teetering on the edge of running out of memory on some handsets.

Methods tested (on colorlcd)
* Unmodified: 44 calls to update() completed in 5.43s, starting from after the deviceInfo is received
* Update only if new data was received via `crossfireTelemetryPop()`: 44 calls / 5.4s. Literally every time there was new data
* Update every time a new config item is fully received: 42 updates / 5.2s. Almost every pop contains a whole new item
* Don't draw if telemetryPushed, so it can be sent without delay: 2 updates in 2.9s but did not update the screen at all while loading
* Update every 400ms: 7 updates / 3.24s
* Update only every Bad/Good update: 4 updates / 3.0-3.2s

I've gone with the last option there as the main trigger, with the full list at the top of the PR. **This code is used on B&W screens too**, which now can load in ~2.5s. It isn't really needed, but it is faster and I don't want to add more code just to see 44 progress bar updates. 😄 There's only like 5 lines of changes in this PR, so I kept it toight! It does appear that there's less RAM being used on B&W thanks to not redrawing every loop too, so this may help with that as well.

Where the code reads the `crossfireTelemetryPop()` has also been changed to a loop, because multiple packets can be queued up and we can handle them all in one `update()` without delaying 100ms/160ms in between.

### Timing (colorlcd)
* lcd.clear() ~10ms
* lcd_title() ~20ms
* Just not drawing any config items (but still iterating through them ~20ms
* Full screen draw 50-60ms

### Tested
* TX16S internal module
* ES900TX external module on colorlcd
* Taranis Q X7 on OpenTX 2.3.12 w/ SIYI FM30 external
* Boxer internal
* Jumper T-Pro AION TX
* DUPLETX_ESP running as an internal module on EdgeTX 2.6

### Unrelated changes
I removed our binary error code from the warning title bar. This was confusing people who thought `Model Mismatch       8` meant that they needed to set their model number to 8. Nobody needs that number. Less code too!

_Thanks to @pkendall64 for suggesting "I think drawing the screen every loop is what makes it take so long", and I frowned my disbelief frown because drawing 10 lines of text can't take 3 seconds right?! He was right_