### PR TITLE
Add elrsjoystick 2400 rx

### DIFF
--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -294,6 +294,20 @@
             }
         }
     },
+    "elrsjoystick": {
+        "name": "ELRSJoystick",
+        "rx_2400": {
+            "elrsjoystick": {
+                "product_name": "ELRSJoystick 2.4GHz",
+                "lua_name": "ELRSJoystick 2400",
+                "layout_file": "Generic 2400.json",
+                "upload_methods": ["uart", "wifi", "betaflight"],
+                "platform": "esp8285",
+                "firmware": "Unified_ESP8285_2400_RX",
+                "prior_target_name": "DIY_2400_RX_ESP8285_SX1280"
+            }
+        }
+    },
     "emax": {
         "name": "EMAX",
         "tx_900": {


### PR DESCRIPTION
This is a small toy based on https://github.com/mikeneiderhauser/CRSFJoystick.
It lets you play FPV simulators with ELRS TX wirelessly.
![64e1d1593510bf2f9b62a94b0381637](https://github.com/ExpressLRS/ExpressLRS/assets/33802186/9daf621e-5f12-448e-ba9c-607c554a9811)

