### PR TITLE
STM32 SX1272 PCB: add to targets.json for configurator

### DIFF
--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -260,6 +260,17 @@
                 "platform": "esp32",
                 "firmware": "Unified_ESP32_900_TX",
                 "prior_target_name": "DIY_900_TX_ESP32_SX127x_RFM95"
+            },
+            "stm32-sx1272": {
+                "product_name": "DIY STM32 SX1272 TX",
+                "upload_methods": ["stlink"],
+                "platform": "stm32",
+                "firmware": "DIY_900_TX_STM32_SX1272",
+                "stlink": {
+                    "cpus": ["STM32F103C8T6", "STM32F103CBT6"],
+                    "offset": "0x4000",
+                    "bootloader": "sx1272_pcb_bootloader.bin"
+                }
             }
         },
         "rx_900": {
@@ -287,6 +298,17 @@
                 "platform": "esp8285",
                 "firmware": "Unified_ESP8285_900_RX",
                 "prior_target_name": "DIY_900_RX_HUZZAH_RFM95W"
+            },
+            "stm32-sx1272": {
+                "product_name": "DIY STM32 SX1272 RX",
+                "upload_methods": ["stlink"],
+                "platform": "stm32",
+                "firmware": "DIY_900_RX_STM32_SX1272",
+                "stlink": {
+                    "cpus": ["STM32F103C8T6", "STM32F103CBT6"],
+                    "offset": "0x4000",
+                    "bootloader": "sx1272_pcb_bootloader.bin"
+                }
             }
         },
         "tx_2400": {


### PR DESCRIPTION
After adding my [DIY STM32 SX1272 PCB](https://github.com/ExpressLRS/ExpressLRS/pull/2219)
I added it [to the configuator](https://github.com/ExpressLRS/ExpressLRS-Configurator/pull/506)
Now it doesn't show up in the configuator after [cloudbuilds](https://github.com/ExpressLRS/ExpressLRS-Configurator/pull/429) Adding the TX and RX firmware here to targets.json and using the local feature in the configurator works now.

Are the devices json files like [diy-900.json](https://github.com/ExpressLRS/ExpressLRS-Configurator/blob/master/devices/diy-900.json) in the configurator still used and are these device json files in the configurator to be removed?