### PR TITLE
Happymodel 900 TX not able to select 1W

### DIFF
--- a/src/hardware/TX/HappyModel ES900.json
+++ b/src/hardware/TX/HappyModel ES900.json
@@ -12,7 +12,7 @@
     "power_rxen": 13,
     "power_txen": 12,
     "power_min": 0,
-    "power_high": 4,
+    "power_high": 6,
     "power_max": 6,
     "power_default": 2,
     "power_control": 3,

--- a/src/hardware/targets.json
+++ b/src/hardware/targets.json
@@ -885,6 +885,7 @@
                 "lua_name": "HM ES900TX",
                 "layout_file": "HappyModel ES900.json",
                 "upload_methods": ["uart", "wifi"],
+                "features": ["fan"],
                 "platform": "esp32",
                 "firmware": "Unified_ESP32_900_TX",
                 "prior_target_name": "HappyModel_TX_ES900TX"
@@ -907,7 +908,6 @@
                 "lua_name": "HM ES900RX",
                 "layout_file": "Generic 900.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
-                "features": ["fan"],
                 "platform": "esp8285",
                 "firmware": "Unified_ESP8285_900_RX",
                 "prior_target_name": "HappyModel_RX_ES900RX"


### PR DESCRIPTION
A couple of issues in the changeover to unified target.

Happymodel 900 comes with a fan, so we should just set `power_high` to be the same as `power_max`.
Also, it was missing the `fan` feature flag, it was wrongly put on the RX definition!

Fixes #2347 
