### PR TITLE
Giving the precision back to `fuzzy_snr`

### DIFF
--- a/src/lib/SX12xxDriverCommon/SX12xxDriverCommon.h
+++ b/src/lib/SX12xxDriverCommon/SX12xxDriverCommon.h
@@ -96,20 +96,24 @@ protected:
      * @param threshold The threshold value to control the transition between the lower value and the average value reporting strategy
      * @return The reported SNR value, which is either the lower value of the two input SNRs, their average, or a value in between, depending on the difference between the input SNRs and the threshold value
      */
-    int8_t fuzzy_snr(int8_t snr1, int8_t snr2, int8_t threshold)
+    int8_t fuzzy_snr(int16_t snr1, int16_t snr2, int16_t threshold)
     {
-        int8_t diff = abs(snr1 - snr2);
-        int8_t lower_value = (snr1 < snr2) ? snr1 : snr2;
-        int8_t average_value = (snr1 + snr2) / 2;
+        // scale up the values to get more precision
+        int16_t diff = (int16_t)abs(snr1 - snr2) << 7;
+        int16_t lower_value = (int16_t)(snr1 < snr2 ? snr1 : snr2) << 7;
+        int16_t average_value = ((int16_t)snr1 + snr2) << 6;
 
-        // Polynomial approximation for sigmoid function
-        int16_t scaled_diff = (diff - threshold) * 10 / threshold;
-        int16_t transition_value = scaled_diff / (1 + abs(scaled_diff));
+        int16_t threshold_scaled = (int16_t)threshold << 7;
 
-        // Scale transition_value to the range [0, 1]
-        transition_value = (transition_value + 1) / 2;
-
-        // Interpolate between lower_value and average_value using the transition_value
-        return (int8_t)(lower_value * (1 - transition_value) + average_value * transition_value);
+        if (diff < threshold_scaled) {
+            return lower_value >> 7;
+        }
+        else if (diff > threshold_scaled * 2) {
+            return average_value >> 7;
+        }
+        else {
+            int16_t transition_value = (diff - threshold_scaled) / threshold;
+            return (int8_t)((lower_value * (128 - transition_value) + average_value * transition_value) >> 14);
+        }
     }
 };


### PR DESCRIPTION
In the previous commit, I simulated the new fuzzy_snr with floating points, which resulted in the wrong behavior on the real code on integers. 

For example, this line will always give 0 (instead of a smooth transition between 0..1), with integer type... 😅 
```
// Scale transition_value to the range [0, 1]
transition_value = (transition_value + 1) / 2;
```

So I made a new version, with an internal scale-up for a better precision.

Here's the comparison results (original exp version vs. this update), this time the values are from the properly compiled C++ code snippet, instead of a externally simulated values. 
<img width="549" alt="Screenshot 2023-08-24 at 3 33 11 PM" src="https://github.com/ExpressLRS/ExpressLRS/assets/12195507/83ec5096-3066-48c1-aa26-5c24222abc13">
