### PR TITLE
discriminator was small due to bug!

### DIFF
--- a/src/python/binary_configurator.py
+++ b/src/python/binary_configurator.py
@@ -234,7 +234,7 @@ def patch_unified(args, options):
     if args.domain is not None:
         json_flags['domain'] = domain_number(args.domain)
 
-    json_flags['flash-discriminator'] = randint(1,2^32-1)
+    json_flags['flash-discriminator'] = randint(1,2**32-1)
 
     UnifiedConfiguration.doConfiguration(
         args.file,

--- a/src/python/build_flags.py
+++ b/src/python/build_flags.py
@@ -146,7 +146,7 @@ build_flags.append("-DLATEST_VERSION=" + get_version())
 build_flags.append("-DTARGET_NAME=" + re.sub("_VIA_.*", "", target_name))
 condense_flags()
 
-json_flags['flash-discriminator'] = randint(1,2^32-1)
+json_flags['flash-discriminator'] = randint(1,2**32-1)
 
 if '-DRADIO_SX127X=1' in build_flags:
     # disallow setting 2400s for 900


### PR DESCRIPTION
Apparently `2^32-1` is not what you'd expect!
It actually means 2 before 32 (i.e. 30) - 1 which is 29, which is not very discriminatory, now, is it!?