### PR TITLE
Increasing the autobaud denominator factor by one (for fixing failed autobaud in some modules)

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -826,7 +826,7 @@ uint32_t CRSF::autobaud()
     // sample code at https://github.com/espressif/esp-idf/issues/3336
     // says baud rate = 80000000/min(UART_LOWPULSE_REG, UART_HIGHPULSE_REG);
     // Based on testing use max and add 2 for lowest deviation
-    int32_t calulatedBaud = 80000000 / (max(low_period, high_period) + 2);
+    int32_t calulatedBaud = 80000000 / (max(low_period, high_period) + 3);
     int32_t bestBaud = (int32_t)TxToHandsetBauds[0];
     for(int i=0 ; i<ARRAY_SIZE(TxToHandsetBauds) ; i++)
     {


### PR DESCRIPTION
The current autobaud calculation is based on #1435 which is a bit outdated and is not working well in some gears.

Now we have more variety of modules, so I and CapnBry did some testing...

![autobaud](https://github.com/ExpressLRS/ExpressLRS/assets/12195507/6c598f29-ce61-480c-b9bd-a67de6f069bd)

Autobaud detection works on the following logic:
```C++
    int32_t calulatedBaud = 80000000 / (max(low_period, high_period) + [CORRECTION FACTOR]);
    int32_t bestBaud = (int32_t)TxToHandsetBauds[0];
    for(int i=0 ; i<ARRAY_SIZE(TxToHandsetBauds) ; i++)
    {
        if (abs(calulatedBaud - bestBaud) > abs(calulatedBaud - (int32_t)TxToHandsetBauds[i]))
        {
            bestBaud = (int32_t)TxToHandsetBauds[i];
        }
    }
```

In the table in the image, 
* `baud_set` is the baud rate set by the radio.
* if `baud_measured` is different from `baud_set`, it's the actual baud rate measured by a LA.
* `low` and `high` are measured `low_period` and `high_period`.
* `number` - `error` - `Correct?` fields are the simulation of the autobaud calculation, where the number is the `CORRECTION FACTOR` in the algorithm above. `error` is the difference between the real baudrate and the calculated baudrate in percentage, and `Correct?` is `True` when the estimated baudrate (the nearest baudrate in the `TxToHandsetBauds` table) is equal to the true baudrate.

Among the range of 0 -- 7 correction factors, I conclude `3` is the best working one.