### PR TITLE
Respect when someone declines to flash the wrong target

### DIFF
--- a/src/python/BFinitPassthrough.py
+++ b/src/python/BFinitPassthrough.py
@@ -150,13 +150,13 @@ def reset_to_bootloader(port, baud, target, action, accept=None, half_duplex=Fal
 
     return ElrsUploadResult.Success
 
-def init_passthrough(source, target, env):
+def init_passthrough(source, target, env) -> int:
     env.AutodetectUploadPort([env])
     try:
         bf_passthrough_init(env['UPLOAD_PORT'], env['UPLOAD_SPEED'])
     except PassthroughEnabled as err:
         dbg_print(str(err))
-    reset_to_bootloader(env['UPLOAD_PORT'], env['UPLOAD_SPEED'], env['PIOENV'], source[0])
+    return reset_to_bootloader(env['UPLOAD_PORT'], env['UPLOAD_SPEED'], env['PIOENV'], source[0])
 
 def main(custom_args = None):
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
The upload script was discarding the response given to the question:
```
Wrong target selected! your RX is 'VANTAC_2400_RX', trying to flash 'DIY_2400_RX_ESP8285_SX1280', continue? Y/N
n
Wrong target selected your RX is 'VANTAC_2400_RX', trying to flash 'DIY_2400_RX_ESP8285_SX1280'
Configuring upload protocol...
AVAILABLE: espota, esptool
CURRENT: upload_protocol = esptool
Looking for upload port...
Using manually specified: COM6
Uploading .pio\build\DIY_2400_RX_ESP8285_SX1280_via_BetaflightPassthrough\firmware.bin
...
```
😞

Resulting in overwriting the target with the incorrect one even when I said NO! Not sure if this needs to be checked anywhere else but after this if I say "n" or "no" it aborts with error code -2, at least doing a VSCode upload.