### PR TITLE
Call static things in a static way!

### DIFF
--- a/src/lib/VTX/devVTX.cpp
+++ b/src/lib/VTX/devVTX.cpp
@@ -17,7 +17,6 @@
 // reset between the user switching equipment
 #define VTX_DISCONNECT_DEBOUNCE_MS (10 * 1000)
 
-extern CRSF crsf;
 extern Stream *TxBackpack;
 static uint8_t pitmodeAuxState = 0;
 static bool sendEepromWrite = true;
@@ -61,7 +60,7 @@ static void eepromWriteToMSPOut()
     packet.reset();
     packet.function = MSP_EEPROM_WRITE;
 
-    crsf.AddMspMessage(&packet);
+    CRSF::AddMspMessage(&packet);
 }
 
 static void VtxConfigToMSPOut()
@@ -88,9 +87,9 @@ static void VtxConfigToMSPOut()
         }
     }
 
-    crsf.AddMspMessage(&packet);
+    CRSF::AddMspMessage(&packet);
 
-    if (!crsf.IsArmed()) // Do not send while armed.  There is no need to change the video frequency while armed.  It can also cause VRx modules to flash up their OSD menu e.g. Rapidfire.
+    if (!CRSF::IsArmed()) // Do not send while armed.  There is no need to change the video frequency while armed.  It can also cause VRx modules to flash up their OSD menu e.g. Rapidfire.
     {
         MSP::sendPacket(&packet, TxBackpack); // send to tx-backpack as MSP
     }
@@ -164,7 +163,7 @@ static int timeout()
         VtxSendState = VTXSS_UNKNOWN;
         // Never received a connection, clear the queue which now
         // has multiple VTX config packets in it
-        crsf.ResetMspQueue();
+        CRSF::ResetMspQueue();
     }
 
     return DURATION_NEVER;

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -25,9 +25,6 @@
 #define MSP_PACKET_SEND_INTERVAL 10LU
 
 /// define some libs to use ///
-hwTimer hwTimer;
-CRSF crsf;
-POWERMGNT POWERMGNT;
 MSP msp;
 ELRS_EEPROM eeprom;
 TxConfig config;
@@ -154,16 +151,16 @@ void ICACHE_RAM_ATTR LinkStatsFromOta(OTA_LinkStats_s * const ls)
   // Antenna is the high bit in the RSSI_1 value
   // RSSI received is signed, inverted polarity (positive value = -dBm)
   // OpenTX's value is signed and will display +dBm and -dBm properly
-  crsf.LinkStatistics.uplink_RSSI_1 = -(ls->uplink_RSSI_1);
-  crsf.LinkStatistics.uplink_RSSI_2 = -(ls->uplink_RSSI_2);
-  crsf.LinkStatistics.uplink_Link_quality = ls->lq;
+  CRSF::LinkStatistics.uplink_RSSI_1 = -(ls->uplink_RSSI_1);
+  CRSF::LinkStatistics.uplink_RSSI_2 = -(ls->uplink_RSSI_2);
+  CRSF::LinkStatistics.uplink_Link_quality = ls->lq;
 #if defined(DEBUG_FREQ_CORRECTION)
   // Don't descale the FreqCorrection value being send in SNR
-  crsf.LinkStatistics.uplink_SNR = snrScaled;
+  CRSF::LinkStatistics.uplink_SNR = snrScaled;
 #else
-  crsf.LinkStatistics.uplink_SNR = SNR_DESCALE(snrScaled);
+  CRSF::LinkStatistics.uplink_SNR = SNR_DESCALE(snrScaled);
 #endif
-  crsf.LinkStatistics.active_antenna = ls->antenna;
+  CRSF::LinkStatistics.active_antenna = ls->antenna;
   connectionHasModelMatch = ls->modelMatch;
   // -- downlink_SNR / downlink_RSSI is updated for any packet received, not just Linkstats
   // -- uplink_TX_Power is updated when sending to the handset, so it updates when missing telemetry
