### PR TITLE
add DACWRITE functionality for receivers

### DIFF
--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -274,7 +274,7 @@ void POWERMGNT::setPower(PowerLevels_e Power)
     Radio.SetOutputPower(0b0000);
     dacWrite(GPIO_PIN_RFamp_APC2, powerValues[Power - MinPower]);
 #else
-    #if defined(TARGET_UNIFIED_TX) && defined(PLATFORM_ESP32)
+    #if defined(PLATFORM_ESP32)
     if (POWER_OUTPUT_DACWRITE)
     {
         Radio.SetOutputPower(0b0000);

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -270,7 +270,7 @@ void POWERMGNT::setPower(PowerLevels_e Power)
     //Set DACs PA5 & PA4
     analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095 2.7V
     analogWrite(GPIO_PIN_RFamp_APC2, powerValues[Power - MinPower]);
-#elif defined(POWER_OUTPUT_DACWRITE) && defined(PLATFORM_ESP32)
+#elif defined(POWER_OUTPUT_DACWRITE)
     Radio.SetOutputPower(0b0000);
     dacWrite(GPIO_PIN_RFamp_APC2, powerValues[Power - MinPower]);
 #else

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -270,18 +270,10 @@ void POWERMGNT::setPower(PowerLevels_e Power)
     //Set DACs PA5 & PA4
     analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095 2.7V
     analogWrite(GPIO_PIN_RFamp_APC2, powerValues[Power - MinPower]);
-#elif defined(POWER_OUTPUT_DACWRITE) && !defined(TARGET_UNIFIED_TX) && !defined(TARGET_UNIFIED_RX)
+#elif defined(POWER_OUTPUT_DACWRITE)
     Radio.SetOutputPower(0b0000);
     dacWrite(GPIO_PIN_RFamp_APC2, powerValues[Power - MinPower]);
 #else
-    #if defined(TARGET_UNIFIED_TX) && defined(PLATFORM_ESP32)
-    if (POWER_OUTPUT_DACWRITE)
-    {
-        Radio.SetOutputPower(0b0000);
-        dacWrite(GPIO_PIN_RFamp_APC2, powerValues[Power - MinPower]);
-    }
-    else
-    #endif
     if (POWER_OUTPUT_FIXED != -99)
     {
         Radio.SetOutputPower(POWER_OUTPUT_FIXED);

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -270,10 +270,18 @@ void POWERMGNT::setPower(PowerLevels_e Power)
     //Set DACs PA5 & PA4
     analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095 2.7V
     analogWrite(GPIO_PIN_RFamp_APC2, powerValues[Power - MinPower]);
-#elif defined(POWER_OUTPUT_DACWRITE)
+#elif defined(POWER_OUTPUT_DACWRITE) && !defined(TARGET_UNIFIED_TX) && !defined(TARGET_UNIFIED_RX)
     Radio.SetOutputPower(0b0000);
     dacWrite(GPIO_PIN_RFamp_APC2, powerValues[Power - MinPower]);
 #else
+    #if defined(TARGET_UNIFIED_TX) && defined(PLATFORM_ESP32)
+    if (POWER_OUTPUT_DACWRITE)
+    {
+        Radio.SetOutputPower(0b0000);
+        dacWrite(GPIO_PIN_RFamp_APC2, powerValues[Power - MinPower]);
+    }
+    else
+    #endif
     if (POWER_OUTPUT_FIXED != -99)
     {
         Radio.SetOutputPower(POWER_OUTPUT_FIXED);

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -270,7 +270,7 @@ void POWERMGNT::setPower(PowerLevels_e Power)
     //Set DACs PA5 & PA4
     analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095 2.7V
     analogWrite(GPIO_PIN_RFamp_APC2, powerValues[Power - MinPower]);
-#elif defined(POWER_OUTPUT_DACWRITE)
+#elif defined(POWER_OUTPUT_DACWRITE) && defined(PLATFORM_ESP32)
     Radio.SetOutputPower(0b0000);
     dacWrite(GPIO_PIN_RFamp_APC2, powerValues[Power - MinPower]);
 #else


### PR DESCRIPTION
This allows esp32 receivers to also use dacWrite when controlling an RF amp e.g. turning a 900 tx into a 1W rx 💪 

Please carefully review I haven't stuffed anything here in the simplification!