### PR TITLE
Enable power and pitmode handling for MSP_SET_VTX_CONFIG command

### DIFF
--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -5,6 +5,7 @@
 #include "logging.h"
 #include "OTA.h"
 #include "FHSS.h"
+#include "devVTX.h"
 
 #define STR_LUA_ALLAUX         "AUX1;AUX2;AUX3;AUX4;AUX5;AUX6;AUX7;AUX8;AUX9;AUX10"
 
@@ -266,7 +267,6 @@ static char luaBadGoodString[10];
 static int event();
 
 extern TxConfig config;
-extern void VtxTriggerSend();
 extern void ResetPower();
 extern uint8_t adjustPacketRateForBaud(uint8_t rate);
 extern void SetSyncSpam();

--- a/src/lib/SCREEN/menu.cpp
+++ b/src/lib/SCREEN/menu.cpp
@@ -8,6 +8,7 @@
 #include "POWERMGNT.h"
 #include "CRSF.h"
 #include "OTA.h"
+#include "devVTX.h"
 
 #ifdef HAS_THERMAL
 #include "thermal.h"
@@ -22,7 +23,6 @@ extern bool InBindingMode;
 extern bool RxWiFiReadyToSend;
 extern bool TxBackpackWiFiReadyToSend;
 extern bool VRxBackpackWiFiReadyToSend;
-extern void VtxTriggerSend();
 extern void ResetPower();
 extern void setWifiUpdateMode();
 extern void SetSyncSpam();

--- a/src/lib/VTX/devVTX.h
+++ b/src/lib/VTX/devVTX.h
@@ -3,6 +3,6 @@
 #include "device.h"
 
 // Call this to trigger sending of Vtx packet
-void VtxTriggerSend();
+void VtxTriggerSend(bool toBackpack = true);
 void VtxPitmodeSwitchUpdate();
 extern device_t VTX_device;

--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -172,7 +172,7 @@ void initUID()
     else
     {
     #ifdef PLATFORM_ESP32
-        esp_err_t WiFiErr = esp_read_mac(MasterUID, ESP_MAC_WIFI_STA);
+        /*esp_err_t WiFiErr =*/ esp_read_mac(MasterUID, ESP_MAC_WIFI_STA);
     #elif PLATFORM_STM32
         MasterUID[0] = (uint8_t)HAL_GetUIDw0();
         MasterUID[1] = (uint8_t)(HAL_GetUIDw0() >> 8);

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -989,16 +989,25 @@ void ProcessMSPPacket(uint32_t now, mspPacket_t *packet)
   }
   else if (packet->function == MSP_SET_VTX_CONFIG)
   {
-    if (packet->payload[0] < 48) // Standard 48 channel VTx table size e.g. A, B, E, F, R, L
+    if (2 <= packet->payloadSize && packet->payload[0] < 48) // Standard 48 channel VTx table size e.g. A, B, E, F, R, L
     {
       config.SetVtxBand(packet->payload[0] / 8 + 1);
       config.SetVtxChannel(packet->payload[0] % 8);
-    } else
+      if (3 <= packet->payloadSize)
+      {
+        config.SetVtxPower(packet->payload[2]);
+      }
+      if (4 <= packet->payloadSize)
+      {
+        config.SetVtxPitmode(!!packet->payload[3]);
+      }
+    }
+    else
     {
       return; // Packets containing frequency in MHz are not yet supported.
     }
 
-    VtxTriggerSend();
+    VtxTriggerSend(false);
   }
 #endif
   if (packet->function == MSP_ELRS_GET_BACKPACK_VERSION)


### PR DESCRIPTION
This is for a lap timer integration.
Lap timer can force pilots to use correct power in along with the correct video channel.