### PR TITLE
Adding Happymodel EPW6 900MHz PWMP target

### DIFF
--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -888,7 +888,7 @@
                 "platform": "esp32",
                 "firmware": "Unified_ESP32_900_TX",
                 "prior_target_name": "HappyModel_TX_ES900TX"
-            }
+            },
         },
         "rx_900": {
             "es915": {
@@ -919,7 +919,16 @@
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "platform": "esp32",
                 "firmware": "Unified_ESP32_900_RX"
-            }
+            },
+            "epw6": {
+                "product_name": "HappyModel EPW6 PWM RX",
+                "lua_name": "HM EPW6 900RX",
+                "layout_file": "Generic 900 PWMP.json",
+                "upload_methods": ["uart", "wifi", "betaflight"],
+                "platform": "esp8285",
+                "firmware": "Unified_ESP8285_900_RX",
+                "prior_target_name": "DIY_900_RX_PWMP"
+            },
         },
         "tx_2400": {
             "es24": {

--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -888,7 +888,7 @@
                 "platform": "esp32",
                 "firmware": "Unified_ESP32_900_TX",
                 "prior_target_name": "HappyModel_TX_ES900TX"
-            },
+            }
         },
         "rx_900": {
             "es915": {
@@ -928,7 +928,7 @@
                 "platform": "esp8285",
                 "firmware": "Unified_ESP8285_900_RX",
                 "prior_target_name": "DIY_900_RX_PWMP"
-            },
+            }
         },
         "tx_2400": {
             "es24": {


### PR DESCRIPTION
Previous Configurator uses DIY_900_RX_PWMP for this particular pwm receiver:
https://www.happymodel.cn/index.php/2022/01/04/happymodel-expresslrs-elrs-epw6-900mhz-6ch-pwm-rc-receiver-for-fixed-wing/
However, users cannot find this in the new 1.6.0 Configurator because it has become 
Generic ESP8285 SX127x with PWM 900MHz RX

With this PR, it'll have its own target that will hopefully be easier to find.