### PR TITLE
Correct rx power when using Regulatory_Domain_EU_CE_2400

### DIFF
--- a/src/lib/POWERMGNT/POWERMGNT.h
+++ b/src/lib/POWERMGNT/POWERMGNT.h
@@ -98,26 +98,23 @@ public:
      * For devices that support the HighPower override, i.e. R9M with the fan hack,
      * the MaxPower is normally HighPower unless the 'unlock_higher_power' option
      * is set at compile time.
-     * 
+     *
      * @return PowerLevels_e the maximum power level supported
      */
     static PowerLevels_e getMaxPower() {
-        PowerLevels_e returnedMaxPower = MaxPower;
-        PowerLevels_e returnedHighPower = HighPower;
-        
+        PowerLevels_e power;
+        #if defined(TARGET_RX)
+            power = MaxPower;
+        #else
+            power = firmwareOptions.unlock_higher_power ? MaxPower : HighPower;
+        #endif
         #if defined(Regulatory_Domain_EU_CE_2400)
-            if (MaxPower > PWR_100mW)
+            if (power > PWR_100mW)
             {
-                returnedMaxPower = PWR_100mW;
-                returnedHighPower = PWR_100mW;
+                power = PWR_100mW;
             }
         #endif
-
-        #if defined(TARGET_RX)
-            return returnedMaxPower;
-        #else
-            return firmwareOptions.unlock_higher_power ? returnedMaxPower : returnedHighPower;
-        #endif
+        return power;
     }
 
     /**

--- a/src/lib/POWERMGNT/POWERMGNT.h
+++ b/src/lib/POWERMGNT/POWERMGNT.h
@@ -17,16 +17,6 @@
     #define DefaultPower PWR_50mW
 #endif
 
-#if defined(Regulatory_Domain_EU_CE_2400)
-    #undef MaxPower
-    #define MaxPower PWR_100mW
-
-    #if defined(HighPower)
-        #undef HighPower
-        #define HighPower MaxPower
-    #endif
-#endif
-
 #if !defined(HighPower)
 #define HighPower MaxPower
 #endif
@@ -112,10 +102,21 @@ public:
      * @return PowerLevels_e the maximum power level supported
      */
     static PowerLevels_e getMaxPower() {
+        PowerLevels_e returnedMaxPower = MaxPower;
+        PowerLevels_e returnedHighPower = HighPower;
+        
+        #if defined(Regulatory_Domain_EU_CE_2400)
+            if (MaxPower > PWR_100mW)
+            {
+                returnedMaxPower = PWR_100mW;
+                returnedHighPower = PWR_100mW;
+            }
+        #endif
+
         #if defined(TARGET_RX)
-            return MaxPower;
+            return returnedMaxPower;
         #else
-            return firmwareOptions.unlock_higher_power ? MaxPower : HighPower;
+            return firmwareOptions.unlock_higher_power ? returnedMaxPower : returnedHighPower;
         #endif
     }
 

--- a/src/lib/SCREEN/menu.cpp
+++ b/src/lib/SCREEN/menu.cpp
@@ -159,7 +159,7 @@ static void setupValueIndex(bool init)
 
     case STATE_POWER_MAX:
         values_min = MinPower;
-        values_max = MaxPower;
+        values_max = POWERMGNT::getMaxPower();
         values_index = config.GetPower();
         break;
     case STATE_POWER_DYNAMIC:


### PR DESCRIPTION
The Europeans think their receivers can now do 100mW just because of LBT... Im here to put a stop to it!

