### PR TITLE
Remove INFOLN

### DIFF
--- a/src/lib/FHSS/FHSS.cpp
+++ b/src/lib/FHSS/FHSS.cpp
@@ -59,7 +59,7 @@ Approach:
 void FHSSrandomiseFHSSsequence(const uint32_t seed)
 {
     FHSSconfig = &domains[firmwareOptions.domain];
-    INFOLN("Setting %s Mode", FHSSconfig->domain);
+    DBGLN("Setting %s Mode", FHSSconfig->domain);
     DBGLN("Number of FHSS frequencies = %u", FHSSconfig->freq_count);
 
     sync_channel = (FHSSconfig->freq_count / 2) + 1;

--- a/src/lib/logging/logging.h
+++ b/src/lib/logging/logging.h
@@ -41,14 +41,8 @@ void debugFreeInitLogger();
 #endif
 
 #if defined(CRITICAL_FLASH) || ((defined(DEBUG_RCVR_LINKSTATS)) && !defined(DEBUG_LOG))
-  #define INFOLN(msg, ...)
   #define ERRLN(msg, ...)
 #else
-  #define INFOLN(msg, ...) { \
-      debugPrintf(msg, ##__VA_ARGS__); \
-      LOGGING_UART.println(); \
-    }
-
   #define ERRLN(msg, ...) IFNE(__VA_ARGS__)({ \
       LOGGING_UART.print("ERROR: "); \
       debugPrintf(msg, ##__VA_ARGS__); \

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1443,7 +1443,7 @@ static void updateBindingMode(unsigned long now)
     // and we're not already in binding mode, enter binding
     if (!config.GetIsBound() && !InBindingMode)
     {
-        INFOLN("RX has not been bound, enter binding mode...");
+        DBGLN("RX has not been bound, enter binding mode...");
         EnterBindingMode();
     }
 #endif
@@ -1482,7 +1482,7 @@ static void updateBindingMode(unsigned long now)
         config.SetPowerOnCounter(0);
         config.Commit();
 
-        INFOLN("Power on counter >=3, enter binding mode...");
+        DBGLN("Power on counter >=3, enter binding mode...");
         config.SetIsBound(false);
         EnterBindingMode();
     }
@@ -1649,7 +1649,7 @@ void setup()
         #endif
         setupSerial();
 
-        INFOLN("ExpressLRS Module Booting...");
+        DBGLN("ExpressLRS Module Booting...");
 
         devicesRegister(ui_devices, ARRAY_SIZE(ui_devices));
         devicesInit();


### PR DESCRIPTION
Replacing INFOLN with DBGLN to cleanup the serial output on boot when no debug define is set.