### PR TITLE
Append prior target name to firmware

### DIFF
--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -11,7 +11,8 @@
                 },
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "platform": "esp8285",
-                "firmware": "Unified_ESP8285_2400_RX"
+                "firmware": "Unified_ESP8285_2400_RX",
+                "prior_target_name": "MATEK_2400_RX_R24D"
             },
             "dual-radio": {
                 "product_name": "Anyleaf 2.4GHz dual radio RX",
@@ -30,7 +31,8 @@
                 "layout_file": "Generic 2400.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "platform": "esp8285",
-                "firmware": "Unified_ESP8285_2400_RX"
+                "firmware": "Unified_ESP8285_2400_RX",
+                "prior_target_name": "DIY_2400_RX_ESP8285_SX1280"
             }
         }
     },
@@ -184,7 +186,7 @@
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "platform": "esp8285",
                 "firmware": "Unified_ESP8285_2400_RX",
-                "prior_target_name": "BETAFPV_2400_RX"
+                "prior_target_name": "BETAFPV_Nano_2400_RX"
             },
             "pwmp": {
                 "product_name": "BETAFPV PWM 2.4GHz RX",
@@ -204,7 +206,8 @@
                 },
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "platform": "esp32",
-                "firmware": "Unified_ESP32_2400_RX"
+                "firmware": "Unified_ESP32_2400_RX",
+                "prior_target_name": "BETAFPV_SuperD_2400_RX"
             },
             "superp": {
                 "product_name": "BETAFPV SuperP 14Ch 2.4GHz RX",
@@ -280,7 +283,8 @@
                 "layout_file": "DIY 900 TTGO V1.json",
                 "upload_methods": ["uart", "wifi"],
                 "platform": "esp32",
-                "firmware": "Unified_ESP32_900_RX"
+                "firmware": "Unified_ESP32_900_RX",
+                "prior_target_name": "DIY_900_RX_TTGO_V1_SX127x"
             },
             "ttgov2": {
                 "product_name": "DIY TTGO V2 900MHz RX",
@@ -288,7 +292,8 @@
                 "layout_file": "DIY 900 TTGO V2.json",
                 "upload_methods": ["uart", "wifi"],
                 "platform": "esp32",
-                "firmware": "Unified_ESP32_900_RX"
+                "firmware": "Unified_ESP32_900_RX",
+                "prior_target_name": "DIY_900_RX_TTGO_V2_SX127x"
             },
             "huzzah": {
                 "product_name": "DIY Huzzah RFM95 900MHz TX",
@@ -362,7 +367,8 @@
                 "features": ["fan"],
                 "upload_methods": ["uart", "wifi"],
                 "platform": "esp32",
-                "firmware": "Unified_ESP32_900_TX"
+                "firmware": "Unified_ESP32_900_TX",
+                "prior_target_name": "EMAX_900_TX"
             },
             "nano": {
                 "product_name": "EMAX Nano 900MHz TX",
@@ -371,7 +377,8 @@
                 "features": ["fan"],
                 "upload_methods": ["uart", "wifi"],
                 "platform": "esp32",
-                "firmware": "Unified_ESP32_900_TX"
+                "firmware": "Unified_ESP32_900_TX",
+                "prior_target_name": "EMAX_NANO_900_TX"
             }
         },
         "rx_900": {
@@ -381,7 +388,8 @@
                 "layout_file": "Generic 900.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "platform": "esp8285",
-                "firmware": "Unified_ESP8285_900_RX"
+                "firmware": "Unified_ESP8285_900_RX",
+                "prior_target_name": "DIY_900_RX_ESP8285_SX127x"
             }
         },
         "tx_2400": {
@@ -392,7 +400,8 @@
                 "features": ["fan"],
                 "upload_methods": ["uart", "wifi"],
                 "platform": "esp32",
-                "firmware": "Unified_ESP32_2400_TX"
+                "firmware": "Unified_ESP32_2400_TX",
+                "prior_target_name": "EMAX_2400_TX"
             },
             "nano": {
                 "product_name": "EMAX Nano 2.4GHz TX",
@@ -401,7 +410,8 @@
                 "features": ["fan"],
                 "upload_methods": ["uart", "wifi"],
                 "platform": "esp32",
-                "firmware": "Unified_ESP32_2400_TX"
+                "firmware": "Unified_ESP32_2400_TX",
+                "prior_target_name": "EMAX_NANO_2400_TX"
             }
         },
         "rx_2400": {
@@ -414,7 +424,8 @@
                 },
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "platform": "esp8285",
-                "firmware": "Unified_ESP8285_2400_RX"
+                "firmware": "Unified_ESP8285_2400_RX",
+                "prior_target_name": "DIY_2400_RX_ESP8285_SX1280"
             },
             "pa": {
                 "product_name": "EMAX 2.4GHz PA RX",
@@ -425,7 +436,8 @@
                 },
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "platform": "esp8285",
-                "firmware": "Unified_ESP8285_2400_RX"
+                "firmware": "Unified_ESP8285_2400_RX",
+                "prior_target_name": "BETAFPV_Nano_2400_RX"
             }
         }
     },
