### PR TITLE
Return wifi to R9M upload methods

### DIFF
--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -493,7 +493,7 @@
         "tx_900": {
             "r9m": {
                 "product_name": "FrSky R9M 900MHz TX",
-                "upload_methods": ["stlink", "stock"],
+                "upload_methods": ["stlink", "stock", "wifi"],
                 "platform": "stm32",
                 "firmware": "Frsky_TX_R9M",
                 "features": ["buzzer", "unlock-higher-power", "fan"],


### PR DESCRIPTION
Returns R9M wifi upload mode for users who have added a backpack. Removed in #2253, but [our docs](https://www.expresslrs.org/hardware/backpack/esp-backpack/#supported-tx-backpack-targets) say it is supported if added. There is still code used on the backpack that supports sending it, and the main project `binary_flash.py` / `upload_via_esp8266_backpack.py` still appear to support it.

I've asked @Gorilla-Link to provide information for our docs as they seem to rely on this but we have zero information on it so it is likely to be broken / removed eventually due to the mystery of its usage.