### PR TITLE
Fix no backpack overwriting channels

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -478,7 +478,8 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
       }
       else
       {
-        if (config.GetPTREnableChannel() != HT_OFF)
+        // if the backpack is communicating and PTR is not off
+        if (config.GetPTREnableChannel() != HT_OFF && backpackVersion[0] != 0)
         {
           uint8_t ptrStartChannel = config.GetPTRStartChannel();
           uint32_t chan = ChannelData[config.GetPTREnableChannel() / 2 + 3];


### PR DESCRIPTION
This fix basically disables head-tracking if a backpack is not detected, i.e. backpack has not responded to the version query.
For head tracking the backpack would have to be updated for that feature and that also includes the version query response code.

As mentioned in the ticket (#2254) the problem is actually with the config not being upgraded correctly, but we can't retroactively fix that so this fix is working around that problem.

Fixes #2254 