@@ -464,7 +476,8 @@
                 },
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "platform": "esp8285",
-                "firmware": "Unified_ESP8285_2400_RX"
+                "firmware": "Unified_ESP8285_2400_RX",
+                "prior_target_name": "Foxeer_2400_RX"
             },
             "lite": {
                 "product_name": "Foxeer Lite 2.4GHz RX",
@@ -660,7 +673,7 @@
                 "upload_methods": ["uart", "wifi", "etx"],
                 "platform": "esp32",
                 "firmware": "Unified_ESP32_2400_TX",
-                "prior_target_name": "Unified_ESP32_2400_TX"
+                "prior_target_name": "DIY_2400_TX_GEMINI"
             }
         },
         "rx_2400": {
@@ -708,7 +721,8 @@
                 "layout_file": "Vario 2400.json",
                 "upload_methods": ["uart", "wifi"],
                 "platform": "esp32",
-                "firmware": "Unified_ESP32_2400_RX"
+                "firmware": "Unified_ESP32_2400_RX",
+                "prior_target_name": "DIY_2400_RX_PWM_VARIO"
             },
             "pwm7": {
                 "product_name": "Generic ESP8285 7xPWM 2.4Ghz RX",
@@ -732,7 +746,8 @@
                 "layout_file": "Generic 2400 PA RGB.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "platform": "esp8285",
-                "firmware": "Unified_ESP8285_2400_RX"
+                "firmware": "Unified_ESP8285_2400_RX",
+                "prior_target_name": "DIY_2400_PA_RGB_RX"
             },
             "diversity": {
                 "product_name": "Generic ESP8285 Diversity PA 2.4Ghz RX",
@@ -809,7 +824,8 @@
                 "layout_file": "Generic 900.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "platform": "esp8285",
-                "firmware": "Unified_ESP8285_900_RX"
+                "firmware": "Unified_ESP8285_900_RX",
+                "prior_target_name": "DIY_900_RX_ESP8285_SX127x"
             }
         },
         "rx_2400": {
@@ -951,7 +967,8 @@
                 "layout_file": "Generic 2400 True Diversity PA.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "platform": "esp32",
-                "firmware": "Unified_ESP32_2400_RX"
+                "firmware": "Unified_ESP32_2400_RX",
+                "prior_target_name": "HappyModel_EP_Dual_2400_RX"
             },
             "epw5": {
                 "product_name": "HappyModel EPW5 2.4GHz PWM RX",
@@ -1282,7 +1299,8 @@
                 },
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "platform": "esp8285",
-                "firmware": "Unified_ESP8285_2400_RX"
+                "firmware": "Unified_ESP8285_2400_RX",
+                "prior_target_name": "Jumper_AION_Nano_2400_RX"
             }
         },
         "rx_900": {
@@ -1457,7 +1475,8 @@
                 "layout_file": "Generic 2400 Diversity PA.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "platform": "esp8285",
-                "firmware": "Unified_ESP8285_2400_RX"
+                "firmware": "Unified_ESP8285_2400_RX",
+                "prior_target_name": "DIY_2400_RX_ESP8285_SX1280"
             }
         }
     },
