### PR TITLE
Optimise airport serial communications

### DIFF
--- a/src/src/rx-serial/SerialAirPort.cpp
+++ b/src/src/rx-serial/SerialAirPort.cpp
@@ -29,7 +29,7 @@ void SerialAirPort::sendMSPFrameToFC(uint8_t* data)
     // unsupported
 }
 
-int SerialAirPort::getMaxInputBytes()
+int SerialAirPort::getMaxSerialReadSize()
 {
     return AP_MAX_BUF_LEN - apInputBuffer.size();
 }

--- a/src/src/rx-serial/SerialAirPort.cpp
+++ b/src/src/rx-serial/SerialAirPort.cpp
@@ -29,19 +29,24 @@ void SerialAirPort::sendMSPFrameToFC(uint8_t* data)
     // unsupported
 }
 
-void SerialAirPort::processByte(uint8_t byte)
+int SerialAirPort::getMaxInputBytes()
 {
-    if (apInputBuffer.size() < AP_MAX_BUF_LEN && connectionState == connected)
+    return AP_MAX_BUF_LEN - apInputBuffer.size();
+}
+
+void SerialAirPort::processBytes(uint8_t *bytes, u_int16_t size)
+{
+    if (connectionState == connected)
     {
-        apInputBuffer.push(byte);
+        apInputBuffer.pushBytes(bytes, size);
     }
 }
 
 void SerialAirPort::handleUARTout()
 {
-    while (apOutputBuffer.size())
-    {
-        _outputPort->write(apOutputBuffer.pop());
-    }
+    auto size = apOutputBuffer.size();
+    uint8_t buf[size];
+    apOutputBuffer.popBytes(buf, size);
+    _outputPort->write(buf, size);
 }
 #endif

--- a/src/src/rx-serial/SerialAirPort.h
+++ b/src/src/rx-serial/SerialAirPort.h
@@ -17,8 +17,10 @@ public:
     void sendMSPFrameToFC(uint8_t* data) override;
     void sendLinkStatisticsToFC() override;
 
+    int getMaxInputBytes() override;
     void handleUARTout() override;
 
 private:
-    void processByte(uint8_t byte) override;
+    void processBytes(uint8_t *bytes, u_int16_t size) override;
+    void processByte(uint8_t byte) override {};
 };

--- a/src/src/rx-serial/SerialAirPort.h
+++ b/src/src/rx-serial/SerialAirPort.h
@@ -17,7 +17,7 @@ public:
     void sendMSPFrameToFC(uint8_t* data) override;
     void sendLinkStatisticsToFC() override;
 
-    int getMaxInputBytes() override;
+    int getMaxSerialReadSize() override;
     void handleUARTout() override;
 
 private:

--- a/src/src/rx-serial/SerialIO.cpp
+++ b/src/src/rx-serial/SerialIO.cpp
@@ -34,14 +34,9 @@ void SerialIO::handleUARTout()
     }
 }
 
-int SerialIO::getMaxInputBytes()
-{
-    return 64;
-}
-
 void SerialIO::handleUARTin()
 {
-    auto maxBytes = getMaxInputBytes();
+    auto maxBytes = getMaxSerialReadSize();
     uint8_t buffer[maxBytes];
     auto size = min(_inputPort->available(), maxBytes);
     _inputPort->readBytes(buffer, size);

--- a/src/src/rx-serial/SerialIO.cpp
+++ b/src/src/rx-serial/SerialIO.cpp
@@ -34,13 +34,25 @@ void SerialIO::handleUARTout()
     }
 }
 
+int SerialIO::getMaxInputBytes()
+{
+    return 64;
+}
 
 void SerialIO::handleUARTin()
 {
-    while (_inputPort->available())
+    auto maxBytes = getMaxInputBytes();
+    uint8_t buffer[maxBytes];
+    auto size = min(_inputPort->available(), maxBytes);
+    _inputPort->readBytes(buffer, size);
+    processBytes(buffer, size);
+}
+
+void SerialIO::processBytes(uint8_t *bytes, uint16_t size)
+{
+    for (int i=0 ; i<size ; i++)
     {
-        uint8_t byte = _inputPort->read();
-        processByte(byte);
+        processByte(bytes[i]);
     }
 }
 

--- a/src/src/rx-serial/SerialIO.h
+++ b/src/src/rx-serial/SerialIO.h
@@ -15,6 +15,7 @@ public:
 
     virtual uint32_t sendRCFrameToFC(bool frameAvailable, uint32_t *channelData) = 0;
 
+    virtual int getMaxInputBytes();
     virtual void handleUARTout();
     virtual void handleUARTin();
 
@@ -24,5 +25,6 @@ protected:
     FIFO _fifo;
     bool failsafe = false;
 
+    virtual void processBytes(uint8_t *bytes, uint16_t size);
     virtual void processByte(uint8_t byte) = 0;
 };

--- a/src/src/rx-serial/SerialIO.h
+++ b/src/src/rx-serial/SerialIO.h
@@ -5,6 +5,8 @@
 
 class SerialIO {
 public:
+    const int defaultMaxSerialReadSize = 64;
+
     SerialIO(Stream *output, Stream *input) : _outputPort(output), _inputPort(input) {}
     virtual ~SerialIO() {}
 
@@ -15,7 +17,7 @@ public:
 
     virtual uint32_t sendRCFrameToFC(bool frameAvailable, uint32_t *channelData) = 0;
 
-    virtual int getMaxInputBytes();
+    virtual int getMaxSerialReadSize() { return defaultMaxSerialReadSize; }
     virtual void handleUARTout();
     virtual void handleUARTin();
 

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1312,9 +1312,15 @@ void loop()
 
   executeDeferredFunction(now);
 
-  if (firmwareOptions.is_airport && apInputBuffer.size() < AP_MAX_BUF_LEN && connectionState == connected && TxUSB->available())
+  if (firmwareOptions.is_airport && connectionState == connected)
   {
-    apInputBuffer.push(TxUSB->read());
+    auto size = std::min(AP_MAX_BUF_LEN - apInputBuffer.size(), TxUSB->available());
+    if (size > 0)
+    {
+      uint8_t buf[size];
+      TxUSB->readBytes(buf, size);
+      apInputBuffer.pushBytes(buf, size);
+    }
   }
 
   if (TxBackpack->available())


### PR DESCRIPTION
# Problem
ESP32 based RX using airport could not run at full 4800 baud

# Solution
Perform some optimisation on the code so that it does not do byte-by-byte pushing of the serial data into the FIFO. On the ESP32 the FIFO is protected with a "critical section" which when doing individual bytes is too slow to keep up with the data transfer. 