### PR TITLE
Respect model match on all protocols

### DIFF
--- a/src/src/rx-serial/devSerialIO.cpp
+++ b/src/src/rx-serial/devSerialIO.cpp
@@ -31,15 +31,22 @@ static int event()
 
 static int timeout()
 {
-    if (connectionState != serialUpdate)
+    if (connectionState == serialUpdate)
     {
-        uint32_t duration = serialIO->sendRCFrameToFC(frameAvailable, ChannelData);
-        frameAvailable = false;
-        serialIO->handleUARTout();
-        serialIO->handleUARTin();
-        return duration;
+        return DURATION_NEVER;  // stop callbacks when doing serial update
     }
-    return DURATION_IMMEDIATELY;
+
+    uint32_t duration = 10; // 10ms callback (i.e. when no theres no model match)
+    // only send frames if we have a model match
+    if (connectionHasModelMatch)
+    {
+        duration = serialIO->sendRCFrameToFC(frameAvailable, ChannelData);
+    }
+    frameAvailable = false;
+    // still get telemetry and send link stats if theres no model match
+    serialIO->handleUARTout();
+    serialIO->handleUARTin();
+    return duration;
 }
 
 device_t Serial_device = {


### PR DESCRIPTION
# Problem
When using SBUS protocol, the model match setting is not respected and SBUS data is spewed out the serial port even though the model says "Model mismatch" on the handset.

# Solution
In the devSerial code for the RX, check the model match flag before sending RC data out the serial port.
Fixes #2206 

# Testing
- With current master, set RX to SBUS, then power off RX
- Set model match on TX to a different model and turn it on
- Power on the TX and see the LED do triple blink and radio show mismatch
- Note that the RX is spewing SBUS packets
- Flash RX with this PR
- Now not that the RX is not spewing packets
- Set the TX back to the correct model and see the packets start to flow