@@ -1480,7 +1499,7 @@
                 "upload_methods": ["uart", "wifi"],
                 "platform": "esp32",
                 "firmware": "Unified_ESP32_2400_TX",
-                "prior_target_name": "QuadKopters_SLIM_2400_TX"
+                "prior_target_name": "QuadKopters_JR_2400_TX"
             }
         },
         "rx_2400": {
@@ -1531,7 +1550,8 @@
                 "layout_file": "Radiomaster Ranger.json",
                 "upload_methods": ["uart", "wifi"],
                 "platform": "esp32",
-                "firmware": "Unified_ESP32_2400_TX"
+                "firmware": "Unified_ESP32_2400_TX",
+                "prior_target_name": "RadioMaster_Ranger_2400_TX"
             },
             "ranger-micro": {
                 "product_name": "RadioMaster Ranger Micro 2.4GHz TX",
@@ -1539,7 +1559,8 @@
                 "layout_file": "Radiomaster Ranger Micro.json",
                 "upload_methods": ["uart", "wifi"],
                 "platform": "esp32",
-                "firmware": "Unified_ESP32_2400_TX"
+                "firmware": "Unified_ESP32_2400_TX",
+                "prior_target_name": "RadioMaster_Ranger_Micro_2400_TX"
             },
             "ranger-nano": {
                 "product_name": "RadioMaster Ranger Nano 2.4GHz TX",
@@ -1550,7 +1571,8 @@
                 },
                 "upload_methods": ["uart", "wifi"],
                 "platform": "esp32",
-                "firmware": "Unified_ESP32_2400_TX"
+                "firmware": "Unified_ESP32_2400_TX",
+                "prior_target_name": "RadioMaster_Ranger_Nano_2400_TX"
 			},
             "boxer": {
                 "product_name": "RadioMaster Boxer Internal 2.4GHz TX",
@@ -1558,7 +1580,8 @@
                 "layout_file": "Radiomaster Boxer.json",
                 "upload_methods": ["uart", "wifi", "etx"],
                 "platform": "esp32",
-                "firmware": "Unified_ESP32_2400_TX"
+                "firmware": "Unified_ESP32_2400_TX",
+                "prior_target_name": "RadioMaster_Boxer_2400_TX"
             }
         },
         "rx_2400": {
@@ -1654,7 +1677,8 @@
                 "layout_file": "Generic 2400.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "platform": "esp8285",
-                "firmware": "Unified_ESP8285_2400_RX"
+                "firmware": "Unified_ESP8285_2400_RX",
+                "prior_target_name": "HappyModel_EP_2400_RX"
             },
             "rp2": {
                 "product_name": "RadioMaster RP2 2.4GHz RX",
@@ -1662,7 +1686,8 @@
                 "layout_file": "Generic 2400.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "platform": "esp8285",
-                "firmware": "Unified_ESP8285_2400_RX"
+                "firmware": "Unified_ESP8285_2400_RX",
+                "prior_target_name": "HappyModel_EP_2400_RX"
             },
             "rp3": {
                 "product_name": "RadioMaster RP3 Diversity 2.4GHz RX",
@@ -1673,7 +1698,8 @@
                 },
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "platform": "esp8285",
-                "firmware": "Unified_ESP8285_2400_RX"
+                "firmware": "Unified_ESP8285_2400_RX",
+                "prior_target_name": "MATEK_2400_RX_R24D"
             }
         }
     },
@@ -1727,7 +1753,7 @@
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "platform": "esp8285",
                 "firmware": "Unified_ESP8285_2400_RX",
-                "prior_target_name": "MATEK_2400_RX"
+                "prior_target_name": "MATEK_2400_RX_R24D"
             }
         }
     },

