### PR TITLE
Add Back Stock BL to other STM targets

### DIFF
--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -529,7 +529,7 @@
             },
             "r9m-lite-pro": {
                 "product_name": "FrSky R9M Lite Pro 900MHz TX",
-                "upload_methods": ["stlink"],
+                "upload_methods": ["stlink","stock"],
                 "platform": "stm32",
                 "firmware": "Frsky_TX_R9M_LITE_PRO",
                 "stlink": {
@@ -1191,7 +1191,7 @@
         "tx_2400": {
             "ghost": {
                 "product_name": "Ghost 2.4GHz TX",
-                "upload_methods": ["stlink"],
+                "upload_methods": ["stlink","stock"],
                 "platform": "stm32",
                 "firmware": "GHOST_2400_TX",
                 "features": ["buzzer"],
@@ -1203,7 +1203,7 @@
             },
             "ghost_lite": {
                 "product_name": "Ghost Lite 2.4GHz TX",
-                "upload_methods": ["stlink"],
+                "upload_methods": ["stlink","stock"],
                 "platform": "stm32",
                 "firmware": "GHOST_2400_TX_LITE",
                 "features": ["buzzer"],


### PR DESCRIPTION
For now, we have R9M and R9M Lite with Stock BL options

the Ghost TX lost this, and you cannot flash these devices via the radio for updates.. 
same with the Lite Pro. 

https://www.expresslrs.org/quick-start/transmitters/ghost2400/#via-stock_bl