### PR TITLE
Allow user to specify range for Ch5 armed position

### DIFF
--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -9,6 +9,7 @@
 #include "common.h"
 #include "msp.h"
 #include "msptypes.h"
+#include "options.h"
 #include "LowPassFilter.h"
 #include "../CRC/crc.h"
 #include "telemetry_protocol.h"
@@ -61,7 +62,7 @@ public:
     static uint32_t VersionStrToU32(const char *verStr);
 
     #ifdef CRSF_TX_MODULE
-    static bool IsArmed() { return CRSF_to_BIT(ChannelData[4]); } // AUX1
+    static bool IsArmed() { return ( (CRSF_to_US(ChannelData[4]) >= firmwareOptions.arm_range_min ) && (CRSF_to_US(ChannelData[4]) <= firmwareOptions.arm_range_max) ); } // AUX1
     static void ICACHE_RAM_ATTR sendLinkStatisticsToTX();
     static void ICACHE_RAM_ATTR sendTelemetryToTX(uint8_t *data);
 

--- a/src/lib/OPTIONS/options.cpp
+++ b/src/lib/OPTIONS/options.cpp
@@ -150,6 +150,16 @@ __attribute__ ((used)) const firmware_options_t firmwareOptions = {
     .uart_baud = 0,
 #endif
 #endif
+#if defined(ARM_RANGE_MIN)
+    .arm-range-min = ARM_RANGE_MIN,
+#else
+    .arm-range-min = 1500,
+#endif
+#if defined(ARM_RANGE_MAX)
+    .arm-range-max = ARM_RANGE_MAX,
+#else
+    .arm-range-max = 2012,
+#endif
 };
 
 #else // TARGET_UNIFIED_TX || TARGET_UNIFIED_RX
@@ -212,6 +222,8 @@ void saveOptions(Stream &stream, bool customised)
     doc["is-airport"] = firmwareOptions.is_airport;
     doc["domain"] = firmwareOptions.domain;
     doc["customised"] = customised;
+    doc["arm-range-min"] = firmwareOptions.arm_range_min;
+    doc["arm-range-max"] = firmwareOptions.arm_range_max;
     doc["flash-discriminator"] = flash_discriminator;
 
     serializeJson(doc, stream);
@@ -323,6 +335,8 @@ static void options_LoadFromFlashOrFile(EspFlashStream &strmFlash)
     #endif
     firmwareOptions.lock_on_first_connection = doc["lock-on-first-connection"] | true;
     #endif
+    firmwareOptions.arm_range_min = doc["arm-range-min"] | 1500;
+    firmwareOptions.arm_range_max = doc["arm-range-max"] | 2012;
     firmwareOptions.domain = doc["domain"] | 0;
     flash_discriminator = doc["flash-discriminator"] | 0U;
 

--- a/src/lib/OPTIONS/options.h
+++ b/src/lib/OPTIONS/options.h
@@ -24,6 +24,8 @@ typedef struct _options {
     uint8_t     domain;         // depends on radio chip
     uint8_t     hasUID;
     uint8_t     uid[6];         // MY_UID derived from MY_BINDING_PHRASE
+    uint16_t    arm_range_min;  // Start of "armed" range
+    uint16_t    arm_range_max;  // End of "armed" range
 #if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
     int32_t     wifi_auto_on_interval;
     char        home_wifi_ssid[33];

--- a/src/python/binary_configurator.py
+++ b/src/python/binary_configurator.py
@@ -231,6 +231,12 @@ def patch_unified(args, options):
     if args.lock_on_first_connection is not None:
         json_flags['lock-on-first-connection'] = args.lock_on_first_connection
 
+    if args.arm-range-min is not None:
+        json_flags['arm-range-min'] = args.arm_range_min
+
+    if args.arm-range-max is not None:
+        json_flags['arm-range-max'] = args.arm_range_max
+
     if args.domain is not None:
         json_flags['domain'] = domain_number(args.domain)
 
@@ -327,6 +333,9 @@ def main():
     parser.add_argument('--unlock-higher-power', dest='unlock_higher_power', action='store_true', help='DANGER: Unlocks the higher power on modules that do not normally have sufficient cooling e.g. 1W on R9M')
     parser.add_argument('--no-unlock-higher-power', dest='unlock_higher_power', action='store_false', help='Set the max power level at the safe maximum level')
     parser.set_defaults(unlock_higher_power=None)
+    # Arming
+    parser.add_argument('--arm-range-min', type=int, help='Minimum uS for Ch 5 to be defined as armed')
+    parser.add_argument('--arm-range-max', type=int, help='Maximum uS for Ch 5 to be defined as armed')
     # Buzzer
     parser.add_argument('--buzzer-mode', type=BuzzerMode, choices=list(BuzzerMode), default=None, help='Which buzzer mode to use, if there is a buzzer')
     parser.add_argument('--buzzer-melody', type=str, default=None, help='If the mode is "custom", then this is the tune')

--- a/src/python/build_flags.py
+++ b/src/python/build_flags.py
@@ -63,6 +63,12 @@ def process_json_flag(define):
                 json_flags['rcvr-uart-baud'] = int(dequote(parts.group(2)))
             else:
                 json_flags['airport-uart-baud'] = int(dequote(parts.group(2)))
+        if parts.group(1) == "ARM_RANGE_MIN":
+            parts = re.search("-D(.*)\s*=\s*\"?([0-9]+).*\"?$", define)
+            json_flags['arm-range-min'] = int(dequote(parts.group(2)))
+        if parts.group(1) == "ARM_RANGE_MAX":
+            parts = re.search("-D(.*)\s*=\s*\"?([0-9]+).*\"?$", define)
+            json_flags['arm-range-max'] = int(dequote(parts.group(2)))
     if define == "-DUART_INVERTED" and not isRX:
         json_flags['uart-inverted'] = True
     if define == "-DUNLOCK_HIGHER_POWER"  and not isRX:

--- a/src/user_defines.txt
+++ b/src/user_defines.txt
@@ -59,6 +59,15 @@
 
 ### OTHER OPTIONS: ###
 
+# Set an "armed" range on Ch5. This allows you to set a range, in which the system is defined as armed. This allows
+# more flexibility than the arm range having to be greater than 1500. If not set, the arming range will match the old
+# range of 1500 to 2012. The total range is 988 to 2012.
+#
+# NOTE: If you change this setting. It must match on your TX and all RXs.
+#-DARM_RANGE_MIN=1500
+#-DARM_RANGE_MAX=2012
+
+# Wi-Fi Preferences
 -DAUTO_WIFI_ON_INTERVAL=60
 #-DHOME_WIFI_SSID=""
 #-DHOME_WIFI_PASSWORD=""


### PR DESCRIPTION
By default, ExpressLRS specifies that arming must be on Channel 5; and when armed the channel must be above 1500us. This PR adds the optional ability for the user to define the range for **ARMED** on Channel 5. This can be changed in the `user_defines.txt` file, and must be the same on the TX and all RX bound to it. This adds flexibility to Ch 5 for advanced pilots. But for basic set-ups, it will work as it does now.