### PR TITLE
Speed bootup of ESP32 RXes without a vario

### DIFF
--- a/src/lib/Baro/baro_spl06.cpp
+++ b/src/lib/Baro/baro_spl06.cpp
@@ -11,21 +11,21 @@
 #include "baro_spl06.h"
 #include "baro_spl06_regs.h"
 
-void SPL06::writeRegister(uint8_t reg, uint8_t *data, uint8_t size)
+void SPL06::writeRegister(uint8_t reg, uint8_t *data, size_t size)
 {
-    Wire.beginTransmission(SPL06_I2C_ADDR);
+    Wire.beginTransmission((uint16_t)SPL06_I2C_ADDR);
     Wire.write(reg);
     Wire.write(data, size);
     Wire.endTransmission();
 }
 
-void SPL06::readRegister(uint8_t reg, uint8_t *data, uint8_t size)
+void SPL06::readRegister(uint8_t reg, uint8_t *data, size_t size)
 {
-    Wire.beginTransmission(SPL06_I2C_ADDR);
+    Wire.beginTransmission((uint16_t)SPL06_I2C_ADDR);
     Wire.write(reg);
     if (Wire.endTransmission() == 0)
     {
-        Wire.requestFrom((uint8_t)SPL06_I2C_ADDR, size);
+        Wire.requestFrom((uint16_t)SPL06_I2C_ADDR, size);
         Wire.readBytes(data, size);
     }
 }

--- a/src/lib/Baro/baro_spl06.cpp
+++ b/src/lib/Baro/baro_spl06.cpp
@@ -23,10 +23,11 @@ void SPL06::readRegister(uint8_t reg, uint8_t *data, uint8_t size)
 {
     Wire.beginTransmission(SPL06_I2C_ADDR);
     Wire.write(reg);
-    Wire.endTransmission();
-
-    Wire.requestFrom((uint8_t)SPL06_I2C_ADDR, size);
-    Wire.readBytes(data, size);
+    if (Wire.endTransmission() == 0)
+    {
+        Wire.requestFrom((uint8_t)SPL06_I2C_ADDR, size);
+        Wire.readBytes(data, size);
+    }
 }
 
 uint8_t SPL06::oversampleToRegVal(const uint8_t oversamples) const

--- a/src/lib/Baro/baro_spl06.h
+++ b/src/lib/Baro/baro_spl06.h
@@ -18,7 +18,7 @@ public:
     void startTemperature();
     int32_t getTemperature();
 protected:
-    // 32x Pressure + 8x Temperature = 70ms per update1
+    // 32x Pressure + 8x Temperature = 70ms per update
     // 4x=8.4ms/2.5PaRMS, 8x=14.8ms, 16x=27.6ms/1.2Pa, 32x=53.2ms/0.9Pa, 64x=104.4ms/0.5Pa
     const uint8_t OVERSAMPLING_PRESSURE = 32;
     const uint8_t OVERSAMPLING_TEMPERATURE = 8;

--- a/src/lib/Baro/baro_spl06.h
+++ b/src/lib/Baro/baro_spl06.h
@@ -18,13 +18,13 @@ public:
     void startTemperature();
     int32_t getTemperature();
 protected:
-    // 32x Pressure + 8x Temperature = 70ms per update
+    // 32x Pressure + 8x Temperature = 70ms per update1
     // 4x=8.4ms/2.5PaRMS, 8x=14.8ms, 16x=27.6ms/1.2Pa, 32x=53.2ms/0.9Pa, 64x=104.4ms/0.5Pa
     const uint8_t OVERSAMPLING_PRESSURE = 32;
     const uint8_t OVERSAMPLING_TEMPERATURE = 8;
 
-    static void readRegister(uint8_t reg, uint8_t *data, uint8_t size);
-    static void writeRegister(uint8_t reg, uint8_t *data, uint8_t size);
+    static void readRegister(uint8_t reg, uint8_t *data, size_t size);
+    static void writeRegister(uint8_t reg, uint8_t *data, size_t size);
 
     uint8_t oversampleToRegVal(const uint8_t oversamples) const;
     int32_t oversampleToScaleFactor(const uint8_t oversamples) const;


### PR DESCRIPTION
Fixes slow bootup of ESP32 RXes without a vario, without which it is hard to pull off a traditional rebind.

## Details
ESP32 RXes are difficult to pull off the traditional rebind procedure of plug/unplug 3x, this is because
* You must wait at least 0.5s before unplugging
* You must pull power before ~2.5s after plugging
* The rainbow LED show starts around 2.5s. If you see the rainbow, you waited too long and must restart

### Before
```
Doing power-up check for loan revocation and/or re-binding
(commit)
Time = 385ms
Bind timeout = 2386ms
RAINBOW STARTUP 2536ms
```

What's holding it up is devBaro looking for a barometer, which is hung on what seems like a two second timeout in the Wire library. This can be avoided if the wire master write returns that the address wasn't found in the stop interval.

### After
```
Doing power-up check for loan revocation and/or re-binding
(commit)
Time = 391ms
RAINBOW STARTUP 569ms
Bind timeout = 2391ms
```

### Other I2C devices (LM75A)
I also checked our code for any other places we could fall victim to this blunder and looks like the only other device is a LM75A on the TX module. For that, there is a hardware options flag that disables it entirely so it shouldn't affect boot time of the TX. We could consider refactoring that to remove the flag and just do detection to enable it in our code if found, but I did not do that here as it is too late in the cycle to make a change like that.