### PR TITLE
ER6-G/GV and ER6/ER8/ER8G/ER8GV VBAT values swapped

### DIFF
--- a/src/hardware/RX/Radiomaster 2400 ER8G.json
+++ b/src/hardware/RX/Radiomaster 2400 ER8G.json
@@ -29,7 +29,7 @@
     "i2c_scl": 18,
     "vbat": 39,
     "button": 0,
-    "vbat_scale": 700,
-    "vbat_offset": -30,
+    "vbat_scale": 1024,
+    "vbat_offset": -62,
     "vbat_atten": 7
 }

--- a/src/hardware/RX/Vario 2400.json
+++ b/src/hardware/RX/Vario 2400.json
@@ -21,7 +21,7 @@
     "pwm_outputs": [14,1,3,15,2,4],
     "vbat": 39,
     "button": 0,
-    "vbat_scale": 1024,
-    "vbat_offset": -62,
+    "vbat_scale": 700,
+    "vbat_offset": -30,
     "vbat_atten": 7
 }


### PR DESCRIPTION
I'm not going to say who is at fault here, but clearly someone involved swapped the two VBAT scale/offsets and then someone else didn't engage their brain enough to notice they were backward.  😅 

VBAT is reading super high on ER6/ER8/ER8G/ER8GV and super low on the ER6-G/GV, this swaps the values so they're back where they should be.