### PR TITLE
VTX Fixes 1

### DIFF
--- a/src/lib/VTXSPI/devVTXSPI.cpp
+++ b/src/lib/VTXSPI/devVTXSPI.cpp
@@ -185,13 +185,26 @@ void VTxOutputMinimum()
 
 static void VTxOutputIncrease()
 {
-    if (vtxSPIPWM > vtxMinPWM) vtxSPIPWM -= 1;
+    if (GPIO_PIN_RF_AMP_PWM == 25 || GPIO_PIN_RF_AMP_PWM == 26)
+    {
+        if (vtxSPIPWM < vtxMaxPWM) vtxSPIPWM += 1;
+    }
+    else {
+        if (vtxSPIPWM > vtxMinPWM) vtxSPIPWM -= 1;
+    }
     setPWM();
 }
 
 static void VTxOutputDecrease()
 {
-    if (vtxSPIPWM < vtxMaxPWM) vtxSPIPWM += 1;
+    if (GPIO_PIN_RF_AMP_PWM == 25 || GPIO_PIN_RF_AMP_PWM == 26)
+    {
+        if (vtxSPIPWM > vtxMinPWM) vtxSPIPWM -= 1;
+    }
+    else
+    {
+        if (vtxSPIPWM < vtxMaxPWM) vtxSPIPWM += 1;
+    }
     setPWM();
 }
 

--- a/src/lib/VTXSPI/devVTXSPI.cpp
+++ b/src/lib/VTXSPI/devVTXSPI.cpp
@@ -110,6 +110,8 @@ static void rtc6705ResetSynthRegA()
 
 static void rtc6705SetFrequency(uint32_t freq)
 {
+    DBGLN("VTX: frequency: %d", freq);
+    
     rtc6705ResetSynthRegA();
 
     VTxOutputMinimum(); // Set power to zero for clear channel switching

--- a/src/lib/VTXSPI/devVTXSPI.cpp
+++ b/src/lib/VTXSPI/devVTXSPI.cpp
@@ -160,8 +160,8 @@ static void setPWM()
 #if defined(PLATFORM_ESP32)
     if (GPIO_PIN_RF_AMP_PWM == 25 || GPIO_PIN_RF_AMP_PWM == 26)
     {
-        DBGLN("VTX: setPWM (dac), value: %d", vtxSPIPWM >> 4);
-        dacWrite(GPIO_PIN_RF_AMP_PWM, vtxSPIPWM >> 4);
+        DBGLN("VTX: setPWM (dac), value: %d", vtxSPIPWM);
+        dacWrite(GPIO_PIN_RF_AMP_PWM, vtxSPIPWM);
     }
     else
     {

--- a/src/lib/VTXSPI/devVTXSPI.cpp
+++ b/src/lib/VTXSPI/devVTXSPI.cpp
@@ -333,6 +333,8 @@ static void initialize()
                 ledcAttachPin(GPIO_PIN_RF_AMP_PWM, rfAmpPwmChannel);
             }
         #endif
+
+        SetVpdSetPoint();
         setPWM();
 
         delay(RTC6705_BOOT_DELAY);

--- a/src/lib/VTXSPI/devVTXSPI.cpp
+++ b/src/lib/VTXSPI/devVTXSPI.cpp
@@ -179,7 +179,14 @@ void VTxOutputMinimum()
 {
     RfAmpVrefOff();
 
-    vtxSPIPWM = vtxMaxPWM;
+    if (GPIO_PIN_RF_AMP_PWM == 25 || GPIO_PIN_RF_AMP_PWM == 26)
+    {
+        vtxSPIPWM = vtxMinPWM;
+    } 
+    else 
+    {
+        vtxSPIPWM = vtxMaxPWM;
+    }
     setPWM();
 }
 
@@ -336,7 +343,7 @@ static void initialize()
             {
                 vtxMinPWM = MIN_DAC;
                 vtxMaxPWM = MAX_DAC;
-                vtxSPIPWM = vtxMaxPWM;
+                vtxSPIPWM = vtxMinPWM;
                 DBGLN("VTX: Using DAC, min: %d, max: %d, spipwm: %d", vtxMinPWM, vtxMaxPWM, vtxSPIPWM);
             }
             else

--- a/src/lib/VTXSPI/devVTXSPI.cpp
+++ b/src/lib/VTXSPI/devVTXSPI.cpp
@@ -52,6 +52,7 @@ uint8_t vtxSPIPitmode = 1;
 static uint8_t vtxSPIPitmodeCurrent = 1;
 static uint8_t RfAmpVrefState = 0;
 static uint16_t vtxSPIPWM = MAX_PWM;
+static uint16_t vtxPreviousSPIPWM = 0;
 static uint16_t vtxMinPWM = MIN_PWM;
 static uint16_t vtxMaxPWM = MAX_PWM;
 static uint16_t VpdSetPoint = 0;
@@ -150,6 +151,10 @@ static void RfAmpVrefOff()
 
 static void setPWM()
 {
+    if (vtxSPIPWM == vtxPreviousSPIPWM) {
+        return;
+    }
+
 #if defined(PLATFORM_ESP32)
     if (GPIO_PIN_RF_AMP_PWM == 25 || GPIO_PIN_RF_AMP_PWM == 26)
     {
@@ -164,6 +169,8 @@ static void setPWM()
 #else
     analogWrite(GPIO_PIN_RF_AMP_PWM, vtxSPIPWM);
 #endif
+
+    vtxPreviousSPIPWM = vtxSPIPWM;
 }
 
 void VTxOutputMinimum()


### PR DESCRIPTION
See individual commits for details.

All code tested using the following schematic for the DAC / RF-AMP.

![image](https://github.com/ExpressLRS/ExpressLRS/assets/57075/efe78aa5-7280-4879-be50-358e8cfb20f9)

![image](https://github.com/ExpressLRS/ExpressLRS/assets/57075/8b6f3ebe-1165-4e75-9630-67fc2bea6b94)


The only schematic I could find for the PWM VTX PA RF BIAS was this:

![image](https://github.com/ExpressLRS/ExpressLRS/assets/57075/672f08d1-3408-42db-bce9-bbcd5904ecdb)

![image](https://github.com/ExpressLRS/ExpressLRS/assets/57075/05689764-d95d-4274-8cc8-a90f2d70e6f7)

![image](https://github.com/ExpressLRS/ExpressLRS/assets/57075/cb0730e1-2dbd-446f-9644-96e11105a1e8)

See https://oshwlab.com/jyesmith/openvtx-rfpa5542

