### PR TITLE
Fix for airport to enable CRSF communication

### DIFF
--- a/src/lib/CRSF/devCRSF_tx.cpp
+++ b/src/lib/CRSF/devCRSF_tx.cpp
@@ -7,10 +7,6 @@
 
 static int start()
 {
-    if (firmwareOptions.is_airport)
-    {
-        return DURATION_NEVER;
-    }
     CRSF::Begin();
 #if defined(DEBUG_TX_FREERUN)
     CRSF::CRSFstate = true;


### PR DESCRIPTION
Hey girls, guys, both and neither!

I removed lines 10-13 in src/lib/CRSF/devCRSF_tx.cpp, as it was preventing transmitters which had been flashed with airport from being able to use the Lua scripts. 

-Senk02