### PR TITLE
Force Telemetry value not displaying in webui due to typo

### DIFF
--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -259,7 +259,7 @@ function updateConfig(data, options) {
     storedModelId = 255;
   }
   _('modelid').value = storedModelId;
-  _('force-tlm').checked = data.hasOwnProperty('force-tlm') && data.forcetlm;
+  _('force-tlm').checked = data.hasOwnProperty('force-tlm') && data['force-tlm'];
   _('serial-protocol').onchange = () => {
     if (_('is-airport').checked) {
       _('rcvr-uart-baud').disabled = false;


### PR DESCRIPTION
As Jye reported, the "Force telemetry off" checkbox in the receiver webui worked, but did not display the current value properly. This is due to a typo in the property name used to populate it. Soclose.

### Steps to reproduce
* Boot an RX into the webui
* Go to the Model page, check the "Force telemetry off" checkbox
* Save
* Reload the page. BEHOLD the checkbox isn't checked