### PR TITLE
Change airport packet type to PACKET_TYPE_TLM

### DIFF
--- a/src/lib/OTA/OTA.cpp
+++ b/src/lib/OTA/OTA.cpp
@@ -581,6 +581,8 @@ void OtaUpdateSerializers(OtaSwitchMode_e const switchMode, uint8_t packetSize)
 
 void OtaPackAirportData(OTA_Packet_s * const otaPktPtr, FIFO_GENERIC<AP_MAX_BUF_LEN>  * inputBuffer)
 {
+    otaPktPtr->std.type = PACKET_TYPE_TLM;
+
     uint8_t count = inputBuffer->size();
     if (OtaIsFullRes)
     {

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -390,6 +390,11 @@ void ICACHE_RAM_ATTR SX127xDriver::TXnb(uint8_t * data, uint8_t size, SX12XX_Rad
   // }
   SetMode(SX127x_OPMODE_STANDBY, SX12XX_Radio_All);
 
+  if (radioNumber == SX12XX_Radio_NONE)
+  {
+      return;
+  }
+
 #if defined(DEBUG_RCVR_SIGNAL_STATS)
     if (radioNumber == SX12XX_Radio_All || radioNumber == SX12XX_Radio_1)
     {

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -484,6 +484,12 @@ void ICACHE_RAM_ATTR SX1280Driver::TXnb(uint8_t * data, uint8_t size, SX12XX_Rad
         return;
     }
 
+    if (radioNumber == SX12XX_Radio_NONE)
+    {
+        instance->SetMode(SX1280_MODE_FS, SX12XX_Radio_All);
+        return;
+    }
+
 #if defined(DEBUG_RCVR_SIGNAL_STATS)
     if (radioNumber == SX12XX_Radio_All || radioNumber == SX12XX_Radio_1)
     {

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -429,7 +429,7 @@ bool ICACHE_RAM_ATTR HandleSendTelemetryResponse()
 {
     uint8_t modresult = (OtaNonce + 1) % ExpressLRS_currTlmDenom;
 
-    if (config.GetForceTlmOff() || (connectionState == disconnected) || (ExpressLRS_currTlmDenom == 1) || (alreadyTLMresp == true) || (modresult != 0))
+    if ((connectionState == disconnected) || (ExpressLRS_currTlmDenom == 1) || (alreadyTLMresp == true) || (modresult != 0))
     {
         return false; // don't bother sending tlm if disconnected or TLM is off
     }
@@ -507,12 +507,15 @@ bool ICACHE_RAM_ATTR HandleSendTelemetryResponse()
 
 #if defined(Regulatory_Domain_EU_CE_2400)
     transmittingRadio &= ChannelIsClear(transmittingRadio);   // weed out the radio(s) if channel in use
-
-    if (transmittingRadio != SX12XX_Radio_NONE)               // send packet if channel available
 #endif
+
+    if (config.GetForceTlmOff())
     {
-        Radio.TXnb((uint8_t*)&otaPkt, ExpressLRS_currAirRate_Modparams->PayloadLength, transmittingRadio);
+        transmittingRadio = SX12XX_Radio_NONE;
     }
+
+    Radio.TXnb((uint8_t*)&otaPkt, ExpressLRS_currAirRate_Modparams->PayloadLength, transmittingRadio);
+ 
     return true;
 }
 

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -557,7 +557,7 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
   transmittingRadio &= ChannelIsClear(transmittingRadio);   // weed out the radio(s) if channel in use
 #endif
 
-    Radio.TXnb((uint8_t*)&otaPkt, ExpressLRS_currAirRate_Modparams->PayloadLength, transmittingRadio);
+  Radio.TXnb((uint8_t*)&otaPkt, ExpressLRS_currAirRate_Modparams->PayloadLength, transmittingRadio);
 
 	if (transmittingRadio == SX12XX_Radio_NONE)               // don't send packet if no radio available
   {                                                         // but do status update (issue #2028)

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -555,15 +555,13 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
 
 #if defined(Regulatory_Domain_EU_CE_2400)
   transmittingRadio &= ChannelIsClear(transmittingRadio);   // weed out the radio(s) if channel in use
+#endif
+
+    Radio.TXnb((uint8_t*)&otaPkt, ExpressLRS_currAirRate_Modparams->PayloadLength, transmittingRadio);
 
 	if (transmittingRadio == SX12XX_Radio_NONE)               // don't send packet if no radio available
   {                                                         // but do status update (issue #2028)
 		Radio.TXdoneCallback();
-  }
-	else
-#endif
-  {
-    Radio.TXnb((uint8_t*)&otaPkt, ExpressLRS_currAirRate_Modparams->PayloadLength, transmittingRadio);
   }
 }
 


### PR DESCRIPTION
**This is a breaking change for anyone currently using Airport!**

The Airport downlink currently uses PACKET_TYPE_TLM but the uplink uses PACKET_TYPE_RCDATA.  This PR changes the uplink to also use data type PACKET_TYPE_TLM, which currently completely unused.  

This does 2 things.  Keeps the packet type the same for both up and down links. But more importantly it frees the PACKET_TYPE_RCDATA type for side loading RC data from the handset.  Future work can then be done to add RC control without making a breaking change to Airport.