### PR TITLE
Removing WiFi upload methods from STM targets

### DIFF
--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -435,7 +435,7 @@
         "tx_900": {
             "r9m": {
                 "product_name": "FrSky R9M 900MHz TX",
-                "upload_methods": ["stlink", "wifi", "stock"],
+                "upload_methods": ["stlink", "stock"],
                 "platform": "stm32",
                 "firmware": "Frsky_TX_R9M",
                 "features": ["buzzer", "unlock-higher-power", "fan"],
@@ -771,7 +771,7 @@
         "tx_900": {
             "es915": {
                 "product_name": "HappyModel ES915 TX",
-                "upload_methods": ["stlink", "wifi", "stock"],
+                "upload_methods": ["stlink", "stock"],
                 "platform": "stm32",
                 "firmware": "HappyModel_TX_ES915TX",
                 "has_buzzer": true,
@@ -1225,7 +1225,7 @@
         "tx_900": {
             "voyager_stm": {
                 "product_name": "NamimnoRC Voyager 900MHz TX",
-                "upload_methods": ["stlink", "wifi"],
+                "upload_methods": ["stlink", "stock"],
                 "platform": "stm32",
                 "firmware": "NamimnoRC_VOYAGER_900_TX",
                 "features": ["fan"],
@@ -1270,7 +1270,7 @@
         "tx_2400": {
             "flash_stm": {
                 "product_name": "NamimnoRC Flash 2.4GHz TX",
-                "upload_methods": ["stlink", "wifi"],
+                "upload_methods": ["stlink", "stock"],
                 "platform": "stm32",
                 "firmware": "NamimnoRC_FLASH_2400_TX",
                 "features": ["fan"],


### PR DESCRIPTION
STM targets had WiFi upload options, which is not actually available wrt expresslrs.org documents.