### PR TITLE
Binary patching of STM based targets broken

### DIFF
--- a/src/lib/OPTIONS/options.cpp
+++ b/src/lib/OPTIONS/options.cpp
@@ -29,7 +29,7 @@ const char *wifi_ap_address = "10.0.0.1";
 const char device_name[] = DEVICE_NAME;
 const char *product_name = (const char *)(target_name+4);
 
-__attribute__ ((used)) const firmware_options_t firmwareOptions = {
+__attribute__ ((used)) static firmware_options_t flashedOptions = {
     ._magic_ = {0xBE, 0xEF, 0xBA, 0xBE, 0xCA, 0xFE, 0xF0, 0x0D},
     ._version_ = 1,
 #if defined(Regulatory_Domain_ISM_2400)
@@ -151,6 +151,18 @@ __attribute__ ((used)) const firmware_options_t firmwareOptions = {
 #endif
 #endif
 };
+
+/*
+ * This all seems rather convoluted, but it means that the compiler/linker optimisations
+ * don't create multiple copies of the UID. This code forces the firmwareOptions to be copied
+ * into RAM and all the other areas of code are forced to use the RAM copy.
+ */
+firmware_options_t firmwareOptions;
+bool options_init()
+{
+    firmwareOptions = flashedOptions;
+    return true;
+}
 
 #else // TARGET_UNIFIED_TX || TARGET_UNIFIED_RX
 

--- a/src/lib/OPTIONS/options.h
+++ b/src/lib/OPTIONS/options.h
@@ -69,8 +69,9 @@ extern uint32_t flash_discriminator;
 #include "EspFlashStream.h"
 extern bool options_HasStringInFlash(EspFlashStream &strmFlash);
 #else
-extern const firmware_options_t firmwareOptions;
+extern firmware_options_t firmwareOptions;
 extern const char device_name[];
 extern const char *product_name;
+extern bool options_init();
 
 #endif

--- a/src/python/binary_configurator.py
+++ b/src/python/binary_configurator.py
@@ -387,7 +387,7 @@ def main():
         pos = firmware.get_hardware(mm)
         options = FirmwareOptions(
             False if config['platform'] == 'stm32' else True,
-            True if 'features' in config and 'buzzer' in config['features'] == True else False,
+            True if 'features' in config and 'buzzer' in config['features'] else False,
             MCUType.STM32 if config['platform'] == 'stm32' else MCUType.ESP32 if config['platform'] == 'esp32' else MCUType.ESP8266,
             DeviceType.RX if '.rx_' in args.target else DeviceType.TX,
             RadioType.SX127X if '_900.' in args.target else RadioType.SX1280,

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -516,7 +516,7 @@ bool ICACHE_RAM_ATTR HandleSendTelemetryResponse()
     }
 
     Radio.TXnb((uint8_t*)&otaPkt, ExpressLRS_currAirRate_Modparams->PayloadLength, transmittingRadio);
- 
+
     return true;
 }
 
@@ -1651,6 +1651,8 @@ void setup()
 
         connectionState = hardwareUndefined;
     }
+    #else
+    hardwareConfigured = options_init();
     #endif
 
     if (hardwareConfigured)

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1180,6 +1180,8 @@ bool setupHardwareFromOptions()
     connectionState = hardwareUndefined;
     return false;
   }
+#else
+  options_init();
 #endif
 
   return true;


### PR DESCRIPTION
# Problem
At some stage the during the development cycle the `firmwareOptions` singleton structure, which contains all the "compile time" options sort of broke in an unexpected way.
The UID which is placed into the structure was duplicated to 2 positions in the resulting firmware, and so when the patching happened it only updated the one place, which tuned out not to be the place that it was required.

# Solution
Change the `firmwareOptions` to be a RAM based structure and copy the flashed version to RAM during initialisation.
This forces there to be only a single copy of the firmware options available at runtime i.e. the one on RAM.

This does increase the RAM requirement ever so slightly, but hey, we're still under 25% used.

Fixes #2293

# Testing
Build the firmware R9M target with an empty set of defines.
Then run this command to put your bind-phrase in.
```bash
python3 python/binary_configurator.py --buzzer-mode default-tune --tx --phrase my-phrase .pio/build/Frsky_TX_R9M_via_stock_BL/firmware.elrs
```
Select the option for R9M target. Copy the firmware.elrs file to the radio and flash via EdgeTX stock mode and test.