### PR TITLE
Binary flashing fixes

### DIFF
--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -856,7 +856,8 @@
                     "cpus": ["STM32L432KCUx"],
                     "offset": "0x4000",
                     "bootloader": "sx1280_rx_nano_pcb_v0.5_bootloader.bin"
-                }
+                },
+                "prior_target_name": "HappyModel_PP_2400_RX"
             },
             "ep": {
                 "product_name": "HappyModel EP1/2 2.4GHz RX",

--- a/src/python/binary_configurator.py
+++ b/src/python/binary_configurator.py
@@ -395,6 +395,7 @@ def main():
                     shutil.copyfileobj(f_in, f_out)
 
         if args.flash:
+            args.target = config.get('firmware')
             args.accept = config.get('prior_target_name')
             return binary_flash.upload(options, args)
 

--- a/src/python/binary_flash.py
+++ b/src/python/binary_flash.py
@@ -46,7 +46,7 @@ def upload_wifi(args, options, upload_addr, isstm: bool):
 def upload_stm32_uart(args):
     if args.port == None:
         args.port = serials_find.get_serial_port()
-    return UARTupload.uart_upload(args.port, args.file.name, args.baud, target=args.target, accept=args.accept)
+    return UARTupload.uart_upload(args.port, args.file.name, args.baud, target=args.target, accept=args.accept, ignore_incorrect_target=args.force)
 
 def upload_stm32_stlink(args, options: FirmwareOptions):
     stlink.on_upload([args.file.name], None, {'UPLOAD_FLAGS': [f'BOOTLOADER={options.bootloader}', f'VECT_OFFSET={options.offset}']})


### PR DESCRIPTION
Pass correct target name (firmware name) to flasher, fixes #2191
Pass force flag to UART/BF flash for STM32 RX targets, fixes #2192
