### PR TITLE
Implement failsafe modes for SBUS

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -166,7 +166,7 @@
 @@if not isTX:
 			<div class="mui-tabs__pane" id="pane-justified-3">
 				<div class="mui-panel">
-					<div id="pwm_tab">
+					<div id="model_tab">
 						<h2>PWM Output</h2>
 						Set PWM output mode and failsafe positions.
 						<ul>
@@ -205,6 +205,23 @@
 								<label>Serial Protocol</label>
 							</div>
 						</div>
+						<div id="sbus-config" style="display: none;">
+							<h2>SBUS Failsafe</h2>
+							Set the failsafe behaviour when using the SBUS protocol:<br/>
+							<ul>
+								<li>"No Pulses" stops sending SBUS data when a connection to the transmitter is lost</li>
+								<li>"Last Position" continues to send the last received channel data along with the FAILSAFE bit set</li>
+							</ul>
+							<br/>
+							<div class="mui-select">
+								<select id='sbus-failsafe' name='serial-failsafe'>
+									<option value='0'>No Pulses</option>
+									<option value='1'>Last Position</option>
+								</select>
+								<label>SBUS Failsafe</label>
+							</div>
+						</div>
+
 						<h2>Model Match</h2>
 						Specify the 'Receiver' number in OpenTX/EdgeTX model setup page and turn on the 'Model Match'
 						in the ExpressLRS Lua script for that model. 'Model Match' is between 0 and 63 inclusive.

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -50,7 +50,7 @@ function enumSelectGenerate(id, val, arOptions) {
 @@if not isTX:
 function updatePwmSettings(arPwm) {
   if (arPwm === undefined) {
-    if (_('pwm_tab')) _('pwm_tab').style.display = 'none';
+    if (_('model_tab')) _('model_tab').style.display = 'none';
     return;
   }
   var pin1Index = undefined;
@@ -224,7 +224,7 @@ function updateConfig(data) {
     storedModelId = 255;
   }
   _('modelid').value = storedModelId;
-  _('force-tlm').checked = data.hasOwnProperty('forcetlm') && data.forcetlm;
+  _('force-tlm').checked = data.hasOwnProperty('force-tlm') && data.forcetlm;
   _('serial-protocol').onchange = () => {
     if (_('serial-protocol').value == 0 || _('serial-protocol').value == 1) {
       _('rcvr-uart-baud').disabled = false;
@@ -237,6 +237,8 @@ function updateConfig(data) {
     else {
       _('rcvr-uart-baud').disabled = true;
       _('rcvr-uart-baud').value = '100000';
+      _('sbus-config').style.display = 'block';
+      _('sbus-failsafe').value = data['sbus-failsafe'];
     }
   }
   updatePwmSettings(data.pwm);
@@ -519,9 +521,10 @@ if (_('config') != undefined) {
         xmlhttp.setRequestHeader('Content-Type', 'application/json');
         return JSON.stringify({
           "pwm": getPwmFormData(),
-          "protocol": +_('serial-protocol').value,
+          "serial-protocol": +_('serial-protocol').value,
+          "sbus-failsafe": +_('sbus-failsafe').value,
           "modelid": +_('modelid').value,
-          "forcetlm": +_('force-tlm').checked
+          "force-tlm": +_('force-tlm').checked
         });
       }));
 }

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -188,6 +188,13 @@ enum eSerialProtocol : uint8_t
 	PROTOCOL_SUMD
 };
 
+enum eFailsafeMode : uint8_t
+{
+    FAILSAFE_NO_PULSES,
+    FAILSAFE_LAST_POSITION,
+    FAILSAFE_SET_POSITION
+};
+
 #ifndef UNIT_TEST
 #if defined(RADIO_SX127X)
 #define RATE_MAX 6

--- a/src/lib/CONFIG/config.cpp
+++ b/src/lib/CONFIG/config.cpp
@@ -1019,4 +1019,13 @@ void RxConfig::SetSerialProtocol(eSerialProtocol serialProtocol)
         m_modified = true;
     }
 }
+
+void RxConfig::SetFailsafeMode(eFailsafeMode failsafeMode)
+{
+    if (m_config.failsafeMode != failsafeMode)
+    {
+        m_config.failsafeMode = failsafeMode;
+        m_modified = true;
+    }
+}
 #endif

--- a/src/lib/CONFIG/config.h
+++ b/src/lib/CONFIG/config.h
@@ -202,8 +202,9 @@ typedef struct {
                 forceTlmOff:1,
                 rateInitialIdx:4;   // Rate to start rateCycling at on boot
     uint8_t     modelId;
-    uint8_t     serialProtocol:3,
-                unused:5;
+    uint8_t     serialProtocol:4,
+                failsafeMode:2,
+                unused:2;
     rx_config_pwm_t pwmChannels[PWM_MAX_CHANNELS];
 } rx_config_t;
 
