### PR TITLE
Fix displayed UART baud in airport & CRSF mode

### DIFF
--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -267,7 +267,7 @@ function updateConfig(data, options) {
     }
     else if (_('serial-protocol').value == 0 || _('serial-protocol').value == 1) {
       _('rcvr-uart-baud').disabled = false;
-      _('rcvr-uart-baud').value = '420000';
+      _('rcvr-uart-baud').value = options['rcvr-uart-baud'];
     }
     else if (_('serial-protocol').value == 2 || _('serial-protocol').value == 3) {
       _('rcvr-uart-baud').disabled = true;

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -202,7 +202,7 @@ function timeoutCurrentColors() {
   }
 }
 
-function updateConfig(data) {
+function updateConfig(data, options) {
   if (data.product_name) _('product_name').textContent = data.product_name;
   if (data.reg_domain) _('reg_domain').textContent = data.reg_domain;
   if (data.uid) _('uid').value = data.uid.toString();
@@ -263,7 +263,7 @@ function updateConfig(data) {
   _('serial-protocol').onchange = () => {
     if (_('is-airport').checked) {
       _('rcvr-uart-baud').disabled = false;
-      _('rcvr-uart-baud').value = data['rcvr-uart-baud'];
+      _('rcvr-uart-baud').value = options['rcvr-uart-baud'];
     }
     else if (_('serial-protocol').value == 0 || _('serial-protocol').value == 1) {
       _('rcvr-uart-baud').disabled = false;
@@ -311,7 +311,7 @@ function initOptions() {
     if (this.readyState == 4 && this.status == 200) {
       const data = JSON.parse(this.responseText);
       updateOptions(data['options']);
-      updateConfig(data['config']);
+      updateConfig(data['config'], data['options']);
       setTimeout(getNetworks, 2000);
     }
   };

--- a/src/lib/CRSF/devCRSF_tx.cpp
+++ b/src/lib/CRSF/devCRSF_tx.cpp
@@ -7,6 +7,10 @@
 
 static int start()
 {
+    if (firmwareOptions.is_airport)
+    {
+        return DURATION_NEVER;
+    }
     CRSF::Begin();
 #if defined(DEBUG_TX_FREERUN)
     CRSF::CRSFstate = true;

--- a/src/lib/OPTIONS/options.h
+++ b/src/lib/OPTIONS/options.h
@@ -36,7 +36,7 @@ typedef struct _options {
     bool        _unused2:1; // r9mm_mini_sbus
     bool        is_airport:1;
 #endif
-#if defined(TARGET_TX)
+#if defined(TARGET_TX) || defined(UNIT_TEST)
     uint32_t    tlm_report_interval;
     uint32_t    fan_min_runtime;
     bool        uart_inverted:1;


### PR DESCRIPTION
Fix yet another bug in the web UI for Airport!
This one was that the textfield was getting set to the wrong value in the config section, because the baud is actually in the options!

Any changes entered into the field were saved in the correct location, they were just displayed wrongly.

EDIT: This also affected CRSF mode as well as the baud-rate is editable for that mode as well, it's just not done that often!

Fixes #2204