### PR TITLE
disable msp vtx after no comms on boot

### DIFF
--- a/src/lib/MSPVTX/devMSPVTX.cpp
+++ b/src/lib/MSPVTX/devMSPVTX.cpp
@@ -17,6 +17,7 @@
 #define FC_QUERY_PERIOD_MS      200 // poll every 200ms
 #define MSP_VTX_FUNCTION_OFFSET 7
 #define MSP_VTX_PAYLOAD_OFFSET  11
+#define MSP_VTX_TIMEOUT_NO_CONNECTION 5000
 
 typedef enum
 {
@@ -26,6 +27,7 @@ typedef enum
   SET_RCE_PIT_MODE,
   SEND_EEPROM_WRITE,
   MONITORING,
+  STOP_MSPVTX,
   MSP_STATE_MAX
 } mspVtxState_e;
 
@@ -347,7 +349,7 @@ static void mspVtxStateUpdate(void)
 
 void disableMspVtx(void)
 {
-    mspState = MSP_STATE_MAX;
+    mspState = STOP_MSPVTX;
 }
 
 static int event(void)
@@ -361,6 +363,11 @@ static int event(void)
 
 static int timeout(void)
 {
+    if (mspState == STOP_MSPVTX || (mspState != MONITORING && millis() > MSP_VTX_TIMEOUT_NO_CONNECTION))
+    {
+        return DURATION_NEVER;
+    }
+
     if (hwTimer::running && !hwTimer::isTick)
     {
         // Only run code during rx free time or when disconnected.

--- a/src/lib/VTXSPI/devVTXSPI.cpp
+++ b/src/lib/VTXSPI/devVTXSPI.cpp
@@ -345,12 +345,12 @@ static int event()
 
 static int timeout()
 {
-    if (GPIO_PIN_SPI_VTX_NSS == UNDEF_PIN)
+    if ((GPIO_PIN_SPI_VTX_NSS == UNDEF_PIN) || stopVtxMonitoring)
     {
         return DURATION_NEVER;
     }
 
-    if ((hwTimer::running && !hwTimer::isTick) || stopVtxMonitoring)
+    if (hwTimer::running && !hwTimer::isTick)
     {
         // Dont run spi and analog reads during rx hopping, wifi or updating
         return DURATION_IMMEDIATELY;


### PR DESCRIPTION
After 5s of the MSP VTx talking to itself, the device will now stop and no longer be called.  This will quieten the uart for more important things like 1000Hz of RC packets.