### PR TITLE
No exp() and float in fuzzy_snr (faster)

### DIFF
--- a/src/lib/SX12xxDriverCommon/SX12xxDriverCommon.h
+++ b/src/lib/SX12xxDriverCommon/SX12xxDriverCommon.h
@@ -80,7 +80,6 @@ protected:
         TXdoneCallback = nullCallbackTx;
     }
 
-
     /**
      * @brief Calculates the reported SNR value using a fuzzy logic approach
      *
@@ -88,9 +87,9 @@ protected:
      * The reported SNR is determined by a smooth transition between the lower value of the two input SNRs and their average.
      * The transition is controlled by the difference between the input SNRs and the threshold value.
      *
-     * The sigmoid function is used to create a smooth S-shaped curve that maps the difference between the input SNRs
-     * to a value between 0 and 1. This value is then used to interpolate between the lower value and the average value,
-     * providing a smooth transition between the two conditions.
+     * A polynomial approximation is used to create a smooth S-shaped curve that maps the difference between the input SNRs
+     * to a value between 0 and 1. This approximation enables faster computation while maintaining a similar transition effect.
+     * This value is then used to interpolate between the lower value and the average value, providing a smooth transition between the two conditions.
      *
      * @param snr1 The first SNR value
      * @param snr2 The second SNR value
@@ -99,15 +98,18 @@ protected:
      */
     int8_t fuzzy_snr(int8_t snr1, int8_t snr2, int8_t threshold)
     {
-        double diff = fabs(snr1 - snr2);
-        double lower_value = fmin(snr1, snr2);
-        double average_value = ((double)snr1 + snr2) / 2;
+        int8_t diff = abs(snr1 - snr2);
+        int8_t lower_value = (snr1 < snr2) ? snr1 : snr2;
+        int8_t average_value = (snr1 + snr2) / 2;
 
-        // Map the difference to a value between 0 and 1, using sigmoid function
-        // Scale and shift the sigmoid curve to cover the desired transition range
-        double transition_value  = 1.0 / (1.0 + exp(-1.0*((diff - threshold) * 10 / threshold)));
+        // Polynomial approximation for sigmoid function
+        int16_t scaled_diff = (diff - threshold) * 10 / threshold;
+        int16_t transition_value = scaled_diff / (1 + abs(scaled_diff));
 
-        // Interpolate between lower_value and average_value using the transition_value, then round to the nearest int
-        return (int8_t)round(lower_value * (1.0 - transition_value) + average_value * transition_value);
+        // Scale transition_value to the range [0, 1]
+        transition_value = (transition_value + 1) / 2;
+
+        // Interpolate between lower_value and average_value using the transition_value
+        return (int8_t)(lower_value * (1 - transition_value) + average_value * transition_value);
     }
 };


### PR DESCRIPTION
The original function comes from the use of the exponential function exp() and floating-point arithmetic. We can make some approximations to the sigmoid function and simplify the arithmetic to make the function faster.

A commonly used approximation for the sigmoid function is based on the hyperbolic tangent function (tanh). Since the hyperbolic tangent function is still computationally expensive, we can use a polynomial approximation for it.

Here's the comparison between the original and new (=faster) functions.
![original](https://github.com/ExpressLRS/ExpressLRS/assets/12195507/f5cbe4d0-7de8-4806-bc97-d13d60513b08)
![faster](https://github.com/ExpressLRS/ExpressLRS/assets/12195507/ee3eb8be-57cd-4329-bc5a-de36fcbc7e7b)

The original function took 85 us 
![original_time](https://github.com/ExpressLRS/ExpressLRS/assets/12195507/12eb2044-4aeb-429b-bac4-6374b46d9f55)

And the faster function took almost no time
![faster_time](https://github.com/ExpressLRS/ExpressLRS/assets/12195507/736f02ef-d52b-4ac6-84dc-4fc4c459e85f)