### PR TITLE
[WIP] ExpressLRS Radar

### DIFF
--- a/src/include/target/Unified_ESP_RX.h
+++ b/src/include/target/Unified_ESP_RX.h
@@ -138,3 +138,5 @@
 #define GPIO_PIN_SPI_VTX_SCK hardware_pin(HARDWARE_vtx_sck)
 #define VPD_VALUES_25MW hardware_u16_array(HARDWARE_vtx_amp_vpd_25mW)
 #define VPD_VALUES_100MW hardware_u16_array(HARDWARE_vtx_amp_vpd_100mW)
+
+#define USE_RADAR

--- a/src/lib/AnalogVbat/devAnalogVbat.h
+++ b/src/lib/AnalogVbat/devAnalogVbat.h
@@ -4,7 +4,9 @@
 #include "device.h"
 
 #if defined(USE_ANALOG_VBAT)
-void Vbat_enableSlowUpdate(bool enable);
+enum VbatUpdateRate_e { vurNormal, vurSlow, vurDisabled };
+
+void Vbat_setUpdateRate(VbatUpdateRate_e rate);
 
 extern device_t AnalogVbat_device;
 #endif

--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -980,7 +980,7 @@ void CRSF::GetDeviceInformation(uint8_t *frame, uint8_t fieldCount)
 
 void CRSF::SetMspV2Request(uint8_t *frame, uint16_t function, uint8_t *payload, uint8_t payloadLength)
 {
-    uint8_t *packet = (uint8_t *)(frame + sizeof(crsf_ext_header_t));                
+    uint8_t *packet = (uint8_t *)(frame + sizeof(crsf_ext_header_t));
     packet[0] = 0x50;          // no error, version 2, beginning of the frame, first frame (0)
     packet[1] = 0;             // flags
     packet[2] = function & 0xFF;
@@ -993,7 +993,7 @@ void CRSF::SetMspV2Request(uint8_t *frame, uint16_t function, uint8_t *payload, 
 
 void CRSF::SetHeaderAndCrc(uint8_t *frame, uint8_t frameType, uint8_t frameSize, uint8_t destAddr)
 {
-    crsf_header_t *header = (crsf_header_t *)frame;
+    crsf_std_header_t *header = (crsf_std_header_t *)frame;
     header->device_addr = destAddr;
     header->frame_size = frameSize;
     header->type = frameType;

--- a/src/lib/MSP/msp.h
+++ b/src/lib/MSP/msp.h
@@ -61,6 +61,12 @@ typedef struct {
         payload[payloadSize++] = b;
     }
 
+    void add(uint8_t *b, uint8_t len)
+    {
+        while (len--)
+            addByte(*b++);
+    }
+
     void makeResponse()
     {
         type = MSP_PACKET_RESPONSE;

--- a/src/lib/MSP/msptypes.h
+++ b/src/lib/MSP/msptypes.h
@@ -35,6 +35,12 @@
 #define ENCAPSULATED_MSP_MAX_PAYLOAD_SIZE   4
 #define ENCAPSULATED_MSP_MAX_FRAME_LEN      (ENCAPSULATED_MSP_HEADER_CRC_LEN + ENCAPSULATED_MSP_MAX_PAYLOAD_SIZE)
 
+#define MSP_SET_RADAR_POS        248 //SET radar position information
+#define MSP_SET_RADAR_ITD        249 //SET radar information to display
+
+#define MSP2_COMMON_SET_RADAR_POS       0x100B //SET radar position information
+#define MSP2_COMMON_SET_RADAR_ITD       0x100C //SET radar information to display
+
 // ELRS backpack protocol opcodes
 // See: https://docs.google.com/document/d/1u3c7OTiO4sFL2snI-hIo-uRSLfgBK4h16UrbA08Pd6U/edit#heading=h.1xw7en7jmvsj
 #define MSP_ELRS_BACKPACK_GET_CHANNEL_INDEX     0x0300

--- a/src/lib/Radar/RadarReceiver.cpp
+++ b/src/lib/Radar/RadarReceiver.cpp
@@ -1,16 +1,163 @@
+#include "devRadar.h"
+
 #if defined(USE_RADAR)
 
-static
+#include "user_interface.h"
+#include "logging.h"
+#include "libopendroneid/opendroneid.h"
+#include "libopendroneid/odid_wifi.h"
+
+#if defined(PLATFORM_ESP8266)
+
+typedef struct {
+	signed rssi: 8;
+	unsigned rate: 4;
+	unsigned is_group: 1;
+	unsigned: 1;
+	unsigned sig_mode: 2;
+	unsigned legacy_length: 12;
+	unsigned damatch0: 1;
+	unsigned damatch1: 1;
+	unsigned bssidmatch0: 1;
+	unsigned bssidmatch1: 1;
+	unsigned MCS: 7;
+	unsigned CWB: 1;
+	unsigned HT_length: 16;
+	unsigned Smoothing: 1;
+	unsigned Not_Sounding: 1;
+	unsigned: 1;
+	unsigned Aggregation: 1;
+	unsigned STBC: 2;
+	unsigned FEC_CODING: 1;
+	unsigned SGI: 1;
+	unsigned rxend_state: 8;
+	unsigned ampdu_cnt: 8;
+	unsigned channel: 4;
+	unsigned: 12;
+} wifi_pkt_rx_ctrl_t;
+
+typedef struct {
+	wifi_pkt_rx_ctrl_t rx_ctrl;
+	uint8_t payload[0]; /* ieee80211 packet buff */
+} wifi_promiscuous_pkt_t;
+
+#endif // PLATFORM_ESP8266
+
+#define IEEE80211_ELEMID_SSID		0x00
+#define IEEE80211_ELEMID_RATES		0x01
+#define IEEE80211_ELEMID_VENDOR		0xDD
+
+typedef struct tagRadarPilotInfo {
+    uint8_t mac[6]; // because we can't rely on users to not fly two things with the same OID
+    char operator_id[RADAR_ID_LEN+1];
+    int8_t rssi;         // dBm
+    uint32_t last_seen;  // ms
+    int32_t latitude;    // in * 10M
+    int32_t longitude;   // in * 10M
+    int16_t altitude;    // in m
+} RadarPilotInfo;
+
+static void wifi_promiscuous_cb(uint8 *buf, uint16 len)
+{
+    wifi_promiscuous_pkt_t *pkt = (wifi_promiscuous_pkt_t *)buf;
+    ieee80211_mgmt *hdr = (ieee80211_mgmt *)pkt->payload;
+
+    // Looking for a beacon frame, 0x8000
+    // MAC of transmitter is in hdr.sa
+    if (hdr->frame_control != htons(0x8000))
+        return;
+
+    RadarPilotInfo pilot;
+    size_t payloadlen = len - sizeof(wifi_pkt_rx_ctrl_t);
+    size_t offset = sizeof(ieee80211_mgmt) + sizeof(ieee80211_beacon);
+    bool found_odid = false;
+    while (offset < payloadlen && !found_odid)
+    {
+        switch (pkt->payload[offset]) // ieee80211 element_id
+        {
+        case IEEE80211_ELEMID_SSID:
+            {
+                // Operator ID is in the SSID field
+                ieee80211_ssid *iessid = (ieee80211_ssid *)&pkt->payload[offset];
+                uint8_t ssid_len = std::min((uint8_t)RADAR_ID_LEN, iessid->length);
+                memcpy(pilot.operator_id, iessid->ssid, ssid_len);
+                pilot.operator_id[ssid_len] = '\0';
+                offset += sizeof(ieee80211_ssid) + iessid->length;
+                break;
+            }
+        case IEEE80211_ELEMID_RATES:
+            {
+                ieee80211_supported_rates *iesr = (ieee80211_supported_rates *)&pkt->payload[offset];
+                if (iesr->length > 1 || iesr->supported_rates != 0x8C)  // ODID beacon is 6 mbit
+                    return;
+                offset += sizeof(ieee80211_supported_rates);
+                break;
+            }
+        case IEEE80211_ELEMID_VENDOR:
+            {
+                ieee80211_vendor_specific *ievs = (ieee80211_vendor_specific *)&pkt->payload[offset];
+                // The OUI of opendroneid is FA-0B-BC
+                if (ievs->oui[0] != 0xfa || ievs->oui[1] != 0x0b || ievs->oui[2] != 0xbc || ievs->oui_type != 0x0d)
+                    return;
+                offset += sizeof(ieee80211_vendor_specific);
+                found_odid = true;
+                break;
+            }
+        default:
+            // Any unexpected element_id means we can pound sand
+            return;
+        } // switch
+    } // while (<len)
+
+    if (!found_odid)
+        return;
+
+    //DBGLN("Found ODID: %s", pilot.operator_id);
+
+    pilot.rssi = pkt->rx_ctrl.rssi;
+    pilot.last_seen = millis();
+    memcpy(pilot.mac, hdr->sa, sizeof(pilot.mac));
+
+    //ODID_service_info *si = (struct ODID_service_info *)&pkt->payload[offset];
+    // can use si->counter to maybe do link quality, by detecting missing packet
+    offset += sizeof(ODID_service_info);
+
+    // Espressif are assholes for not giving us the whole packet, can't decode it because it is short
+    ODID_MessagePack_encoded *msg_pack_enc = (ODID_MessagePack_encoded *)&pkt->payload[offset];
+    offset += 3; // Version/MessageType SingleMessageSize MsgPackSize
+    //size_t expected_msg_size = sizeof(*msg_pack_enc) - ODID_MESSAGE_SIZE * (ODID_PACK_MAX_MESSAGES - msg_pack_enc->MsgPackSize);
+    //DBGLN("Found ODID: %s (%d dBm)", pilot.operator_id, pilot.rssi);
+    for (unsigned i=0; i<msg_pack_enc->MsgPackSize && (offset+ODID_MESSAGE_SIZE)<payloadlen; ++i)
+    {
+        uint8_t MessageType = decodeMessageType(msg_pack_enc->Messages[i].rawData[0]);
+        if (MessageType == ODID_MESSAGETYPE_LOCATION)
+        {
+            ODID_Location_encoded *loc = (ODID_Location_encoded *)&msg_pack_enc->Messages[i];
+            // Conveniently, lat/lon are already 10M scale integer which is our format
+            pilot.latitude = loc->Latitude;
+            pilot.longitude = loc->Longitude;
+            // Altitude is encoded 2x scale + 1000
+            pilot.altitude = loc->Height / 2 - 1000;
+            DBGLN("%d %d %d", pilot.latitude, pilot.longitude, pilot.altitude);
+            //return;
+        }
+        offset += msg_pack_enc->SingleMessageSize;
+        // off=94 len=116, means there's 22 of 25 bytes in msg[1]
+        //DBGLN("off=%u len=%u", offset, payloadlen);
+    }
+}
 
 void RadarRx_Begin()
 {
     wifi_promiscuous_enable(0);
-    wifi_set_promiscuous_rx_cb(promisc_cb);
+    wifi_set_promiscuous_rx_cb(&wifi_promiscuous_cb);
     wifi_promiscuous_enable(1);
 }
 
 void RadarRx_End()
 {
-
+    wifi_promiscuous_enable(0);
+    //wifi_set_promiscuous_rx_cb(nullptr);
 }
+
 #endif

--- a/src/lib/Radar/RadarReceiver.cpp
+++ b/src/lib/Radar/RadarReceiver.cpp
@@ -1,0 +1,16 @@
+#if defined(USE_RADAR)
+
+static
+
+void RadarRx_Begin()
+{
+    wifi_promiscuous_enable(0);
+    wifi_set_promiscuous_rx_cb(promisc_cb);
+    wifi_promiscuous_enable(1);
+}
+
+void RadarRx_End()
+{
+
+}
+#endif

--- a/src/lib/Radar/RadarReceiver.h
+++ b/src/lib/Radar/RadarReceiver.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#if defined(USE_RADAR)
+void RadarRx_Begin();
+void RadarRx_End();
+#endif

--- a/src/lib/Radar/RadarReceiver.h
+++ b/src/lib/Radar/RadarReceiver.h
@@ -1,6 +1,30 @@
 #pragma once
 
+#include "devRadar.h"
+
 #if defined(USE_RADAR)
+
+#define MAC_LEN 6
+
+typedef struct tagRadarPilotInfo {
+    uint8_t mac[MAC_LEN]; // because we can't rely on users to not fly two things with the same OID
+    char operator_id[RADAR_ID_LEN+1];
+    int8_t rssi;         // dBm
+    uint32_t last_seen;  // ms
+    int32_t latitude;    // in * 10M
+    int32_t longitude;   // in * 10M
+    int16_t altitude;    // in m
+    uint16_t heading;
+    uint16_t speed;
+    uint8_t dirty;       // set to 1 on update
+} RadarPilotInfo;
+
 void RadarRx_Begin();
 void RadarRx_End();
+
+#define RADAR_PILOT_IDX_INVALID 0xff
+
+uint8_t Radar_FindNextDirtyIdx();
+extern RadarPilotInfo pilots[];
+
 #endif

--- a/src/lib/Radar/devRadar.cpp
+++ b/src/lib/Radar/devRadar.cpp
@@ -1,0 +1,231 @@
+#include "devRadar.h"
+
+// TODO: we need accurate time
+// TODO: Need to validate all the fields going into the UAS structure
+//   to be sure they are in range (whole section won't go if one value is outside the correct range)
+// TODO: WGS-84 Operator alitude is required?
+
+#if defined(USE_RADAR)
+#include "logging.h"
+
+#include <ESP8266WiFi.h>
+#include "libopendroneid/opendroneid.h"
+
+#define BEACON_REPORT_INTERVAL_MS 3000
+#define BEACON_WIFI_CHANNEL       6
+// A pack with 2x BasicID, 1xLoc, 1xSelfID, 1xSystem, 1xOperatorID ~223 bytes
+#define WIFI_BUFF_SIZE 250
+
+// State variables
+static crsf_sensor_gps_t radar_Gps;
+static struct tagOperatorLocation {
+    bool isValid;
+    double latitude;
+    double longitude;
+} OperatorLocation;
+
+// User-supplied parameters
+static RadarPhyMethod_e radar_PhyMethod;
+// Operator ID (up to 20 chars)
+static const char *radar_OperatorId = "FAA-OP-CAPNBRY1337";
+// Drone ID (up to 20 chars)
+static const char *radar_UasId = "CapnForceOne"; // FhpxNQvpxSNN";
+// Transmitter serial number (4+1+12)
+static const char *radar_serialId = "ELRSC123456789012";  // ANSI/CTA-2063-A
+
+// Somewhat fixed parameters
+static const ODID_uatype_t radar_UAType = ODID_UATYPE_HELICOPTER_OR_MULTIROTOR; // or ODID_UATYPE_AEROPLANE
+static const char *radar_SelfId = "Recreational";
+
+void Radar_UpdatePosition(const crsf_sensor_gps_t *gps)
+{
+    // The values are Big Endian, convert them to native byte order
+    radar_Gps.latitude = be32toh(gps->latitude);
+    radar_Gps.longitude = be32toh(gps->longitude);
+    radar_Gps.groundspeed = be16toh(gps->groundspeed);
+    radar_Gps.heading = be16toh(gps->heading);
+    radar_Gps.altitude = be16toh(gps->altitude);
+    radar_Gps.satellites = gps->satellites;
+
+    // First time there are >5 sats, declare this operator position
+    if (!OperatorLocation.isValid && radar_Gps.satellites > 5)
+    {
+        OperatorLocation.isValid = true;
+        OperatorLocation.latitude = radar_Gps.latitude / 10000000.0;
+        OperatorLocation.longitude = radar_Gps.longitude / 10000000.0;
+    }
+}
+
+/***
+ * @brief: Return a set of supported Phy Methods that can be used for transmission
+ * @return: A bit set for each supproted method
+ *          e.g. just rpmDisabled = 0x01
+ *          e.g. both rpmDisabled and rpmWifiBeacon = 0x03
+*/
+uint32_t Radar_GetSupportedPhyMethods()
+{
+#if defined(PLATFORM_ESP8266)
+    return bit(rpmDisabled) | bit(rpmWifiBeacon);
+#elif defined(PLATFORM_ESP32)
+    return bit(rpmDisabled) | bit(rpmWifiBeacon) | bit(rpmBluetoothLegacy);
+#else
+    return bit(rpmDisabled);
+#endif
+}
+
+static int start()
+{
+    radar_PhyMethod = rpmWifiBeacon;
+
+    // Start an AP with SSID=OperatorID, hidden, on the correct channel
+    WiFi.softAP(radar_OperatorId, nullptr, BEACON_WIFI_CHANNEL, 1, 2, false);
+    //WiFi.mode(WIFI_STA);
+    //WiFi.setPhyMode(WIFI_PHY_MODE_11B);
+    //wifi_set_phy_mode(PHY_MODE_11B);
+    //esp_wifi_set_bandwidth(WIFI_IF_AP, WIFI_BW_HT20);
+
+    // Output power
+    //WiFi.setOutputPower(20);
+    //system_phy_set_max_tpw(80);
+    //esp_wifi_set_max_tx_power(80); // +20dBm
+
+    // Some test data
+    // radar_Gps.heading = 9000; // 90 degrees
+    // radar_Gps.groundspeed = 880; // 88kph
+    // radar_Gps.latitude = (int32_t)(28.085 * 10000000);
+    // radar_Gps.longitude = (int32_t)(-82.641 * 10000000);
+    // radar_Gps.altitude = 15 + 1000;
+    // radar_Gps.satellites = 3;
+
+    return BEACON_REPORT_INTERVAL_MS;
+}
+
+static void radar_FillUasData(ODID_UAS_Data &uasData)
+{
+    memset(&uasData, 0, sizeof(uasData));
+
+    // Basic ID
+    //odid_initBasicIDData(&uasData.BasicID[0]);
+    uasData.BasicID[0].UAType = radar_UAType;
+    uasData.BasicID[0].IDType = ODID_IDTYPE_SERIAL_NUMBER;
+    strcpy(uasData.BasicID[0].UASID, radar_serialId);
+    uasData.BasicIDValid[0] = 1;
+    //odid_initBasicIDData(&uasData.BasicID[1]);
+    uasData.BasicID[1].UAType = radar_UAType;
+    uasData.BasicID[1].IDType = ODID_IDTYPE_CAA_REGISTRATION_ID;
+    strcpy(uasData.BasicID[1].UASID, radar_UasId);
+    uasData.BasicIDValid[1] = 1;
+
+    // Location
+    //odid_initLocationData(&uasData.Location);
+    uasData.Location.Status = ODID_STATUS_AIRBORNE; // CRSF::IsArmed() lollllls : ODID_STATUS_GROUND;
+    uasData.Location.Direction = radar_Gps.heading / 100.0;
+    uasData.Location.SpeedHorizontal = radar_Gps.groundspeed / 36.0;
+    uasData.Location.SpeedVertical = INV_SPEED_V;
+    uasData.Location.Latitude = radar_Gps.latitude / 10000000.0;
+    uasData.Location.Longitude = radar_Gps.longitude / 10000000.0;
+    uasData.Location.HeightType = ODID_HEIGHT_REF_OVER_TAKEOFF;
+    uasData.Location.Height = radar_Gps.altitude - 1000.0;
+    uasData.Location.AltitudeGeo  = INV_ALT;
+    uasData.Location.AltitudeBaro = INV_ALT;
+    uasData.Location.TimeStamp = INV_TIMESTAMP;
+    uasData.LocationValid = 1;
+
+    // Authdata
+    // odid_initAuthData(&uasData.Auth[0]);
+    // uasData.AuthValid[ODID_AUTH_MAX_PAGES] = 0;
+
+    // SelfID
+    //odid_initSelfIDData(&uasData.SelfID);
+    uasData.SelfID.DescType = ODID_DESC_TYPE_TEXT;
+    strcpy(uasData.SelfID.Desc, radar_SelfId);
+    uasData.SelfIDValid = 1;
+
+    // System
+    //odid_initSystemData(&uasData.System)
+    uasData.System.OperatorLocationType = ODID_OPERATOR_LOCATION_TYPE_TAKEOFF;
+    uasData.System.ClassificationType = ODID_CLASSIFICATION_TYPE_UNDECLARED;  // or EU?
+    uasData.System.OperatorLatitude =  OperatorLocation.latitude;
+    uasData.System.OperatorLongitude = OperatorLocation.longitude;
+    uasData.System.AreaCount = 1;
+    uasData.System.AreaRadius = 0;
+    uasData.System.AreaCeiling = INV_ALT;
+    uasData.System.AreaFloor = INV_ALT;
+    //uasData.System.CategoryEU = ODID_CATEGORY_EU_OPEN;
+    //uasData.System.ClassEU = ODID_CLASS_EU_CLASS_4; // oh yeah I am totally a class 4 pilot, baby
+    uasData.System.OperatorAltitudeGeo = INV_ALT;
+    uasData.System.Timestamp = INV_TIMESTAMP;
+    uasData.SystemValid = 1;
+
+    // OperatorID
+    //odid_initOperatorIDData(&uasData.OperatorID);
+    strcpy(uasData.OperatorID.OperatorId, radar_OperatorId);
+    uasData.OperatorID.OperatorIdType = ODID_OPERATOR_ID;
+    uasData.OperatorIDValid = 1;
+}
+
+static void radar_sendBeacon()
+{
+    // Stuff that could be done in init
+    uint8_t wifimac[6];
+    wifi_get_macaddr(SOFTAP_IF, wifimac);
+    //wifi_get_macaddr(STATION_IF, wifimac);
+
+    ODID_UAS_Data uasData;
+    radar_FillUasData(uasData);
+
+    static uint8_t counter;
+    uint8_t buf[WIFI_BUFF_SIZE];
+
+    int packedLen = 0;
+    if (radar_PhyMethod == rpmWifiBeacon)
+    {
+        packedLen = odid_wifi_build_message_pack_beacon_frame(
+            &uasData, (char *)wifimac,
+            radar_OperatorId, strlen(radar_OperatorId), BEACON_REPORT_INTERVAL_MS,
+            counter, buf, WIFI_BUFF_SIZE);
+    }
+    else if (radar_PhyMethod == rpmWifiNan)
+    {
+        packedLen = odid_wifi_build_message_pack_nan_action_frame(
+            &uasData, (char *)wifimac,
+            counter, buf, WIFI_BUFF_SIZE);
+    }
+
+    if (packedLen > 0)
+    {
+        ++counter;
+        int err = wifi_send_pkt_freedom(buf, packedLen, true);
+        DBGLN("wifi_send_pkt_freedom=%d", err);
+
+        // ESP32
+        //esp_wifi_80211_tx(WIFI_IF_AP, buf, packedLen, true);
+    }
+}
+
+static int event()
+{
+    return DURATION_IGNORE;
+}
+
+static int timeout()
+{
+    // Stop all transmitting if in wifi mode, update mode, etc
+    if (connectionState > MODE_STATES || radar_PhyMethod == rpmDisabled)
+    {
+        return DURATION_NEVER;
+    }
+
+    radar_sendBeacon();
+
+    return BEACON_REPORT_INTERVAL_MS;
+}
+
+device_t Radar_device = {
+    .initialize = nullptr,
+    .start = start,
+    .event = event,
+    .timeout = timeout,
+};
+
+#endif // USE_RADAR

--- a/src/lib/Radar/devRadar.h
+++ b/src/lib/Radar/devRadar.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "common.h"
+#include "device.h"
+#include "CRSF.h"
+
+#if defined(USE_RADAR)
+
+enum RadarPhyMethod_e {
+    rpmDisabled,
+    rpmWifiBeacon,
+    rpmWifiNan,
+    rpmBluetoothLegacy,
+    rpmBluetoothLongRange,
+};
+
+uint32_t Radar_GetSupportedPhyMethods();
+void Radar_UpdatePosition(const crsf_sensor_gps_t *gps);
+
+extern device_t Radar_device;
+
+#endif

--- a/src/lib/Radar/devRadar.h
+++ b/src/lib/Radar/devRadar.h
@@ -6,6 +6,9 @@
 
 #if defined(USE_RADAR)
 
+#define RADAR_ID_LEN        20
+#define RADAR_SERIAL_LEN    17
+
 enum RadarPhyMethod_e {
     rpmDisabled,
     rpmWifiBeacon,

--- a/src/lib/Radar/devRadar.h
+++ b/src/lib/Radar/devRadar.h
@@ -17,6 +17,18 @@ enum RadarPhyMethod_e {
     rpmBluetoothLongRange,
 };
 
+/* Stolen MSP definitions from the FormationFlight project */
+struct msp_radar_pos_t {
+  uint8_t id;
+  uint8_t state;    // disarmed(0) armed (1)
+  int32_t lat;      // decimal degrees latitude * 10000000
+  int32_t lon;      // decimal degrees longitude * 10000000
+  int32_t alt;      // cm
+  uint16_t heading; // deg
+  uint16_t speed;   // cm/s
+  uint8_t lq;       // lq
+} __attribute__((packed));
+
 uint32_t Radar_GetSupportedPhyMethods();
 void Radar_UpdatePosition(const crsf_sensor_gps_t *gps);
 

--- a/src/lib/Radar/libopendroneid/odid_wifi.h
+++ b/src/lib/Radar/libopendroneid/odid_wifi.h
@@ -1,0 +1,106 @@
+/*
+Copyright (C) 2019 Intel Corporation
+
+SPDX-License-Identifier: Apache-2.0
+
+Open Drone ID C Library
+
+Maintainer:
+Gabriel Cox
+gabriel.c.cox@intel.com
+*/
+
+#ifndef _ODID_WIFI_H_
+#define _ODID_WIFI_H_
+
+/**
+* IEEE 802.11 structs to build management action frame
+*/
+struct __attribute__((__packed__)) ieee80211_mgmt {
+    uint16_t frame_control;
+    uint16_t duration;
+    uint8_t da[6];
+    uint8_t sa[6];
+    uint8_t bssid[6];
+    uint16_t seq_ctrl;
+};
+
+struct __attribute__((__packed__)) ieee80211_beacon {
+    uint64_t timestamp;
+    uint16_t beacon_interval;
+    uint16_t capability;
+};
+
+struct __attribute__((__packed__)) ieee80211_ssid {
+    uint8_t element_id;
+    uint8_t length;
+    uint8_t ssid[];
+};
+
+struct __attribute__((__packed__)) ieee80211_supported_rates {
+    uint8_t element_id;
+    uint8_t length;
+    uint8_t supported_rates;
+};
+
+struct __attribute__((__packed__)) ieee80211_vendor_specific {
+	uint8_t element_id;
+	uint8_t length;
+	uint8_t oui[3];
+	uint8_t oui_type;
+};
+
+struct __attribute__((__packed__)) nan_service_discovery {
+    uint8_t category;
+    uint8_t action_code;
+    uint8_t oui[3];
+    uint8_t oui_type;
+};
+
+struct __attribute__((__packed__)) nan_attribute_header {
+    uint8_t attribute_id;
+    uint16_t length;
+};
+
+struct __attribute__((__packed__)) nan_master_indication_attribute {
+    struct nan_attribute_header header;
+    uint8_t master_preference;
+    uint8_t random_factor;
+};
+
+struct __attribute__((__packed__)) nan_cluster_attribute {
+    struct nan_attribute_header header;
+    uint8_t device_mac[6];
+    uint8_t random_factor;
+    uint8_t master_preference;
+    uint8_t hop_count_to_anchor_master;
+    uint8_t anchor_master_beacon_transmission_time[4];
+};
+
+struct __attribute__((__packed__)) nan_service_id_list_attribute {
+    struct nan_attribute_header header;
+    uint8_t service_id[6];
+};
+
+struct __attribute__((__packed__)) nan_service_descriptor_attribute {
+    struct nan_attribute_header header;
+    uint8_t service_id[6];
+    uint8_t instance_id;
+    uint8_t requestor_instance_id;
+    uint8_t service_control;
+    uint8_t service_info_length;
+};
+
+struct __attribute__((__packed__)) nan_service_descriptor_extension_attribute {
+    struct nan_attribute_header header;
+    uint8_t instance_id;
+    uint16_t control;
+    uint8_t service_update_indicator;
+};
+
+struct __attribute__((__packed__)) ODID_service_info {
+    uint8_t message_counter;
+    ODID_MessagePack_encoded odid_message_pack[];
+};
+
+#endif // _ODID_WIFI_H_

--- a/src/lib/Radar/libopendroneid/opendroneid.c
+++ b/src/lib/Radar/libopendroneid/opendroneid.c
@@ -1,0 +1,1476 @@
+/*
+Copyright (C) 2019 Intel Corporation
+
+SPDX-License-Identifier: Apache-2.0
+
+Open Drone ID C Library
+
+Maintainer:
+Gabriel Cox
+gabriel.c.cox@intel.com
+*/
+
+#include "opendroneid.h"
+#include <math.h>
+#include <stdio.h>
+#define ENABLE_DEBUG 1
+
+const float SPEED_DIV[2] = {0.25f, 0.75f};
+const float VSPEED_DIV = 0.5f;
+const int32_t LATLON_MULT = 10000000;
+const float ALT_DIV = 0.5f;
+const int ALT_ADDER = 1000;
+
+static char *safe_dec_copyfill(char *dstStr, const char *srcStr, int dstSize);
+static int intRangeMax(int64_t inValue, int startRange, int endRange);
+static int intInRange(int inValue, int startRange, int endRange);
+
+/**
+* Initialize basic ID data fields to their default values
+*
+* @param data (non encoded/packed) structure
+*/
+void odid_initBasicIDData(ODID_BasicID_data *data)
+{
+    if (!data)
+        return;
+    memset(data, 0, sizeof(ODID_BasicID_data));
+}
+
+/**
+* Initialize location data fields to their default values
+*
+* @param data (non encoded/packed) structure
+*/
+void odid_initLocationData(ODID_Location_data *data)
+{
+    if (!data)
+        return;
+    memset(data, 0, sizeof(ODID_Location_data));
+    data->Direction = INV_DIR;
+    data->SpeedHorizontal = INV_SPEED_H;
+    data->SpeedVertical = INV_SPEED_V;
+    data->AltitudeBaro = INV_ALT;
+    data->AltitudeGeo = INV_ALT;
+    data->Height = INV_ALT;
+}
+
+/**
+* Initialize authorization data fields to their default values
+*
+* @param data (non encoded/packed) structure
+*/
+void odid_initAuthData(ODID_Auth_data *data)
+{
+    if (!data)
+        return;
+    memset(data, 0, sizeof(ODID_Auth_data));
+}
+
+/**
+* Initialize self ID data fields to their default values
+*
+* @param data (non encoded/packed) structure
+*/
+void odid_initSelfIDData(ODID_SelfID_data *data)
+{
+    if (!data)
+        return;
+    memset(data, 0, sizeof(ODID_SelfID_data));
+}
+
+/**
+* Initialize system data fields to their default values
+*
+* @param data (non encoded/packed) structure
+*/
+
+void odid_initSystemData(ODID_System_data *data)
+{
+    if (!data)
+        return;
+    memset(data, 0, sizeof(ODID_System_data));
+    data->AreaCount = 1;
+    data->AreaCeiling = INV_ALT;
+    data->AreaFloor = INV_ALT;
+    data->OperatorAltitudeGeo = INV_ALT;
+}
+
+/**
+* Initialize operator ID data fields to their default values
+*
+* @param data (non encoded/packed) structure
+*/
+
+void odid_initOperatorIDData(ODID_OperatorID_data *data)
+{
+    if (!data)
+        return;
+    memset(data, 0, sizeof(ODID_OperatorID_data));
+}
+
+/**
+* Initialize message pack data fields to their default values
+*
+* @param data (non encoded/packed) structure
+*/
+
+void odid_initMessagePackData(ODID_MessagePack_data *data)
+{
+    if (!data)
+        return;
+    memset(data, 0, sizeof(ODID_MessagePack_data));
+    data->SingleMessageSize = ODID_MESSAGE_SIZE;
+}
+
+/**
+* Initialize UAS data fields to their default values
+*
+* @param data (non encoded/packed) structure
+*/
+
+void odid_initUasData(ODID_UAS_Data *data)
+{
+    if (!data)
+        return;
+    for (int i = 0; i < ODID_BASIC_ID_MAX_MESSAGES; i++) {
+        data->BasicIDValid[i] = 0;
+        odid_initBasicIDData(&data->BasicID[i]);
+    }
+    data->LocationValid = 0;
+    odid_initLocationData(&data->Location);
+    for (int i = 0; i < ODID_AUTH_MAX_PAGES; i++) {
+        data->AuthValid[i] = 0;
+        odid_initAuthData(&data->Auth[i]);
+    }
+    data->SelfIDValid = 0;
+    odid_initSelfIDData(&data->SelfID);
+    data->SystemValid = 0;
+    odid_initSystemData(&data->System);
+    data->OperatorIDValid = 0;
+    odid_initOperatorIDData(&data->OperatorID);
+}
+
+/**
+* Encode direction as defined by Open Drone ID
+*
+* The encoding method uses 8 bits for the direction in degrees and
+* one extra bit for indicating the East/West direction.
+*
+* @param Direcction in degrees. 0 <= x < 360. Route course based on true North
+* @param EWDirection Bit flag indicating whether the direction is towards
+                     East (0 - 179 degrees) or West (180 - 359)
+* @return Encoded Direction in a single byte
+*/
+static uint8_t encodeDirection(float Direction, uint8_t *EWDirection)
+{
+    unsigned int direction_int = (unsigned int) roundf(Direction);
+    if (direction_int < 180) {
+        *EWDirection = 0;
+    } else {
+        *EWDirection = 1;
+        direction_int -= 180;
+    }
+    return (uint8_t) intRangeMax(direction_int, 0, UINT8_MAX);
+}
+
+/**
+* Encode speed into units defined by Open Drone ID
+*
+* The quantization algorithm allows for speed to be stored in units of 0.25 m/s
+* on the low end of the scale and 0.75 m/s on the high end of the scale.
+* This allows for more precise speeds to be represented in a single Uint8 byte
+* rather than using a large float value.
+*
+* @param Speed_data Speed (and decimal) in m/s
+* @param mult a (write only) value that sets the multiplier flag
+* @return Encoded Speed in a single byte or max speed if over max encoded speed.
+*/
+static uint8_t encodeSpeedHorizontal(float Speed_data, uint8_t *mult)
+{
+    if (Speed_data <= UINT8_MAX * SPEED_DIV[0]) {
+        *mult = 0;
+        return (uint8_t) (Speed_data / SPEED_DIV[0]);
+    } else {
+        *mult = 1;
+        int big_value = (int) ((Speed_data - (UINT8_MAX * SPEED_DIV[0])) / SPEED_DIV[1]);
+        return (uint8_t) intRangeMax(big_value, 0, UINT8_MAX);
+    }
+}
+
+/**
+* Encode Vertical Speed into a signed Integer ODID format
+*
+* @param SpeedVertical_data vertical speed (in m/s)
+* @return Encoded vertical speed
+*/
+static int8_t encodeSpeedVertical(float SpeedVertical_data)
+{
+    int encValue = (int) (SpeedVertical_data / VSPEED_DIV);
+    return (int8_t) intRangeMax(encValue, INT8_MIN, INT8_MAX);
+}
+
+/**
+* Encode Latitude or Longitude value into a signed Integer ODID format
+*
+* This encodes a 64bit double into a 32 bit integer yet still maintains
+* 10^7 of a degree of accuracy (about 1cm)
+*
+* @param LatLon_data Either Lat or Lon double float value
+* @return Encoded Lat or Lon
+*/
+static int32_t encodeLatLon(double LatLon_data)
+{
+    return (int32_t) intRangeMax((int64_t) (LatLon_data * LATLON_MULT), -180 * LATLON_MULT, 180 * LATLON_MULT);
+}
+
+/**
+* Encode Altitude value into an int16 ODID format
+*
+* This encodes a 32bit floating point altitude into an uint16 compressed
+* scale that starts at -1000m.
+*
+* @param Alt_data Altitude to encode (in meters)
+* @return Encoded Altitude
+*/
+static uint16_t encodeAltitude(float Alt_data)
+{
+    return (uint16_t) intRangeMax( (int) ((Alt_data + (float) ALT_ADDER) / ALT_DIV), 0, UINT16_MAX);
+}
+
+/**
+* Encode timestamp data in ODID format
+*
+* This encodes a fractional seconds value into a 2 byte int16
+* on a scale of tenths of seconds since after the hour.
+*
+* @param Seconds_data Seconds (to at least 1 decimal place) since the hour
+* @return Encoded timestamp (Tenths of seconds since the hour)
+*/
+static uint16_t encodeTimeStamp(float Seconds_data)
+{
+    if (Seconds_data == INV_TIMESTAMP)
+        return INV_TIMESTAMP;
+    else
+        return (uint16_t) intRangeMax((int64_t) roundf(Seconds_data*10), 0, MAX_TIMESTAMP * 10);
+}
+
+/**
+* Encode area radius data in ODID format
+*
+* This encodes the area radius in meters into a 1 byte value
+*
+* @param Radius The radius of the drone area/swarm
+* @return Encoded area radius
+*/
+static uint8_t encodeAreaRadius(uint16_t Radius)
+{
+    return (uint8_t) intRangeMax(Radius / 10, 0, 255);
+}
+
+/**
+* Encode Basic ID message (packed, ready for broadcast)
+*
+* @param outEncoded Output (encoded/packed) structure
+* @param inData     Input data (non encoded/packed) structure
+* @return           ODID_SUCCESS or ODID_FAIL;
+*/
+int encodeBasicIDMessage(ODID_BasicID_encoded *outEncoded, ODID_BasicID_data *inData)
+{
+    if (!outEncoded || !inData ||
+        !intInRange(inData->IDType, 0, 15) ||
+        !intInRange(inData->UAType, 0, 15))
+        return ODID_FAIL;
+
+    outEncoded->MessageType = ODID_MESSAGETYPE_BASIC_ID;
+    outEncoded->ProtoVersion = ODID_PROTOCOL_VERSION;
+    outEncoded->IDType = inData->IDType;
+    outEncoded->UAType = inData->UAType;
+    strncpy(outEncoded->UASID, inData->UASID, sizeof(outEncoded->UASID));
+    memset(outEncoded->Reserved, 0, sizeof(outEncoded->Reserved));
+    return ODID_SUCCESS;
+}
+
+/**
+* Encode Location message (packed, ready for broadcast)
+*
+* @param outEncoded Output (encoded/packed) structure
+* @param inData     Input data (non encoded/packed) structure
+* @return           ODID_SUCCESS or ODID_FAIL;
+*/
+int encodeLocationMessage(ODID_Location_encoded *outEncoded, ODID_Location_data *inData)
+{
+    uint8_t bitflag;
+    if (!outEncoded || !inData ||
+        !intInRange(inData->Status, 0, 15) ||
+        !intInRange(inData->HeightType, 0, 1) ||
+        !intInRange(inData->HorizAccuracy, 0, 15) ||
+        !intInRange(inData->VertAccuracy, 0, 15) ||
+        !intInRange(inData->BaroAccuracy, 0, 15) ||
+        !intInRange(inData->SpeedAccuracy, 0, 15) ||
+        !intInRange(inData->TSAccuracy, 0, 15))
+        return ODID_FAIL;
+
+    if (inData->Direction < MIN_DIR || inData->Direction > INV_DIR ||
+        (inData->Direction > MAX_DIR && inData->Direction < INV_DIR))
+        return ODID_FAIL;
+
+    if (inData->SpeedHorizontal < MIN_SPEED_H || inData->SpeedHorizontal > INV_SPEED_H ||
+        (inData->SpeedHorizontal > MAX_SPEED_H && inData->SpeedHorizontal < INV_SPEED_H))
+        return ODID_FAIL;
+
+    if (inData->SpeedVertical < MIN_SPEED_V || inData->SpeedVertical > INV_SPEED_V ||
+        (inData->SpeedVertical > MAX_SPEED_V && inData->SpeedVertical < INV_SPEED_V))
+        return ODID_FAIL;
+
+    if (inData->Latitude < MIN_LAT || inData->Latitude > MAX_LAT ||
+        inData->Longitude < MIN_LON || inData->Longitude > MAX_LON)
+        return ODID_FAIL;
+
+    if (inData->AltitudeBaro < MIN_ALT || inData->AltitudeBaro > MAX_ALT ||
+        inData->AltitudeGeo < MIN_ALT || inData->AltitudeGeo > MAX_ALT ||
+        inData->Height < MIN_ALT || inData->Height > MAX_ALT)
+        return ODID_FAIL;
+
+    if (inData->TimeStamp < 0 ||
+        (inData->TimeStamp > MAX_TIMESTAMP && inData->TimeStamp != INV_TIMESTAMP))
+        return ODID_FAIL;
+
+    outEncoded->MessageType = ODID_MESSAGETYPE_LOCATION;
+    outEncoded->ProtoVersion = ODID_PROTOCOL_VERSION;
+    outEncoded->Status = inData->Status;
+    outEncoded->Reserved = 0;
+    outEncoded->Direction = encodeDirection(inData->Direction, &bitflag);
+    outEncoded->EWDirection = bitflag;
+    outEncoded->SpeedHorizontal = encodeSpeedHorizontal(inData->SpeedHorizontal, &bitflag);
+    outEncoded->SpeedMult = bitflag;
+    outEncoded->SpeedVertical = encodeSpeedVertical(inData->SpeedVertical);
+    outEncoded->Latitude = encodeLatLon(inData->Latitude);
+    outEncoded->Longitude = encodeLatLon(inData->Longitude);
+    outEncoded->AltitudeBaro = encodeAltitude(inData->AltitudeBaro);
+    outEncoded->AltitudeGeo = encodeAltitude(inData->AltitudeGeo);
+    outEncoded->HeightType = inData->HeightType;
+    outEncoded->Height = encodeAltitude(inData->Height);
+    outEncoded->HorizAccuracy = inData->HorizAccuracy;
+    outEncoded->VertAccuracy = inData->VertAccuracy;
+    outEncoded->BaroAccuracy = inData->BaroAccuracy;
+    outEncoded->SpeedAccuracy = inData->SpeedAccuracy;
+    outEncoded->TSAccuracy = inData->TSAccuracy;
+    outEncoded->Reserved2 = 0;
+    outEncoded->TimeStamp = encodeTimeStamp(inData->TimeStamp);
+    outEncoded->Reserved3 = 0;
+    return ODID_SUCCESS;
+}
+
+/**
+* Encode Auth message (packed, ready for broadcast)
+*
+* @param outEncoded Output (encoded/packed) structure
+* @param inData     Input data (non encoded/packed) structure
+* @return           ODID_SUCCESS or ODID_FAIL;
+*/
+int encodeAuthMessage(ODID_Auth_encoded *outEncoded, ODID_Auth_data *inData)
+{
+    if (!outEncoded || !inData || !intInRange(inData->AuthType, 0, 15))
+        return ODID_FAIL;
+
+    if (inData->DataPage >= ODID_AUTH_MAX_PAGES)
+        return ODID_FAIL;
+
+    if (inData->DataPage == 0) {
+        if (inData->LastPageIndex >= ODID_AUTH_MAX_PAGES)
+            return ODID_FAIL;
+
+#if (MAX_AUTH_LENGTH < UINT8_MAX)
+        if (inData->Length > MAX_AUTH_LENGTH)
+            return ODID_FAIL;
+#endif
+
+        int len = ODID_AUTH_PAGE_ZERO_DATA_SIZE +
+                  inData->LastPageIndex * ODID_AUTH_PAGE_NONZERO_DATA_SIZE;
+        if (len < inData->Length)
+            return ODID_FAIL;
+    }
+
+    outEncoded->page_zero.MessageType = ODID_MESSAGETYPE_AUTH;
+    outEncoded->page_zero.ProtoVersion = ODID_PROTOCOL_VERSION;
+    outEncoded->page_zero.AuthType = inData->AuthType;
+    outEncoded->page_zero.DataPage = inData->DataPage;
+
+    if (inData->DataPage == 0) {
+        outEncoded->page_zero.LastPageIndex = inData->LastPageIndex;
+        outEncoded->page_zero.Length = inData->Length;
+        outEncoded->page_zero.Timestamp = inData->Timestamp;
+        memcpy(outEncoded->page_zero.AuthData, inData->AuthData,
+               sizeof(outEncoded->page_zero.AuthData));
+    } else {
+        memcpy(outEncoded->page_non_zero.AuthData, inData->AuthData,
+               sizeof(outEncoded->page_non_zero.AuthData));
+    }
+    return ODID_SUCCESS;
+}
+
+/**
+* Encode Self ID message (packed, ready for broadcast)
+*
+* @param outEncoded Output (encoded/packed) structure
+* @param inData     Input data (non encoded/packed) structure
+* @return           ODID_SUCCESS or ODID_FAIL;
+*/
+int encodeSelfIDMessage(ODID_SelfID_encoded *outEncoded, ODID_SelfID_data *inData)
+{
+    if (!outEncoded || !inData || !intInRange(inData->DescType, 0, 255))
+        return ODID_FAIL;
+
+    outEncoded->MessageType = ODID_MESSAGETYPE_SELF_ID;
+    outEncoded->ProtoVersion = ODID_PROTOCOL_VERSION;
+    outEncoded->DescType = inData->DescType;
+    strncpy(outEncoded->Desc, inData->Desc, sizeof(outEncoded->Desc));
+    return ODID_SUCCESS;
+}
+
+/**
+* Encode System message (packed, ready for broadcast)
+*
+* @param outEncoded Output (encoded/packed) structure
+* @param inData     Input data (non encoded/packed) structure
+* @return           ODID_SUCCESS or ODID_FAIL;
+*/
+int encodeSystemMessage(ODID_System_encoded *outEncoded, ODID_System_data *inData)
+{
+    if (!outEncoded || !inData ||
+        !intInRange(inData->OperatorLocationType, 0, 3) ||
+        !intInRange(inData->ClassificationType, 0, 7) ||
+        !intInRange(inData->CategoryEU, 0, 15) ||
+        !intInRange(inData->ClassEU, 0, 15))
+        return ODID_FAIL;
+
+    if (inData->OperatorLatitude < MIN_LAT || inData->OperatorLatitude > MAX_LAT ||
+        inData->OperatorLongitude < MIN_LON || inData->OperatorLongitude > MAX_LON)
+        return ODID_FAIL;
+
+    if (inData->AreaRadius > MAX_AREA_RADIUS)
+        return ODID_FAIL;
+
+    if (inData->AreaCeiling < MIN_ALT || inData->AreaCeiling > MAX_ALT ||
+        inData->AreaFloor < MIN_ALT || inData->AreaFloor > MAX_ALT ||
+        inData->OperatorAltitudeGeo < MIN_ALT || inData->OperatorAltitudeGeo > MAX_ALT)
+        return ODID_FAIL;
+
+    outEncoded->MessageType = ODID_MESSAGETYPE_SYSTEM;
+    outEncoded->ProtoVersion = ODID_PROTOCOL_VERSION;
+    outEncoded->Reserved = 0;
+    outEncoded->OperatorLocationType = inData->OperatorLocationType;
+    outEncoded->ClassificationType = inData->ClassificationType;
+    outEncoded->OperatorLatitude = encodeLatLon(inData->OperatorLatitude);
+    outEncoded->OperatorLongitude = encodeLatLon(inData->OperatorLongitude);
+    outEncoded->AreaCount = inData->AreaCount;
+    outEncoded->AreaRadius = encodeAreaRadius(inData->AreaRadius);
+    outEncoded->AreaCeiling = encodeAltitude(inData->AreaCeiling);
+    outEncoded->AreaFloor = encodeAltitude(inData->AreaFloor);
+    outEncoded->CategoryEU = inData->CategoryEU;
+    outEncoded->ClassEU = inData->ClassEU;
+    outEncoded->OperatorAltitudeGeo = encodeAltitude(inData->OperatorAltitudeGeo);
+    outEncoded->Timestamp = inData->Timestamp;
+    outEncoded->Reserved2 = 0;
+    return ODID_SUCCESS;
+}
+
+/**
+* Encode Operator ID message (packed, ready for broadcast)
+*
+* @param outEncoded Output (encoded/packed) structure
+* @param inData     Input data (non encoded/packed) structure
+* @return           ODID_SUCCESS or ODID_FAIL;
+*/
+int encodeOperatorIDMessage(ODID_OperatorID_encoded *outEncoded, ODID_OperatorID_data *inData)
+{
+    if (!outEncoded || !inData || !intInRange(inData->OperatorIdType, 0, 255))
+        return ODID_FAIL;
+
+    outEncoded->MessageType = ODID_MESSAGETYPE_OPERATOR_ID;
+    outEncoded->ProtoVersion = ODID_PROTOCOL_VERSION;
+    outEncoded->OperatorIdType = inData->OperatorIdType;
+    strncpy(outEncoded->OperatorId, inData->OperatorId, sizeof(outEncoded->OperatorId));
+    memset(outEncoded->Reserved, 0, sizeof(outEncoded->Reserved));
+    return ODID_SUCCESS;
+}
+
+/**
+* Check whether the data fields of a pack structure are valid
+*
+* @param msgs   Pointer to the buffer containing the messages
+* @param amount The amount of messages in the pack
+* @return       ODID_SUCCESS or ODID_FAIL;
+*/
+static int checkPackContent(ODID_Message_encoded *msgs, int amount)
+{
+    if (amount <= 0 || amount > ODID_PACK_MAX_MESSAGES)
+        return ODID_FAIL;
+
+    int numMessages[6] = { 0 }; // Counters for relevant parts of ODID_messagetype_t
+    for (int i = 0; i < amount; i++) {
+        uint8_t MessageType = decodeMessageType(msgs[i].rawData[0]);
+
+        // Check for illegal content. This also avoids recursive calls between
+        // decodeOpenDroneID() and decodeMessagePack()/checkPackContent()
+        if (MessageType <= ODID_MESSAGETYPE_OPERATOR_ID)
+            numMessages[MessageType]++;
+        else
+            return ODID_FAIL;
+    }
+
+    // Allow max one of each message except Basic ID and Authorization.
+    if (numMessages[ODID_MESSAGETYPE_BASIC_ID] > ODID_BASIC_ID_MAX_MESSAGES ||
+        numMessages[ODID_MESSAGETYPE_LOCATION] > 1 ||
+        numMessages[ODID_MESSAGETYPE_AUTH] > ODID_AUTH_MAX_PAGES ||
+        numMessages[ODID_MESSAGETYPE_SELF_ID] > 1 ||
+        numMessages[ODID_MESSAGETYPE_SYSTEM] > 1 ||
+        numMessages[ODID_MESSAGETYPE_OPERATOR_ID] > 1)
+        return ODID_FAIL;
+
+    return ODID_SUCCESS;
+}
+
+/**
+* Encode message pack. I.e. a collection of multiple encoded messages
+*
+* @param outEncoded Output (encoded/packed) structure
+* @param inData     Input data (non encoded/packed) structure
+* @return           ODID_SUCCESS or ODID_FAIL;
+*/
+int encodeMessagePack(ODID_MessagePack_encoded *outEncoded, ODID_MessagePack_data *inData)
+{
+    if (!outEncoded || !inData || inData->SingleMessageSize != ODID_MESSAGE_SIZE)
+        return ODID_FAIL;
+
+    if (checkPackContent(inData->Messages, inData->MsgPackSize) != ODID_SUCCESS)
+        return ODID_FAIL;
+
+    outEncoded->MessageType = ODID_MESSAGETYPE_PACKED;
+    outEncoded->ProtoVersion = ODID_PROTOCOL_VERSION;
+
+    outEncoded->SingleMessageSize = inData->SingleMessageSize;
+    outEncoded->MsgPackSize = inData->MsgPackSize;
+
+    for (int i = 0; i < inData->MsgPackSize; i++)
+        memcpy(&outEncoded->Messages[i], &inData->Messages[i], ODID_MESSAGE_SIZE);
+
+    return ODID_SUCCESS;
+}
+
+/**
+* Dencode direction from Open Drone ID packed message
+*
+* @param Direction_enc encoded direction
+* @param EWDirection East/West direction flag
+* @return direction in degrees (0 - 359)
+*/
+static float decodeDirection(uint8_t Direction_enc, uint8_t EWDirection)
+{
+    if (EWDirection)
+        return (float) Direction_enc + 180;
+    else
+        return (float) Direction_enc;
+}
+
+/**
+* Dencode speed from Open Drone ID packed message
+*
+* @param Speed_enc encoded speed
+* @param mult multiplier flag
+* @return decoded speed in m/s
+*/
+static float decodeSpeedHorizontal(uint8_t Speed_enc, uint8_t mult)
+{
+    if (mult)
+        return ((float) Speed_enc * SPEED_DIV[1]) + (UINT8_MAX * SPEED_DIV[0]);
+    else
+        return (float) Speed_enc * SPEED_DIV[0];
+}
+
+/**
+* Decode Vertical Speed from Open Drone ID Packed Message
+*
+* @param SpeedVertical_enc Encoded Vertical Speed
+* @return decoded Vertical Speed in m/s
+*/
+static float decodeSpeedVertical(int8_t SpeedVertical_enc)
+{
+    return (float) SpeedVertical_enc * VSPEED_DIV;
+}
+
+/**
+* Decode Latitude or Longitude value into a signed Integer ODID format
+*
+* @param LatLon_enc Either Lat or Lon ecoded int value
+* @return decoded (double) Lat or Lon
+*/
+static double decodeLatLon(int32_t LatLon_enc)
+{
+    return (double) LatLon_enc / LATLON_MULT;
+}
+
+/**
+* Decode Altitude from ODID packed format
+*
+* @param Alt_enc Encoded Altitude to decode
+* @return decoded Altitude (in meters)
+*/
+static float decodeAltitude(uint16_t Alt_enc)
+{
+    return (float) Alt_enc * ALT_DIV - (float) ALT_ADDER;
+}
+
+/**
+* Decode timestamp data from ODID packed format
+*
+* @param Seconds_enc Encoded Timestamp
+* @return Decoded timestamp (seconds since the hour)
+*/
+static float decodeTimeStamp(uint16_t Seconds_enc)
+{
+    if (Seconds_enc == INV_TIMESTAMP)
+        return INV_TIMESTAMP;
+    else
+        return (float) Seconds_enc / 10;
+}
+
+/**
+* Decode area radius data from ODID format
+*
+* This decodes a 1 byte value to the area radius in meters
+*
+* @param Radius_enc Encoded area radius
+* @return The radius of the drone area/swarm in meters
+*/
+static uint16_t decodeAreaRadius(uint8_t Radius_enc)
+{
+    return (uint16_t) ((int) Radius_enc * 10);
+}
+
+/**
+* Get the ID type of the basic ID message
+*
+* @param inEncoded  Input message (encoded/packed) structure
+* @param idType     Output: The ID type of this basic ID message
+* @return           ODID_SUCCESS or ODID_FAIL;
+*/
+int getBasicIDType(ODID_BasicID_encoded *inEncoded, enum ODID_idtype *idType)
+{
+    if (!inEncoded || !idType || inEncoded->MessageType != ODID_MESSAGETYPE_BASIC_ID)
+        return ODID_FAIL;
+
+    *idType = (enum ODID_idtype) inEncoded->IDType;
+    return ODID_SUCCESS;
+}
+
+/**
+* Decode Basic ID data from packed message
+*
+* @param outData   Output: decoded message
+* @param inEncoded Input message (encoded/packed) structure
+* @return          ODID_SUCCESS or ODID_FAIL;
+*/
+int decodeBasicIDMessage(ODID_BasicID_data *outData, ODID_BasicID_encoded *inEncoded)
+{
+    if (!outData || !inEncoded ||
+        inEncoded->MessageType != ODID_MESSAGETYPE_BASIC_ID ||
+        !intInRange(inEncoded->IDType, 0, 15) ||
+        !intInRange(inEncoded->UAType, 0, 15))
+        return ODID_FAIL;
+
+    outData->IDType = (ODID_idtype_t) inEncoded->IDType;
+    outData->UAType = (ODID_uatype_t) inEncoded->UAType;
+    safe_dec_copyfill(outData->UASID, inEncoded->UASID, sizeof(outData->UASID));
+    return ODID_SUCCESS;
+}
+
+/**
+* Decode Location data from packed message
+*
+* @param outData   Output: decoded message
+* @param inEncoded Input message (encoded/packed) structure
+* @return          ODID_SUCCESS or ODID_FAIL;
+*/
+int decodeLocationMessage(ODID_Location_data *outData, ODID_Location_encoded *inEncoded)
+{
+    if (!outData || !inEncoded ||
+        inEncoded->MessageType != ODID_MESSAGETYPE_LOCATION ||
+        !intInRange(inEncoded->Status, 0, 15))
+        return ODID_FAIL;
+
+    outData->Status = (ODID_status_t) inEncoded->Status;
+    outData->Direction = decodeDirection(inEncoded->Direction, inEncoded-> EWDirection);
+    outData->SpeedHorizontal = decodeSpeedHorizontal(inEncoded->SpeedHorizontal, inEncoded->SpeedMult);
+    outData->SpeedVertical = decodeSpeedVertical(inEncoded->SpeedVertical);
+    outData->Latitude = decodeLatLon(inEncoded->Latitude);
+    outData->Longitude = decodeLatLon(inEncoded->Longitude);
+    outData->AltitudeBaro = decodeAltitude(inEncoded->AltitudeBaro);
+    outData->AltitudeGeo = decodeAltitude(inEncoded->AltitudeGeo);
+    outData->HeightType = (ODID_Height_reference_t) inEncoded->HeightType;
+    outData->Height = decodeAltitude(inEncoded->Height);
+    outData->HorizAccuracy = (ODID_Horizontal_accuracy_t) inEncoded->HorizAccuracy;
+    outData->VertAccuracy = (ODID_Vertical_accuracy_t) inEncoded->VertAccuracy;
+    outData->BaroAccuracy = (ODID_Vertical_accuracy_t) inEncoded->BaroAccuracy;
+    outData->SpeedAccuracy = (ODID_Speed_accuracy_t) inEncoded->SpeedAccuracy;
+    outData->TSAccuracy = (ODID_Timestamp_accuracy_t) inEncoded->TSAccuracy;
+    outData->TimeStamp = decodeTimeStamp(inEncoded->TimeStamp);
+    return ODID_SUCCESS;
+}
+
+/**
+* Get the page number of the authorization message
+*
+* @param inEncoded  Input message (encoded/packed) structure
+* @param pageNum    Output: The page number of this authorization message
+* @return           ODID_SUCCESS or ODID_FAIL;
+*/
+int getAuthPageNum(ODID_Auth_encoded *inEncoded, int *pageNum)
+{
+    if (!inEncoded || !pageNum ||
+        inEncoded->page_zero.MessageType != ODID_MESSAGETYPE_AUTH ||
+        !intInRange(inEncoded->page_zero.AuthType, 0, 15) ||
+        !intInRange(inEncoded->page_zero.DataPage, 0, ODID_AUTH_MAX_PAGES - 1))
+        return ODID_FAIL;
+
+    *pageNum = inEncoded->page_zero.DataPage;
+    return ODID_SUCCESS;
+}
+
+/**
+* Decode Auth data from packed message
+*
+* @param outData   Output: decoded message
+* @param inEncoded Input message (encoded/packed) structure
+* @return          ODID_SUCCESS or ODID_FAIL;
+*/
+int decodeAuthMessage(ODID_Auth_data *outData, ODID_Auth_encoded *inEncoded)
+{
+    if (!outData || !inEncoded ||
+        inEncoded->page_zero.MessageType != ODID_MESSAGETYPE_AUTH ||
+        !intInRange(inEncoded->page_zero.AuthType, 0, 15) ||
+        !intInRange(inEncoded->page_zero.DataPage, 0, ODID_AUTH_MAX_PAGES - 1))
+        return ODID_FAIL;
+
+    if (inEncoded->page_zero.DataPage == 0) {
+        if (inEncoded->page_zero.LastPageIndex >= ODID_AUTH_MAX_PAGES)
+            return ODID_FAIL;
+
+#if (MAX_AUTH_LENGTH < UINT8_MAX)
+        if (inEncoded->page_zero.Length > MAX_AUTH_LENGTH)
+            return ODID_FAIL;
+#endif
+
+        int len = ODID_AUTH_PAGE_ZERO_DATA_SIZE +
+                  inEncoded->page_zero.LastPageIndex * ODID_AUTH_PAGE_NONZERO_DATA_SIZE;
+        if (len < inEncoded->page_zero.Length)
+            return ODID_FAIL;
+    }
+
+    outData->AuthType = (ODID_authtype_t) inEncoded->page_zero.AuthType;
+    outData->DataPage = inEncoded->page_zero.DataPage;
+    if (inEncoded->page_zero.DataPage == 0) {
+        outData->LastPageIndex = inEncoded->page_zero.LastPageIndex;
+        outData->Length = inEncoded->page_zero.Length;
+        outData->Timestamp = inEncoded->page_zero.Timestamp;
+        memset(outData->AuthData, 0, sizeof(outData->AuthData));
+        memcpy(outData->AuthData, inEncoded->page_zero.AuthData,
+               ODID_AUTH_PAGE_ZERO_DATA_SIZE);
+    } else {
+        memset(outData->AuthData, 0, sizeof(outData->AuthData));
+        memcpy(outData->AuthData, inEncoded->page_non_zero.AuthData,
+               ODID_AUTH_PAGE_NONZERO_DATA_SIZE);
+    }
+
+    return ODID_SUCCESS;
+}
+
+/**
+* Decode Self ID data from packed message
+*
+* @param outData   Output: decoded message
+* @param inEncoded Input message (encoded/packed) structure
+* @return          ODID_SUCCESS or ODID_FAIL;
+*/
+int decodeSelfIDMessage(ODID_SelfID_data *outData, ODID_SelfID_encoded *inEncoded)
+{
+    if (!outData || !inEncoded ||
+        inEncoded->MessageType != ODID_MESSAGETYPE_SELF_ID)
+        return ODID_FAIL;
+
+    outData->DescType = (ODID_desctype_t) inEncoded->DescType;
+    safe_dec_copyfill(outData->Desc, inEncoded->Desc, sizeof(outData->Desc));
+    return ODID_SUCCESS;
+}
+
+/**
+* Decode System data from packed message
+*
+* @param outData   Output: decoded message
+* @param inEncoded Input message (encoded/packed) structure
+* @return          ODID_SUCCESS or ODID_FAIL;
+*/
+int decodeSystemMessage(ODID_System_data *outData, ODID_System_encoded *inEncoded)
+{
+    if (!outData || !inEncoded ||
+        inEncoded->MessageType != ODID_MESSAGETYPE_SYSTEM)
+        return ODID_FAIL;
+
+    outData->OperatorLocationType =
+        (ODID_operator_location_type_t) inEncoded->OperatorLocationType;
+    outData->ClassificationType =
+        (ODID_classification_type_t) inEncoded->ClassificationType;
+    outData->OperatorLatitude = decodeLatLon(inEncoded->OperatorLatitude);
+    outData->OperatorLongitude = decodeLatLon(inEncoded->OperatorLongitude);
+    outData->AreaCount = inEncoded->AreaCount;
+    outData->AreaRadius = decodeAreaRadius(inEncoded->AreaRadius);
+    outData->AreaCeiling = decodeAltitude(inEncoded->AreaCeiling);
+    outData->AreaFloor = decodeAltitude(inEncoded->AreaFloor);
+    outData->CategoryEU = (ODID_category_EU_t) inEncoded->CategoryEU;
+    outData->ClassEU = (ODID_class_EU_t) inEncoded->ClassEU;
+    outData->OperatorAltitudeGeo = decodeAltitude(inEncoded->OperatorAltitudeGeo);
+    outData->Timestamp = inEncoded->Timestamp;
+    return ODID_SUCCESS;
+}
+
+/**
+* Decode Operator ID data from packed message
+*
+* @param outData   Output: decoded message
+* @param inEncoded Input message (encoded/packed) structure
+* @return          ODID_SUCCESS or ODID_FAIL;
+*/
+int decodeOperatorIDMessage(ODID_OperatorID_data *outData, ODID_OperatorID_encoded *inEncoded)
+{
+    if (!outData || !inEncoded ||
+        inEncoded->MessageType != ODID_MESSAGETYPE_OPERATOR_ID)
+        return ODID_FAIL;
+
+    outData->OperatorIdType = (ODID_operatorIdType_t) inEncoded->OperatorIdType;
+    safe_dec_copyfill(outData->OperatorId, inEncoded->OperatorId, sizeof(outData->OperatorId));
+    return ODID_SUCCESS;
+}
+
+/**
+* Decode Message Pack from packed message
+*
+* The various Valid flags in uasData are set true whenever a message has been
+* decoded and the corresponding data structure has been filled. The caller must
+* clear these flags before calling decodeMessagePack().
+*
+* @param uasData Output: Structure containing buffers for all message data
+* @param pack    Pointer to an encoded packed message
+* @return        ODID_SUCCESS or ODID_FAIL;
+*/
+int decodeMessagePack(ODID_UAS_Data *uasData, ODID_MessagePack_encoded *pack)
+{
+    if (!uasData || !pack || pack->MessageType != ODID_MESSAGETYPE_PACKED)
+        return ODID_FAIL;
+
+    if (pack->SingleMessageSize != ODID_MESSAGE_SIZE)
+        return ODID_FAIL;
+
+    if (checkPackContent(pack->Messages, pack->MsgPackSize) != ODID_SUCCESS)
+        return ODID_FAIL;
+
+    for (int i = 0; i < pack->MsgPackSize; i++) {
+        decodeOpenDroneID(uasData, pack->Messages[i].rawData);
+    }
+    return ODID_SUCCESS;
+}
+
+/**
+* Decodes the message type of a packed Open Drone ID message
+*
+* @param byte   The first byte of the message
+* @return       The message type: ODID_messagetype_t
+*/
+ODID_messagetype_t decodeMessageType(uint8_t byte)
+{
+    switch (byte >> 4)
+    {
+    case ODID_MESSAGETYPE_BASIC_ID:
+        return ODID_MESSAGETYPE_BASIC_ID;
+    case ODID_MESSAGETYPE_LOCATION:
+        return ODID_MESSAGETYPE_LOCATION;
+    case ODID_MESSAGETYPE_AUTH:
+        return ODID_MESSAGETYPE_AUTH;
+    case ODID_MESSAGETYPE_SELF_ID:
+        return ODID_MESSAGETYPE_SELF_ID;
+    case ODID_MESSAGETYPE_SYSTEM:
+        return ODID_MESSAGETYPE_SYSTEM;
+    case ODID_MESSAGETYPE_OPERATOR_ID:
+        return ODID_MESSAGETYPE_OPERATOR_ID;
+    case ODID_MESSAGETYPE_PACKED:
+        return ODID_MESSAGETYPE_PACKED;
+    default:
+        return ODID_MESSAGETYPE_INVALID;
+    }
+}
+
+/**
+* Parse encoded Open Drone ID data to identify the message type. Then decode
+* from Open Drone ID packed format into the appropriate Open Drone ID structure
+*
+* This function assumes that msgData points to a buffer containing all
+* ODID_MESSAGE_SIZE bytes of an Open Drone ID message.
+*
+* The various Valid flags in uasData are set true whenever a message has been
+* decoded and the corresponding data structure has been filled. The caller must
+* clear these flags before calling decodeOpenDroneID().
+*
+* @param uasData    Structure containing buffers for all message data
+* @param msgData    Pointer to a buffer containing a full encoded Open Drone ID
+*                   message
+* @return           The message type: ODID_messagetype_t
+*/
+ODID_messagetype_t decodeOpenDroneID(ODID_UAS_Data *uasData, uint8_t *msgData)
+{
+    if (!uasData || !msgData)
+        return ODID_MESSAGETYPE_INVALID;
+
+    switch (decodeMessageType(msgData[0]))
+    {
+    case ODID_MESSAGETYPE_BASIC_ID: {
+        ODID_BasicID_encoded *basicId = (ODID_BasicID_encoded *) msgData;
+        enum ODID_idtype idType;
+        if (getBasicIDType(basicId, &idType) == ODID_SUCCESS) {
+            // Find a free slot to store the current message in or overwrite old data of the same type.
+            for (int i = 0; i < ODID_BASIC_ID_MAX_MESSAGES; i++) {
+                enum ODID_idtype storedType = uasData->BasicID[i].IDType;
+                if (storedType == ODID_IDTYPE_NONE || storedType == idType) {
+                    if (decodeBasicIDMessage(&uasData->BasicID[i], basicId) == ODID_SUCCESS) {
+                        uasData->BasicIDValid[i] = 1;
+                        return ODID_MESSAGETYPE_BASIC_ID;
+                    }
+                }
+            }
+        }
+        break;
+    }
+    case ODID_MESSAGETYPE_LOCATION: {
+        ODID_Location_encoded *location = (ODID_Location_encoded *) msgData;
+        if (decodeLocationMessage(&uasData->Location, location) == ODID_SUCCESS) {
+            uasData->LocationValid = 1;
+            return ODID_MESSAGETYPE_LOCATION;
+        }
+        break;
+    }
+    case ODID_MESSAGETYPE_AUTH: {
+        ODID_Auth_encoded *auth = (ODID_Auth_encoded *) msgData;
+        int pageNum;
+        if (getAuthPageNum(auth, &pageNum) == ODID_SUCCESS) {
+            ODID_Auth_data *authData = &uasData->Auth[pageNum];
+            if (decodeAuthMessage(authData, auth) == ODID_SUCCESS) {
+                uasData->AuthValid[pageNum] = 1;
+                return ODID_MESSAGETYPE_AUTH;
+            }
+        }
+        break;
+    }
+    case ODID_MESSAGETYPE_SELF_ID: {
+        ODID_SelfID_encoded *selfId = (ODID_SelfID_encoded *) msgData;
+        if (decodeSelfIDMessage(&uasData->SelfID, selfId) == ODID_SUCCESS) {
+            uasData->SelfIDValid = 1;
+            return ODID_MESSAGETYPE_SELF_ID;
+        }
+        break;
+    }
+    case ODID_MESSAGETYPE_SYSTEM: {
+        ODID_System_encoded *system = (ODID_System_encoded *) msgData;
+        if (decodeSystemMessage(&uasData->System, system) == ODID_SUCCESS) {
+            uasData->SystemValid = 1;
+            return ODID_MESSAGETYPE_SYSTEM;
+        }
+        break;
+    }
+    case ODID_MESSAGETYPE_OPERATOR_ID: {
+        ODID_OperatorID_encoded *operatorId = (ODID_OperatorID_encoded *) msgData;
+        if (decodeOperatorIDMessage(&uasData->OperatorID, operatorId) == ODID_SUCCESS) {
+            uasData->OperatorIDValid = 1;
+            return ODID_MESSAGETYPE_OPERATOR_ID;
+        }
+        break;
+    }
+    case ODID_MESSAGETYPE_PACKED: {
+        ODID_MessagePack_encoded *pack = (ODID_MessagePack_encoded *) msgData;
+        if (decodeMessagePack(uasData, pack) == ODID_SUCCESS)
+            return ODID_MESSAGETYPE_PACKED;
+        break;
+    }
+    default:
+        break;
+    }
+
+    return ODID_MESSAGETYPE_INVALID;
+}
+
+/**
+* Safely fill then copy string to destination (when decoding)
+*
+* This prevents overrun and guarantees copy behavior (fully null padded)
+* This function was specially made because the encoded data may not be null
+* terminated (if full size).
+* Therefore, the destination must use the last byte for a null (and is +1 in size)
+*
+* @param dstStr Destination string
+* @param srcStr Source string
+* @param dstSize Destination size
+*/
+static char *safe_dec_copyfill(char *dstStr, const char *srcStr, int dstSize)
+{
+    memset(dstStr, 0, dstSize);  // fills destination with nulls
+    strncpy(dstStr, srcStr, dstSize-1); // copy only up to dst size-1 (no overruns)
+    return dstStr;
+}
+
+/**
+* Safely range check a value and return the minimum or max within the range if exceeded
+*
+* @param inValue Value to range-check
+* @param startRange Start of range to compare
+* @param endRange End of range to compare
+* @return same value if it fits, otherwise, min or max of range as appropriate.
+*/
+static int intRangeMax(int64_t inValue, int startRange, int endRange) {
+    if ( inValue < startRange ) {
+        return startRange;
+    } else if (inValue > endRange) {
+        return endRange;
+    } else {
+        return (int) inValue;
+    }
+}
+
+/**
+ * Determine if an Int is in range
+ *
+ * @param inValue Value to range-check
+ * @param startRange Start of range to compare
+ * @param endRange End of range to compare
+ * @return 1 = yes, 0 = no
+ */
+static int intInRange(int inValue, int startRange, int endRange)
+{
+    if (inValue < startRange || inValue > endRange) {
+        return 0;
+    } else {
+        return 1;
+    }
+}
+
+/**
+* This converts a horizontal accuracy float value to the corresponding enum
+*
+* @param Accuracy The horizontal accuracy in meters
+* @return Enum value representing the accuracy
+*/
+ODID_Horizontal_accuracy_t createEnumHorizontalAccuracy(float Accuracy)
+{
+    if (Accuracy >= 18520)
+        return ODID_HOR_ACC_UNKNOWN;
+    else if (Accuracy >= 7408)
+        return ODID_HOR_ACC_10NM;
+    else if (Accuracy >= 3704)
+        return ODID_HOR_ACC_4NM;
+    else if (Accuracy >= 1852)
+        return ODID_HOR_ACC_2NM;
+    else if (Accuracy >= 926)
+        return ODID_HOR_ACC_1NM;
+    else if (Accuracy >= 555.6f)
+        return ODID_HOR_ACC_0_5NM;
+    else if (Accuracy >= 185.2f)
+        return ODID_HOR_ACC_0_3NM;
+    else if (Accuracy >= 92.6f)
+        return ODID_HOR_ACC_0_1NM;
+    else if (Accuracy >= 30)
+        return ODID_HOR_ACC_0_05NM;
+    else if (Accuracy >= 10)
+        return ODID_HOR_ACC_30_METER;
+    else if (Accuracy >= 3)
+        return ODID_HOR_ACC_10_METER;
+    else if (Accuracy >= 1)
+        return ODID_HOR_ACC_3_METER;
+    else if (Accuracy > 0)
+        return ODID_HOR_ACC_1_METER;
+    else
+        return ODID_HOR_ACC_UNKNOWN;
+}
+
+/**
+* This converts a vertical accuracy float value to the corresponding enum
+*
+* @param Accuracy The vertical accuracy in meters
+* @return Enum value representing the accuracy
+*/
+ODID_Vertical_accuracy_t createEnumVerticalAccuracy(float Accuracy)
+{
+    if (Accuracy >= 150)
+        return ODID_VER_ACC_UNKNOWN;
+    else if (Accuracy >= 45)
+        return ODID_VER_ACC_150_METER;
+    else if (Accuracy >= 25)
+        return ODID_VER_ACC_45_METER;
+    else if (Accuracy >= 10)
+        return ODID_VER_ACC_25_METER;
+    else if (Accuracy >= 3)
+        return ODID_VER_ACC_10_METER;
+    else if (Accuracy >= 1)
+        return ODID_VER_ACC_3_METER;
+    else if (Accuracy > 0)
+        return ODID_VER_ACC_1_METER;
+    else
+        return ODID_VER_ACC_UNKNOWN;
+}
+
+/**
+* This converts a speed accuracy float value to the corresponding enum
+*
+* @param Accuracy The speed accuracy in m/s
+* @return Enum value representing the accuracy
+*/
+ODID_Speed_accuracy_t createEnumSpeedAccuracy(float Accuracy)
+{
+    if (Accuracy >= 10)
+        return ODID_SPEED_ACC_UNKNOWN;
+    else if (Accuracy >= 3)
+        return ODID_SPEED_ACC_10_METERS_PER_SECOND;
+    else if (Accuracy >= 1)
+        return ODID_SPEED_ACC_3_METERS_PER_SECOND;
+    else if (Accuracy >= 0.3f)
+        return ODID_SPEED_ACC_1_METERS_PER_SECOND;
+    else if (Accuracy > 0)
+        return ODID_SPEED_ACC_0_3_METERS_PER_SECOND;
+    else
+        return ODID_SPEED_ACC_UNKNOWN;
+}
+
+/**
+* This converts a timestamp accuracy float value to the corresponding enum
+*
+* @param Accuracy The timestamp accuracy in seconds
+* @return Enum value representing the accuracy
+*/
+ODID_Timestamp_accuracy_t createEnumTimestampAccuracy(float Accuracy)
+{
+    if (Accuracy > 1.5f)
+        return ODID_TIME_ACC_UNKNOWN;
+    else if (Accuracy > 1.4f)
+        return ODID_TIME_ACC_1_5_SECOND;
+    else if (Accuracy > 1.3f)
+        return ODID_TIME_ACC_1_4_SECOND;
+    else if (Accuracy > 1.2f)
+        return ODID_TIME_ACC_1_3_SECOND;
+    else if (Accuracy > 1.1f)
+        return ODID_TIME_ACC_1_2_SECOND;
+    else if (Accuracy > 1.0f)
+        return ODID_TIME_ACC_1_1_SECOND;
+    else if (Accuracy > 0.9f)
+        return ODID_TIME_ACC_1_0_SECOND;
+    else if (Accuracy > 0.8f)
+        return ODID_TIME_ACC_0_9_SECOND;
+    else if (Accuracy > 0.7f)
+        return ODID_TIME_ACC_0_8_SECOND;
+    else if (Accuracy > 0.6f)
+        return ODID_TIME_ACC_0_7_SECOND;
+    else if (Accuracy > 0.5f)
+        return ODID_TIME_ACC_0_6_SECOND;
+    else if (Accuracy > 0.4f)
+        return ODID_TIME_ACC_0_5_SECOND;
+    else if (Accuracy > 0.3f)
+        return ODID_TIME_ACC_0_4_SECOND;
+    else if (Accuracy > 0.2f)
+        return ODID_TIME_ACC_0_3_SECOND;
+    else if (Accuracy > 0.1f)
+        return ODID_TIME_ACC_0_2_SECOND;
+    else if (Accuracy > 0.0f)
+        return ODID_TIME_ACC_0_1_SECOND;
+    else
+        return ODID_TIME_ACC_UNKNOWN;
+}
+
+/**
+* This decodes a horizontal accuracy enum to the corresponding float value
+*
+* @param Accuracy Enum value representing the accuracy
+* @return The maximum horizontal accuracy in meters
+*/
+float decodeHorizontalAccuracy(ODID_Horizontal_accuracy_t Accuracy)
+{
+    switch (Accuracy)
+    {
+    case ODID_HOR_ACC_UNKNOWN:
+        return 18520;
+    case ODID_HOR_ACC_10NM:
+        return 18520;
+    case ODID_HOR_ACC_4NM:
+        return 7808;
+    case ODID_HOR_ACC_2NM:
+        return 3704;
+    case ODID_HOR_ACC_1NM:
+        return 1852;
+    case ODID_HOR_ACC_0_5NM:
+        return 926;
+    case ODID_HOR_ACC_0_3NM:
+        return 555.6f;
+    case ODID_HOR_ACC_0_1NM:
+        return 185.2f;
+    case ODID_HOR_ACC_0_05NM:
+        return 92.6f;
+    case ODID_HOR_ACC_30_METER:
+        return 30;
+    case ODID_HOR_ACC_10_METER:
+        return 10;
+    case ODID_HOR_ACC_3_METER:
+        return 3;
+    case ODID_HOR_ACC_1_METER:
+        return 1;
+    default:
+        return 18520;
+    }
+}
+
+/**
+* This decodes a vertical accuracy enum to the corresponding float value
+*
+* @param Accuracy Enum value representing the accuracy
+* @return The maximum vertical accuracy in meters
+*/
+float decodeVerticalAccuracy(ODID_Vertical_accuracy_t Accuracy)
+{
+    switch (Accuracy)
+    {
+    case ODID_VER_ACC_UNKNOWN:
+        return 150;
+    case ODID_VER_ACC_150_METER:
+        return 150;
+    case ODID_VER_ACC_45_METER:
+        return 45;
+    case ODID_VER_ACC_25_METER:
+        return 25;
+    case ODID_VER_ACC_10_METER:
+        return 10;
+    case ODID_VER_ACC_3_METER:
+        return 3;
+    case ODID_VER_ACC_1_METER:
+        return 1;
+    default:
+        return 150;
+    }
+}
+
+/**
+* This decodes a speed accuracy enum to the corresponding float value
+*
+* @param Accuracy Enum value representing the accuracy
+* @return The maximum speed accuracy in m/s
+*/
+float decodeSpeedAccuracy(ODID_Speed_accuracy_t Accuracy)
+{
+    switch (Accuracy)
+    {
+    case ODID_SPEED_ACC_UNKNOWN:
+        return 10;
+    case ODID_SPEED_ACC_10_METERS_PER_SECOND:
+        return 10;
+    case ODID_SPEED_ACC_3_METERS_PER_SECOND:
+        return 3;
+    case ODID_SPEED_ACC_1_METERS_PER_SECOND:
+        return 1;
+    case ODID_SPEED_ACC_0_3_METERS_PER_SECOND:
+        return 0.3f;
+    default:
+        return 10;
+    }
+}
+
+/**
+* This decodes a timestamp accuracy enum to the corresponding float value
+*
+* @param Accuracy Enum value representing the accuracy
+* @return The maximum timestamp accuracy in seconds
+*/
+float decodeTimestampAccuracy(ODID_Timestamp_accuracy_t Accuracy)
+{
+    switch (Accuracy)
+    {
+    case ODID_TIME_ACC_UNKNOWN:
+        return 0.0f;
+    case ODID_TIME_ACC_0_1_SECOND:
+        return 0.1f;
+    case ODID_TIME_ACC_0_2_SECOND:
+        return 0.2f;
+    case ODID_TIME_ACC_0_3_SECOND:
+        return 0.3f;
+    case ODID_TIME_ACC_0_4_SECOND:
+        return 0.4f;
+    case ODID_TIME_ACC_0_5_SECOND:
+        return 0.5f;
+    case ODID_TIME_ACC_0_6_SECOND:
+        return 0.6f;
+    case ODID_TIME_ACC_0_7_SECOND:
+        return 0.7f;
+    case ODID_TIME_ACC_0_8_SECOND:
+        return 0.8f;
+    case ODID_TIME_ACC_0_9_SECOND:
+        return 0.9f;
+    case ODID_TIME_ACC_1_0_SECOND:
+        return 1.0f;
+    case ODID_TIME_ACC_1_1_SECOND:
+        return 1.1f;
+    case ODID_TIME_ACC_1_2_SECOND:
+        return 1.2f;
+    case ODID_TIME_ACC_1_3_SECOND:
+        return 1.3f;
+    case ODID_TIME_ACC_1_4_SECOND:
+        return 1.4f;
+    case ODID_TIME_ACC_1_5_SECOND:
+        return 1.5f;
+    default:
+        return 0.0f;
+    }
+}
+
+#ifndef ODID_DISABLE_PRINTF
+
+/**
+* Print array of bytes as a hex string
+*
+* @param byteArray Array of bytes to be printed
+* @param asize Size of array of bytes to be printed
+*/
+
+void printByteArray(uint8_t *byteArray, uint16_t asize, int spaced)
+{
+    if (ENABLE_DEBUG) {
+        int x;
+        for (x=0;x<asize;x++) {
+            printf("%02x", (unsigned int) byteArray[x]);
+            if (spaced) {
+                printf(" ");
+            }
+        }
+        printf("\n");
+    }
+}
+
+/**
+* Print formatted BasicID Data
+*
+* @param BasicID structure to be printed
+*/
+void printBasicID_data(ODID_BasicID_data *BasicID)
+{
+    // Ensure the ID is null-terminated
+    char buf[ODID_ID_SIZE + 1] = { 0 };
+    memcpy(buf, BasicID->UASID, ODID_ID_SIZE);
+
+    const char ODID_BasicID_data_format[] =
+        "UAType: %d\nIDType: %d\nUASID: %s\n";
+    printf(ODID_BasicID_data_format, BasicID->IDType, BasicID->UAType, buf);
+}
+
+/**
+* Print formatted Location Data
+*
+* @param Location structure to be printed
+*/
+void printLocation_data(ODID_Location_data *Location)
+{
+    const char ODID_Location_data_format[] =
+        "Status: %d\nDirection: %.1f\nSpeedHori: %.2f\nSpeedVert: "\
+        "%.2f\nLat/Lon: %.7f, %.7f\nAlt: Baro, Geo, Height above %s: %.2f, "\
+        "%.2f, %.2f\nHoriz, Vert, Baro, Speed, TS Accuracy: %.1f, %.1f, %.1f, "\
+        "%.1f, %.1f\nTimeStamp: %.2f\n";
+    printf(ODID_Location_data_format, Location->Status,
+        (double) Location->Direction, (double) Location->SpeedHorizontal,
+        (double) Location->SpeedVertical, Location->Latitude,
+        Location->Longitude, Location->HeightType ? "Ground" : "TakeOff",
+        (double) Location->AltitudeBaro, (double) Location->AltitudeGeo,
+        (double) Location->Height,
+        (double) decodeHorizontalAccuracy(Location->HorizAccuracy),
+        (double) decodeVerticalAccuracy(Location->VertAccuracy),
+        (double) decodeVerticalAccuracy(Location->BaroAccuracy),
+        (double) decodeSpeedAccuracy(Location->SpeedAccuracy),
+        (double) decodeTimestampAccuracy(Location->TSAccuracy),
+        (double) Location->TimeStamp);
+}
+
+/**
+* Print formatted Auth Data
+*
+* @param Auth structure to be printed
+*/
+void printAuth_data(ODID_Auth_data *Auth)
+{
+    if (Auth->DataPage == 0) {
+        const char ODID_Auth_data_format[] =
+            "AuthType: %d\nDataPage: %d\nLastPageIndex: %d\nLength: %d\n"\
+            "Timestamp: %u\nAuthData: ";
+        printf(ODID_Auth_data_format, Auth->AuthType, Auth->DataPage,
+               Auth->LastPageIndex, Auth->Length, Auth->Timestamp);
+        for (int i = 0; i < ODID_AUTH_PAGE_ZERO_DATA_SIZE; i++)
+            printf("0x%02X ", Auth->AuthData[i]);
+    } else {
+        const char ODID_Auth_data_format[] =
+            "AuthType: %d\nDataPage: %d\nAuthData: ";
+        printf(ODID_Auth_data_format, Auth->AuthType, Auth->DataPage);
+        for (int i = 0; i < ODID_AUTH_PAGE_NONZERO_DATA_SIZE; i++)
+            printf("0x%02X ", Auth->AuthData[i]);
+    }
+    printf("\n");
+}
+
+/**
+* Print formatted SelfID Data
+*
+* @param SelfID structure to be printed
+*/
+void printSelfID_data(ODID_SelfID_data *SelfID)
+{
+    // Ensure the description is null-terminated
+    char buf[ODID_STR_SIZE + 1] = { 0 };
+    memcpy(buf, SelfID->Desc, ODID_STR_SIZE);
+
+    const char ODID_SelfID_data_format[] = "DescType: %d\nDesc: %s\n";
+    printf(ODID_SelfID_data_format, SelfID->DescType, buf);
+}
+
+/**
+* Print formatted System Data
+*
+* @param System_data structure to be printed
+*/
+void printSystem_data(ODID_System_data *System_data)
+{
+    const char ODID_System_data_format[] = "Operator Location Type: %d\n"
+        "Classification Type: %d\nLat/Lon: %.7f, %.7f\n"
+        "Area Count, Radius, Ceiling, Floor: %d, %d, %.2f, %.2f\n"
+        "Category EU: %d, Class EU: %d, Altitude: %.2f, Timestamp: %u\n";
+    printf(ODID_System_data_format, System_data->OperatorLocationType,
+        System_data->ClassificationType,
+        System_data->OperatorLatitude, System_data->OperatorLongitude,
+        System_data->AreaCount, System_data->AreaRadius,
+        (double) System_data->AreaCeiling, (double) System_data->AreaFloor,
+        System_data->CategoryEU, System_data->ClassEU,
+        (double) System_data->OperatorAltitudeGeo, System_data->Timestamp);
+}
+
+/**
+* Print formatted OperatorID Data
+*
+* @param OperatorID structure to be printed
+*/
+void printOperatorID_data(ODID_OperatorID_data *operatorID)
+{
+    // Ensure the ID is null-terminated
+    char buf[ODID_ID_SIZE + 1] = { 0 };
+    memcpy(buf, operatorID->OperatorId, ODID_ID_SIZE);
+
+    const char ODID_OperatorID_data_format[] =
+        "OperatorIdType: %d\nOperatorId: %s\n";
+    printf(ODID_OperatorID_data_format, operatorID->OperatorIdType, buf);
+}
+
+#endif // ODID_DISABLE_PRINTF

--- a/src/lib/Radar/libopendroneid/opendroneid.h
+++ b/src/lib/Radar/libopendroneid/opendroneid.h
@@ -1,0 +1,762 @@
+/*
+Copyright (C) 2019 Intel Corporation
+
+SPDX-License-Identifier: Apache-2.0
+
+Open Drone ID C Library
+
+Maintainer:
+Gabriel Cox
+gabriel.c.cox@intel.com
+*/
+
+#ifndef _OPENDRONEID_H_
+#define _OPENDRONEID_H_
+
+#include <stdint.h>
+#include <string.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ODID_MESSAGE_SIZE 25
+#define ODID_ID_SIZE 20
+#define ODID_STR_SIZE 23
+
+/*
+ * This implementation is compliant with the:
+ *   - ASTM F3411 Specification for Remote ID and Tracking
+ *   - ASD-STAN prEN 4709-002 Direct Remote Identification
+ * 
+ * Since the strategy of the standardization for drone ID has been to not break
+ * backwards compatibility when adding new functionality, no attempt in this
+ * implementation is made to verify the version number when decoding messages.
+ * It is assumed that newer versions can be decoded but some data elements
+ * might be missing in the output.
+ * 
+ * The following protocol versions have been in use:
+ * 0: ASTM F3411-19. Published Feb 14, 2020. https://www.astm.org/f3411-19.html
+ * 1: ASD-STAN prEN 4709-002 P1. Published 31-Oct-2021. http://asd-stan.org/downloads/asd-stan-pren-4709-002-p1/
+ *    ASTM F3411 v1.1 draft sent for first ballot round autumn 2021
+ * 2: ASTM F3411-v1.1 draft sent for second ballot round Q1 2022. (ASTM F3411-22 ?)
+ *    The delta to protocol version 1 is small:
+ *    - New enum values ODID_STATUS_REMOTE_ID_SYSTEM_FAILURE, ODID_DESC_TYPE_EMERGENCY and ODID_DESC_TYPE_EXTENDED_STATUS
+ *    - New Timestamp field in the System message
+ */
+#define ODID_PROTOCOL_VERSION 2
+
+/*
+ * To save memory on implementations that do not need support for 16 pages of
+ * authentication data, define ODID_AUTH_MAX_PAGES to the desired value before
+ * including opendroneid.h. E.g. "-DODID_AUTH_MAX_PAGES=5" when calling cmake.
+ */
+#ifndef ODID_AUTH_MAX_PAGES
+#define ODID_AUTH_MAX_PAGES 16
+#endif
+#if (ODID_AUTH_MAX_PAGES < 1) || (ODID_AUTH_MAX_PAGES > 16)
+#error "ODID_AUTH_MAX_PAGES must be between 1 and 16."
+#endif
+
+#define ODID_AUTH_PAGE_ZERO_DATA_SIZE    17
+#define ODID_AUTH_PAGE_NONZERO_DATA_SIZE 23
+#define MAX_AUTH_LENGTH (ODID_AUTH_PAGE_ZERO_DATA_SIZE + \
+                         ODID_AUTH_PAGE_NONZERO_DATA_SIZE * (ODID_AUTH_MAX_PAGES - 1))
+
+#ifndef ODID_BASIC_ID_MAX_MESSAGES
+#define ODID_BASIC_ID_MAX_MESSAGES 2
+#endif
+#if (ODID_BASIC_ID_MAX_MESSAGES < 1) || (ODID_BASIC_ID_MAX_MESSAGES > 5)
+#error "ODID_BASIC_ID_MAX_MESSAGES must be between 1 and 5."
+#endif
+
+#define ODID_PACK_MAX_MESSAGES 9
+
+#define ODID_SUCCESS    0
+#define ODID_FAIL       1
+
+#define MIN_DIR         0       // Minimum direction
+#define MAX_DIR         360     // Maximum direction
+#define INV_DIR         361     // Invalid direction
+#define MIN_SPEED_H     0       // Minimum speed horizontal
+#define MAX_SPEED_H     254.25f // Maximum speed horizontal
+#define INV_SPEED_H     255     // Invalid speed horizontal
+#define MIN_SPEED_V     (-62)   // Minimum speed vertical
+#define MAX_SPEED_V     62      // Maximum speed vertical
+#define INV_SPEED_V     63      // Invalid speed vertical
+#define MIN_LAT         (-90)   // Minimum latitude
+#define MAX_LAT         90      // Maximum latitude
+#define MIN_LON         (-180)  // Minimum longitude
+#define MAX_LON         180     // Maximum longitude
+#define MIN_ALT         (-1000) // Minimum altitude
+#define MAX_ALT         31767.5f// Maximum altitude
+#define INV_ALT         MIN_ALT // Invalid altitude
+#define MAX_TIMESTAMP   (60 * 60)
+#define INV_TIMESTAMP   0xFFFF  // Invalid, No Value or Unknown Timestamp
+#define MAX_AREA_RADIUS 2550
+
+typedef enum ODID_messagetype {
+    ODID_MESSAGETYPE_BASIC_ID = 0,
+    ODID_MESSAGETYPE_LOCATION = 1,
+    ODID_MESSAGETYPE_AUTH = 2,
+    ODID_MESSAGETYPE_SELF_ID = 3,
+    ODID_MESSAGETYPE_SYSTEM = 4,
+    ODID_MESSAGETYPE_OPERATOR_ID = 5,
+    ODID_MESSAGETYPE_PACKED = 0xF,
+    ODID_MESSAGETYPE_INVALID = 0xFF,
+} ODID_messagetype_t;
+
+// Each message type must maintain it's own message uint8_t counter, which must
+// be incremented if the message content changes. For repeated transmission of
+// the same message content, incrementing the counter is optional.
+typedef enum ODID_msg_counter {
+    ODID_MSG_COUNTER_BASIC_ID = 0,
+    ODID_MSG_COUNTER_LOCATION = 1,
+    ODID_MSG_COUNTER_AUTH = 2,
+    ODID_MSG_COUNTER_SELF_ID = 3,
+    ODID_MSG_COUNTER_SYSTEM = 4,
+    ODID_MSG_COUNTER_OPERATOR_ID = 5,
+    ODID_MSG_COUNTER_PACKED = 6,
+    ODID_MSG_COUNTER_AMOUNT = 7,
+} ODID_msg_counter_t;
+
+typedef enum ODID_idtype {
+    ODID_IDTYPE_NONE = 0,
+    ODID_IDTYPE_SERIAL_NUMBER = 1,
+    ODID_IDTYPE_CAA_REGISTRATION_ID = 2, // Civil Aviation Authority
+    ODID_IDTYPE_UTM_ASSIGNED_UUID = 3,   // UAS (Unmanned Aircraft System) Traffic Management
+    ODID_IDTYPE_SPECIFIC_SESSION_ID = 4, // The exact id type is specified by the first byte of UASID and these type
+                                         // values are managed by ICAO. 0 is reserved. 1 - 224 are managed by ICAO.
+                                         // 225 - 255 are available for private experimental usage only
+    // 5 to 15 reserved
+} ODID_idtype_t;
+
+typedef enum ODID_uatype {
+    ODID_UATYPE_NONE = 0,
+    ODID_UATYPE_AEROPLANE = 1, // Fixed wing
+    ODID_UATYPE_HELICOPTER_OR_MULTIROTOR = 2,
+    ODID_UATYPE_GYROPLANE = 3,
+    ODID_UATYPE_HYBRID_LIFT = 4, // Fixed wing aircraft that can take off vertically
+    ODID_UATYPE_ORNITHOPTER = 5,
+    ODID_UATYPE_GLIDER = 6,
+    ODID_UATYPE_KITE = 7,
+    ODID_UATYPE_FREE_BALLOON = 8,
+    ODID_UATYPE_CAPTIVE_BALLOON = 9,
+    ODID_UATYPE_AIRSHIP = 10, // Such as a blimp
+    ODID_UATYPE_FREE_FALL_PARACHUTE = 11, // Unpowered
+    ODID_UATYPE_ROCKET = 12,
+    ODID_UATYPE_TETHERED_POWERED_AIRCRAFT = 13,
+    ODID_UATYPE_GROUND_OBSTACLE = 14,
+    ODID_UATYPE_OTHER = 15,
+} ODID_uatype_t;
+
+typedef enum ODID_status {
+    ODID_STATUS_UNDECLARED = 0,
+    ODID_STATUS_GROUND = 1,
+    ODID_STATUS_AIRBORNE = 2,
+    ODID_STATUS_EMERGENCY = 3,
+    ODID_STATUS_REMOTE_ID_SYSTEM_FAILURE = 4,
+    // 3 to 15 reserved
+} ODID_status_t;
+
+typedef enum ODID_Height_reference {
+    ODID_HEIGHT_REF_OVER_TAKEOFF = 0,
+    ODID_HEIGHT_REF_OVER_GROUND = 1,
+} ODID_Height_reference_t;
+
+typedef enum ODID_Horizontal_accuracy {
+    ODID_HOR_ACC_UNKNOWN = 0,
+    ODID_HOR_ACC_10NM = 1,      // Nautical Miles. 18.52 km
+    ODID_HOR_ACC_4NM = 2,       // 7.408 km
+    ODID_HOR_ACC_2NM = 3,       // 3.704 km
+    ODID_HOR_ACC_1NM = 4,       // 1.852 km
+    ODID_HOR_ACC_0_5NM = 5,     // 926 m
+    ODID_HOR_ACC_0_3NM = 6,     // 555.6 m
+    ODID_HOR_ACC_0_1NM = 7,     // 185.2 m
+    ODID_HOR_ACC_0_05NM = 8,    // 92.6 m
+    ODID_HOR_ACC_30_METER = 9,
+    ODID_HOR_ACC_10_METER = 10,
+    ODID_HOR_ACC_3_METER = 11,
+    ODID_HOR_ACC_1_METER = 12,
+    // 13 to 15 reserved
+} ODID_Horizontal_accuracy_t;
+
+typedef enum ODID_Vertical_accuracy {
+    ODID_VER_ACC_UNKNOWN = 0,
+    ODID_VER_ACC_150_METER = 1,
+    ODID_VER_ACC_45_METER = 2,
+    ODID_VER_ACC_25_METER = 3,
+    ODID_VER_ACC_10_METER = 4,
+    ODID_VER_ACC_3_METER = 5,
+    ODID_VER_ACC_1_METER = 6,
+    // 7 to 15 reserved
+} ODID_Vertical_accuracy_t;
+
+typedef enum ODID_Speed_accuracy {
+    ODID_SPEED_ACC_UNKNOWN = 0,
+    ODID_SPEED_ACC_10_METERS_PER_SECOND = 1,
+    ODID_SPEED_ACC_3_METERS_PER_SECOND = 2,
+    ODID_SPEED_ACC_1_METERS_PER_SECOND = 3,
+    ODID_SPEED_ACC_0_3_METERS_PER_SECOND = 4,
+    // 5 to 15 reserved
+} ODID_Speed_accuracy_t;
+
+typedef enum ODID_Timestamp_accuracy {
+    ODID_TIME_ACC_UNKNOWN = 0,
+    ODID_TIME_ACC_0_1_SECOND = 1,
+    ODID_TIME_ACC_0_2_SECOND = 2,
+    ODID_TIME_ACC_0_3_SECOND = 3,
+    ODID_TIME_ACC_0_4_SECOND = 4,
+    ODID_TIME_ACC_0_5_SECOND = 5,
+    ODID_TIME_ACC_0_6_SECOND = 6,
+    ODID_TIME_ACC_0_7_SECOND = 7,
+    ODID_TIME_ACC_0_8_SECOND = 8,
+    ODID_TIME_ACC_0_9_SECOND = 9,
+    ODID_TIME_ACC_1_0_SECOND = 10,
+    ODID_TIME_ACC_1_1_SECOND = 11,
+    ODID_TIME_ACC_1_2_SECOND = 12,
+    ODID_TIME_ACC_1_3_SECOND = 13,
+    ODID_TIME_ACC_1_4_SECOND = 14,
+    ODID_TIME_ACC_1_5_SECOND = 15,
+} ODID_Timestamp_accuracy_t;
+
+typedef enum ODID_authtype {
+    ODID_AUTH_NONE = 0,
+    ODID_AUTH_UAS_ID_SIGNATURE = 1, // Unmanned Aircraft System
+    ODID_AUTH_OPERATOR_ID_SIGNATURE = 2,
+    ODID_AUTH_MESSAGE_SET_SIGNATURE = 3,
+    ODID_AUTH_NETWORK_REMOTE_ID = 4, // Authentication provided by Network Remote ID
+    ODID_AUTH_SPECIFIC_AUTHENTICATION = 5, // Specific auth method. The exact authentication type is indicated by the
+                                           // first byte of AuthData and these type values are managed by ICAO.
+                                           // 0 is reserved. 1 - 224 are managed by ICAO. 225 - 255 are available for
+                                           // private experimental usage only
+    // 6 to 9 reserved for the specification. 0xA to 0xF reserved for private use
+} ODID_authtype_t;
+
+typedef enum ODID_desctype {
+    ODID_DESC_TYPE_TEXT = 0,            // General free-form information text
+    ODID_DESC_TYPE_EMERGENCY = 1,       // Additional clarification when ODID_status == EMERGENCY
+    ODID_DESC_TYPE_EXTENDED_STATUS = 2, // Additional clarification when ODID_status != EMERGENCY
+    // 3 to 200 reserved
+    // 201 to 255 available for private use
+} ODID_desctype_t;
+
+typedef enum ODID_operatorIdType {
+    ODID_OPERATOR_ID = 0,
+    // 1 to 200 reserved
+    // 201 to 255 available for private use
+} ODID_operatorIdType_t;
+
+typedef enum ODID_operator_location_type {
+    ODID_OPERATOR_LOCATION_TYPE_TAKEOFF = 0,   // Takeoff location and altitude
+    ODID_OPERATOR_LOCATION_TYPE_LIVE_GNSS = 1, // Dynamic/Live location and altitude
+    ODID_OPERATOR_LOCATION_TYPE_FIXED = 2,     // Fixed location and altitude
+    // 3 to 255 reserved
+} ODID_operator_location_type_t;
+
+typedef enum ODID_classification_type {
+    ODID_CLASSIFICATION_TYPE_UNDECLARED = 0,
+    ODID_CLASSIFICATION_TYPE_EU = 1, // European Union
+    // 2 to 7 reserved
+} ODID_classification_type_t;
+
+typedef enum ODID_category_EU {
+    ODID_CATEGORY_EU_UNDECLARED = 0,
+    ODID_CATEGORY_EU_OPEN = 1,
+    ODID_CATEGORY_EU_SPECIFIC = 2,
+    ODID_CATEGORY_EU_CERTIFIED = 3,
+    // 4 to 15 reserved
+} ODID_category_EU_t;
+
+typedef enum ODID_class_EU {
+    ODID_CLASS_EU_UNDECLARED = 0,
+    ODID_CLASS_EU_CLASS_0 = 1,
+    ODID_CLASS_EU_CLASS_1 = 2,
+    ODID_CLASS_EU_CLASS_2 = 3,
+    ODID_CLASS_EU_CLASS_3 = 4,
+    ODID_CLASS_EU_CLASS_4 = 5,
+    ODID_CLASS_EU_CLASS_5 = 6,
+    ODID_CLASS_EU_CLASS_6 = 7,
+    // 8 to 15 reserved
+} ODID_class_EU_t;
+
+/*
+ * @name ODID_DataStructs
+ * ODID Data Structures in their normative (non-packed) form.
+ * This is the structure that any input adapters should form to
+ * let the encoders put the data into encoded form.
+ */
+typedef struct ODID_BasicID_data {
+    ODID_uatype_t UAType;
+    ODID_idtype_t IDType;
+    char UASID[ODID_ID_SIZE+1]; // Additional byte to allow for null term in normative form. Fill unused space with NULL
+} ODID_BasicID_data;
+
+typedef struct ODID_Location_data {
+    ODID_status_t Status;
+    float Direction;          // Degrees. 0 <= x < 360. Route course based on true North. Invalid, No Value, or Unknown: 361deg
+    float SpeedHorizontal;    // m/s. Positive only. Invalid, No Value, or Unknown: 255m/s. If speed is >= 254.25 m/s: 254.25m/s
+    float SpeedVertical;      // m/s. Invalid, No Value, or Unknown: 63m/s. If speed is >= 62m/s: 62m/s
+    double Latitude;          // Invalid, No Value, or Unknown: 0 deg (both Lat/Lon)
+    double Longitude;         // Invalid, No Value, or Unknown: 0 deg (both Lat/Lon)
+    float AltitudeBaro;       // meter (Ref 29.92 inHg, 1013.24 mb). Invalid, No Value, or Unknown: -1000m
+    float AltitudeGeo;        // meter (WGS84-HAE). Invalid, No Value, or Unknown: -1000m
+    ODID_Height_reference_t HeightType;
+    float Height;             // meter. Invalid, No Value, or Unknown: -1000m
+    ODID_Horizontal_accuracy_t HorizAccuracy;
+    ODID_Vertical_accuracy_t VertAccuracy;
+    ODID_Vertical_accuracy_t BaroAccuracy;
+    ODID_Speed_accuracy_t SpeedAccuracy;
+    ODID_Timestamp_accuracy_t TSAccuracy;
+    float TimeStamp;          // seconds after the full hour relative to UTC. Invalid, No Value, or Unknown: 0xFFFF
+} ODID_Location_data;
+
+/*
+ * The Authentication message can have two different formats:
+ *  - For data page 0, the fields LastPageIndex, Length and TimeStamp are present.
+ *    The size of AuthData is maximum 17 bytes (ODID_AUTH_PAGE_ZERO_DATA_SIZE).
+ *  - For data page 1 through (ODID_AUTH_MAX_PAGES - 1), LastPageIndex, Length and
+ *    TimeStamp are not present.
+ *    For pages 1 to LastPageIndex, the size of AuthData is maximum
+ *    23 bytes (ODID_AUTH_PAGE_NONZERO_DATA_SIZE).
+ *
+ * Unused bytes in the AuthData field must be filled with NULLs (i.e. 0x00).
+ *
+ * Since the Length field is uint8_t, the precise amount of data bytes
+ * transmitted over multiple pages of AuthData can only be specified up to 255.
+ * I.e. the maximum is one page 0, then 10 full pages and finally a page with
+ * 255 - (10*23 + 17) = 8 bytes of data.
+ *
+ * The payload data consisting of actual authentication data can never be
+ * larger than 255 bytes. However, it is possible to transmit additional
+ * support data, such as Forward Error Correction (FEC) data beyond that.
+ * This is e.g. useful when transmitting on Bluetooth 4, which does not have
+ * built-in FEC in the transmission protocol. The presence of this additional
+ * data is indicated by a combination of LastPageIndex and the value of the
+ * AuthData byte right after the last data byte indicated by Length. If this
+ * additional byte is non-zero/non-NULL, the value of the byte indicates the
+ * amount of additional (e.g. FEC) data bytes. The value of LastPageIndex must
+ * always be large enough to include all pages containing normal authentication
+ * and additional data. Some examples are given below. The value in the
+ * "FEC data" column must be stored in the "(Length - 1) + 1" position in the
+ * transmitted AuthData[] array. The total size of valid data in the AuthData
+ * array will be = Length + 1 + "FEC data".
+ *                                                                 Unused bytes
+ *    Authentication data        FEC data   LastPageIndex  Length  on last page
+ * 17 +  1*23 + 23 =  63 bytes    0 bytes         2           63         0
+ * 17 +  1*23 + 23 =  63 bytes   22 bytes         3           63         0
+ * 17 +  2*23 +  1 =  64 bytes    0 bytes         3           64        22
+ * 17 +  2*23 +  1 =  64 bytes   21 bytes         3           64         0
+ * 17 +  2*23 +  1 =  64 bytes   22 bytes         4           64        22
+ * ...
+ * 17 +  4*23 + 19 = 128 bytes    0 bytes         5          128         4
+ * 17 +  4*23 + 19 = 128 bytes    3 bytes         5          128         0
+ * 17 +  4*23 + 20 = 128 bytes   16 bytes         6          128        10
+ * 17 +  4*23 + 20 = 128 bytes   26 bytes         6          128         0
+ * ...
+ * 17 +  9*23 + 23 = 247 bytes    0 bytes        10          247         0
+ * 17 +  9*23 + 23 = 247 bytes   22 bytes        11          247         0
+ * 17 + 10*23 +  1 = 248 bytes    0 bytes        11          248        22
+ * 17 + 10*23 +  1 = 248 bytes   44 bytes        12          248         0
+ * ...
+ * 17 + 10*23 +  8 = 255 bytes    0 bytes        11          255        15
+ * 17 + 10*23 +  8 = 255 bytes   14 bytes        11          255         0
+ * 17 + 10*23 +  8 = 255 bytes   37 bytes        12          255         0
+ * 17 + 10*23 +  8 = 255 bytes   60 bytes        13          255         0
+ */
+typedef struct ODID_Auth_data {
+    uint8_t DataPage;       // 0 - (ODID_AUTH_MAX_PAGES - 1)
+    ODID_authtype_t AuthType;
+    uint8_t LastPageIndex;  // Page 0 only. Maximum (ODID_AUTH_MAX_PAGES - 1)
+    uint8_t Length;         // Page 0 only. Bytes. See description above.
+    uint32_t Timestamp;     // Page 0 only. Relative to 00:00:00 01/01/2019 UTC/Unix Time
+    uint8_t AuthData[ODID_AUTH_PAGE_NONZERO_DATA_SIZE+1]; // Additional byte to allow for null term in normative form
+} ODID_Auth_data;
+
+typedef struct ODID_SelfID_data {
+    ODID_desctype_t DescType;
+    char Desc[ODID_STR_SIZE+1]; // Additional byte to allow for null term in normative form. Fill unused space with NULL
+} ODID_SelfID_data;
+
+typedef struct ODID_System_data {
+    ODID_operator_location_type_t OperatorLocationType;
+    ODID_classification_type_t ClassificationType;
+    double OperatorLatitude;  // Invalid, No Value, or Unknown: 0 deg (both Lat/Lon)
+    double OperatorLongitude; // Invalid, No Value, or Unknown: 0 deg (both Lat/Lon)
+    uint16_t AreaCount;       // Default 1
+    uint16_t AreaRadius;      // meter. Default 0
+    float AreaCeiling;        // meter. Invalid, No Value, or Unknown: -1000m
+    float AreaFloor;          // meter. Invalid, No Value, or Unknown: -1000m
+    ODID_category_EU_t CategoryEU; // Only filled if ClassificationType = ODID_CLASSIFICATION_TYPE_EU
+    ODID_class_EU_t ClassEU;       // Only filled if ClassificationType = ODID_CLASSIFICATION_TYPE_EU
+    float OperatorAltitudeGeo;// meter (WGS84-HAE). Invalid, No Value, or Unknown: -1000m
+    uint32_t Timestamp;       // Relative to 00:00:00 01/01/2019 UTC/Unix Time
+} ODID_System_data;
+
+typedef struct ODID_OperatorID_data {
+    ODID_operatorIdType_t OperatorIdType;
+    char OperatorId[ODID_ID_SIZE+1]; // Additional byte to allow for null term in normative form. Fill unused space with NULL
+} ODID_OperatorID_data;
+
+typedef struct ODID_UAS_Data {
+    ODID_BasicID_data BasicID[ODID_BASIC_ID_MAX_MESSAGES];
+    ODID_Location_data Location;
+    ODID_Auth_data Auth[ODID_AUTH_MAX_PAGES];
+    ODID_SelfID_data SelfID;
+    ODID_System_data System;
+    ODID_OperatorID_data OperatorID;
+
+    uint8_t BasicIDValid[ODID_BASIC_ID_MAX_MESSAGES];
+    uint8_t LocationValid;
+    uint8_t AuthValid[ODID_AUTH_MAX_PAGES];
+    uint8_t SelfIDValid;
+    uint8_t SystemValid;
+    uint8_t OperatorIDValid;
+} ODID_UAS_Data;
+
+/**
+* @Name ODID_PackedStructs
+* Packed Data Structures prepared for broadcast
+* It's best not directly access these.  Use the encoders/decoders.
+*/
+
+typedef struct __attribute__((__packed__)) ODID_BasicID_encoded {
+    // Byte 0 [MessageType][ProtoVersion]  -- must define LSb first
+    uint8_t ProtoVersion: 4;
+    uint8_t MessageType : 4;
+
+    // Byte 1 [IDType][UAType]  -- must define LSb first
+    uint8_t UAType: 4;
+    uint8_t IDType: 4;
+
+    // Bytes 2-21
+    char UASID[ODID_ID_SIZE];
+
+    // 22-24
+    char Reserved[3];
+} ODID_BasicID_encoded;
+
+typedef struct __attribute__((__packed__)) ODID_Location_encoded {
+    // Byte 0 [MessageType][ProtoVersion]  -- must define LSb first
+    uint8_t ProtoVersion: 4;
+    uint8_t MessageType : 4;
+
+    // Byte 1 [Status][Reserved][NSMult][EWMult] -- must define LSb first
+    uint8_t SpeedMult: 1;
+    uint8_t EWDirection: 1;
+    uint8_t HeightType: 1;
+    uint8_t Reserved: 1;
+    uint8_t Status: 4;
+
+    // Bytes 2-18
+    uint8_t Direction;
+    uint8_t SpeedHorizontal;
+    int8_t SpeedVertical;
+    int32_t Latitude;
+    int32_t Longitude;
+    uint16_t AltitudeBaro;
+    uint16_t AltitudeGeo;
+    uint16_t Height;
+
+    // Byte 19 [VertAccuracy][HorizAccuracy]  -- must define LSb first
+    uint8_t HorizAccuracy:4;
+    uint8_t VertAccuracy:4;
+
+    // Byte 20 [BaroAccuracy][SpeedAccuracy]  -- must define LSb first
+    uint8_t SpeedAccuracy:4;
+    uint8_t BaroAccuracy:4;
+
+    // Byte 21-22
+    uint16_t TimeStamp;
+
+    // Byte 23 [Reserved2][TSAccuracy]  -- must define LSb first
+    uint8_t TSAccuracy:4;
+    uint8_t Reserved2:4;
+
+    // Byte 24
+    char Reserved3;
+} ODID_Location_encoded;
+
+typedef struct __attribute__((__packed__)) ODID_Auth_encoded_page_zero {
+    // Byte 0 [MessageType][ProtoVersion]  -- must define LSb first
+    uint8_t ProtoVersion: 4;
+    uint8_t MessageType : 4;
+
+    // Byte 1 [AuthType][DataPage]
+    uint8_t DataPage: 4;
+    uint8_t AuthType: 4;
+
+    // Bytes 2-7
+    uint8_t LastPageIndex;
+    uint8_t Length;
+    uint32_t Timestamp;
+
+    // Byte 8-24
+    uint8_t AuthData[ODID_AUTH_PAGE_ZERO_DATA_SIZE];
+} ODID_Auth_encoded_page_zero;
+
+typedef struct __attribute__((__packed__)) ODID_Auth_encoded_page_non_zero {
+    // Byte 0 [MessageType][ProtoVersion]  -- must define LSb first
+    uint8_t ProtoVersion: 4;
+    uint8_t MessageType : 4;
+
+    // Byte 1 [AuthType][DataPage]
+    uint8_t DataPage: 4;
+    uint8_t AuthType: 4;
+
+    // Byte 2-24
+    uint8_t AuthData[ODID_AUTH_PAGE_NONZERO_DATA_SIZE];
+} ODID_Auth_encoded_page_non_zero;
+
+/*
+ * It is safe to access the first four fields (i.e. ProtoVersion, MessageType,
+ * DataPage and AuthType) from either of the union members, since the declarations
+ * for these fields are identical and the first parts of the structures.
+ * The ISO/IEC 9899:1999 Chapter 6.5.2.3 part 5 and related Example 3 documents this.
+ * https://www.iso.org/standard/29237.html
+ */
+typedef union ODID_Auth_encoded{
+    ODID_Auth_encoded_page_zero page_zero;
+    ODID_Auth_encoded_page_non_zero page_non_zero;
+} ODID_Auth_encoded;
+
+typedef struct __attribute__((__packed__)) ODID_SelfID_encoded {
+    // Byte 0 [MessageType][ProtoVersion]  -- must define LSb first
+    uint8_t ProtoVersion: 4;
+    uint8_t MessageType : 4;
+
+    // Byte 1
+    uint8_t DescType;
+
+    // Byte 2-24
+    char Desc[ODID_STR_SIZE];
+} ODID_SelfID_encoded;
+
+typedef struct __attribute__((__packed__)) ODID_System_encoded {
+    // Byte 0 [MessageType][ProtoVersion]  -- must define LSb first
+    uint8_t ProtoVersion: 4;
+    uint8_t MessageType : 4;
+
+    // Byte 1 [Reserved][ClassificationType][OperatorLocationType]  -- must define LSb first
+    uint8_t OperatorLocationType: 2;
+    uint8_t ClassificationType: 3;
+    uint8_t Reserved: 3;
+
+    // Byte 2-9
+    int32_t OperatorLatitude;
+    int32_t OperatorLongitude;
+
+    // Byte 10-16
+    uint16_t AreaCount;
+    uint8_t  AreaRadius;
+    uint16_t AreaCeiling;
+    uint16_t AreaFloor;
+
+    // Byte 17 [CategoryEU][ClassEU]  -- must define LSb first
+    uint8_t ClassEU: 4;
+    uint8_t CategoryEU: 4;
+
+    // Byte 18-23
+    uint16_t OperatorAltitudeGeo;
+    uint32_t Timestamp;
+
+    // Byte 24
+    char Reserved2;
+} ODID_System_encoded;
+
+typedef struct __attribute__((__packed__)) ODID_OperatorID_encoded {
+    // Byte 0 [MessageType][ProtoVersion]  -- must define LSb first
+    uint8_t ProtoVersion: 4;
+    uint8_t MessageType : 4;
+
+    // Byte 1
+    uint8_t OperatorIdType;
+
+    // Bytes 2-21
+    char OperatorId[ODID_ID_SIZE];
+
+    // 22-24
+    char Reserved[3];
+} ODID_OperatorID_encoded;
+
+/*
+ * It is safe to access the first two fields (i.e. ProtoVersion and MessageType)
+ * from any of the structure parts of the union members, since the declarations
+ * for these fields are identical and the first parts of the structures.
+ * The ISO/IEC 9899:1999 Chapter 6.5.2.3 part 5 and related Example 3 documents this.
+ * https://www.iso.org/standard/29237.html
+ */
+typedef union ODID_Message_encoded {
+    uint8_t rawData[ODID_MESSAGE_SIZE];
+    ODID_BasicID_encoded basicId;
+    ODID_Location_encoded location;
+    ODID_Auth_encoded auth;
+    ODID_SelfID_encoded selfId;
+    ODID_System_encoded system;
+    ODID_OperatorID_encoded operatorId;
+} ODID_Message_encoded;
+
+typedef struct __attribute__((__packed__)) ODID_MessagePack_encoded {
+    // Byte 0 [MessageType][ProtoVersion]  -- must define LSb first
+    uint8_t ProtoVersion: 4;
+    uint8_t MessageType : 4;
+
+    // Byte 1 - 2
+    uint8_t SingleMessageSize;
+    uint8_t MsgPackSize;
+
+    // Byte 3 - 227
+    ODID_Message_encoded Messages[ODID_PACK_MAX_MESSAGES];
+} ODID_MessagePack_encoded;
+
+typedef struct ODID_MessagePack_data {
+    uint8_t SingleMessageSize; // Must always be ODID_MESSAGE_SIZE
+    uint8_t MsgPackSize; // Number of messages in pack (NOT number of bytes)
+
+    ODID_Message_encoded Messages[ODID_PACK_MAX_MESSAGES];
+} ODID_MessagePack_data;
+
+// API Calls
+void odid_initBasicIDData(ODID_BasicID_data *data);
+void odid_initLocationData(ODID_Location_data *data);
+void odid_initAuthData(ODID_Auth_data *data);
+void odid_initSelfIDData(ODID_SelfID_data *data);
+void odid_initSystemData(ODID_System_data *data);
+void odid_initOperatorIDData(ODID_OperatorID_data *data);
+void odid_initMessagePackData(ODID_MessagePack_data *data);
+void odid_initUasData(ODID_UAS_Data *data);
+
+int encodeBasicIDMessage(ODID_BasicID_encoded *outEncoded, ODID_BasicID_data *inData);
+int encodeLocationMessage(ODID_Location_encoded *outEncoded, ODID_Location_data *inData);
+int encodeAuthMessage(ODID_Auth_encoded *outEncoded, ODID_Auth_data *inData);
+int encodeSelfIDMessage(ODID_SelfID_encoded *outEncoded, ODID_SelfID_data *inData);
+int encodeSystemMessage(ODID_System_encoded *outEncoded, ODID_System_data *inData);
+int encodeOperatorIDMessage(ODID_OperatorID_encoded *outEncoded, ODID_OperatorID_data *inData);
+int encodeMessagePack(ODID_MessagePack_encoded *outEncoded, ODID_MessagePack_data *inData);
+
+int decodeBasicIDMessage(ODID_BasicID_data *outData, ODID_BasicID_encoded *inEncoded);
+int decodeLocationMessage(ODID_Location_data *outData, ODID_Location_encoded *inEncoded);
+int decodeAuthMessage(ODID_Auth_data *outData, ODID_Auth_encoded *inEncoded);
+int decodeSelfIDMessage(ODID_SelfID_data *outData, ODID_SelfID_encoded *inEncoded);
+int decodeSystemMessage(ODID_System_data *outData, ODID_System_encoded *inEncoded);
+int decodeOperatorIDMessage(ODID_OperatorID_data *outData, ODID_OperatorID_encoded *inEncoded);
+int decodeMessagePack(ODID_UAS_Data *uasData, ODID_MessagePack_encoded *pack);
+
+int getBasicIDType(ODID_BasicID_encoded *inEncoded, enum ODID_idtype *idType);
+int getAuthPageNum(ODID_Auth_encoded *inEncoded, int *pageNum);
+ODID_messagetype_t decodeMessageType(uint8_t byte);
+ODID_messagetype_t decodeOpenDroneID(ODID_UAS_Data *uas_data, uint8_t *msg_data);
+
+// Helper Functions
+ODID_Horizontal_accuracy_t createEnumHorizontalAccuracy(float Accuracy);
+ODID_Vertical_accuracy_t createEnumVerticalAccuracy(float Accuracy);
+ODID_Speed_accuracy_t createEnumSpeedAccuracy(float Accuracy);
+ODID_Timestamp_accuracy_t createEnumTimestampAccuracy(float Accuracy);
+
+float decodeHorizontalAccuracy(ODID_Horizontal_accuracy_t Accuracy);
+float decodeVerticalAccuracy(ODID_Vertical_accuracy_t Accuracy);
+float decodeSpeedAccuracy(ODID_Speed_accuracy_t Accuracy);
+float decodeTimestampAccuracy(ODID_Timestamp_accuracy_t Accuracy);
+
+// OpenDroneID WiFi functions
+
+/**
+ * drone_export_gps_data - prints drone information to json style string,
+ * according to odid message specification
+ * @UAS_Data: general drone status information
+ * @buf: buffer for the json style string
+ * @buf_size: size of the string buffer
+ *
+ * Returns pointer to gps_data string on success, otherwise returns NULL
+ */
+void drone_export_gps_data(ODID_UAS_Data *UAS_Data, char *buf, size_t buf_size);
+
+/**
+ * odid_message_build_pack - combines the messages and encodes the odid pack
+ * @UAS_Data: general drone status information
+ * @pack: buffer space to write to
+ * @buflen: maximum length of buffer space
+ *
+ * Returns length on success, < 0 on failure. @buf only contains a valid message
+ * if the return code is >0
+ */
+int odid_message_build_pack(ODID_UAS_Data *UAS_Data, void *pack, size_t buflen);
+
+/* odid_wifi_build_nan_sync_beacon_frame - creates a NAN sync beacon frame
+ * that shall be send just before the NAN action frame.
+ * @mac: mac address of the wifi adapter where the NAN frame will be sent
+ * @buf: pointer to buffer space where the NAN will be written to
+ * @buf_size: maximum size of the buffer
+ *
+ * Returns the packet length on success, or < 0 on error.
+ */
+int odid_wifi_build_nan_sync_beacon_frame(char *mac, uint8_t *buf, size_t buf_size);
+
+/* odid_wifi_build_message_pack_nan_action_frame - creates a message pack
+ * with each type of message from the drone information into an NAN action frame.
+ * @UAS_Data: general drone status information
+ * @mac: mac address of the wifi adapter where the NAN frame will be sent
+ * @send_counter: sequence number, to be increased for each call of this function
+ * @buf: pointer to buffer space where the NAN will be written to
+ * @buf_size: maximum size of the buffer
+ *
+ * Returns the packet length on success, or < 0 on error.
+ */
+int odid_wifi_build_message_pack_nan_action_frame(ODID_UAS_Data *UAS_Data, char *mac,
+                                                  uint8_t send_counter,
+                                                  uint8_t *buf, size_t buf_size);
+
+/* odid_wifi_build_message_pack_beacon_frame - creates a message pack
+ * with each type of message from the drone information into an Beacon frame.
+ * @UAS_Data: general drone status information
+ * @mac: mac address of the wifi adapter where the Beacon frame will be sent
+ * @SSID: SSID of the wifi network to be sent
+ * @SSID_len: length in bytes of the SSID string
+ * @interval_tu: beacon interval in wifi Time Units
+ * @send_counter: sequence number, to be increased for each call of this function
+ * @buf: pointer to buffer space where the Beacon will be written to
+ * @buf_size: maximum size of the buffer
+ *
+ * Returns the packet length on success, or < 0 on error.
+ */
+int odid_wifi_build_message_pack_beacon_frame(ODID_UAS_Data *UAS_Data, char *mac,
+                                              const char *SSID, size_t SSID_len,
+                                              uint16_t interval_tu, uint8_t send_counter,
+                                              uint8_t *buf, size_t buf_size);
+
+/* odid_message_process_pack - decodes the messages from the odid message pack
+ * @UAS_Data: general drone status information
+ * @pack: buffer space to read from
+ * @buflen: length of buffer space
+ *
+ * Returns 0 on success
+ */
+int odid_message_process_pack(ODID_UAS_Data *UAS_Data, uint8_t *pack, size_t buflen);
+
+/* odid_wifi_receive_message_pack_nan_action_frame - processes a received message pack
+ * with each type of message from the drone information into an NAN action frame
+ * @UAS_Data: general drone status information
+ * @mac: mac address of the wifi adapter where the NAN frame will be sent
+ * @buf: pointer to buffer space where the NAN is stored
+ * @buf_size: maximum size of the buffer
+ *
+ * Returns 0 on success, or < 0 on error. Will fill 6 bytes into @mac.
+ */
+int odid_wifi_receive_message_pack_nan_action_frame(ODID_UAS_Data *UAS_Data,
+                                                    char *mac, uint8_t *buf, size_t buf_size);
+
+#ifndef ODID_DISABLE_PRINTF
+void printByteArray(uint8_t *byteArray, uint16_t asize, int spaced);
+void printBasicID_data(ODID_BasicID_data *BasicID);
+void printLocation_data(ODID_Location_data *Location);
+void printAuth_data(ODID_Auth_data *Auth);
+void printSelfID_data(ODID_SelfID_data *SelfID);
+void printOperatorID_data(ODID_OperatorID_data *OperatorID);
+void printSystem_data(ODID_System_data *System_data);
+#endif // ODID_DISABLE_PRINTF
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _OPENDRONEID_H_

--- a/src/lib/Radar/libopendroneid/wifi.c
+++ b/src/lib/Radar/libopendroneid/wifi.c
@@ -1,0 +1,618 @@
+/*
+Copyright (C) 2020 Simon Wunderlich, Marek Sobe
+Copyright (C) 2020 Doodle Labs
+
+SPDX-License-Identifier: Apache-2.0
+
+Open Drone ID C Library
+
+Maintainer:
+Simon Wunderlich
+sw@simonwunderlich.de
+*/
+
+#if defined(ARDUINO_ARCH_ESP32)
+#include <Arduino.h>
+int clock_gettime(clockid_t, struct timespec *);
+#else
+#include <string.h>
+#include <stddef.h>
+#include <stdio.h>
+#endif
+
+#include <errno.h>
+#include <time.h>
+
+#include "opendroneid.h"
+#include "odid_wifi.h"
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define cpu_to_le16(x)  (x)
+#define cpu_to_le64(x)  (x)
+#else
+#define cpu_to_le16(x)      (bswap_16(x))
+#define cpu_to_le64(x)      (bswap_64(x))
+#endif
+
+#define IEEE80211_FCTL_FTYPE          0x000c
+#define IEEE80211_FCTL_STYPE          0x00f0
+
+#define IEEE80211_FTYPE_MGMT            0x0000
+#define IEEE80211_STYPE_ACTION          0x00D0
+#define IEEE80211_STYPE_BEACON          0x0080
+
+/* IEEE 802.11-2016 capability info */
+#define IEEE80211_CAPINFO_ESS               0x0001
+#define IEEE80211_CAPINFO_IBSS              0x0002
+#define IEEE80211_CAPINFO_CF_POLLABLE       0x0004
+#define IEEE80211_CAPINFO_CF_POLLREQ        0x0008
+#define IEEE80211_CAPINFO_PRIVACY           0x0010
+#define IEEE80211_CAPINFO_SHORT_PREAMBLE    0x0020
+/* bits 6-7 reserved */
+#define IEEE80211_CAPINFO_SPECTRUM_MGMT     0x0100
+#define IEEE80211_CAPINFO_QOS               0x0200
+#define IEEE80211_CAPINFO_SHORT_SLOTTIME    0x0400
+#define IEEE80211_CAPINFO_APSD              0x0800
+#define IEEE80211_CAPINFO_RADIOMEAS         0x1000
+/* bit 13 reserved */
+#define IEEE80211_CAPINFO_DEL_BLOCK_ACK     0x4000
+#define IEEE80211_CAPINFO_IMM_BLOCK_ACK     0x8000
+
+/* IEEE 802.11 Element IDs */
+#define IEEE80211_ELEMID_SSID		0x00
+#define IEEE80211_ELEMID_RATES		0x01
+#define IEEE80211_ELEMID_VENDOR		0xDD
+
+/* Neighbor Awareness Networking Specification v3.1 in section 2.8.2
+ * The NAN Cluster ID is a MAC address that takes a value from
+ * 50-6F-9A-01-00-00 to 50-6F-9A-01-FF-FF and is carried in the A3 field of
+ * some of the NAN frames. The NAN Cluster ID is randomly chosen by the device
+ * that initiates the NAN Cluster.
+ * However, the ASTM Remote ID specification v1.1 specifies that the NAN
+ * cluster ID must be fixed to the value 50-6F-9A-01-00-FF.
+ */
+static const uint8_t *get_nan_cluster_id(void)
+{
+    static const uint8_t cluster_id[6] = { 0x50, 0x6F, 0x9A, 0x01, 0x00, 0xFF };
+    return cluster_id;
+}
+
+static int buf_fill_ieee80211_mgmt(uint8_t *buf, size_t *len, size_t buf_size,
+                                   const uint16_t subtype,
+                                   const uint8_t *dst_addr,
+                                   const uint8_t *src_addr,
+                                   const uint8_t *bssid)
+{
+    if (*len + sizeof(struct ieee80211_mgmt) > buf_size)
+        return -ENOMEM;
+
+    struct ieee80211_mgmt *mgmt = (struct ieee80211_mgmt *)(buf + *len);
+    mgmt->frame_control = (uint16_t) cpu_to_le16(IEEE80211_FTYPE_MGMT | subtype);
+    mgmt->duration = cpu_to_le16(0x0000);
+    memcpy(mgmt->da, dst_addr, sizeof(mgmt->da));
+    memcpy(mgmt->sa, src_addr, sizeof(mgmt->sa));
+    memcpy(mgmt->bssid, bssid, sizeof(mgmt->bssid));
+    mgmt->seq_ctrl = cpu_to_le16(0x0000);
+    *len += sizeof(*mgmt);
+
+    return 0;
+}
+
+static int buf_fill_ieee80211_beacon(uint8_t *buf, size_t *len, size_t buf_size, uint16_t interval_tu)
+{
+    if (*len + sizeof(struct ieee80211_beacon) > buf_size)
+        return -ENOMEM;
+
+    struct ieee80211_beacon *beacon = (struct ieee80211_beacon *)(buf + *len);
+    struct timespec ts;
+    uint64_t mono_us = 0;
+
+#if defined(CLOCK_MONOTONIC)
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    mono_us = (uint64_t)((double) ts.tv_sec * 1e6 + (double) ts.tv_nsec * 1e-3);
+#elif defined(CLOCK_REALTIME)
+    clock_gettime(CLOCK_REALTIME, &ts);
+    mono_us = (uint64_t)((double) ts.tv_sec * 1e6 + (double) ts.tv_nsec * 1e-3);
+#elif defined(ARDUINO)
+#warning "No REALTIME or MONOTONIC clock, using micros()."
+    mono_us = micros();
+#else
+#warning "Unable to set wifi timestamp."
+#endif
+    beacon->timestamp = cpu_to_le64(mono_us);
+    beacon->beacon_interval = cpu_to_le16(interval_tu);
+    beacon->capability = cpu_to_le16(IEEE80211_CAPINFO_SHORT_SLOTTIME | IEEE80211_CAPINFO_SHORT_PREAMBLE);
+    *len += sizeof(*beacon);
+
+    return 0;
+}
+
+void drone_export_gps_data(ODID_UAS_Data *UAS_Data, char *buf, size_t buf_size)
+{
+    ptrdiff_t len = 0;
+
+#define mprintf(...) {\
+    len += snprintf(buf + len, buf_size - (size_t)len, __VA_ARGS__); \
+    if ((len < 0) || ((size_t)len >= buf_size)) \
+        return; \
+    }
+
+    mprintf("{\n\t\"Version\": \"1.1\",\n\t\"Response\": {\n");
+
+    mprintf("\t\t\"BasicID\": {\n");
+    for (int i = 0; i < ODID_BASIC_ID_MAX_MESSAGES; i++) {
+        if (!UAS_Data->BasicIDValid[i])
+            continue;
+        mprintf("\t\t\t\"UAType%d\": %d,\n", i, UAS_Data->BasicID[i].UAType);
+        mprintf("\t\t\t\"IDType%d\": %d,\n", i, UAS_Data->BasicID[i].IDType);
+        mprintf("\t\t\t\"UASID%d\": %s,\n", i, UAS_Data->BasicID[i].UASID);
+    }
+    mprintf("\t\t},\n");
+
+    mprintf("\t\t\"Location\": {\n");
+    mprintf("\t\t\t\"Status\": %d,\n", (int)UAS_Data->Location.Status);
+    mprintf("\t\t\t\"Direction\": %f,\n", (double) UAS_Data->Location.Direction);
+    mprintf("\t\t\t\"SpeedHorizontal\": %f,\n", (double) UAS_Data->Location.SpeedHorizontal);
+    mprintf("\t\t\t\"SpeedVertical\": %f,\n", (double) UAS_Data->Location.SpeedVertical);
+    mprintf("\t\t\t\"Latitude\": %f,\n", UAS_Data->Location.Latitude);
+    mprintf("\t\t\t\"Longitude\": %f,\n", UAS_Data->Location.Longitude);
+    mprintf("\t\t\t\"AltitudeBaro\": %f,\n", (double) UAS_Data->Location.AltitudeBaro);
+    mprintf("\t\t\t\"AltitudeGeo\": %f,\n", (double) UAS_Data->Location.AltitudeGeo);
+    mprintf("\t\t\t\"HeightType\": %d,\n", UAS_Data->Location.HeightType);
+    mprintf("\t\t\t\"Height\": %f,\n", (double) UAS_Data->Location.Height);
+    mprintf("\t\t\t\"HorizAccuracy\": %d,\n", UAS_Data->Location.HorizAccuracy);
+    mprintf("\t\t\t\"VertAccuracy\": %d,\n", UAS_Data->Location.VertAccuracy);
+    mprintf("\t\t\t\"BaroAccuracy\": %d,\n", UAS_Data->Location.BaroAccuracy);
+    mprintf("\t\t\t\"SpeedAccuracy\": %d,\n", UAS_Data->Location.SpeedAccuracy);
+    mprintf("\t\t\t\"TSAccuracy\": %d,\n", UAS_Data->Location.TSAccuracy);
+    mprintf("\t\t\t\"TimeStamp\": %f,\n", (double) UAS_Data->Location.TimeStamp);
+    mprintf("\t\t},\n");
+
+    mprintf("\t\t\"Authentication\": {\n");
+    mprintf("\t\t\t\"AuthType\": %d,\n", UAS_Data->Auth[0].AuthType);
+    mprintf("\t\t\t\"LastPageIndex\": %d,\n", UAS_Data->Auth[0].LastPageIndex);
+    mprintf("\t\t\t\"Length\": %d,\n", UAS_Data->Auth[0].Length);
+    mprintf("\t\t\t\"Timestamp\": %u,\n", UAS_Data->Auth[0].Timestamp);
+    for (int i = 0; i <= UAS_Data->Auth[0].LastPageIndex; i++) {
+        mprintf("\t\t\t\"AuthData Page %d,\": %s\n", i, UAS_Data->Auth[i].AuthData);
+    }
+    mprintf("\t\t},\n");
+
+    mprintf("\t\t\"SelfID\": {\n");
+    mprintf("\t\t\t\"Description Type\": %d,\n", UAS_Data->SelfID.DescType);
+    mprintf("\t\t\t\"Description\": %s,\n", UAS_Data->SelfID.Desc);
+    mprintf("\t\t},\n");
+
+    mprintf("\t\t\"Operator\": {\n");
+    mprintf("\t\t\t\"OperatorLocationType\": %d,\n", UAS_Data->System.OperatorLocationType);
+    mprintf("\t\t\t\"ClassificationType\": %d,\n", UAS_Data->System.ClassificationType);
+    mprintf("\t\t\t\"OperatorLatitude\": %f,\n", UAS_Data->System.OperatorLatitude);
+    mprintf("\t\t\t\"OperatorLongitude\": %f,\n", UAS_Data->System.OperatorLongitude);
+    mprintf("\t\t\t\"AreaCount\": %d,\n", UAS_Data->System.AreaCount);
+    mprintf("\t\t\t\"AreaRadius\": %d,\n", UAS_Data->System.AreaRadius);
+    mprintf("\t\t\t\"AreaCeiling\": %f,\n", (double) UAS_Data->System.AreaCeiling);
+    mprintf("\t\t\t\"AreaFloor\": %f,\n", (double) UAS_Data->System.AreaFloor);
+    mprintf("\t\t\t\"CategoryEU\": %d,\n", UAS_Data->System.CategoryEU);
+    mprintf("\t\t\t\"ClassEU\": %d,\n", UAS_Data->System.ClassEU);
+    mprintf("\t\t\t\"OperatorAltitudeGeo\": %f,\n", (double) UAS_Data->System.OperatorAltitudeGeo);
+    mprintf("\t\t\t\"Timestamp\": %u,\n", UAS_Data->System.Timestamp);
+    mprintf("\t\t}\n");
+
+    mprintf("\t\t\"OperatorID\": {\n");
+    mprintf("\t\t\t\"OperatorIdType\": %d,\n", UAS_Data->OperatorID.OperatorIdType);
+    mprintf("\t\t\t\"OperatorId\": \"%s\",\n", UAS_Data->OperatorID.OperatorId);
+    mprintf("\t\t},\n");
+
+    mprintf("\t}\n}");
+}
+
+int odid_message_build_pack(ODID_UAS_Data *UAS_Data, void *pack, size_t buflen)
+{
+    ODID_MessagePack_data msg_pack;
+    ODID_MessagePack_encoded *msg_pack_enc;
+    size_t len;
+
+    /* create a complete message pack */
+    msg_pack.SingleMessageSize = ODID_MESSAGE_SIZE;
+    msg_pack.MsgPackSize = 0;
+    for (int i = 0; i < ODID_BASIC_ID_MAX_MESSAGES; i++) {
+        if (UAS_Data->BasicIDValid[i]) {
+            if (msg_pack.MsgPackSize >= ODID_PACK_MAX_MESSAGES)
+                return -EINVAL;
+            if (encodeBasicIDMessage((void *)&msg_pack.Messages[msg_pack.MsgPackSize], &UAS_Data->BasicID[i]) == ODID_SUCCESS)
+                msg_pack.MsgPackSize++;
+        }
+    }
+    if (UAS_Data->LocationValid) {
+        if (msg_pack.MsgPackSize >= ODID_PACK_MAX_MESSAGES)
+            return -EINVAL;
+        if (encodeLocationMessage((void *)&msg_pack.Messages[msg_pack.MsgPackSize], &UAS_Data->Location) == ODID_SUCCESS)
+            msg_pack.MsgPackSize++;
+    }
+    for (int i = 0; i < ODID_AUTH_MAX_PAGES; i++)
+    {
+        if (UAS_Data->AuthValid[i]) {
+            if (msg_pack.MsgPackSize >= ODID_PACK_MAX_MESSAGES)
+                return -EINVAL;
+            if (encodeAuthMessage((void *)&msg_pack.Messages[msg_pack.MsgPackSize], &UAS_Data->Auth[i]) == ODID_SUCCESS)
+                msg_pack.MsgPackSize++;
+        }
+    }
+    if (UAS_Data->SelfIDValid) {
+        if (msg_pack.MsgPackSize >= ODID_PACK_MAX_MESSAGES)
+            return -EINVAL;
+        if (encodeSelfIDMessage((void *)&msg_pack.Messages[msg_pack.MsgPackSize], &UAS_Data->SelfID) == ODID_SUCCESS)
+            msg_pack.MsgPackSize++;
+    }
+    if (UAS_Data->SystemValid) {
+        if (msg_pack.MsgPackSize >= ODID_PACK_MAX_MESSAGES)
+            return -EINVAL;
+        if (encodeSystemMessage((void *)&msg_pack.Messages[msg_pack.MsgPackSize], &UAS_Data->System) == ODID_SUCCESS)
+            msg_pack.MsgPackSize++;
+    }
+    if (UAS_Data->OperatorIDValid) {
+        if (msg_pack.MsgPackSize >= ODID_PACK_MAX_MESSAGES)
+            return -EINVAL;
+        if (encodeOperatorIDMessage((void *)&msg_pack.Messages[msg_pack.MsgPackSize], &UAS_Data->OperatorID) == ODID_SUCCESS)
+            msg_pack.MsgPackSize++;
+    }
+
+    /* check that there is at least one message to send. */
+    if (msg_pack.MsgPackSize == 0)
+        return -EINVAL;
+
+    /* calculate the exact encoded message pack size. */
+    len = sizeof(*msg_pack_enc) - (ODID_PACK_MAX_MESSAGES - msg_pack.MsgPackSize) * ODID_MESSAGE_SIZE;
+
+    /* check if there is enough space for the message pack. */
+    if (len > buflen)
+        return -ENOMEM;
+
+    msg_pack_enc = (ODID_MessagePack_encoded *) pack;
+    if (encodeMessagePack(msg_pack_enc, &msg_pack) != ODID_SUCCESS)
+        return -1;
+
+    return (int) len;
+}
+
+int odid_wifi_build_nan_sync_beacon_frame(char *mac, uint8_t *buf, size_t buf_size)
+{
+    /* Broadcast address */
+    uint8_t target_addr[6] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+    uint8_t wifi_alliance_oui[3] = { 0x50, 0x6F, 0x9A };
+    /* "org.opendroneid.remoteid" hash */
+    uint8_t service_id[6] = { 0x88, 0x69, 0x19, 0x9D, 0x92, 0x09 };
+    const uint8_t *cluster_id = get_nan_cluster_id();
+    struct ieee80211_vendor_specific *vendor;
+    struct nan_master_indication_attribute *master_indication_attr;
+    struct nan_cluster_attribute *cluster_attr;
+    struct nan_service_id_list_attribute *nsila;
+    int ret;
+    size_t len = 0;
+
+    /* IEEE 802.11 Management Header */
+    ret = buf_fill_ieee80211_mgmt(buf, &len, buf_size, IEEE80211_STYPE_BEACON, target_addr, (uint8_t *)mac, cluster_id);
+    if (ret <0)
+        return ret;
+
+    /* Beacon */
+    ret = buf_fill_ieee80211_beacon(buf, &len, buf_size, 0x0200);
+    if (ret <0)
+        return ret;
+
+    /* Vendor Specific */
+    if (len + sizeof(*vendor) > buf_size)
+        return -ENOMEM;
+
+    vendor = (struct ieee80211_vendor_specific *)(buf + len);
+    memset(vendor, 0, sizeof(*vendor));
+    vendor->element_id = IEEE80211_ELEMID_VENDOR;
+    vendor->length = 0x22;
+    memcpy(vendor->oui, wifi_alliance_oui, sizeof(vendor->oui));
+    vendor->oui_type = 0x13;
+    len += sizeof(*vendor);
+
+    /* NAN Master Indication attribute */
+    if (len + sizeof(*master_indication_attr) > buf_size)
+        return -ENOMEM;
+
+    master_indication_attr = (struct nan_master_indication_attribute *)(buf + len);
+    memset(master_indication_attr, 0, sizeof(*master_indication_attr));
+    master_indication_attr->header.attribute_id = 0x00;
+    master_indication_attr->header.length = cpu_to_le16(0x0002);
+    /* Information that is used to indicate a NAN Device’s preference to serve
+     * as the role of Master, with a larger value indicating a higher
+     * preference. Values 1 and 255 are used for testing purposes only.
+     */
+    master_indication_attr->master_preference = 0xFE;
+    /* Random factor value 0xEA is recommended by the European Standard */
+    master_indication_attr->random_factor = 0xEA;
+    len += sizeof(*master_indication_attr);
+
+    /* NAN Cluster attribute */
+    if (len + sizeof(*cluster_attr) > buf_size)
+        return -ENOMEM;
+
+    cluster_attr = (struct nan_cluster_attribute *)(buf + len);
+    memset(cluster_attr, 0, sizeof(*cluster_attr));
+    cluster_attr->header.attribute_id = 0x1;
+    cluster_attr->header.length = cpu_to_le16(0x000D);
+    memcpy(cluster_attr->device_mac, mac, sizeof(cluster_attr->device_mac));
+    cluster_attr->random_factor = 0xEA;
+    cluster_attr->master_preference = 0xFE;
+    cluster_attr->hop_count_to_anchor_master = 0x00;
+    memset(cluster_attr->anchor_master_beacon_transmission_time, 0, sizeof(cluster_attr->anchor_master_beacon_transmission_time));
+    len += sizeof(*cluster_attr);
+
+    /* NAN attributes */
+    if (len + sizeof(*nsila) > buf_size)
+        return -ENOMEM;
+
+    nsila = (struct nan_service_id_list_attribute *)(buf + len);
+    memset(nsila, 0, sizeof(*nsila));
+    nsila->header.attribute_id = 0x02;
+    nsila->header.length = cpu_to_le16(0x0006);
+    memcpy(nsila->service_id, service_id, sizeof(service_id));
+    len += sizeof(*nsila);
+
+    return (int) len;
+}
+
+int odid_wifi_build_message_pack_nan_action_frame(ODID_UAS_Data *UAS_Data, char *mac,
+                                                  uint8_t send_counter,
+                                                  uint8_t *buf, size_t buf_size)
+{
+    /* Neighbor Awareness Networking Specification v3.0 in section 2.8.1
+     * NAN Network ID calls for the destination mac to be 51-6F-9A-01-00-00 */
+    uint8_t target_addr[6] = { 0x51, 0x6F, 0x9A, 0x01, 0x00, 0x00 };
+    /* "org.opendroneid.remoteid" hash */
+    uint8_t service_id[6] = { 0x88, 0x69, 0x19, 0x9D, 0x92, 0x09 };
+    uint8_t wifi_alliance_oui[3] = { 0x50, 0x6F, 0x9A };
+    const uint8_t *cluster_id = get_nan_cluster_id();
+    struct nan_service_discovery *nsd;
+    struct nan_service_descriptor_attribute *nsda;
+    struct nan_service_descriptor_extension_attribute *nsdea;
+    struct ODID_service_info *si;
+    int ret;
+    size_t len = 0;
+
+    /* IEEE 802.11 Management Header */
+    ret = buf_fill_ieee80211_mgmt(buf, &len, buf_size, IEEE80211_STYPE_ACTION, target_addr, (uint8_t *)mac, cluster_id);
+    if (ret <0)
+        return ret;
+
+    /* NAN Service Discovery header */
+    if (len + sizeof(*nsd) > buf_size)
+        return -ENOMEM;
+
+    nsd = (struct nan_service_discovery *)(buf + len);
+    memset(nsd, 0, sizeof(*nsd));
+    nsd->category = 0x04;               /* IEEE 802.11 Public Action frame */
+    nsd->action_code = 0x09;            /* IEEE 802.11 Public Action frame Vendor Specific*/
+    memcpy(nsd->oui, wifi_alliance_oui, sizeof(nsd->oui));
+    nsd->oui_type = 0x13;               /* Identify Type and version of the NAN */
+    len += sizeof(*nsd);
+
+    /* NAN Attribute for Service Descriptor header */
+    if (len + sizeof(*nsda) > buf_size)
+        return -ENOMEM;
+
+    nsda = (struct nan_service_descriptor_attribute *)(buf + len);
+    nsda->header.attribute_id = 0x3;    /* Service Descriptor Attribute type */
+    memcpy(nsda->service_id, service_id, sizeof(service_id));
+    /* always 1 */
+    nsda->instance_id = 0x01;           /* always 1 */
+    nsda->requestor_instance_id = 0x00; /* from triggering frame */
+    nsda->service_control = 0x10;       /* follow up */
+    len += sizeof(*nsda);
+
+    /* ODID Service Info Attribute header */
+    if (len + sizeof(*si) > buf_size)
+        return -ENOMEM;
+
+    si = (struct ODID_service_info *)(buf + len);
+    memset(si, 0, sizeof(*si));
+    si->message_counter = send_counter;
+    len += sizeof(*si);
+
+    ret = odid_message_build_pack(UAS_Data, buf + len, buf_size - len);
+    if (ret < 0)
+        return ret;
+    len += ret;
+
+    /* set the lengths according to the message pack lengths */
+    nsda->service_info_length = sizeof(*si) + ret;
+    nsda->header.length = cpu_to_le16(sizeof(*nsda) - sizeof(struct nan_attribute_header) + nsda->service_info_length);
+
+    /* NAN Attribute for Service Descriptor extension header */
+    if (len + sizeof(*nsdea) > buf_size)
+        return -ENOMEM;
+
+    nsdea = (struct nan_service_descriptor_extension_attribute *)(buf + len);
+    nsdea->header.attribute_id = 0xE;
+    nsdea->header.length = cpu_to_le16(0x0004);
+    nsdea->instance_id = 0x01;
+    nsdea->control = cpu_to_le16(0x0200);
+    nsdea->service_update_indicator = send_counter;
+    len += sizeof(*nsdea);
+
+    return (int) len;
+}
+
+int odid_wifi_build_message_pack_beacon_frame(ODID_UAS_Data *UAS_Data, char *mac,
+                                              const char *SSID, size_t SSID_len,
+                                              uint16_t interval_tu, uint8_t send_counter,
+                                              uint8_t *buf, size_t buf_size)
+{
+    /* Broadcast address */
+    uint8_t target_addr[6] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+    uint8_t asd_stan_oui[3] = { 0xFA, 0x0B, 0xBC };
+    /* Mgmt Beacon frame mandatory fields + IE 221 */
+    struct ieee80211_ssid *ssid_s;
+    struct ieee80211_supported_rates *rates;
+    struct ieee80211_vendor_specific *vendor;
+
+    /* Message Pack */
+    struct ODID_service_info *si;
+
+    int ret;
+    size_t len = 0;
+
+    /* IEEE 802.11 Management Header */
+    ret = buf_fill_ieee80211_mgmt(buf, &len, buf_size, IEEE80211_STYPE_BEACON, target_addr, (uint8_t *)mac, (uint8_t *)mac);
+    if (ret <0)
+        return ret;
+
+    /* Mandatory Beacon as of 802.11-2016 Part 11 */
+    ret = buf_fill_ieee80211_beacon(buf, &len, buf_size, interval_tu);
+    if (ret <0)
+        return ret;
+
+    /* SSID: 1-32 bytes */
+    if (len + sizeof(*ssid_s) > buf_size)
+        return -ENOMEM;
+
+    ssid_s = (struct ieee80211_ssid *)(buf + len);
+    if(!SSID || (SSID_len ==0) || (SSID_len > 32))
+        return -EINVAL;
+    ssid_s->element_id = IEEE80211_ELEMID_SSID;
+    ssid_s->length = (uint8_t) SSID_len;
+    memcpy(ssid_s->ssid, SSID, ssid_s->length);
+    len += sizeof(*ssid_s) + SSID_len;
+
+    /* Supported Rates: 1 record at minimum */
+    if (len + sizeof(*rates) > buf_size)
+        return -ENOMEM;
+
+    rates = (struct ieee80211_supported_rates *)(buf + len);
+    rates->element_id = IEEE80211_ELEMID_RATES;
+    rates->length = 1; // One rate only
+    rates->supported_rates = 0x8C;     // 6 Mbps
+    len += sizeof(*rates);
+
+    /* Vendor Specific Information Element (IE 221) */
+    if (len + sizeof(*vendor) > buf_size)
+        return -ENOMEM;
+
+    vendor = (struct ieee80211_vendor_specific *)(buf + len);
+    vendor->element_id = IEEE80211_ELEMID_VENDOR;
+    vendor->length = 0x00;  // Length updated at end of function
+    memcpy(vendor->oui, asd_stan_oui, sizeof(vendor->oui));
+    vendor->oui_type = 0x0D;
+    len += sizeof(*vendor);
+
+    /* ODID Service Info Attribute header */
+    if (len + sizeof(*si) > buf_size)
+        return -ENOMEM;
+
+    si = (struct ODID_service_info *)(buf + len);
+    memset(si, 0, sizeof(*si));
+    si->message_counter = send_counter;
+    len += sizeof(*si);
+
+    ret = odid_message_build_pack(UAS_Data, buf + len, buf_size - len);
+    if (ret < 0)
+        return ret;
+    len += ret;
+
+    /* set the lengths according to the message pack lengths */
+    vendor->length = sizeof(vendor->oui) + sizeof(vendor->oui_type) + sizeof(*si) + ret;
+
+    return (int) len;
+}
+
+int odid_message_process_pack(ODID_UAS_Data *UAS_Data, uint8_t *pack, size_t buflen)
+{
+    ODID_MessagePack_encoded *msg_pack_enc = (ODID_MessagePack_encoded *) pack;
+    size_t size = sizeof(*msg_pack_enc) - ODID_MESSAGE_SIZE * (ODID_PACK_MAX_MESSAGES - msg_pack_enc->MsgPackSize);
+    if (size > buflen)
+        return -ENOMEM;
+
+    odid_initUasData(UAS_Data);
+
+    if (decodeMessagePack(UAS_Data, msg_pack_enc) != ODID_SUCCESS)
+        return -1;
+
+    return (int) size;
+}
+
+int odid_wifi_receive_message_pack_nan_action_frame(ODID_UAS_Data *UAS_Data,
+                                                    char *mac, uint8_t *buf, size_t buf_size)
+{
+    struct ieee80211_mgmt *mgmt;
+    struct nan_service_discovery *nsd;
+    struct nan_service_descriptor_attribute *nsda;
+    struct nan_service_descriptor_extension_attribute *nsdea;
+    struct ODID_service_info *si;
+    uint8_t target_addr[6] = { 0x51, 0x6F, 0x9A, 0x01, 0x00, 0x00 };
+    uint8_t wifi_alliance_oui[3] = { 0x50, 0x6F, 0x9A };
+    uint8_t service_id[6] = { 0x88, 0x69, 0x19, 0x9D, 0x92, 0x09 };
+    int ret;
+    size_t len = 0;
+
+    /* IEEE 802.11 Management Header */
+    if (len + sizeof(*mgmt) > buf_size)
+        return -EINVAL;
+    mgmt = (struct ieee80211_mgmt *)(buf + len);
+    if ((mgmt->frame_control & cpu_to_le16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) !=
+        cpu_to_le16(IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_ACTION))
+        return -EINVAL;
+    if (memcmp(mgmt->da, target_addr, sizeof(mgmt->da)) != 0)
+        return -EINVAL;
+    memcpy(mac, mgmt->sa, sizeof(mgmt->sa));
+
+    len += sizeof(*mgmt);
+
+    /* NAN Service Discovery header */
+    if (len + sizeof(*nsd) > buf_size)
+        return -EINVAL;
+    nsd = (struct nan_service_discovery *)(buf + len);
+    if (nsd->category != 0x04)
+        return -EINVAL;
+    if (nsd->action_code != 0x09)
+        return -EINVAL;
+    if (memcmp(nsd->oui, wifi_alliance_oui, sizeof(wifi_alliance_oui)) != 0)
+        return -EINVAL;
+    if (nsd->oui_type != 0x13)
+        return -EINVAL;
+    len += sizeof(*nsd);
+
+    /* NAN Attribute for Service Descriptor header */
+    if (len + sizeof(*nsda) > buf_size)
+        return -EINVAL;
+    nsda = (struct nan_service_descriptor_attribute *)(buf + len);
+    if (nsda->header.attribute_id != 0x3)
+        return -EINVAL;
+    if (memcmp(nsda->service_id, service_id, sizeof(service_id)) != 0)
+        return -EINVAL;
+    if (nsda->instance_id != 0x01)
+        return -EINVAL;
+    if (nsda->service_control != 0x10)
+        return -EINVAL;
+    len += sizeof(*nsda);
+
+    si = (struct ODID_service_info *)(buf + len);
+    ret = odid_message_process_pack(UAS_Data, buf + len + sizeof(*si), buf_size - len - sizeof(*nsdea));
+    if (ret < 0)
+        return -EINVAL;
+    if (nsda->service_info_length != (sizeof(*si) + ret))
+        return -EINVAL;
+    if (nsda->header.length != (cpu_to_le16(sizeof(*nsda) - sizeof(struct nan_attribute_header) + nsda->service_info_length)))
+        return -EINVAL;
+    len += sizeof(*si) + ret;
+
+    /* NAN Attribute for Service Descriptor extension header */
+    if (len + sizeof(*nsdea) > buf_size)
+        return -ENOMEM;
+    nsdea = (struct nan_service_descriptor_extension_attribute *)(buf + len);
+    if (nsdea->header.attribute_id != 0xE)
+        return -EINVAL;
+    if (nsdea->header.length != cpu_to_le16(0x0004))
+        return -EINVAL;
+    if (nsdea->instance_id != 0x01)
+        return -EINVAL;
+    if (nsdea->control != cpu_to_le16(0x0200))
+        return -EINVAL;
+
+    return 0;
+}

--- a/src/lib/Telemetry/telemetry.h
+++ b/src/lib/Telemetry/telemetry.h
@@ -58,12 +58,14 @@ public:
     bool ShouldCallUpdateModelMatch();
     bool ShouldSendDeviceFrame();
     void CheckCrsfBatterySensorDetected();
-    bool GetCrsfBatterySensorDetected() { return crsfBatterySensorDetected; };
     uint8_t GetUpdatedModelMatch() { return modelMatchId; }
     bool GetNextPayload(uint8_t* nextPayloadSize, uint8_t **payloadData);
     uint8_t UpdatedPayloadCount();
     uint8_t ReceivedPackagesCount();
     bool AppendTelemetryPackage(uint8_t *package);
+
+    // Callback for complete, CRC-verified packages received from the UART (not internal ads)
+    void (*OnPackageReceived)(crsf_header_t *package);
 private:
     void AppendToPackage(volatile crsf_telemetry_package_t *current);
     uint8_t CRSFinBuffer[CRSF_MAX_PACKET_LEN];
@@ -76,6 +78,5 @@ private:
     bool callEnterBind;
     bool callUpdateModelMatch;
     bool sendDeviceFrame;
-    bool crsfBatterySensorDetected;
     uint8_t modelMatchId;
 };

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -33,6 +33,7 @@
 #include "devSerialUpdate.h"
 #include "devBaro.h"
 #include "devMSPVTX.h"
+#include "devRadar.h"
 
 #if defined(PLATFORM_ESP8266)
 #include <FS.h>
@@ -83,6 +84,9 @@ device_affinity_t ui_devices[] = {
 #endif
 #ifdef HAS_MSP_VTX
   {&MSPVTx_device, 0}, // dependency on VTxSPI_device
+#endif
+#ifdef USE_RADAR
+  {&Radar_device, 0},
 #endif
 };
 
@@ -1294,6 +1298,13 @@ static void telem_PackageReceived(crsf_header_t *package)
     {
         // If a battery sensor item is received, disable our internal VBAT measurement
         Vbat_setUpdateRate(vurDisabled);
+    }
+#endif
+#if defined(USE_RADAR)
+    if (package->std.type == CRSF_FRAMETYPE_GPS)
+    {
+        const crsf_sensor_gps_t *gps = (const crsf_sensor_gps_t *)package->std.payload;
+        Radar_UpdatePosition(gps);
     }
 #endif
 }

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1287,6 +1287,17 @@ void reconfigureSerial()
     setupSerial();
 }
 
