### PR TITLE
Disable MSPVTX if theres to SPI VTX

### DIFF
--- a/src/lib/MSPVTX/devMSPVTX.cpp
+++ b/src/lib/MSPVTX/devMSPVTX.cpp
@@ -73,7 +73,7 @@ static void clearVtxTable(void)
         0, // idx MSB
         3, // 25mW Power idx
         0, // pitmode
-        0, // lowPowerDisarm 
+        0, // lowPowerDisarm
         0, // pitModeFreq LSB
         0, // pitModeFreq MSB
         4, // newBand - Band Fatshark
@@ -155,7 +155,7 @@ static void setVtxTablePowerLevel(uint8_t idx)
     payload[0] = idx;
     payload[1] = powerLevelsLut[idx - 1] & 0xFF;         // powerValue LSB
     payload[2] = (powerLevelsLut[idx - 1] >> 8) & 0xFF; // powerValue MSB
-    payload[3] = POWER_LEVEL_LABEL_LENGTH; 
+    payload[3] = POWER_LEVEL_LABEL_LENGTH;
     payload[4] = powerLevelsLabel[((idx - 1) * POWER_LEVEL_LABEL_LENGTH) + 0];
     payload[5] = powerLevelsLabel[((idx - 1) * POWER_LEVEL_LABEL_LENGTH) + 1];
     payload[6] = powerLevelsLabel[((idx - 1) * POWER_LEVEL_LABEL_LENGTH) + 2];
@@ -214,7 +214,7 @@ void mspVtxProcessPacket(uint8_t *packet)
 
             if (vtxConfigPacket->lowPowerDisarm) // Force 0mw on boot because BF doesnt send a low power index.
             {
-                power = 1; 
+                power = 1;
             }
 
             if (power >= NUM_POWER_LEVELS)
@@ -222,7 +222,7 @@ void mspVtxProcessPacket(uint8_t *packet)
                 power = 3; // 25 mW
             }
 
-            channel = ((vtxConfigPacket->band - 1) * 8) + (vtxConfigPacket->channel - 1);   
+            channel = ((vtxConfigPacket->band - 1) * 8) + (vtxConfigPacket->channel - 1);
             if (channel >= FREQ_TABLE_SIZE)
             {
                 channel = 27; // F4 5800MHz
@@ -352,6 +352,10 @@ void disableMspVtx(void)
 
 static int event(void)
 {
+    if (GPIO_PIN_SPI_VTX_NSS == UNDEF_PIN)
+    {
+        return DURATION_NEVER;
+    }
     return DURATION_IMMEDIATELY;
 }
 


### PR DESCRIPTION
As it says, disable the MSPVTX device if there is no SPI VTX device defined in the hardware layout.