### PR TITLE
Wide switch mode + TLM ratio change v.bad interaction

### DIFF
--- a/src/lib/OTA/OTA.cpp
+++ b/src/lib/OTA/OTA.cpp
@@ -215,7 +215,7 @@ void ICACHE_RAM_ATTR GenerateChannelDataHybridWide(OTA_Packet_s * const otaPktPt
     }
     else
     {
-        bool telemInEveryPacket = (tlmDenom < 8);
+        bool telemInEveryPacket = (tlmDenom > 1) && (tlmDenom < 8);
         value = HybridWideSwitchToOta(channelData, nextSwitchIndex + 1, telemInEveryPacket);
         if (telemInEveryPacket)
             value |= telemBit;
@@ -411,7 +411,7 @@ bool ICACHE_RAM_ATTR UnpackChannelDataHybridWide(OTA_Packet_s const * const otaP
 
     // The round-robin switch, 6-7 bits with the switch index implied by the nonce
     const uint8_t switchByte = ota4->rc.switches;
-    bool telemInEveryPacket = (tlmDenom < 8);
+    bool telemInEveryPacket = (tlmDenom > 1) && (tlmDenom < 8);
     uint8_t switchIndex = HybridWideNonceToSwitchIndex(OtaNonce);
     if (telemInEveryPacket || switchIndex == 7)
           TelemetryStatus = (switchByte & 0b01000000) >> 6;


### PR DESCRIPTION
Works around an MAJOR issue when Arming in Race TLM mode, which causes the switch channels to change during the arm/disarm transition and operate in low precision mode while armed. This has been broken since Race telemetry mode was added.

Note I said that this works around the issue, as it won't happen any more with our current codebase, but will be Tomorrow Bryan's problem someday if we actually change our code enough to run into it again. Also there is another case where this can occur, see below.

### Details
Given: When arming with Race telemetry mode, the TX sends a SYNC packet telling the RX to set Telemetry Ratio = Off, but keeps sending packets at the old TLM ratio until the connection drops, somewhat verifying the RX has updated itself with the new parameter. 

Given: Wide switch mode uses 7 bits for switch data for TLM ratios of 1:8 or greater, or 6 bits for TLM ratios 1:4 and 1:2. Due to an omission on my part, it also uses 6 bits when TLM ratio is off.

Problem: The interaction between these two means any time the TLM ratio is mismatched between the TX and RX, the value of the switches will also be in disagreement. BEHOLD! This can happen with any switch channel
```
// Watching CH9 value on the RX side
// Start with moving the 3pos switch myself (behaves normally)
CH9=191   // Low
CH9=997   // 7-bit Mid
CH9=1792  // High
CH9=997   // 7-bit Mid
New TLMrate 1:1  <-- Armed, SYNC turns telem off on the RX
CH9=191   // RX and TX are in disagreement on the bit depth of the switch channels, switch appears low
CH9=1004  // TX is now in agreement, but we're in 6-bit switch mode
New TLMrate 1:128  <-- Disarm
CH9=997   // Switch returns to 7-bit Mid
New TLMrate 1:1  // Repeating test
CH9=191
CH9=1004
New TLMrate 1:128
CH9=997
```
This is a major problem that happens any time TLM ratio crosses the 1:8 threshold, but only if the RX doesn't get the SYNC packet with the TLM ratio change.

### The "Fix"
This PR simply moves the "Telemetry Ratio = OFF" case into the 7-bit realm, thus avoiding the problem. None of our Std ratios are below 1:8, so this prevents the bug from happening by always being in 7-bit mode. 
```
// Testing channels manually after this PR
CH9=191
CH9=997
CH9=1792
CH9=997
New TLMrate 1:1  <-- Armed, note no changed value
New TLMrate 1:128 <-- Disarmed
New TLMrate 1:1 <-- Armed
New TLMrate 1:128 <-- Disarmed
New TLMrate 1:1 <-- etc
New TLMrate 1:128
```

However, any time the ratio changes, such as to TLM Burst mode (1:2) it will affect the channels values and could potentially result in a mismatch between the TX and RX if the RX missed the SYNC.

You can see here when I launch the Lua (which engages TLM Burst), the channel monitors in BF/iNav show the channel values change to their 6-bit versions and back real fast. If this was done in a <100% LQ environment, the values would change drastically until the RX and TX were in agreement on the TLM ratio.
![1508-short](https://github.com/ExpressLRS/ExpressLRS/assets/677183/073a521f-bab3-441c-a167-7968f0bb8adc)

###  The Real Fix
I uhhhh.... (trails off)