### PR TITLE
Spam DEVICE_INFO packet when TX is waiting for the handset

### DIFF
--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -65,7 +65,7 @@ public:
     static void ICACHE_RAM_ATTR sendLinkStatisticsToTX();
     static void ICACHE_RAM_ATTR sendTelemetryToTX(uint8_t *data);
 
-    static void packetQueueExtended(uint8_t type, void *data, uint8_t len);
+    static void packetQueueExtended(uint8_t type, void *data, uint8_t len, bool force);
 
     ///// Variables for OpenTX Syncing //////////////////////////
     #define OpenTXsyncPacketInterval 200 // in ms

--- a/src/lib/LUA/lua.h
+++ b/src/lib/LUA/lua.h
@@ -132,7 +132,7 @@ void registerLUAParameter(void *definition, luaCallback callback = nullptr, uint
 
 uint8_t findLuaSelectionLabel(const void *luaStruct, char *outarray, uint8_t value);
 
-void sendLuaDevicePacket(void);
+void sendLuaDevicePacket(bool force);
 inline void setLuaTextSelectionValue(struct luaItem_selection *luaStruct, uint8_t newvalue) {
     luaStruct->value = newvalue;
 }


### PR DESCRIPTION
This PR is not for merging but is only to allow EdgeTX to experiment. This was brought up as a possible way for EdgeTX to auto-identify the TX modules (ELRS vs MULTI).

The code here:
* Sends a CRSF DEVICE_INFO packet 4x a second to the handset until the TX module leaves the "No Handset" state
  * For ESP32, the packet is sent at 400k baud **unless** the autobaud routine has selected a different baud rate due to incoming data. If autobaud has a better guess at the baud rate, the packet is sent at that rate (921600, 5250000, etc)
  * For STM32 TX modules, the packet it sent at each baud rate the module tries
