### PR TITLE
Add mention of the 10KHzDuty mode in the WebUI PWM output page

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -176,7 +176,7 @@
 						Set PWM output mode and failsafe positions.
 						<ul>
 							<li><b>Output:</b> Receiver output pin</li>
-							<li><b>Mode:</b> Output frequency, binary On/Off, or Serial (for MCU pins 1 and 3 only) mode</li>
+							<li><b>Mode:</b> Output frequency, 10KHz 0-100% duty cycle, binary On/Off or Serial (for MCU pins 1 and 3 only) mode</li>
 							<ul>
 								<li>When enabling serial pins, be sure to select the <b>Serial Protocol</b>below and <b>UART baud</b> on the <b>Options</b> tab</li>
 							</ul>


### PR DESCRIPTION
Thought this was missing, even if the mode title is maybe clear enough.
(Yes I pressed enter by mistake while typing out the commit message)