@@ -231,6 +232,7 @@ public:
     bool GetForceTlmOff() const { return m_config.forceTlmOff; }
     uint8_t GetRateInitialIdx() const { return m_config.rateInitialIdx; }
     eSerialProtocol GetSerialProtocol() const { return (eSerialProtocol)m_config.serialProtocol; }
+    eFailsafeMode GetFailsafeMode() const { return (eFailsafeMode)m_config.failsafeMode; }
 
     // Setters
     void SetIsBound(bool isBound);
@@ -250,6 +252,7 @@ public:
     void SetForceTlmOff(bool forceTlmOff);
     void SetRateInitialIdx(uint8_t rateInitialIdx);
     void SetSerialProtocol(eSerialProtocol serialProtocol);
+    void SetFailsafeMode(eFailsafeMode failsafeMode);
 
 private:
     void UpgradeEepromV4();

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -22,6 +22,13 @@ static struct luaItem_selection luaSerialProtocol = {
     STR_EMPTYSPACE
 };
 
+static struct luaItem_selection luaFailsafeMode = {
+    {"Failsafe Mode", CRSF_TEXT_SELECTION},
+    0, // value
+    "No Pulses;Last Pos",
+    STR_EMPTYSPACE
+};
+
 #if defined(POWER_OUTPUT_VALUES)
 static struct luaItem_selection luaTlmPower = {
     {"Tlm Power", CRSF_TEXT_SELECTION},
@@ -289,6 +296,13 @@ static void registerLuaParameters()
     }
   });
 
