### PR TITLE
Allow SPI VTx operation without FC

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1135,6 +1135,17 @@ void MspReceiveComplete()
                 UpdateModelMatch(MspData[9]);
                 break;
             }
+            else if (OPT_HAS_VTX_SPI && MspData[7] == MSP_SET_VTX_CONFIG)
+            {
+                vtxSPIFrequency = getFreqByIdx(MspData[8]);
+                if (MspData[6] >= 4) // If packet has 4 bytes it also contains power idx and pitmode.
+                {
+                    vtxSPIPowerIdx = MspData[10];
+                    vtxSPIPitmode = MspData[11];
+                }
+                devicesTriggerEvent();
+                break;
+            }
             // FALLTHROUGH
         default:
             if ((receivedHeader->dest_addr == CRSF_ADDRESS_BROADCAST || receivedHeader->dest_addr == CRSF_ADDRESS_CRSF_RECEIVER))


### PR DESCRIPTION
Currently a SPI VTx requires a FC connected and configured for a MSP VTx.  This PR allows a standalone Rx+SPI VTx to be controlled just from Lua and without a FC.  If a FC is connected the VTx details are still forwarded to the FC so that the OSD parameters can be updated.

@phobos- tagging you here since I cant set you as a reviewer for some reason.