### PR TITLE
Further Jumper T-20 power calibration upon CMU200

### DIFF
--- a/src/hardware/TX/Jumper T-20 2400.json
+++ b/src/hardware/TX/Jumper T-20 2400.json
@@ -18,5 +18,5 @@
     "power_max": 6,
     "power_default": 2,
     "power_control": 0,
-    "power_values": [-17,-14,-10,-6,-3,3]
+    "power_values": [-16,-13,-9,-5,-3,3]
 }

--- a/src/hardware/TX/Jumper T-20 900.json
+++ b/src/hardware/TX/Jumper T-20 900.json
@@ -15,5 +15,5 @@
     "power_max": 6,
     "power_default": 4,
     "power_control": 0,
-    "power_values": [0,4,15]
+    "power_values": [0,3,15]
 }


### PR DESCRIPTION
Further power calibration is performed based on the power measured on CMU-200

2.4g
| set (unit: dBm) | measured |
| --- | --- |
| 14 | 14.2 |
| 17 | 17.1 |
| 24 | 24.5 |
| 27 | 27.9 |
| 30 | 29.2 |

900M
| set (unit: dBm) | measured |
| --- | --- |
| 24 | 24.3 |
| 27 | 27.3 |
| 30 | 30.1 |