+static void telem_PackageReceived(crsf_header_t *package)
+{
+#if defined(USE_ANALOG_VBAT)
+    if (package->std.type == CRSF_FRAMETYPE_BATTERY_SENSOR)
+    {
+        // If a battery sensor item is received, disable our internal VBAT measurement
+        Vbat_setUpdateRate(vurDisabled);
+    }
+#endif
+}
+
 static void setupConfigAndPocCheck()
 {
     eeprom.Begin();
@@ -1394,6 +1405,8 @@ static void setupRadio()
     // Start slow on the selected rate to give it the best chance
     // to connect before beginning rate cycling
     RFmodeCycleMultiplier = RFmodeCycleMultiplierSlow / 2;
+
+    telemetry.OnPackageReceived = &telem_PackageReceived;
 }
 
 static void updateTelemetryBurst()


### PR DESCRIPTION
Sometimes it is nice to know where other pilots are, a lot of people think it is a good idea. This PR adds radar functionality to existing ExpressLRS Team900 and Team2.4 hardware which is capable of broadcasting and receiving pilot / model location and identification information **while still using the hardware for the control link**. ESP and ESP32 hardware only, sorry PP / R9 receivers, you're not capable.

Currently supported:
* A Basic ID message containing a device serial number (ANSI/CTA-2063-A), i.e. a device ID
* A Basic ID message contain a Civil Aviation Authority (CAA) issued registration number, i.e. a pilot ID
* One of the two Basic ID messages can be replaced with an UTM assigned ID if operating with a UTM system
* An Operator ID message, if not present in a Basic ID message
* A location message containing current UAS position: latitude, longitude, altitude, speed, heading
* Pilot (control station) takeoff location: latitude, longitude, altitude
* Transmission interval for completing send of all messages 500ms (2 updates per second) currently
* WiFi 2.4GHz Beacon mode operation (up to 20dBm EIRP possible)
* Operates from takeoff to shutdown
* Transmission is non-proprietary using radio frequency compatible with personal wireless devices in accordance with part 15 of title 47, Code of Federal Regulations where operations may occur without FCC individual license

