### PR TITLE
More fixes for the flasher

### DIFF
--- a/src/python/binary_configurator.py
+++ b/src/python/binary_configurator.py
@@ -411,10 +411,11 @@ def main():
             return binary_flash.upload(options, args)
         elif 'upload_methods' in config and 'stock' in config['upload_methods']:
             shutil.copy(args.file.name, 'firmware.elrs')
+    return 0
 
 if __name__ == '__main__':
     try:
-        main()
+        exit(main())
     except AssertionError as e:
         print(e)
         exit(1)


### PR DESCRIPTION
Fix for binary configurator not exiting with the return code from the flasher.
Add the ability for the passphrase to be passed as the UID (6 numbers comma separated) 