### PR TITLE
Fix LBT TLM reception bug

### DIFF
--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -388,6 +388,9 @@ void ICACHE_RAM_ATTR SX127xDriver::TXnb(uint8_t * data, uint8_t size, SX12XX_Rad
   //   DBGLN("abort TX");
   //   return; // we were already TXing so abort. this should never happen!!!
   // }
+
+  transmittingRadio = radioNumber;
+  
   SetMode(SX127x_OPMODE_STANDBY, SX12XX_Radio_All);
 
   if (radioNumber == SX12XX_Radio_NONE)

--- a/src/lib/SX127xDriver/SX127x.h
+++ b/src/lib/SX127xDriver/SX127x.h
@@ -69,8 +69,6 @@ public:
     int8_t GetLastPacketSNRRaw(SX12XX_Radio_Number_t radioNumber);
     int8_t GetCurrRSSI(SX12XX_Radio_Number_t radioNumber);
     void GetLastPacketStats();
-    SX12XX_Radio_Number_t GetProcessingPacketRadio(){return processingPacketRadio;}
-    SX12XX_Radio_Number_t GetLastSuccessfulPacketRadio() { return lastSuccessfulPacketRadio; }
 
     ////////////Non-blocking TX related Functions/////////////////
     void TXnb(uint8_t * data, uint8_t size, SX12XX_Radio_Number_t radioNumber);
@@ -89,8 +87,6 @@ private:
     SX127x_ModulationModes ModFSKorLoRa;
     uint8_t currSyncWord;
     uint8_t currPreambleLen;
-    SX12XX_Radio_Number_t processingPacketRadio;
-    SX12XX_Radio_Number_t lastSuccessfulPacketRadio;
     uint8_t pwrCurrent;
     uint8_t pwrPending;
     uint8_t lowFrequencyMode;

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -474,6 +474,8 @@ void ICACHE_RAM_ATTR SX1280Driver::TXnbISR()
 
 void ICACHE_RAM_ATTR SX1280Driver::TXnb(uint8_t * data, uint8_t size, SX12XX_Radio_Number_t radioNumber)
 {
+    transmittingRadio = radioNumber;
+    
     //catch TX timeout
     if (currOpmode == SX1280_MODE_TX)
     {

--- a/src/lib/SX1280Driver/SX1280.h
+++ b/src/lib/SX1280Driver/SX1280.h
@@ -51,8 +51,6 @@ public:
     uint8_t GetRxBufferAddr(SX12XX_Radio_Number_t radioNumber);
     int8_t GetRssiInst(SX12XX_Radio_Number_t radioNumber);
     void GetLastPacketStats();
-    SX12XX_Radio_Number_t GetProcessingPacketRadio() { return processingPacketRadio; }
-    SX12XX_Radio_Number_t GetLastSuccessfulPacketRadio() { return lastSuccessfulPacketRadio; }
 
 private:
     // constant used for no power change pending
@@ -62,8 +60,6 @@ private:
     SX1280_RadioOperatingModes_t currOpmode;
     uint8_t packet_mode;
     bool modeSupportsFei;
-    SX12XX_Radio_Number_t processingPacketRadio;
-    SX12XX_Radio_Number_t lastSuccessfulPacketRadio;
     uint8_t pwrCurrent;
     uint8_t pwrPending;
 

--- a/src/lib/SX12xxDriverCommon/SX12xxDriverCommon.h
+++ b/src/lib/SX12xxDriverCommon/SX12xxDriverCommon.h
@@ -47,7 +47,7 @@ public:
     SX12XX_Radio_Number_t transmittingRadio;
     SX12XX_Radio_Number_t GetProcessingPacketRadio() { return processingPacketRadio; }
     SX12XX_Radio_Number_t GetLastSuccessfulPacketRadio() { return lastSuccessfulPacketRadio; }
-    SX12XX_Radio_Number_t GetLastTransmitRadio() {return transmittingRadio;}
+    SX12XX_Radio_Number_t GetLastTransmitRadio() {return transmittingRadio; }
 
     /////////////Packet Stats//////////
     int8_t LastPacketRSSI;

--- a/src/lib/SX12xxDriverCommon/SX12xxDriverCommon.h
+++ b/src/lib/SX12xxDriverCommon/SX12xxDriverCommon.h
@@ -42,6 +42,13 @@ public:
     uint8_t PayloadLength;
     bool IQinverted;
 
+    SX12XX_Radio_Number_t processingPacketRadio;
+    SX12XX_Radio_Number_t lastSuccessfulPacketRadio;
+    SX12XX_Radio_Number_t transmittingRadio;
+    SX12XX_Radio_Number_t GetProcessingPacketRadio() { return processingPacketRadio; }
+    SX12XX_Radio_Number_t GetLastSuccessfulPacketRadio() { return lastSuccessfulPacketRadio; }
+    SX12XX_Radio_Number_t GetLastTransmitRadio() {return transmittingRadio;}
+
     /////////////Packet Stats//////////
     int8_t LastPacketRSSI;
     int8_t LastPacketRSSI2;

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -88,7 +88,6 @@ device_affinity_t ui_devices[] = {
 
 uint8_t antenna = 0;    // which antenna is currently in use
 uint8_t geminiMode = 0;
-SX12XX_Radio_Number_t transmittingRadio;
 
 hwTimer hwTimer;
 POWERMGNT POWERMGNT;
@@ -505,7 +504,7 @@ bool ICACHE_RAM_ATTR HandleSendTelemetryResponse()
 
     OtaGeneratePacketCrc(&otaPkt);
 
-    transmittingRadio = geminiMode ? SX12XX_Radio_All : Radio.GetLastSuccessfulPacketRadio();
+    SX12XX_Radio_Number_t transmittingRadio = geminiMode ? SX12XX_Radio_All : Radio.GetLastSuccessfulPacketRadio();
 
 #if defined(Regulatory_Domain_EU_CE_2400)
     transmittingRadio &= ChannelIsClear(transmittingRadio);   // weed out the radio(s) if channel in use
@@ -728,7 +727,7 @@ static void ICACHE_RAM_ATTR updateDiversity()
 
 void ICACHE_RAM_ATTR HWtimerCallbackTock()
 {
-    if (tlmSent && transmittingRadio == SX12XX_Radio_NONE)
+    if (tlmSent && Radio.GetLastTransmitRadio() == SX12XX_Radio_NONE)
     {
         Radio.TXdoneCallback();
     }

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -77,8 +77,6 @@ StubbornReceiver TelemetryReceiver;
 StubbornSender MspSender;
 uint8_t CRSFinBuffer[CRSF_MAX_PACKET_LEN+1];
 
-SX12XX_Radio_Number_t transmittingRadio;
-
 device_affinity_t ui_devices[] = {
   {&CRSF_device, 1},
 #ifdef HAS_LED
@@ -531,7 +529,7 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
   ///// Next, Calculate the CRC and put it into the buffer /////
   OtaGeneratePacketCrc(&otaPkt);
 
-  transmittingRadio = Radio.GetLastSuccessfulPacketRadio();
+  SX12XX_Radio_Number_t transmittingRadio = Radio.GetLastSuccessfulPacketRadio();
 
   if (isDualRadio())
   {
@@ -568,7 +566,7 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
 void ICACHE_RAM_ATTR timerCallbackNormal()
 {
   // No packet has been sent due to LBT.  Call TXdoneCallback to prepare for TLM.
-	if (transmittingRadio == SX12XX_Radio_NONE)
+	if (Radio.GetLastTransmitRadio() == SX12XX_Radio_NONE)
   {
 		Radio.TXdoneCallback();
   }


### PR DESCRIPTION
Like all good bug, I caused this one https://github.com/ExpressLRS/ExpressLRS/pull/2055#issuecomment-1429352171

Calling TXdoneCallback in SendRCdataToRF after aborting TXnb due to LBT means that RX mode is potentially started early and ready for TLM.  Sounds good, except that a timeout is used for RX mode on the tx module!  This means it will exit RX mode early and miss the tlm packet.

Moving TXdoneCallback back to timerCallbackNormal will start RX mode correctly and be ready for the TLM packet.