+  if (config.GetSerialProtocol() == PROTOCOL_SBUS || config.GetSerialProtocol() == PROTOCOL_INVERTED_SBUS)
+  {
+    registerLUAParameter(&luaFailsafeMode, [](struct luaPropertiesCommon* item, uint8_t arg){
+      config.SetFailsafeMode((eFailsafeMode)arg);
+    });
+  }
+
   if (GPIO_PIN_ANT_CTRL != UNDEF_PIN)
   {
     registerLUAParameter(&luaAntennaMode, [](struct luaPropertiesCommon* item, uint8_t arg){
@@ -350,6 +364,7 @@ static void registerLuaParameters()
 static int event()
 {
   setLuaTextSelectionValue(&luaSerialProtocol, config.GetSerialProtocol());
+  setLuaTextSelectionValue(&luaFailsafeMode, config.GetFailsafeMode());
 
   if (GPIO_PIN_ANT_CTRL != UNDEF_PIN)
   {

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -315,8 +315,9 @@ static void GetConfiguration(AsyncWebServerRequest *request)
     json["config"]["mode"] = wifiMode == WIFI_STA ? "STA" : "AP";
     #if defined(TARGET_RX)
     json["config"]["serial-protocol"] = config.GetSerialProtocol();
+    json["config"]["sbus-failsafe"] = config.GetFailsafeMode();
     json["config"]["modelid"] = config.GetModelId();
-    json["config"]["forcetlm"] = config.GetForceTlmOff();
+    json["config"]["force-tlm"] = config.GetForceTlmOff();
     #if defined(GPIO_PIN_PWM_OUTPUTS)
     for (uint8_t ch=0; ch<GPIO_PIN_PWM_OUTPUTS_COUNT; ++ch)
     {
@@ -434,16 +435,20 @@ static void WebUpdateButtonColors(AsyncWebServerRequest *request, JsonVariant &j
 #else
 static void UpdateConfiguration(AsyncWebServerRequest *request, JsonVariant &json)
 {
-  uint8_t protocol = json["protocol"] | 0;
+  uint8_t protocol = json["serial-protocol"] | 0;
   DBGLN("Setting serial protocol %u", protocol);
   config.SetSerialProtocol((eSerialProtocol)protocol);
+
+  uint8_t failsafe = json["sbus-failsafe"] | 0;
+  DBGLN("Setting SBUS failsafe mode %u", failsafe);
+  config.SetFailsafeMode((eFailsafeMode)failsafe);
 
   long modelid = json["modelid"] | 255;
   if (modelid < 0 || modelid > 63) modelid = 255;
   DBGLN("Setting model match id %u", (uint8_t)modelid);
   config.SetModelId((uint8_t)modelid);
 
-  long forceTlm = json["forcetlm"] | 0;
+  long forceTlm = json["force-tlm"] | 0;
   DBGLN("Setting force telemetry %u", (uint8_t)forceTlm);
   config.SetForceTlmOff(forceTlm != 0);
 

--- a/src/python/serve_html.py
+++ b/src/python/serve_html.py
@@ -62,6 +62,7 @@ config = {
                 }
             ],
             "serial-protocol": 3,
+            "sbus-failsafe": 0,
             "product_name": "Generic ESP8285 + 5xPWM 2.4Ghz RX",
             "lua_name": "ELRS+PWM 2400RX",
             "reg_domain": "ISM2G4",

--- a/src/src/rx-serial/SerialIO.cpp
+++ b/src/src/rx-serial/SerialIO.cpp
@@ -46,3 +46,8 @@ void SerialIO::handleUARTin()
         processByte(byte);
     }
 }
+
+void SerialIO::setFailsafe(bool failsafe)
+{
+    this->failsafe = failsafe;
+}

--- a/src/src/rx-serial/SerialIO.cpp
+++ b/src/src/rx-serial/SerialIO.cpp
@@ -17,7 +17,6 @@ void SerialIO::handleUARTout()
         while (msp2crsf.FIFOout.size() > msp2crsf.FIFOout.peek() && (bytesWritten + msp2crsf.FIFOout.peek()) < maxBytesPerCall)
         {
             uint8_t OutPktLen = msp2crsf.FIFOout.pop();
-
             uint8_t OutData[OutPktLen];
             msp2crsf.FIFOout.popBytes(OutData, OutPktLen);
             this->_outputPort->write(OutData, OutPktLen); // write the packet out
@@ -27,11 +26,9 @@ void SerialIO::handleUARTout()
 
     while (_fifo.size() > _fifo.peek() && (bytesWritten + _fifo.peek()) < maxBytesPerCall)
     {
-        noInterrupts();
         uint8_t OutPktLen = _fifo.pop();
         uint8_t OutData[OutPktLen];
         _fifo.popBytes(OutData, OutPktLen);
-        interrupts();
         this->_outputPort->write(OutData, OutPktLen); // write the packet out
         bytesWritten += OutPktLen;
     }

--- a/src/src/rx-serial/SerialIO.h
+++ b/src/src/rx-serial/SerialIO.h
@@ -11,6 +11,7 @@ public:
     virtual void setLinkQualityStats(uint16_t lq, uint16_t rssi) = 0;
     virtual void sendLinkStatisticsToFC() = 0;
     virtual void sendMSPFrameToFC(uint8_t* data) = 0;
+    virtual void setFailsafe(bool failsafe);
 
     virtual uint32_t sendRCFrameToFC(bool frameAvailable, uint32_t *channelData) = 0;
 
@@ -21,6 +22,7 @@ protected:
     Stream *_outputPort;
     Stream *_inputPort;
     FIFO _fifo;
+    bool failsafe = false;
 
     virtual void processByte(uint8_t byte) = 0;
 };

--- a/src/src/rx-serial/SerialSBUS.cpp
+++ b/src/src/rx-serial/SerialSBUS.cpp
@@ -24,11 +24,13 @@ void SerialSBUS::sendLinkStatisticsToFC()
 
 uint32_t SerialSBUS::sendRCFrameToFC(bool frameAvailable, uint32_t *channelData)
 {
-    if (failsafe && config.GetFailsafeMode() == FAILSAFE_NO_PULSES)
+    static auto sendPackets = false;
+    if ((failsafe && config.GetFailsafeMode() == FAILSAFE_NO_PULSES) || (!sendPackets && connectionState != connected))
     {
         return SBUS_CALLBACK_INTERVAL_MS;
     }
-    
+    sendPackets = true;
+
     // TODO: if failsafeMode == FAILSAFE_SET_POSITION then we use the set positions rather than the last values
     crsf_channels_s PackedRCdataOut;
     PackedRCdataOut.ch0 = channelData[0];

--- a/src/src/rx-serial/devSerialIO.cpp
+++ b/src/src/rx-serial/devSerialIO.cpp
@@ -21,6 +21,14 @@ static int start()
     return DURATION_IMMEDIATELY;
 }
 
+static int event()
+{
+    static connectionState_e lastConnectionState = disconnected;
+    serialIO->setFailsafe(connectionState == disconnected && lastConnectionState == connected);
+    lastConnectionState = connectionState;
+    return DURATION_IGNORE;
+}
+
 static int timeout()
 {
     if (connectionState != serialUpdate)
@@ -37,7 +45,7 @@ static int timeout()
 device_t Serial_device = {
     .initialize = nullptr,
     .start = start,
-    .event = nullptr,
+    .event = event,
     .timeout = timeout
 };
 


### PR DESCRIPTION
Two failsafe modes have been implemented in this PR...
1. No Pulses - No data is sent down the serial line (good for flight controllers)
2. Last Position - The last position is sent every interval and the FAILSAFE bit is set in the packet.

Ideally we'd also have a "Set Position" mode which sends specific/configurable positions for the channels as well and the FAILSAFE bit. I think that this can come later. 

Fixes #2175 