@@ -197,8 +194,8 @@ bool ICACHE_RAM_ATTR ProcessTLMpacket(SX12xxDriverCommon::rx_status const status
   LQCalc.add();
 
   Radio.GetLastPacketStats();
-  crsf.LinkStatistics.downlink_SNR = SNR_DESCALE(Radio.LastPacketSNRRaw);
-  crsf.LinkStatistics.downlink_RSSI = Radio.LastPacketRSSI;
+  CRSF::LinkStatistics.downlink_SNR = SNR_DESCALE(Radio.LastPacketSNRRaw);
+  CRSF::LinkStatistics.downlink_RSSI = Radio.LastPacketRSSI;
 
   // Full res mode
   if (OtaIsFullRes)
@@ -264,7 +261,7 @@ expresslrs_tlm_ratio_e ICACHE_RAM_ATTR UpdateTlmRatioEffective()
   // If Armed, telemetry is disabled, otherwise use STD
   else if (ratioConfigured == TLM_RATIO_DISARMED)
   {
-    if (crsf.IsArmed())
+    if (CRSF::IsArmed())
     {
       retVal = TLM_RATIO_NO_TLM;
       // Avoid updating ExpressLRS_currTlmDenom until connectionState == disconnected
@@ -312,22 +309,22 @@ void ICACHE_RAM_ATTR GenerateSyncPacketData(OTA_Sync_s * const syncPtr)
   // For model match, the last byte of the binding ID is XORed with the inverse of the modelId
   if (!InBindingMode && config.GetModelMatch())
   {
-    syncPtr->UID5 ^= (~crsf.getModelID()) & MODELMATCH_MASK;
+    syncPtr->UID5 ^= (~CRSF::getModelID()) & MODELMATCH_MASK;
   }
 }
 
 uint8_t adjustPacketRateForBaud(uint8_t rateIndex)
 {
   #if defined(RADIO_SX128X)
-    if (crsf.GetCurrentBaudRate() == 115200 && GPIO_PIN_RCSIGNAL_RX == GPIO_PIN_RCSIGNAL_TX) // Packet rate limited to 150Hz if we are on 115k baud on external module
+    if (CRSF::GetCurrentBaudRate() == 115200 && GPIO_PIN_RCSIGNAL_RX == GPIO_PIN_RCSIGNAL_TX) // Packet rate limited to 150Hz if we are on 115k baud on external module
     {
       rateIndex = get_elrs_HandsetRate_max(rateIndex, 6666);
     }
-    else if (crsf.GetCurrentBaudRate() == 115200) // Packet rate limited to 250Hz if we are on 115k baud (on internal module)
+    else if (CRSF::GetCurrentBaudRate() == 115200) // Packet rate limited to 250Hz if we are on 115k baud (on internal module)
     {
       rateIndex = get_elrs_HandsetRate_max(rateIndex, 4000);
     }
-    else if (crsf.GetCurrentBaudRate() == 400000) // Packet rate limited to 500Hz if we are on 400k baud
+    else if (CRSF::GetCurrentBaudRate() == 400000) // Packet rate limited to 500Hz if we are on 400k baud
     {
       rateIndex = get_elrs_HandsetRate_max(rateIndex, 2000);
     }
@@ -354,7 +351,7 @@ void ICACHE_RAM_ATTR SetRFLinkRate(uint8_t index) // Set speed of RF link (hz)
 #if defined(DEBUG_FREQ_CORRECTION) && defined(RADIO_SX128X)
   interval = interval * 12 / 10; // increase the packet interval by 20% to allow adding packet header
 #endif
-  hwTimer.updateInterval(interval);
+  hwTimer::updateInterval(interval);
   Radio.Config(ModParams->bw, ModParams->sf, ModParams->cr, GetInitialFreq(),
                ModParams->PreambleLen, invertIQ, ModParams->PayloadLength, ModParams->interval
 #if defined(RADIO_SX128X)
@@ -374,9 +371,9 @@ void ICACHE_RAM_ATTR SetRFLinkRate(uint8_t index) // Set speed of RF link (hz)
 
   ExpressLRS_currAirRate_Modparams = ModParams;
   ExpressLRS_currAirRate_RFperfParams = RFperf;
-  crsf.LinkStatistics.rf_Mode = ModParams->enum_rate;
+  CRSF::LinkStatistics.rf_Mode = ModParams->enum_rate;
 
-  crsf.setSyncParams(interval * ExpressLRS_currAirRate_Modparams->numOfSends);
+  CRSF::setSyncParams(interval * ExpressLRS_currAirRate_Modparams->numOfSends);
   connectionState = disconnected;
   rfModeLastChangedMS = millis();
 }
@@ -462,7 +459,7 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
   uint32_t SyncInterval = (connectionState == connected && !isTlmDisarmed) ? ExpressLRS_currAirRate_RFperfParams->SyncPktIntervalConnected : ExpressLRS_currAirRate_RFperfParams->SyncPktIntervalDisconnected;
   bool skipSync = InBindingMode ||
     // TLM_RATIO_DISARMED keeps sending sync packets even when armed until the RX stops sending telemetry and the TLM=Off has taken effect
-    (isTlmDisarmed && crsf.IsArmed() && (ExpressLRS_currTlmDenom == 1));
+    (isTlmDisarmed && CRSF::IsArmed() && (ExpressLRS_currTlmDenom == 1));
 
   uint8_t NonceFHSSresult = OtaNonce % ExpressLRS_currAirRate_Modparams->FHSShopInterval;
   bool WithinSyncSpamResidualWindow = now - rfModeLastChangedMS < syncSpamAResidualTimeMS;
@@ -574,7 +571,7 @@ void ICACHE_RAM_ATTR timerCallbackNormal()
   // Sync OpenTX to this point
   if (!(OtaNonce % ExpressLRS_currAirRate_Modparams->numOfSends))
   {
-    crsf.JustSentRFpacket();
+    CRSF::JustSentRFpacket();
   }
 
   // Do not transmit or advance FHSS/Nonce until in disconnected/connected state
@@ -600,9 +597,9 @@ void ICACHE_RAM_ATTR timerCallbackNormal()
     TelemetryRcvPhase = ttrpExpectingTelem;
 #if defined(Regulatory_Domain_EU_CE_2400)
     // Use downlink LQ for LBT success ratio instead for EU/CE reg domain
-    crsf.LinkStatistics.downlink_Link_quality = LBTSuccessCalc.getLQ();
+    CRSF::LinkStatistics.downlink_Link_quality = LBTSuccessCalc.getLQ();
 #else
-    crsf.LinkStatistics.downlink_Link_quality = LQCalc.getLQ();
+    CRSF::LinkStatistics.downlink_Link_quality = LQCalc.getLQ();
 #endif
     LQCalc.inc();
     return;
@@ -621,7 +618,7 @@ void ICACHE_RAM_ATTR timerCallbackNormal()
   // Do not send a stale channels packet to the RX if one has not been received from the handset
   // *Do* send data if a packet has never been received from handset and the timer is running
   //     this is the case when bench testing and TXing without a handset
-  uint32_t lastRcData = crsf.GetRCdataLastRecv();
+  uint32_t lastRcData = CRSF::GetRCdataLastRecv();
   if (!lastRcData || (micros() - lastRcData < 1000000))
   {
     busyTransmitting = true;
@@ -641,7 +638,7 @@ void ICACHE_RAM_ATTR timerCallbackIdle()
 
 static void UARTdisconnected()
 {
-  hwTimer.stop();
+  hwTimer::stop();
   connectionState = noCrossfire;
 }
 
@@ -660,7 +657,7 @@ static void UARTconnected()
     connectionState = awaitingModelId;
   }
   // But start the timer to get OpenTX sync going and a ModelID update sent
-  hwTimer.resume();
+  hwTimer::resume();
 }
 
 void ResetPower()
@@ -669,20 +666,20 @@ void ResetPower()
   // (user may be turning up the power while flying and dropping the power may compromise the link)
   if (config.GetDynamicPower())
   {
-    if (!crsf.IsArmed())
+    if (!CRSF::IsArmed())
     {
       // if dynamic power enabled and not armed then set to MinPower
-      POWERMGNT.setPower(MinPower);
+      POWERMGNT::setPower(MinPower);
     }
-    else if (POWERMGNT.currPower() < config.GetPower())
+    else if (POWERMGNT::currPower() < config.GetPower())
     {
       // if the new config is a higher power then set it, otherwise leave it alone
-      POWERMGNT.setPower((PowerLevels_e)config.GetPower());
+      POWERMGNT::setPower((PowerLevels_e)config.GetPower());
     }
   }
   else
   {
-    POWERMGNT.setPower((PowerLevels_e)config.GetPower());
+    POWERMGNT::setPower((PowerLevels_e)config.GetPower());
   }
   // TLM interval is set on the next SYNC packet
 #if defined(Regulatory_Domain_EU_CE_2400)
@@ -700,7 +697,7 @@ static void ChangeRadioParams()
 void ModelUpdateReq()
 {
   // Force synspam with the current rate parameters in case already have a connection established
-  if (config.SetModelId(crsf.getModelID()))
+  if (config.SetModelId(CRSF::getModelID()))
   {
     syncSpamCounter = syncSpamAmount;
     ModelUpdatePending = true;
@@ -723,7 +720,7 @@ static void ConfigChangeCommit()
   // Change params after the blocking finishes as a rate change will change the radio freq
   ChangeRadioParams();
   // Resume the timer, will take one hop for the radio to be on the right frequency if we missed a hop
-  hwTimer.callbackTock = &timerCallbackNormal;
+  hwTimer::callbackTock = &timerCallbackNormal;
   // UpdateFolderNames is expensive so it is called directly instead of in event() which gets called a lot
   luadevUpdateFolderNames();
   devicesTriggerEvent();
@@ -749,7 +746,7 @@ static void CheckConfigChangePending()
     // adding one cycle that will be eaten by busywaiting for the transmit to end
     uint32_t pauseCycles = ((EEPROM_WRITE_DURATION + cycleInterval - 1) / cycleInterval) + 1;
     // Pause won't return until paused, and has just passed the tick ISR (but not fired)
-    hwTimer.pause(pauseCycles * cycleInterval);
+    hwTimer::pause(pauseCycles * cycleInterval);
 
     while (busyTransmitting); // wait until no longer transmitting
 
@@ -758,7 +755,7 @@ static void CheckConfigChangePending()
       timerCallbackIdle();
 #endif
     // Prevent any other RF SPI traffic during the commit from RX or scheduled TX
-    hwTimer.callbackTock = &timerCallbackIdle;
+    hwTimer::callbackTock = &timerCallbackIdle;
     // If telemetry expected in the next interval, the radio was in RX mode
     // and will skip sending the next packet when the timer resumes.
     // Return to normal send mode because if the skipped packet happened
@@ -825,7 +822,7 @@ static void UpdateConnectDisconnectStatus()
     if (connectionState != connected)
     {
       connectionState = connected;
-      crsf.ForwardDevicePings = true;
+      CRSF::ForwardDevicePings = true;
       DBGLN("got downlink conn");
 
       if (firmwareOptions.is_airport)
@@ -841,7 +838,7 @@ static void UpdateConnectDisconnectStatus()
   {
     connectionState = disconnected;
     connectionHasModelMatch = true;
-    crsf.ForwardDevicePings = false;
+    CRSF::ForwardDevicePings = false;
   }
 }
 
@@ -871,7 +868,7 @@ static void CheckReadyToSend()
   if (RxWiFiReadyToSend)
   {
     RxWiFiReadyToSend = false;
-    if (!crsf.IsArmed())
+    if (!CRSF::IsArmed())
     {
       SendRxWiFiOverMSP();
     }
@@ -884,7 +881,7 @@ void OnPowerGetCalibration(mspPacket_t *packet)
   uint8_t index = packet->readByte();
   UNUSED(index);
   int8_t values[PWR_COUNT] = {0};
-  POWERMGNT.GetPowerCaliValues(values, PWR_COUNT);
+  POWERMGNT::GetPowerCaliValues(values, PWR_COUNT);
   DBGLN("power get calibration value %d",  values[index]);
 }
 
@@ -898,15 +895,15 @@ void OnPowerSetCalibration(mspPacket_t *packet)
     DBGLN("calibration error index %d out of range", index);
     return;
   }
-  hwTimer.stop();
+  hwTimer::stop();
   delay(20);
 
   int8_t values[PWR_COUNT] = {0};
-  POWERMGNT.GetPowerCaliValues(values, PWR_COUNT);
+  POWERMGNT::GetPowerCaliValues(values, PWR_COUNT);
   values[index] = value;
-  POWERMGNT.SetPowerCaliValues(values, PWR_COUNT);
+  POWERMGNT::SetPowerCaliValues(values, PWR_COUNT);
   DBGLN("power calibration done %d, %d", index, value);
-  hwTimer.resume();
+  hwTimer::resume();
 }
 #endif
 
@@ -927,7 +924,7 @@ void EnterBindingMode()
   }
 
   // Disable the TX timer and wait for any TX to complete
-  hwTimer.stop();
+  hwTimer::stop();
   while (busyTransmitting);
 
   // Queue up sending the Master UID as MSP packets
@@ -949,7 +946,7 @@ void EnterBindingMode()
     Radio.SetFrequencyReg(FHSSgetInitialGeminiFreq(), SX12XX_Radio_2);
   }
   // Start transmitting again
