### PR TITLE
upload method fix for SIYI mini RX

### DIFF
--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -1540,7 +1540,7 @@
         "rx_2400": {
             "mini": {
                 "product_name": "SIYI FM30 Mini 2.4GHz RX",
-                "upload_methods": ["uart", "stlink"],
+                "upload_methods": ["stlink", "betaflight"],
                 "platform": "stm32",
                 "firmware": "FM30_RX_MINI",
                 "stlink": {


### PR DESCRIPTION
Upload methods for SIYI Rx should be `betaflight` not `uart`