### PR TITLE
More complete fail_count calculation

### DIFF
--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -475,8 +475,14 @@ void ICACHE_RAM_ATTR SX127xDriver::GetLastPacketStats()
       }
     }
 
-    // second radio received the same packet to the processing radio
     gotRadio[secondRadioIdx] = isSecondRadioGotData;
+    #if defined(DEBUG_RCVR_SIGNAL_STATS)
+    // second radio received the same packet to the processing radio
+    if(!isSecondRadioGotData)
+    {
+      instance->rxSignalStats[secondRadioIdx].fail_count++;
+    }
+    #endif
   }
 
   int8_t rssi[2];

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -630,6 +630,12 @@ void ICACHE_RAM_ATTR SX1280Driver::GetLastPacketStats()
 
         // second radio received the same packet to the processing radio
         gotRadio[secondRadioIdx] = isSecondRadioGotData;
+        #if defined(DEBUG_RCVR_SIGNAL_STATS)
+        if(!isSecondRadioGotData)
+        {
+        instance->rxSignalStats[secondRadioIdx].fail_count++;
+        }
+        #endif
     }
 
     uint8_t status[2];

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -633,7 +633,7 @@ void ICACHE_RAM_ATTR SX1280Driver::GetLastPacketStats()
         #if defined(DEBUG_RCVR_SIGNAL_STATS)
         if(!isSecondRadioGotData)
         {
-        instance->rxSignalStats[secondRadioIdx].fail_count++;
+            instance->rxSignalStats[secondRadioIdx].fail_count++;
         }
         #endif
     }


### PR DESCRIPTION
When using `DEBUG_RCVR_SINGAL_STAT`, `fail_count` increases only if IRQ ISR is called but fails to be parsed as a valid packet. The second radio's `irq_count` increases when one radio passes all the checks, and the second radio gets the same packet.

So it's possible that the second radio's dio_1 interrupt does not increase  irq_count nor `fail_count` when the first radio passes the CRC check, but the second radio's packet failed the check. 

so with the current logic, `cnt`+`fail` could be not equal to the actual # of `DIO` calls

This PR increases the fail count in the situation where the second radio fails to get the valid packet as well, which will be a more complete report of the real radio rx stats. 