--- a/src/python/UnifiedConfiguration.py
+++ b/src/python/UnifiedConfiguration.py
@@ -52,7 +52,10 @@ def appendToFirmware(firmware_file, product_name, lua_name, defines, config, lay
             sys.stderr.write(f'Error opening file "{layout_file}"\n')
             exit(1)
     firmware_file.write(b'\0')
-    # firmware_file.truncate(firmware_file.tell())  # Stupid Windoze! (Permission denied)
+    if 'prior_target_name' in config:
+        firmware_file.write(b'\xBE\xEF\xCA\xFE')
+        firmware_file.write(config['prior_target_name'].upper().encode())
+        firmware_file.write(b'\0')
 
 def doConfiguration(file, defines, config, moduletype, frequency, platform, device_name):
     product_name = "Unified"

--- a/src/python/UnifiedConfiguration.py
+++ b/src/python/UnifiedConfiguration.py
@@ -52,7 +52,7 @@ def appendToFirmware(firmware_file, product_name, lua_name, defines, config, lay
             sys.stderr.write(f'Error opening file "{layout_file}"\n')
             exit(1)
     firmware_file.write(b'\0')
-    if 'prior_target_name' in config:
+    if config is not None and 'prior_target_name' in config:
         firmware_file.write(b'\xBE\xEF\xCA\xFE')
         firmware_file.write(config['prior_target_name'].upper().encode())
         firmware_file.write(b'\0')

--- a/src/python/targets_validator.py
+++ b/src/python/targets_validator.py
@@ -1,14 +1,22 @@
 import os, sys
 import json
 import glob
+import argparse
 
 hadError = False
+warnEnabled = False
 firmwares = set()
 
 def error(msg):
     global hadError
     hadError = True
     print(msg)
+
+def warn(msg):
+    if warnEnabled:
+        global hadError
+        hadError = True
+        print(msg)
 
 def validate_stm32(vendor, type, devname, device):
     for method in device['upload_methods']:
@@ -34,6 +42,8 @@ def validate_esp(vendor, type, devname, device):
     if len(device['lua_name']) > 16:
         error(f'device "{vendor}.{type}.{devname}" must have a "lua_name" of 16 characters or less')
     # validate layout_file
+    if not device['firmware'].startswith('Unified'):
+        error(f'ESP target "{vendor}.{type}.{devname}" must be using the Unifified firmware')
     if 'layout_file' not in device:
         error(f'device "{vendor}.{type}.{devname}" must have a "layout_file" child element')
     else:
@@ -42,6 +52,9 @@ def validate_esp(vendor, type, devname, device):
             layout_file = device['layout_file']
             error(f'File specified by layout_file "{layout_file}" in target "{vendor}.{type}.{devname}", does not exist')
     # could validate overlay
+    if 'prior_target_name' not in device:
+        warn(f'device "{vendor}.{type}.{devname}" should have a "prior_target_name" child element')
+
 
 def validate_esp32(vendor, type, devname, device):
     for method in device['upload_methods']:
@@ -107,6 +120,11 @@ def validate_vendor(name, types):
                 validate_devices(name, type, device, types[type][device])
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Configure Binary Firmware")
+    parser.add_argument("--warn", "-w", action='store_true', default=False, help="Print warnings")
+    args = parser.parse_args()
+    warnEnabled = args.warn
+
     targets = {}
     with open('hardware/targets.json') as f:
         targets = json.load(f)

--- a/src/python/targets_validator.py
+++ b/src/python/targets_validator.py
@@ -43,7 +43,7 @@ def validate_esp(vendor, type, devname, device):
         error(f'device "{vendor}.{type}.{devname}" must have a "lua_name" of 16 characters or less')
     # validate layout_file
     if not device['firmware'].startswith('Unified'):
-        error(f'ESP target "{vendor}.{type}.{devname}" must be using the Unifified firmware')
+        error(f'ESP target "{vendor}.{type}.{devname}" must be using a Unified firmware')
     if 'layout_file' not in device:
         error(f'device "{vendor}.{type}.{devname}" must have a "layout_file" child element')
     else:


### PR DESCRIPTION
This allows new unified firmware to be updated without the annoying target mismatch warning popup.