### PR TITLE
Increase maximum number of Lua params

### DIFF
--- a/src/lib/LUA/lua.cpp
+++ b/src/lib/LUA/lua.cpp
@@ -20,7 +20,7 @@ static uint8_t luaWarningFlags = 0b00000000; //8 flag, 1 bit for each flag. set 
 static void (*devicePingCallback)() = nullptr;
 #endif
 
-#define LUA_MAX_PARAMS 32
+#define LUA_MAX_PARAMS 64
 static uint8_t parameterType;
 static uint8_t parameterIndex;
 static uint8_t parameterArg;


### PR DESCRIPTION
During testing of gemini module it was found that we have run over our maximum number of Lua parameters, so we'll just increase that.