### PR TITLE
External module baudrate 400k baud max air-rate is 333Hz

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -83,8 +83,8 @@ uint8_t CRSF::CRSFoutBuffer[CRSF_MAX_PACKET_LEN] = {0};
 uint8_t CRSF::maxPacketBytes = CRSF_MAX_PACKET_LEN;
 uint8_t CRSF::maxPeriodBytes = CRSF_MAX_PACKET_LEN;
 uint32_t CRSF::TxToHandsetBauds[] = {400000, 115200, 5250000, 3750000, 1870000, 921600, 2250000};
-uint8_t CRSF::UARTcurrentBaudIdx = 0;
 uint32_t CRSF::UARTrequestedBaud = 5250000;
+uint8_t CRSF::UARTcurrentBaudIdx = 0;   // only used for baud-cycling i.e. not baud-rate detection
 #if defined(PLATFORM_ESP32)
 bool CRSF::UARTinverted = false;
 #endif
@@ -108,7 +108,7 @@ void CRSF::Begin()
 #if defined(PLATFORM_ESP32)
     portDISABLE_INTERRUPTS();
     UARTinverted = firmwareOptions.uart_inverted;
-    CRSF::Port.begin(TxToHandsetBauds[UARTcurrentBaudIdx], SERIAL_8N1,
+    CRSF::Port.begin(UARTrequestedBaud, SERIAL_8N1,
                      GPIO_PIN_RCSIGNAL_RX, GPIO_PIN_RCSIGNAL_TX,
                      false, 500);
     CRSF::duplex_set_RX();
@@ -121,7 +121,7 @@ void CRSF::Begin()
     }
 #elif defined(PLATFORM_ESP8266)
     // Uses default UART pins
-    CRSF::Port.begin(TxToHandsetBauds[UARTcurrentBaudIdx]);
+    CRSF::Port.begin(UARTrequestedBaud);
     // Invert RX/TX (not done, connection is full duplex uninverted)
     //USC0(UART0) |= BIT(UCRXI) | BIT(UCTXI);
     // No log message because this is our only UART
@@ -139,7 +139,7 @@ void CRSF::Begin()
     CRSF::Port.setHalfDuplex();
     #endif
 
-    CRSF::Port.begin(TxToHandsetBauds[UARTcurrentBaudIdx]);
+    CRSF::Port.begin(UARTrequestedBaud);
 
 #if defined(TARGET_TX_GHOST)
     USART1->CR1 &= ~USART_CR1_UE;

--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -812,9 +812,9 @@ uint32_t CRSF::autobaud()
 
     if ((*autobaud_reg & 1) == 0) {
         *autobaud_reg = (4 << 8) | 1;    // enable, glitch filter 4
-        return 400000;
+        return 0;
     } else if ((*autobaud_reg & 1) && (*rxd_cnt_reg < 300))
-        return 400000;
+        return 0;
 
     state = MEASURED;
 
