### PR TITLE
Jumper T-20 2400 and 900 target defines

### DIFF
--- a/src/hardware/TX/Jumper T-20 2400.json
+++ b/src/hardware/TX/Jumper T-20 2400.json
@@ -3,7 +3,6 @@
     "serial_tx": 1,
     "radio_busy": 21,
     "radio_dio1": 4,
-    "radio_dio2": 22,
     "radio_miso": 19,
     "radio_mosi": 23,
     "radio_nss": 5,

--- a/src/hardware/TX/Jumper T-20 2400.json
+++ b/src/hardware/TX/Jumper T-20 2400.json
@@ -1,0 +1,23 @@
+{
+    "serial_rx": 3,
+    "serial_tx": 1,
+    "radio_busy": 21,
+    "radio_dio1": 4,
+    "radio_dio2": 22,
+    "radio_miso": 19,
+    "radio_mosi": 23,
+    "radio_nss": 5,
+    "radio_rst": 14,
+    "radio_sck": 18,
+    "radio_dcdc": true,
+    "power_enable": 25,
+    "power_rxen": 27,
+    "power_txen": 26,
+    "power_lna_gain": 12,
+    "power_min": 1,
+    "power_high": 6,
+    "power_max": 6,
+    "power_default": 2,
+    "power_control": 0,
+    "power_values": [-17,-14,-10,-6,-3,3]
+}

--- a/src/hardware/TX/Jumper T-20 900.json
+++ b/src/hardware/TX/Jumper T-20 900.json
@@ -1,0 +1,19 @@
+{
+    "serial_rx": 3,
+    "serial_tx": 1,
+    "radio_dio0": 26,
+    "radio_dio1": 25,
+    "radio_miso": 19,
+    "radio_mosi": 23,
+    "radio_nss": 5,
+    "radio_rst": 14,
+    "radio_sck": 18,
+    "power_rxen": 13,
+    "power_txen": 12,
+    "power_min": 4,
+    "power_high": 4,
+    "power_max": 6,
+    "power_default": 4,
+    "power_control": 0,
+    "power_values": [0,4,15]
+}

--- a/src/hardware/TX/Jumper T-20 900.json
+++ b/src/hardware/TX/Jumper T-20 900.json
@@ -11,7 +11,7 @@
     "power_rxen": 13,
     "power_txen": 12,
     "power_min": 4,
-    "power_high": 4,
+    "power_high": 6,
     "power_max": 6,
     "power_default": 4,
     "power_control": 0,

--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -1249,7 +1249,7 @@
                 "layout_file": "Jumper T-20 900.json",
                 "upload_methods": ["uart", "wifi", "etx"],
                 "platform": "esp32",
-                "firmware": "Unified_ESP32_2400_TX"
+                "firmware": "Unified_ESP32_900_TX"
             }
         },
         "rx_2400": {

--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -1206,6 +1206,14 @@
     "jumper": {
         "name": "Jumper",
         "tx_2400": {
+            "t-20": {
+                "product_name": "Jumper T-20 2.4GHz TX",
+                "lua_name": "T-20 2G4 TX",
+                "layout_file": "Jumper T-20 2400.json",
+                "upload_methods": ["uart", "wifi", "etx"],
+                "platform": "esp32",
+                "firmware": "Unified_ESP32_2400_TX"
+            },
             "t-pro": {
                 "product_name": "Jumper AION T-Pro 2.4GHz TX",
                 "lua_name": "AION T-Pro TX",
@@ -1232,6 +1240,16 @@
                 "platform": "esp32",
                 "firmware": "Unified_ESP32_2400_TX",
                 "prior_target_name": "Jumper_AION_NANO_2400_TX"
+            }
+        },
+        "tx_900": {
+            "t-20": {
+                "product_name": "Jumper T-20 900M TX",
+                "lua_name": "T-20 900 TX",
+                "layout_file": "Jumper T-20 900.json",
+                "upload_methods": ["uart", "wifi", "etx"],
+                "platform": "esp32",
+                "firmware": "Unified_ESP32_2400_TX"
             }
         },
         "rx_2400": {


### PR DESCRIPTION
New targets for Jumper T-20 internal 2400 and 900 modules.

Power values have been calibrated using the supplied samples.