### PR TITLE
Corrections for BetaFPV Super-P VBAT measurement

### DIFF
--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -106,9 +106,9 @@
                 "layout_file": "Generic 900 True Diversity PWM 16.json",
                 "overlay": {
                     "pwm_outputs":[13,15,2,0,4,9,10,5,18,23,19,22,3,1],
-                    "vbat_offset": 4,
-                    "vbat_scale": 285,
-                    "vbat_atten": 4
+                    "vbat_offset": 18,
+                    "vbat_scale": 1284,
+                    "vbat_atten": 7
                 },
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "platform": "esp32",
@@ -212,9 +212,9 @@
                 "layout_file": "Generic 2400 True Diversity PA PWM 14.json",
                 "overlay": {
                     "radio_dcdc": true,
-                    "vbat_offset": 4,
-                    "vbat_scale": 285,
-                    "vbat_atten": 4
+                    "vbat_offset": 18,
+                    "vbat_scale": 1284,
+                    "vbat_atten": 7
                 },
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "platform": "esp32",


### PR DESCRIPTION
The production version of the Super-P has a different resistor divider network to the samples provided to the devs.
BetaFPV kindly sent some production units to the devs and we've redone the calibration calculations.

The is accurate within 0.1V from 1.0 to 24.5V.