### PR TITLE
Binary flasher fixes

### DIFF
--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -435,7 +435,7 @@
         "tx_900": {
             "r9m": {
                 "product_name": "FrSky R9M 900MHz TX",
-                "upload_methods": ["stlink", "wifi"],
+                "upload_methods": ["stlink", "wifi", "stock"],
                 "platform": "stm32",
                 "firmware": "Frsky_TX_R9M",
                 "features": ["buzzer", "unlock-higher-power", "fan"],
@@ -447,7 +447,7 @@
             },
             "r9m-lite": {
                 "product_name": "FrSky R9M Lite 900MHz TX",
-                "upload_methods": ["stlink"],
+                "upload_methods": ["stlink", "stock"],
                 "platform": "stm32",
                 "firmware": "Frsky_TX_R9M_LITE",
                 "stlink": {
@@ -771,7 +771,7 @@
         "tx_900": {
             "es915": {
                 "product_name": "HappyModel ES915 TX",
-                "upload_methods": ["stlink", "wifi"],
+                "upload_methods": ["stlink", "wifi", "stock"],
                 "platform": "stm32",
                 "firmware": "HappyModel_TX_ES915TX",
                 "has_buzzer": true,

--- a/src/python/UnifiedConfiguration.py
+++ b/src/python/UnifiedConfiguration.py
@@ -52,7 +52,7 @@ def appendToFirmware(firmware_file, product_name, lua_name, defines, config, lay
             sys.stderr.write(f'Error opening file "{layout_file}"\n')
             exit(1)
     firmware_file.write(b'\0')
-    firmware_file.truncate(firmware_file.tell())
+    # firmware_file.truncate(firmware_file.tell())  # Stupid Windoze! (Permission denied)
 
 def doConfiguration(file, defines, config, moduletype, frequency, platform, device_name):
     product_name = "Unified"

--- a/src/python/binary_configurator.py
+++ b/src/python/binary_configurator.py
@@ -398,6 +398,8 @@ def main():
             args.target = config.get('firmware')
             args.accept = config.get('prior_target_name')
             return binary_flash.upload(options, args)
+        elif 'upload_methods' in config and 'stock' in config['upload_methods']:
+            shutil.copy(args.file.name, 'firmware.elrs')
 
 if __name__ == '__main__':
     try:

--- a/src/python/binary_flash.py
+++ b/src/python/binary_flash.py
@@ -27,6 +27,7 @@ class UploadMethod(Enum):
     betaflight = 'bf'
     edgetx = 'etx'
     stlink = 'stlink'
+    stock = 'stock'
     dir = 'dir'
 
     def __str__(self):
@@ -129,7 +130,10 @@ def upload_esp32_bf(args, options):
 
 def upload_dir(mcuType, args):
     if mcuType == MCUType.ESP8266 or mcuType == MCUType.STM32:
-        shutil.copy2(args.file.name, args.out)
+        if args.flash == UploadMethod.stock:
+            shutil.copy2(args.file.name, os.path.join(args.out, 'firmware.elrs'))
+        else:
+            shutil.copy2(args.file.name, args.out)
     elif mcuType == MCUType.ESP32:
         dir = os.path.dirname(args.file.name)
         shutil.copy2(args.file.name, args.out)
@@ -143,7 +147,7 @@ def upload(options: FirmwareOptions, args):
         if args.flash == UploadMethod.betaflight:
             args.baud = 420000
 
-    if args.flash == UploadMethod.dir:
+    if args.flash == UploadMethod.dir or args.flash == UploadMethod.stock:
         return upload_dir(options.mcuType, args)
     elif options.deviceType == DeviceType.RX:
         if options.mcuType == MCUType.ESP8266:

--- a/src/python/targets_validator.py
+++ b/src/python/targets_validator.py
@@ -12,7 +12,7 @@ def error(msg):
 
 def validate_stm32(vendor, type, devname, device):
     for method in device['upload_methods']:
-        if method not in ['stlink', 'dfu', 'uart', 'wifi', 'betaflight']:
+        if method not in ['stlink', 'dfu', 'uart', 'wifi', 'betaflight', 'stock']:
             error(f'Invalid upload method "{method}" for target "{vendor}.{type}.{devname}"')
     if 'stlink' not in device['upload_methods']:
         error(f'STM32 based devices must always have "stlink" as an upload_method for target "{vendor}.{type}.{devname}"')


### PR DESCRIPTION
A couple of fixes for the binary flasher.
1. remove file.truncate to work around windows permission denied error
2. add "stock" flash method for Frsky R9M, R9M Lite & HM915 TX modules (this is the same as "dir", but renames the file to `firmware.elrs`)