### PR TITLE
Cosmetic tweaks to Target Names

### DIFF
--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -148,7 +148,7 @@
                 "prior_target_name": "BETAFPV_2400_TX_MICRO_1000mw"
             },
             "literadio3": {
-                "product_name": "BETAFPV 2.4GHz LiteRadio 3",
+                "product_name": "BETAFPV 2.4GHz LiteRadio 3 Pro",
                 "lua_name": "BETAFPV LR3 Pro",
                 "layout_file": "BETAFPV 2400 LiteRadio 3.json",
                 "upload_methods": ["uart", "wifi", "etx"],
@@ -966,9 +966,18 @@
                 },
                 "prior_target_name": "HappyModel_PP_2400_RX"
             },
-            "ep": {
-                "product_name": "HappyModel EP1/2 2.4GHz RX",
-                "lua_name": "HM EP 2400",
+            "ep1": {
+                "product_name": "HappyModel EP1 2.4GHz RX",
+                "lua_name": "HM EP1 2400",
+                "layout_file": "Generic 2400.json",
+                "upload_methods": ["uart", "wifi", "betaflight"],
+                "platform": "esp8285",
+                "firmware": "Unified_ESP8285_2400_RX",
+                "prior_target_name": "HappyModel_EP_2400_RX"
+            },
+            "ep2": {
+                "product_name": "HappyModel EP2 2.4GHz RX",
+                "lua_name": "HM EP2 2400",
                 "layout_file": "Generic 2400.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "platform": "esp8285",
@@ -1198,7 +1207,7 @@
         },
         "rx_2400": {
             "atto": {
-                "product_name": "Ghost Atto 2.4GHz TX",
+                "product_name": "Ghost Atto 2.4GHz RX",
                 "upload_methods": ["stlink", "betaflight"],
                 "platform": "stm32",
                 "firmware": "GHOST_ATTO_2400_RX",
@@ -1532,7 +1541,7 @@
         "name": "RadioMaster",
         "tx_2400": {
             "zorro": {
-                "product_name": "RadioMaster Zorro 2.4GHz TX",
+                "product_name": "RadioMaster Zorro Internal 2.4GHz TX",
                 "lua_name": "RM Zorro",
                 "layout_file": "Radiomaster Zorro.json",
                 "upload_methods": ["uart", "wifi", "etx"],

--- a/src/targets/happymodel_2400.ini
+++ b/src/targets/happymodel_2400.ini
@@ -23,7 +23,7 @@ extends = env:HappyModel_ES24TX_Pro_Series_2400_TX_via_UART
 
 [env:HappyModel_EP_2400_RX_via_UART]
 extends = env:Unified_ESP8285_2400_RX_via_UART
-board_config = happymodel.rx_2400.ep
+board_config = happymodel.rx_2400.ep1
 
 [env:HappyModel_EP_2400_RX_via_BetaflightPassthrough]
 extends = env:HappyModel_EP_2400_RX_via_UART


### PR DESCRIPTION
1. BetaFPV Lite Radio 3 Pro is missing the Pro
2. Ghost Atto is an RX, not a TX (We demand samples! j/k)
3. Internal is added to the Zorro target, to standardize the list
4. Happymodel EP1/2 is separated, like the RadioMaster RP1 and RP2

Had to close the other one and start over. Conflict resolution would be a bitch as I didn't realize the branch I got is old.
I forgot to fetch the branch itself.