@@ -851,7 +851,7 @@ bool CRSF::UARTwdt()
     uint32_t now = millis();
     if (now >= (UARTwdtLastChecked + UARTwdtInterval))
     {
-        if (BadPktsCount >= GoodPktsCount)
+        if (BadPktsCount >= GoodPktsCount || !CRSFstate)
         {
             DBGLN("Too many bad UART RX packets!");
 
@@ -863,34 +863,35 @@ bool CRSF::UARTwdt()
             }
 
             UARTrequestedBaud = autobaud();
+            if (UARTrequestedBaud != 0)
+            {
+                DBGLN("UART WDT: Switch to: %d baud", UARTrequestedBaud);
 
-            DBGLN("UART WDT: Switch to: %d baud", UARTrequestedBaud);
+                adjustMaxPacketSize();
 
-            adjustMaxPacketSize();
-
-            SerialOutFIFO.flush();
+                SerialOutFIFO.flush();
 #if defined(PLATFORM_ESP8266) || defined(PLATFORM_ESP32)
-            CRSF::Port.flush();
-            CRSF::Port.updateBaudRate(UARTrequestedBaud);
+                CRSF::Port.flush();
+                CRSF::Port.updateBaudRate(UARTrequestedBaud);
 #elif defined(TARGET_TX_GHOST)
-            CRSF::Port.begin(UARTrequestedBaud);
-            USART1->CR1 &= ~USART_CR1_UE;
-            USART1->CR3 |= USART_CR3_HDSEL;
-            USART1->CR2 |= USART_CR2_RXINV | USART_CR2_TXINV | USART_CR2_SWAP; //inverted/swapped
-            USART1->CR1 |= USART_CR1_UE;
+                CRSF::Port.begin(UARTrequestedBaud);
+                USART1->CR1 &= ~USART_CR1_UE;
+                USART1->CR3 |= USART_CR3_HDSEL;
+                USART1->CR2 |= USART_CR2_RXINV | USART_CR2_TXINV | USART_CR2_SWAP; //inverted/swapped
+                USART1->CR1 |= USART_CR1_UE;
 #elif defined(TARGET_TX_FM30_MINI)
-            CRSF::Port.begin(UARTrequestedBaud);
-            LL_GPIO_SetPinPull(GPIOA, GPIO_PIN_2, LL_GPIO_PULL_DOWN); // default is PULLUP
-            USART2->CR1 &= ~USART_CR1_UE;
-            USART2->CR2 |= USART_CR2_RXINV | USART_CR2_TXINV; //inverted
-            USART2->CR1 |= USART_CR1_UE;
+                CRSF::Port.begin(UARTrequestedBaud);
+                LL_GPIO_SetPinPull(GPIOA, GPIO_PIN_2, LL_GPIO_PULL_DOWN); // default is PULLUP
+                USART2->CR1 &= ~USART_CR1_UE;
+                USART2->CR2 |= USART_CR2_RXINV | USART_CR2_TXINV; //inverted
+                USART2->CR1 |= USART_CR1_UE;
 #else
-            CRSF::Port.begin(UARTrequestedBaud);
+                CRSF::Port.begin(UARTrequestedBaud);
 #endif
-            duplex_set_RX();
-            // cleanup input buffer
-            flush_port_input();
-
+                duplex_set_RX();
+                // cleanup input buffer
+                flush_port_input();
+            }
             retval = true;
         }
 #ifdef DEBUG_OPENTX_SYNC
@@ -980,7 +981,7 @@ void CRSF::GetDeviceInformation(uint8_t *frame, uint8_t fieldCount)
 
 void CRSF::SetMspV2Request(uint8_t *frame, uint16_t function, uint8_t *payload, uint8_t payloadLength)
 {
-    uint8_t *packet = (uint8_t *)(frame + sizeof(crsf_ext_header_t));                
+    uint8_t *packet = (uint8_t *)(frame + sizeof(crsf_ext_header_t));
     packet[0] = 0x50;          // no error, version 2, beginning of the frame, first frame (0)
     packet[1] = 0;             // flags
     packet[2] = function & 0xFF;

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -327,6 +327,10 @@ uint8_t adjustPacketRateForBaud(uint8_t rateIndex)
     {
       rateIndex = get_elrs_HandsetRate_max(rateIndex, 4000);
     }
+    else if (crsf.GetCurrentBaudRate() == 400000 && GPIO_PIN_RCSIGNAL_RX == GPIO_PIN_RCSIGNAL_TX) // Packet rate limited to 333Hz if we are on 400k baud on external module
+    {
+      rateIndex = get_elrs_HandsetRate_max(rateIndex, 3003);
+    }
     else if (crsf.GetCurrentBaudRate() == 400000) // Packet rate limited to 500Hz if we are on 400k baud
     {
       rateIndex = get_elrs_HandsetRate_max(rateIndex, 2000);

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -339,7 +339,7 @@ uint8_t adjustPacketRateForBaud(uint8_t rateIndex)
   return rateIndex;
 }
 
-void ICACHE_RAM_ATTR SetRFLinkRate(uint8_t index) // Set speed of RF link (hz)
+void SetRFLinkRate(uint8_t index) // Set speed of RF link (hz)
 {
   expresslrs_mod_settings_s *const ModParams = get_elrs_airRateConfig(index);
   expresslrs_rf_pref_params_s *const RFperf = get_elrs_RFperfParams(index);


### PR DESCRIPTION
External modules can no longer handle 500Hz at 400k baud.
This adds an extra limit for external for modules at 400k baud to 333Hz.

Also during testing it was found that the OLED/TFT & Lua would display the configured the air-rate not the actual air-rate.
Also found was that the sync packet would have the configured air-rate and not the actual air-rate so this would cause non-connection to a receiver!

There are 2 parts to this PR to cover the 2 situations
1. Adjust the air-rate differently for internal vs external modules.
2. Save the adjusted air-rate into the config so all places that read the config get the correct value

EDIT:
The root cause of the problem was that the baud index was `0` i.e. pointing to 400k baud (and initialising the serial port to 400k baud) and then setting the current baud rate variable to 5.25M baud.
This meant that when the main loop came to set the air-rate it thought it was on 5.25M baud so could do all the rates, but the serial was only 400k baud and failed on 500Hz and above.

EDIT2: Fixes #2329