### PR TITLE
Add BETAFPV Super-D 900 target

### DIFF
--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -182,7 +182,7 @@
                 "prior_target_name": "DIY_2400_RX_PWMP"
             },
             "superd": {
-                "product_name": "BETAFPV 2.4GHz SuperD RX",
+                "product_name": "BETAFPV SuperD 2.4GHz RX",
                 "lua_name": "BFPV SuperD 2G4",
                 "layout_file": "Generic 2400 True Diversity PA.json",
                 "overlay": {

--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -91,6 +91,14 @@
                 "platform": "esp8285",
                 "firmware": "Unified_ESP8285_900_RX",
                 "prior_target_name": "BETAFPV_900_RX"
+            },
+            "superd": {
+                "product_name": "BETAFPV SuperD 900MHz RX",
+                "lua_name": "BFPV SuperD 900",
+                "layout_file": "Generic 900 True Diversity PA.json",
+                "upload_methods": ["uart", "wifi", "betaflight"],
+                "platform": "esp32",
+                "firmware": "Unified_ESP32_900_RX"
             }
         },
         "tx_2400": {


### PR DESCRIPTION
Adds the target file for the SuperD 900MHz target
Fixes the product name for the SuperD 2.4GHz target