### PR TITLE
Binary artifact archive updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,6 +156,11 @@ jobs:
       - name: Copy hardware files to firmware folder
         run: cp -r src/hardware dist/firmware
 
+      - name: Copy Lua to to firmware folder
+        run: |
+          mkdir -p dist/firmware/lua
+          cp -r src/lua/elrsV3.lua dist/firmware/lua
+
       - name: Copy bootloader files to firmware folder
         run: cd src ; find bootloader -name \*.bin -o -name \*.frk | grep -v src/ | cpio -pdm ../dist/firmware
 

--- a/src/python/binary_configurator.py
+++ b/src/python/binary_configurator.py
@@ -336,6 +336,7 @@ def main():
     parser.add_argument('--target', type=str, help='Unified target JSON path')
     # Flashing options
     parser.add_argument("--flash", type=UploadMethod, choices=list(UploadMethod), help="Flashing Method")
+    parser.add_argument("--erase", action='store_true', default=False, help="Full chip erase before flashing on ESP devices")
     parser.add_argument('--out', action=writeable_dir, default=None)
     parser.add_argument("--port", type=str, help="SerialPort or WiFi address to flash firmware to")
     parser.add_argument("--baud", type=int, default=0, help="Baud rate for serial communication")

--- a/src/python/binary_flash.py
+++ b/src/python/binary_flash.py
@@ -141,11 +141,13 @@ def upload_esp32_bf(args, options):
     return ElrsUploadResult.Success
 
 def upload_dir(mcuType, args):
-    if mcuType == MCUType.ESP8266 or mcuType == MCUType.STM32:
+    if mcuType == MCUType.STM32:
         if args.flash == UploadMethod.stock:
             shutil.copy2(args.file.name, os.path.join(args.out, 'firmware.elrs'))
         else:
             shutil.copy2(args.file.name, args.out)
+    if mcuType == MCUType.ESP8266:
+        shutil.copy2('firmware.bin.gz', os.path.join(args.out, 'firmware.bin.gz'))
     elif mcuType == MCUType.ESP32:
         dir = os.path.dirname(args.file.name)
         shutil.copy2(args.file.name, args.out)

--- a/src/python/binary_flash.py
+++ b/src/python/binary_flash.py
@@ -72,7 +72,10 @@ def upload_esp8266_uart(args):
     if args.port == None:
         args.port = serials_find.get_serial_port()
     try:
-        esptool.main(['--chip', 'esp8266', '--port', args.port, '--baud', str(args.baud), '--after', 'soft_reset', 'write_flash', '0x0000', args.file.name])
+        cmd = ['--chip', 'esp8266', '--port', args.port, '--baud', str(args.baud), '--after', 'soft_reset', 'write_flash']
+        if args.erase: cmd.append('--erase-all')
+        cmd.extend(['0x0000', args.file.name])
+        esptool.main(cmd)
     except:
         return ElrsUploadResult.ErrorGeneral
     return ElrsUploadResult.Success
@@ -87,7 +90,10 @@ def upload_esp8266_bf(args, options):
     if retval != ElrsUploadResult.Success:
         return retval
     try:
-        esptool.main(['--passthrough', '--chip', 'esp8266', '--port', args.port, '--baud', str(args.baud), '--before', 'no_reset', '--after', 'soft_reset', '--no-stub', 'write_flash', '0x0000', args.file.name])
+        cmd = ['--passthrough', '--chip', 'esp8266', '--port', args.port, '--baud', str(args.baud), '--before', 'no_reset', '--after', 'soft_reset', '--no-stub', 'write_flash']
+        if args.erase: cmd.append('--erase-all')
+        cmd.extend(['0x0000', args.file.name])
+        esptool.main(cmd)
     except:
         return ElrsUploadResult.ErrorGeneral
     return ElrsUploadResult.Success
@@ -97,7 +103,10 @@ def upload_esp32_uart(args):
         args.port = serials_find.get_serial_port()
     try:
         dir = os.path.dirname(args.file.name)
-        esptool.main(['--chip', 'esp32', '--port', args.port, '--baud', str(args.baud), '--after', 'hard_reset', 'write_flash', '-z', '--flash_mode', 'dio', '--flash_freq', '40m', '--flash_size', 'detect', '0x1000', os.path.join(dir, 'bootloader.bin'), '0x8000', os.path.join(dir, 'partitions.bin'), '0xe000', os.path.join(dir, 'boot_app0.bin'), '0x10000', args.file.name])
+        cmd = ['--chip', 'esp32', '--port', args.port, '--baud', str(args.baud), '--after', 'hard_reset', 'write_flash']
+        if args.erase: cmd.append('--erase-all')
+        cmd.extend(['-z', '--flash_mode', 'dio', '--flash_freq', '40m', '--flash_size', 'detect', '0x1000', os.path.join(dir, 'bootloader.bin'), '0x8000', os.path.join(dir, 'partitions.bin'), '0xe000', os.path.join(dir, 'boot_app0.bin'), '0x10000', args.file.name])
+        esptool.main(cmd)
     except:
         return ElrsUploadResult.ErrorGeneral
     return ElrsUploadResult.Success
@@ -108,7 +117,10 @@ def upload_esp32_etx(args):
     ETXinitPassthrough.etx_passthrough_init(args.port, args.baud)
     try:
         dir = os.path.dirname(args.file.name)
-        esptool.main(['--chip', 'esp32', '--port', args.port, '--baud', str(args.baud), '--before', 'no_reset', '--after', 'hard_reset', 'write_flash', '-z', '--flash_mode', 'dio', '--flash_freq', '40m', '--flash_size', 'detect', '0x1000', os.path.join(dir, 'bootloader.bin'), '0x8000', os.path.join(dir, 'partitions.bin'), '0xe000', os.path.join(dir, 'boot_app0.bin'), '0x10000', args.file.name])
+        cmd = ['--chip', 'esp32', '--port', args.port, '--baud', str(args.baud), '--before', 'no_reset', '--after', 'hard_reset', 'write_flash']
+        if args.erase: cmd.append('--erase-all')
+        cmd.extend(['-z', '--flash_mode', 'dio', '--flash_freq', '40m', '--flash_size', 'detect', '0x1000', os.path.join(dir, 'bootloader.bin'), '0x8000', os.path.join(dir, 'partitions.bin'), '0xe000', os.path.join(dir, 'boot_app0.bin'), '0x10000', args.file.name])
+        esptool.main(cmd)
     except:
         return ElrsUploadResult.ErrorGeneral
     return ElrsUploadResult.Success


### PR DESCRIPTION
A couple of extras to the flasher and firmware archive
1. Copy the gzipped firmware to the <out> folder in "dir" flashing mode
2. Add `--erase` option for ESP8266 (UART and BF), ESP32 (UART and ETX), ESP32 BF cannot do erase because we update using the currently running firmware
3. Copy the Lua script to the artifact `.zip` file 