### PR TITLE
add prior_target_name to Jumper T-20

### DIFF
--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -1269,7 +1269,8 @@
                 "layout_file": "Jumper T-20 2400.json",
                 "upload_methods": ["uart", "wifi", "etx"],
                 "platform": "esp32",
-                "firmware": "Unified_ESP32_2400_TX"
+                "firmware": "Unified_ESP32_2400_TX",
+                "prior_target_name": "Jumper_AION_2400_T-Pro_TX"
             },
             "t-pro": {
                 "product_name": "Jumper AION T-Pro 2.4GHz TX",
@@ -1306,7 +1307,8 @@
                 "layout_file": "Jumper T-20 900.json",
                 "upload_methods": ["uart", "wifi", "etx"],
                 "platform": "esp32",
-                "firmware": "Unified_ESP32_900_TX"
+                "firmware": "Unified_ESP32_900_TX",
+                "prior_target_name": "Jumper_AION_2400_T-Pro_TX"
             }
         },
         "rx_2400": {


### PR DESCRIPTION
Looks like the T-20 is shipping with the wrong target ☹️ 

This should prevent the warning for the 2.4 module, and Im winging it for the 900 module.

![image](https://github.com/ExpressLRS/ExpressLRS/assets/14170229/25a9e372-5d74-423d-8cf0-578c8e56dcbb)