-  hwTimer.resume();
+  hwTimer::resume();
 
   DBGLN("Entered binding mode at freq = %d", Radio.currFreq);
 }
@@ -1221,13 +1218,13 @@ void setup()
     Radio.RXdoneCallback = &RXdoneISR;
     Radio.TXdoneCallback = &TXdoneISR;
 
-    crsf.connected = &UARTconnected; // it will auto init when it detects UART connection
+    CRSF::connected = &UARTconnected; // it will auto init when it detects UART connection
     if (!firmwareOptions.is_airport)
     {
-      crsf.disconnected = &UARTdisconnected;
+      CRSF::disconnected = &UARTdisconnected;
     }
-    crsf.RecvModelUpdate = &ModelUpdateReq;
-    hwTimer.callbackTock = &timerCallbackNormal;
+    CRSF::RecvModelUpdate = &ModelUpdateReq;
+    hwTimer::callbackTock = &timerCallbackNormal;
     DBGLN("ExpressLRS TX Module Booted...");
 
     eeprom.Begin(); // Init the eeprom
@@ -1261,7 +1258,7 @@ void setup()
     {
       TelemetryReceiver.SetDataToReceive(CRSFinBuffer, sizeof(CRSFinBuffer));
 
-      POWERMGNT.init();
+      POWERMGNT::init();
       DynamicPower_Init();
 
       // Set the pkt rate, TLM ratio, and power from the stored eeprom values
@@ -1270,7 +1267,7 @@ void setup()
   #if defined(Regulatory_Domain_EU_CE_2400)
       BeginClearChannelAssessment();
   #endif
-      hwTimer.init();
+      hwTimer::init();
       connectionState = noCrossfire;
     }
   }