![image](https://github.com/ExpressLRS/ExpressLRS/assets/677183/d57c34ae-7e0a-48da-972c-6ca9b8d121ab)

Missing requirements to be completed:
* MISSING: A method for indicating the status of the broadcast system (LED or buzzer) which indicates it is operational
* MISSING: A method for the pilot to indicate they are operating in a GNSS Canyon or Indoor operation to disable any Location requirement
* MISSING: A time mark identifying applicability of a position output in UTC

### Features
* The inability to turn it off! I have not yet done any of the configuration side so this PR has it always enabled, using IDs compiled into the code. This will be user configurable when it is complete.
* On-UAS reception of other ExpressLRS Radar users, which is published to the flight controller via MSP2_COMMON_SET_RADAR_POS message (0x100B). iNav has an OSD element for displaying these other users in a radar-fashion. Betaflight and Ardupilot can also support this, and the [FormationFlight project](https://formationflight.org/getting-started/#ardupilot) has test fork builds with the functionality added. Note: this PR currently does not send the data to the flight controller yet as ExpressLRS needs more infrastructure to build the dang packet. (Image courtesy of [Mr.D RC](https://www.mrd-rc.com/tutorials-tools-and-testing/flight-controller-therapy/esp32-radar-finding-your-friends-in-the-sky/))

![ESP32-Radar-View-OSD-elements](https://github.com/ExpressLRS/ExpressLRS/assets/677183/777d18d4-2fee-472a-952d-426da8ae183e)

* Reception possible from cellphone with no additional equipment using the OpenDroneID application ([Android](https://play.google.com/store/apps/details?id=org.opendroneid.android_osm)) or Drone Scanner ([Android](https://play.google.com/store/apps/details?id=cz.dronetag.dronescanner) [iPhone](https://apps.apple.com/gb/app/drone-scanner/id1644548782))

![Screenshot_20230622-124936_OpenDroneID-(2)](https://github.com/ExpressLRS/ExpressLRS/assets/677183/1f009094-c6d1-4b53-ab7a-e3eddfe759ed)![Screenshot_20230702-094434](https://github.com/ExpressLRS/ExpressLRS/assets/677183/fa81da28-20fb-4db5-a70e-831ecbbd1218)

### Is this RemoteID?
No of course not. A RemoteID device must go through a certification process to be considered compliant, and this has not so therefore this is not at all RemoteID. In my limited testing, no current ExpressLRS hardware appears capable of meeting the radiated power requirement (EIRP) for RemoteID due to their size-constrained wifi antennas.

### Details
This adds a new ExpressLRS device class "devRadar" which utilizes the MCU's wifi/bluetooth radios to broadcast [OpenDroneID](https://github.com/opendroneid/opendroneid-core-c) packets. Promiscuous mode is used to sniff and decode other radar broadcasts. GPS information comes from a connected Flight Controller via the CRSF GPS telemetry packet, although PWM RXes can also get Radar if they use an external GPS module + CRSF converter (we could natively support GPS some day too).

The current transmission rate is 2Hz and I see no noticeable degradation in ELRS Link Quality despite having a 2.4GHz transmitter literally adjacent to the SX1280. I'm pretty sure it does have an impact, but further testing will determine if this is safe for long term use.

The range of the transmission is ... not spectacular. This is not a limitation of the radio hardware, but more how the "wifi range" of our tiny receivers is sort of an afterthought in design. This can be improved if necessary using actual wifi antennas, or perhaps a small 2.4GHz PA. Even with the suboptimal hardware, line of sight reception ~90m is currently possible.

### External Needs
* An accurate time source is needed. There is no CRSF message to get GPS time, but maybe the MSP_RTC command can get it? I know there is an MSP time set command, there better be a get! If not, we could use Lua to set it from the handset.
* Geometric Altitude I believe is needed? The altitude in the CRSF GPS packet tends to be a sensor fusion AGL from the baro and GPS. We need an absolute altitude from the GPS source (or a fusion that returns absolute altitude)
* Vertical speed. Both Horizontal and Vertical speed are required. I can calculate this myself using the altitude delta between packets but it would be better to get it directly. Some FC software support the CRSF VSPD sensor.
* A convenience feature would be to be able to set the UAS ID / PilotID from Betaflight, iNav, or Ardupilot configurators. Ardupilot already has these fields in their RemoteID implementation but I believe they are Mavlink commands :/

### TODO
- [x] ESP-based receiver broadcast 2.4GHz beacon signal
- [x] ESP-based receiver reception of beacon signal packets / decoding pilot and location information
- [x] External debugging Radar receiver ([ESP32 implementation](https://github.com/CapnBry/RidRadarReceiver))
- [ ] ESP32-based receiver implementation (easy!)
- [ ] Send Radar updates to flight controller
- [ ] Configuration webui
- [ ] Bluetooth Legacy-based broadcast option (ESP32 receivers only)
- [ ] Get RTC time
- [ ] Vertical speed information
- [ ] Need "geometric altitude" (MSL)?
- [ ] Range testing! Devs allegedly love range testing
- [ ] Control link interference / coexistence stress testing and characterization
- [ ] Lots and lots of documentation
- [ ] Uploading flight logs to your government every time you use the Configurator (this = joke)