### PR TITLE
Channel data over UDP for sims

### DIFF
--- a/src/lib/WIFI/wifiJoystick.cpp
+++ b/src/lib/WIFI/wifiJoystick.cpp
@@ -1,0 +1,106 @@
+#include "device.h"
+
+#include "wifiJoystick.h"
+
+#if defined(HAS_WIFI_JOYSTICK)
+#include <WiFi.h>
+#include <WiFiUdp.h>
+#include "common.h"
+#include "CRSF.h"
+#include "POWERMGNT.h"
+#include "hwTimer.h"
+#include "logging.h"
+
+
+#if defined(Regulatory_Domain_AU_915) || defined(Regulatory_Domain_EU_868) || defined(Regulatory_Domain_IN_866) || defined(Regulatory_Domain_FCC_915) || defined(Regulatory_Domain_AU_433) || defined(Regulatory_Domain_EU_433)
+extern SX127xDriver Radio;
+#elif defined(Regulatory_Domain_ISM_2400)
+extern SX1280Driver Radio;
+#endif
+
+WiFiUDP *WifiJoystick::udp = NULL;
+IPAddress WifiJoystick::remoteIP;
+uint8_t WifiJoystick::channelCount = JOYSTICK_DEFAULT_CHANNEL_COUNT;
+
+void WifiJoystick::StartJoystickService()
+{
+    if (!udp)
+    {
+        
+        udp = new WiFiUDP();
+        udp->begin(JOYSTICK_PORT);
+    }
+
+}
+
+void WifiJoystick::StopJoystickService()
+{
+    udp->stop();
+    delete udp;
+    udp = NULL;
+    
+}
+
+void WifiJoystick::StartSending(IPAddress ip, uint32_t updateInterval, uint8_t newChannelCount)
+{
+    if (!udp)
+    {
+        return;
+    }
+    remoteIP = ip;
+
+    hwTimer::updateInterval(updateInterval);
+    CRSF::setSyncParams(updateInterval);
+    POWERMGNT::setPower(MinPower);
+    Radio.End();
+    
+    CRSF::RCdataCallback = UpdateValues;
+    channelCount = newChannelCount;
+
+    if (channelCount > 16) {
+        channelCount = 16;
+    }
+
+}
+
+
+void WifiJoystick::Loop(unsigned long now)
+{
+   static unsigned long millis = 0;
+   if(!udp) 
+   {
+       return;
+   } 
+
+   if(now >= millis + 5000)
+   {
+      // DBGLN("SSID: %s", WiFi.SSID());  
+       
+       udp->beginPacket("255.255.255.255", 11000);
+       udp->write((uint8_t*)"ELRS_WIFI", 9);
+       udp->endPacket();
+      
+       millis = now;
+   }
+   
+   udp->flush();
+
+}
+
+void WifiJoystick::UpdateValues()
+{
+    if (!udp)
+    {
+        return;
+    }
+    
+    udp->beginPacket(remoteIP, JOYSTICK_PORT);
+    for (uint8_t i = 0; i < channelCount; i++)
+    {
+        udp->write((uint8_t*)&ChannelData[i], 2); 
+    }
+    udp->endPacket();
+    
+}
+
+#endif

--- a/src/lib/WIFI/wifiJoystick.h
+++ b/src/lib/WIFI/wifiJoystick.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#if defined(TARGET_TX) && defined(PLATFORM_ESP32)
+
+#include <WiFiUdp.h>
+#include <AsyncUDP.h>
+
+//#define HAS_WIFI_JOYSTICK 1
+#define JOYSTICK_PORT 11000
+#define JOYSTICK_DEFAULT_UPDATE_INTERVAL 10000
+#define JOYSTICK_DEFAULT_CHANNEL_COUNT 8
+
+class WifiJoystick
+{
+public:
+    static void StartJoystickService();
+    static void StopJoystickService();
+    static void UpdateValues();
+    static void StartSending(IPAddress ip, uint32_t updateInterval, uint8_t newChannelCount);
+    static void Loop(unsigned long now);
+private:
+    static WiFiUDP *udp;
+    static IPAddress remoteIP;
+    static uint8_t channelCount;
+      
+};
+
+#endif

--- a/src/user_defines.txt
+++ b/src/user_defines.txt
@@ -117,3 +117,6 @@
 
 # Use an ELRS TX and RX as a transparent UART over the air
 #-DUSE_AIRPORT_AT_BAUD=9600
+
+# Use to send channel data over UDP. 
+#-DHAS_WIFI_JOYSTICK


### PR DESCRIPTION
 This feature enables channel data to be sent over WiFi as UDP messages. Required by but not limited to Simulators running on IOS devices. Currently there are no RC transmitter units approved by Apple able to directly connect to any IOS device. This approach does not require such approval.      