@@ -1358,13 +1355,13 @@ void loop()
    * is elapsed. This keeps handset happy dispite of the telemetry ratio */
   if ((connectionState == connected) && (LastTLMpacketRecvMillis != 0) &&
       (now >= (uint32_t)(firmwareOptions.tlm_report_interval + TLMpacketReported))) {
-    crsf.sendLinkStatisticsToTX();
+    CRSF::sendLinkStatisticsToTX();
     TLMpacketReported = now;
   }
 
   if (TelemetryReceiver.HasFinishedData())
   {
-      crsf.sendTelemetryToTX(CRSFinBuffer);
+      CRSF::sendTelemetryToTX(CRSFinBuffer);
       TelemetryReceiver.Unlock();
   }
 
@@ -1383,7 +1380,7 @@ void loop()
     if (mspTransferActive)
     {
       // unlock buffer for msp messages
-      crsf.UnlockMspMessage();
+      CRSF::UnlockMspMessage();
       mspTransferActive = false;
     }
     // we are not sending so look for next msp package
@@ -1391,7 +1388,7 @@ void loop()
     {
       uint8_t* mspData;
       uint8_t mspLen;
-      crsf.GetMspMessage(&mspData, &mspLen);
+      CRSF::GetMspMessage(&mspData, &mspLen);
       // if we have a new msp package start sending
       if (mspData != nullptr)
       {

--- a/src/test/test_crsf/test_crsf.cpp
+++ b/src/test/test_crsf/test_crsf.cpp
@@ -8,8 +8,6 @@
 
 using namespace std;
 
-// Create a CRSF object to test,
-CRSF crsf;
 uint32_t ChannelData[CRSF_NUM_CHANNELS];      // Current state of channels, CRSF format
 
 GENERIC_CRC8 test_crc(CRSF_CRC_POLY);
@@ -44,8 +42,8 @@ void test_device_info(void)
     TEST_ASSERT_EQUAL(22, DEVICE_INFORMATION_PAYLOAD_LENGTH);
     TEST_ASSERT_EQUAL(28, DEVICE_INFORMATION_LENGTH);
 
-    crsf.GetDeviceInformation(deviceInformation, 0);
-    crsf.SetExtendedHeaderAndCrc(deviceInformation, CRSF_FRAMETYPE_DEVICE_INFO, DEVICE_INFORMATION_FRAME_SIZE, CRSF_ADDRESS_CRSF_RECEIVER, CRSF_ADDRESS_FLIGHT_CONTROLLER);
+    CRSF::GetDeviceInformation(deviceInformation, 0);
+    CRSF::SetExtendedHeaderAndCrc(deviceInformation, CRSF_FRAMETYPE_DEVICE_INFO, DEVICE_INFORMATION_FRAME_SIZE, CRSF_ADDRESS_CRSF_RECEIVER, CRSF_ADDRESS_FLIGHT_CONTROLLER);
 
     crsf_ext_header_t *header = (crsf_ext_header_t *) deviceInformation;
 

--- a/src/test/test_msp/encapsulated_msp_tests.cpp
+++ b/src/test/test_msp/encapsulated_msp_tests.cpp
@@ -5,19 +5,16 @@
 
 #include "devCRSF.h"
 
-// Create a CRSF object to test
-CRSF crsf;
-
 void test_encapsulated_msp_send(void)
 {
     // TEST CASE:
     // GIVEN the CRSF class has been instantiated using a mock UART
-    // WHEN the crsf.sendMSPFrameToFC() function is called with a valid mspPacket_t MSP command to change the VTX to F1
+    // WHEN the CRSF::sendMSPFrameToFC() function is called with a valid mspPacket_t MSP command to change the VTX to F1
     // THEN the mspPacket_t will be transcoded into an embedded crsf msp packet
     // AND the transcoded packet will be sent to the Stream object associated with the CRSF class
 
     // Make sure no msp messages are in the fifo
-    crsf.ResetMspQueue();
+    CRSF::ResetMspQueue();
 
     // Build an MSP packet with the MSP_SET_VTX_CONFIG cmd
     mspPacket_t packet;
@@ -31,11 +28,11 @@ void test_encapsulated_msp_send(void)
     packet.addByte(0x00);   // don't enable pitmode
 
     // Ask the CRSF class to send the encapsulated packet to the stream
-    crsf.AddMspMessage(&packet);
+    CRSF::AddMspMessage(&packet);
 
     uint8_t* data;
     uint8_t len;
-    crsf.GetMspMessage(&data, &len);
+    CRSF::GetMspMessage(&data, &len);
 
     // Assert that the correct number of total bytes were sent to the stream
     TEST_ASSERT_NOT_EQUAL(NULL, data);
@@ -62,12 +59,12 @@ void test_encapsulated_msp_send_too_long(void)
 {
     // TEST CASE:
     // GIVEN the CRSF class has been instantiated using a mock UART
-    // WHEN the crsf.sendMSPFrameToFC() function is called with a invalid mspPacket_t MSP command (payload too long)
+    // WHEN the CRSF::sendMSPFrameToFC() function is called with a invalid mspPacket_t MSP command (payload too long)
     // THEN the mspPacket_t will NOT be transcoded into an embedded crsf msp packet
     // AND nothing will be sent to the stream
 
     // Make sure no msp messages are in the fifo
-    crsf.ResetMspQueue();
+    CRSF::ResetMspQueue();
 
     // Build an MSP packet with a payload that is too long to send (>4 bytes)
     mspPacket_t packet;
@@ -82,11 +79,11 @@ void test_encapsulated_msp_send_too_long(void)
     packet.addByte(0x05);
 
     // Ask the CRSF class to send the encapsulated packet to the stream
-    crsf.AddMspMessage(&packet);
+    CRSF::AddMspMessage(&packet);
 
     uint8_t* data;
     uint8_t len;
-    crsf.GetMspMessage(&data, &len);
+    CRSF::GetMspMessage(&data, &len);
 
     // Assert that nothing was sent to the stream
     TEST_ASSERT_EQUAL(NULL, data);

--- a/src/test/test_ota/test_switches.cpp
+++ b/src/test/test_ota/test_switches.cpp
@@ -273,7 +273,7 @@ void test_encodingHybridWide(bool highRes, uint8_t nonce)
     }
 
     // Uplink data
-    crsf.LinkStatistics.uplink_TX_Power = 3; // 100mW
+    CRSF::LinkStatistics.uplink_TX_Power = 3; // 100mW
 
     // Save the channels since they go into the same place
     memcpy(ChannelsIn, ChannelData, sizeof(ChannelData));
@@ -304,7 +304,7 @@ void test_encodingHybridWide(bool highRes, uint8_t nonce)
 
     // If slot 7, the uplink_TX_Power should be in the low 6 bits
     if (switchIdx == 7)
-        TEST_ASSERT_EQUAL(crsf.LinkStatistics.uplink_TX_Power, switches & 0b111111);
+        TEST_ASSERT_EQUAL(CRSF::LinkStatistics.uplink_TX_Power, switches & 0b111111);
     else
     {
         uint16_t ch = ChannelData[5+switchIdx];
@@ -358,7 +358,7 @@ void test_decodingHybridWide(bool highRes, uint8_t nonce, uint8_t forceSwitch, u
     }
 
     // Uplink data
-    crsf.LinkStatistics.uplink_TX_Power = 3; // 100mW
+    CRSF::LinkStatistics.uplink_TX_Power = 3; // 100mW
 
     // Save the channels since they go into the same place
     memcpy(ChannelsIn, ChannelData, sizeof(ChannelData));
@@ -369,7 +369,7 @@ void test_decodingHybridWide(bool highRes, uint8_t nonce, uint8_t forceSwitch, u
     OtaPackChannelData(otaPktPtr, ChannelData, nonce % 2, tlmDenom);
 
     // Clear the LinkStatistics to receive it from the encoding
-    crsf.LinkStatistics.uplink_TX_Power = 0;
+    CRSF::LinkStatistics.uplink_TX_Power = 0;
 
     // run the decoder, results in crsf->PackedRCdataOut
     bool telemResult = OtaUnpackChannelData(otaPktPtr, ChannelData, tlmDenom);
@@ -390,7 +390,7 @@ void test_decodingHybridWide(bool highRes, uint8_t nonce, uint8_t forceSwitch, u
 
     if (switchIdx == 7)
     {
-        TEST_ASSERT_EQUAL(crsf.LinkStatistics.uplink_TX_Power, 3);
+        TEST_ASSERT_EQUAL(CRSF::LinkStatistics.uplink_TX_Power, 3);
     }
     else
     {
@@ -440,12 +440,12 @@ void test_encodingFullresPowerLevels()
 
         // This is what we're testing here, just the power
         uint8_t crsfPower = powerToCrsfPower((PowerLevels_e)pwr);
-        crsf.LinkStatistics.uplink_TX_Power = crsfPower;
+        CRSF::LinkStatistics.uplink_TX_Power = crsfPower;
 
         OtaPackChannelData(otaPktPtr, ChannelData, false, 0);
         OtaUnpackChannelData(otaPktPtr, ChannelData, 0);
 
-        TEST_ASSERT_EQUAL(crsfPower, crsf.LinkStatistics.uplink_TX_Power);
+        TEST_ASSERT_EQUAL(crsfPower, CRSF::LinkStatistics.uplink_TX_Power);
     }
 }
 
@@ -457,7 +457,7 @@ void test_encodingFullres8ch()
     TEST_ASSERT_EQUAL(sizeof(ChannelData), sizeof(ChannelsIn));
 
     fullres_fillChannelData();
-    crsf.LinkStatistics.uplink_TX_Power = PWR_250mW;
+    CRSF::LinkStatistics.uplink_TX_Power = PWR_250mW;
 
     // Save the channels since they go into the same place
     memcpy(ChannelsIn, ChannelData, sizeof(ChannelData));


### PR DESCRIPTION
The CRSF, POWERMGMT and hwTimer classes only contain static methods, so we should really be calling them using the static invocation mechanism and not creating instances of the class.

This is just house keeping to make things a little clearer/cleaner.