### PR TITLE
RX Serial cleanup and documentation

### DIFF
--- a/src/src/rx-serial/SerialAirPort.cpp
+++ b/src/src/rx-serial/SerialAirPort.cpp
@@ -9,7 +9,7 @@ FIFO<AP_MAX_BUF_LEN> apInputBuffer;
 FIFO<AP_MAX_BUF_LEN> apOutputBuffer;
 
 
-uint32_t SerialAirPort::sendRCFrameToFC(bool frameAvailable, uint32_t *channelData)
+uint32_t SerialAirPort::sendRCFrame(bool frameAvailable, uint32_t *channelData)
 {
     return DURATION_IMMEDIATELY;
 }
@@ -27,7 +27,7 @@ void SerialAirPort::processBytes(uint8_t *bytes, u_int16_t size)
     }
 }
 
-void SerialAirPort::handleUARTout()
+void SerialAirPort::sendQueuedData(uint32_t maxBytesToSend)
 {
     auto size = apOutputBuffer.size();
     if (size != 0)

--- a/src/src/rx-serial/SerialAirPort.cpp
+++ b/src/src/rx-serial/SerialAirPort.cpp
@@ -9,11 +9,6 @@ FIFO<AP_MAX_BUF_LEN> apInputBuffer;
 FIFO<AP_MAX_BUF_LEN> apOutputBuffer;
 
 
-void SerialAirPort::setLinkQualityStats(uint16_t lq, uint16_t rssi)
-{
-    // unsupported
-}
-
 void SerialAirPort::sendLinkStatisticsToFC()
 {
     // unsupported

--- a/src/src/rx-serial/SerialAirPort.cpp
+++ b/src/src/rx-serial/SerialAirPort.cpp
@@ -9,19 +9,9 @@ FIFO<AP_MAX_BUF_LEN> apInputBuffer;
 FIFO<AP_MAX_BUF_LEN> apOutputBuffer;
 
 
-void SerialAirPort::sendLinkStatisticsToFC()
-{
-    // unsupported
-}
-
 uint32_t SerialAirPort::sendRCFrameToFC(bool frameAvailable, uint32_t *channelData)
 {
     return DURATION_IMMEDIATELY;
-}
-
-void SerialAirPort::sendMSPFrameToFC(uint8_t* data)
-{
-    // unsupported
 }
 
 int SerialAirPort::getMaxSerialReadSize()

--- a/src/src/rx-serial/SerialAirPort.cpp
+++ b/src/src/rx-serial/SerialAirPort.cpp
@@ -44,11 +44,14 @@ void SerialAirPort::processBytes(uint8_t *bytes, u_int16_t size)
 
 void SerialAirPort::handleUARTout()
 {
-    apOutputBuffer.lock();
     auto size = apOutputBuffer.size();
-    uint8_t buf[size];
-    apOutputBuffer.popBytes(buf, size);
-    apOutputBuffer.unlock();
-    _outputPort->write(buf, size);
+    if (size != 0)
+    {
+        uint8_t buf[size];
+        apOutputBuffer.lock();
+        apOutputBuffer.popBytes(buf, size);
+        apOutputBuffer.unlock();
+        _outputPort->write(buf, size);
+    }
 }
 #endif

--- a/src/src/rx-serial/SerialAirPort.h
+++ b/src/src/rx-serial/SerialAirPort.h
@@ -12,7 +12,6 @@ public:
 
     virtual ~SerialAirPort() {}
 
-    void setLinkQualityStats(uint16_t lq, uint16_t rssi) override;
     uint32_t sendRCFrameToFC(bool frameAvailable, uint32_t *channelData) override;
     void sendMSPFrameToFC(uint8_t* data) override;
     void sendLinkStatisticsToFC() override;

--- a/src/src/rx-serial/SerialAirPort.h
+++ b/src/src/rx-serial/SerialAirPort.h
@@ -11,12 +11,12 @@ public:
     explicit SerialAirPort(Stream &out, Stream &in) : SerialIO(&out, &in) {}
     virtual ~SerialAirPort() {}
 
-    void sendLinkStatisticsToFC() override {}
-    void sendMSPFrameToFC(uint8_t* data) override {}
-    uint32_t sendRCFrameToFC(bool frameAvailable, uint32_t *channelData) override;
+    void queueLinkStatisticsPacket() override {}
+    void queueMSPFrameTransmission(uint8_t* data) override {}
+    uint32_t sendRCFrame(bool frameAvailable, uint32_t *channelData) override;
 
     int getMaxSerialReadSize() override;
-    void handleUARTout() override;
+    void sendQueuedData(uint32_t maxBytesToSend) override;
 
 private:
     void processBytes(uint8_t *bytes, u_int16_t size) override;

--- a/src/src/rx-serial/SerialAirPort.h
+++ b/src/src/rx-serial/SerialAirPort.h
@@ -9,17 +9,15 @@ extern FIFO<AP_MAX_BUF_LEN> apOutputBuffer;
 class SerialAirPort : public SerialIO {
 public:
     explicit SerialAirPort(Stream &out, Stream &in) : SerialIO(&out, &in) {}
-
     virtual ~SerialAirPort() {}
 
+    void sendLinkStatisticsToFC() override {}
+    void sendMSPFrameToFC(uint8_t* data) override {}
     uint32_t sendRCFrameToFC(bool frameAvailable, uint32_t *channelData) override;
-    void sendMSPFrameToFC(uint8_t* data) override;
-    void sendLinkStatisticsToFC() override;
 
     int getMaxSerialReadSize() override;
     void handleUARTout() override;
 
 private:
     void processBytes(uint8_t *bytes, u_int16_t size) override;
-    void processByte(uint8_t byte) override {};
 };

--- a/src/src/rx-serial/SerialCRSF.cpp
+++ b/src/src/rx-serial/SerialCRSF.cpp
@@ -117,27 +117,30 @@ void SerialCRSF::sendMSPFrameToFC(uint8_t* data)
     }
 }
 
-void SerialCRSF::processByte(uint8_t byte)
+void SerialCRSF::processBytes(uint8_t *bytes, uint16_t size)
 {
-    telemetry.RXhandleUARTin(byte);
+    for (int i=0 ; i<size ; i++)
+    {
+        telemetry.RXhandleUARTin(bytes[i]);
 
-    if (telemetry.ShouldCallBootloader())
-    {
-        reset_into_bootloader();
-    }
-    if (telemetry.ShouldCallEnterBind())
-    {
-        EnterBindingMode();
-    }
-    if (telemetry.ShouldCallUpdateModelMatch())
-    {
-        UpdateModelMatch(telemetry.GetUpdatedModelMatch());
-    }
-    if (telemetry.ShouldSendDeviceFrame())
-    {
-        uint8_t deviceInformation[DEVICE_INFORMATION_LENGTH];
-        CRSF::GetDeviceInformation(deviceInformation, 0);
-        CRSF::SetExtendedHeaderAndCrc(deviceInformation, CRSF_FRAMETYPE_DEVICE_INFO, DEVICE_INFORMATION_FRAME_SIZE, CRSF_ADDRESS_CRSF_RECEIVER, CRSF_ADDRESS_FLIGHT_CONTROLLER);
-        sendMSPFrameToFC(deviceInformation);
+        if (telemetry.ShouldCallBootloader())
+        {
+            reset_into_bootloader();
+        }
+        if (telemetry.ShouldCallEnterBind())
+        {
+            EnterBindingMode();
+        }
+        if (telemetry.ShouldCallUpdateModelMatch())
+        {
+            UpdateModelMatch(telemetry.GetUpdatedModelMatch());
+        }
+        if (telemetry.ShouldSendDeviceFrame())
+        {
+            uint8_t deviceInformation[DEVICE_INFORMATION_LENGTH];
+            CRSF::GetDeviceInformation(deviceInformation, 0);
+            CRSF::SetExtendedHeaderAndCrc(deviceInformation, CRSF_FRAMETYPE_DEVICE_INFO, DEVICE_INFORMATION_FRAME_SIZE, CRSF_ADDRESS_CRSF_RECEIVER, CRSF_ADDRESS_FLIGHT_CONTROLLER);
+            sendMSPFrameToFC(deviceInformation);
+        }
     }
 }

--- a/src/src/rx-serial/SerialCRSF.cpp
+++ b/src/src/rx-serial/SerialCRSF.cpp
@@ -43,12 +43,6 @@ void SerialCRSF::handleUARTout()
     }
 }
 
-void SerialCRSF::setLinkQualityStats(uint16_t lq, uint16_t rssi)
-{
-    linkQuality = lq;
-    rssiDBM = rssi;
-}
-
 void SerialCRSF::sendLinkStatisticsToFC()
 {
     constexpr uint8_t outBuffer[] = {

--- a/src/src/rx-serial/SerialCRSF.h
+++ b/src/src/rx-serial/SerialCRSF.h
@@ -6,7 +6,6 @@ public:
 
     virtual ~SerialCRSF() {}
 
-    void setLinkQualityStats(uint16_t lq, uint16_t rssi) override;
     uint32_t sendRCFrameToFC(bool frameAvailable, uint32_t *channelData) override;
     void sendMSPFrameToFC(uint8_t* data) override;
     void sendLinkStatisticsToFC() override;
@@ -15,9 +14,6 @@ public:
 private:
     static const uint32_t SERIAL_OUTPUT_FIFO_SIZE = 256U;
     FIFO<SERIAL_OUTPUT_FIFO_SIZE> _fifo;
-
-    uint16_t linkQuality = 0;
-    uint16_t rssiDBM = 0;
 
     void processByte(uint8_t byte) override;
 };

--- a/src/src/rx-serial/SerialCRSF.h
+++ b/src/src/rx-serial/SerialCRSF.h
@@ -10,8 +10,12 @@ public:
     uint32_t sendRCFrameToFC(bool frameAvailable, uint32_t *channelData) override;
     void sendMSPFrameToFC(uint8_t* data) override;
     void sendLinkStatisticsToFC() override;
+    void handleUARTout() override;
 
 private:
+    static const uint32_t SERIAL_OUTPUT_FIFO_SIZE = 256U;
+    FIFO<SERIAL_OUTPUT_FIFO_SIZE> _fifo;
+
     uint16_t linkQuality = 0;
     uint16_t rssiDBM = 0;
 

--- a/src/src/rx-serial/SerialCRSF.h
+++ b/src/src/rx-serial/SerialCRSF.h
@@ -3,7 +3,6 @@
 class SerialCRSF : public SerialIO {
 public:
     explicit SerialCRSF(Stream &out, Stream &in) : SerialIO(&out, &in) {}
-
     virtual ~SerialCRSF() {}
 
     uint32_t sendRCFrameToFC(bool frameAvailable, uint32_t *channelData) override;
@@ -15,5 +14,5 @@ private:
     static const uint32_t SERIAL_OUTPUT_FIFO_SIZE = 256U;
     FIFO<SERIAL_OUTPUT_FIFO_SIZE> _fifo;
 
-    void processByte(uint8_t byte) override;
+    void processBytes(uint8_t *bytes, uint16_t size) override;
 };

--- a/src/src/rx-serial/SerialCRSF.h
+++ b/src/src/rx-serial/SerialCRSF.h
@@ -5,14 +5,11 @@ public:
     explicit SerialCRSF(Stream &out, Stream &in) : SerialIO(&out, &in) {}
     virtual ~SerialCRSF() {}
 
-    uint32_t sendRCFrameToFC(bool frameAvailable, uint32_t *channelData) override;
-    void sendMSPFrameToFC(uint8_t* data) override;
-    void sendLinkStatisticsToFC() override;
-    void handleUARTout() override;
+    uint32_t sendRCFrame(bool frameAvailable, uint32_t *channelData) override;
+    void queueMSPFrameTransmission(uint8_t* data) override;
+    void queueLinkStatisticsPacket() override;
+    void sendQueuedData(uint32_t maxBytesToSend) override;
 
 private:
-    static const uint32_t SERIAL_OUTPUT_FIFO_SIZE = 256U;
-    FIFO<SERIAL_OUTPUT_FIFO_SIZE> _fifo;
-
     void processBytes(uint8_t *bytes, uint16_t size) override;
 };

--- a/src/src/rx-serial/SerialIO.cpp
+++ b/src/src/rx-serial/SerialIO.cpp
@@ -1,6 +1,11 @@
 #include "SerialIO.h"
 
-void SerialIO::handleUARTin()
+void SerialIO::setFailsafe(bool failsafe)
+{
+    this->failsafe = failsafe;
+}
+
+void SerialIO::processSerialInput()
 {
     auto maxBytes = getMaxSerialReadSize();
     uint8_t buffer[maxBytes];
@@ -9,7 +14,18 @@ void SerialIO::handleUARTin()
     processBytes(buffer, size);
 }
 
-void SerialIO::setFailsafe(bool failsafe)
+void SerialIO::sendQueuedData(uint32_t maxBytesToSend)
 {
-    this->failsafe = failsafe;
+    uint32_t bytesWritten = 0;
+
+    while (_fifo.size() > _fifo.peek() && (bytesWritten + _fifo.peek()) < maxBytesToSend)
+    {
+        _fifo.lock();
+        uint8_t OutPktLen = _fifo.pop();
+        uint8_t OutData[OutPktLen];
+        _fifo.popBytes(OutData, OutPktLen);
+        _fifo.unlock();
+        this->_outputPort->write(OutData, OutPktLen); // write the packet out
+        bytesWritten += OutPktLen;
+    }
 }

--- a/src/src/rx-serial/SerialIO.cpp
+++ b/src/src/rx-serial/SerialIO.cpp
@@ -1,43 +1,5 @@
 #include "SerialIO.h"
 
-#if defined(USE_MSP_WIFI)
-#include "crsf2msp.h"
-#include "msp2crsf.h"
-
-extern CROSSFIRE2MSP crsf2msp;
-extern MSP2CROSSFIRE msp2crsf;
-#endif
-
-void SerialIO::handleUARTout()
-{
-    // don't write more than 128 bytes at a time to avoid RX buffer overflow
-    const int maxBytesPerCall = 128;
-    uint32_t bytesWritten = 0;
-    #if defined(USE_MSP_WIFI)
-        while (msp2crsf.FIFOout.size() > msp2crsf.FIFOout.peek() && (bytesWritten + msp2crsf.FIFOout.peek()) < maxBytesPerCall)
-        {
-            msp2crsf.FIFOout.lock();
-            uint8_t OutPktLen = msp2crsf.FIFOout.pop();
-            uint8_t OutData[OutPktLen];
-            msp2crsf.FIFOout.popBytes(OutData, OutPktLen);
-            msp2crsf.FIFOout.unlock();
-            this->_outputPort->write(OutData, OutPktLen); // write the packet out
-            bytesWritten += OutPktLen;
-        }
-    #endif
-
-    while (_fifo.size() > _fifo.peek() && (bytesWritten + _fifo.peek()) < maxBytesPerCall)
-    {
-        _fifo.lock();
-        uint8_t OutPktLen = _fifo.pop();
-        uint8_t OutData[OutPktLen];
-        _fifo.popBytes(OutData, OutPktLen);
-        _fifo.unlock();
-        this->_outputPort->write(OutData, OutPktLen); // write the packet out
-        bytesWritten += OutPktLen;
-    }
-}
-
 void SerialIO::handleUARTin()
 {
     auto maxBytes = getMaxSerialReadSize();

--- a/src/src/rx-serial/SerialIO.cpp
+++ b/src/src/rx-serial/SerialIO.cpp
@@ -9,14 +9,6 @@ void SerialIO::handleUARTin()
     processBytes(buffer, size);
 }
 
-void SerialIO::processBytes(uint8_t *bytes, uint16_t size)
-{
-    for (int i=0 ; i<size ; i++)
-    {
-        processByte(bytes[i]);
-    }
-}
-
 void SerialIO::setFailsafe(bool failsafe)
 {
     this->failsafe = failsafe;

--- a/src/src/rx-serial/SerialIO.h
+++ b/src/src/rx-serial/SerialIO.h
@@ -13,19 +13,18 @@ public:
     virtual void setLinkQualityStats(uint16_t lq, uint16_t rssi) = 0;
     virtual void sendLinkStatisticsToFC() = 0;
     virtual void sendMSPFrameToFC(uint8_t* data) = 0;
-    virtual void setFailsafe(bool failsafe);
-
     virtual uint32_t sendRCFrameToFC(bool frameAvailable, uint32_t *channelData) = 0;
 
     virtual int getMaxSerialReadSize() { return defaultMaxSerialReadSize; }
-    virtual void handleUARTout();
+
+    virtual void handleUARTout() {};
     virtual void handleUARTin();
 
+    void setFailsafe(bool failsafe);
+
 protected:
-    static const uint32_t SERIAL_OUTPUT_FIFO_SIZE = 256U;
     Stream *_outputPort;
     Stream *_inputPort;
-    FIFO<SERIAL_OUTPUT_FIFO_SIZE> _fifo;
     bool failsafe = false;
 
     virtual void processBytes(uint8_t *bytes, uint16_t size);

--- a/src/src/rx-serial/SerialIO.h
+++ b/src/src/rx-serial/SerialIO.h
@@ -5,27 +5,25 @@
 
 class SerialIO {
 public:
-    const int defaultMaxSerialReadSize = 64;
 
     SerialIO(Stream *output, Stream *input) : _outputPort(output), _inputPort(input) {}
     virtual ~SerialIO() {}
 
+    void setFailsafe(bool failsafe);
     virtual void sendLinkStatisticsToFC() = 0;
     virtual void sendMSPFrameToFC(uint8_t* data) = 0;
+
     virtual uint32_t sendRCFrameToFC(bool frameAvailable, uint32_t *channelData) = 0;
-
-    virtual int getMaxSerialReadSize() { return defaultMaxSerialReadSize; }
-
     virtual void handleUARTout() {};
     virtual void handleUARTin();
 
-    void setFailsafe(bool failsafe);
-
 protected:
+    const int defaultMaxSerialReadSize = 64;
+
     Stream *_outputPort;
     Stream *_inputPort;
     bool failsafe = false;
 
-    virtual void processBytes(uint8_t *bytes, uint16_t size);
-    virtual void processByte(uint8_t byte) = 0;
+    virtual int getMaxSerialReadSize() { return defaultMaxSerialReadSize; }
+    virtual void processBytes(uint8_t *bytes, uint16_t size) = 0;
 };

--- a/src/src/rx-serial/SerialIO.h
+++ b/src/src/rx-serial/SerialIO.h
@@ -4,7 +4,7 @@
 #include "FIFO.h"
 
 /**
- * @brief Abstract class that is to be extended by implementqtion classes for different serial protocols on the recevier side.
+ * @brief Abstract class that is to be extended by implementation classes for different serial protocols on the receiver side.
  *
  * At a minimum, a new protocol extension class should implement the following functions
  *
@@ -35,13 +35,13 @@ public:
      * @brief Signals the protocol to queue a link statistics packet
      *
      * The packet should be queued into the `_fifo` member variable as RC packets
-     * are prioritised and ancilliary data is sent after the RC data when the
+     * are prioritised and ancillary data is sent after the RC data when the
      * `sendQueuedData` function is called.
      */
     virtual void queueLinkStatisticsPacket() = 0;
 
     /**
-     * @brief Signals that the MSP frame should be queued for transmision.
+     * @brief Signals that the MSP frame should be queued for transmission.
      *
      * The MSP frame should be queued as in `queueLinkStatisticsPacket` so it can be
      * sent after any RC data.
@@ -54,8 +54,8 @@ public:
      * @brief send the RC channel data to the serial port stream `_outputPort` member
      * variable.
      *
-     * If the function whishes to be called as fast as possible, then it should return
-     * DURATION_IMMEDIATE, otherwise is should return the number of milliseconds delay
+     * If the function wishes to be called as fast as possible, then it should return
+     * DURATION_IMMEDIATE, otherwise it should return the number of milliseconds delay
      * before this method is called again.
      *
      * @param frameAvailable indicates that a new OTA frame of data has been received
@@ -66,8 +66,8 @@ public:
     virtual uint32_t sendRCFrame(bool frameAvailable, uint32_t *channelData) = 0;
 
     /**
-     * @brief send any previsouly queued data to the serial port stream `_outputPort`
-     * member varialbe.
+     * @brief send any previously queued data to the serial port stream `_outputPort`
+     * member variable.
      */
     virtual void sendQueuedData(uint32_t maxBytesToSend);
 
@@ -77,7 +77,7 @@ public:
      * The maximum number of bytes to read per call is obtained
      * from the `getMaxSerialReadSize` method call.
      *
-     * This method *should* not be overridden by custom implementatinos, it is
+     * This method *should* not be overridden by custom implementations, it is
      * only overridden by the `SerialNOOP` implementation.
      */
     virtual void processSerialInput();
@@ -105,7 +105,7 @@ protected:
     FIFO<SERIAL_OUTPUT_FIFO_SIZE> _fifo;
 
     /**
-     * @brief Get the maximum number of bytes to read from teh serial port per call
+     * @brief Get the maximum number of bytes to read from the serial port per call
      *
      * @return the maximum number of bytes to read
      */

--- a/src/src/rx-serial/SerialIO.h
+++ b/src/src/rx-serial/SerialIO.h
@@ -10,19 +10,26 @@ public:
     virtual ~SerialIO() {}
 
     void setFailsafe(bool failsafe);
-    virtual void sendLinkStatisticsToFC() = 0;
-    virtual void sendMSPFrameToFC(uint8_t* data) = 0;
 
-    virtual uint32_t sendRCFrameToFC(bool frameAvailable, uint32_t *channelData) = 0;
-    virtual void handleUARTout() {};
-    virtual void handleUARTin();
+    virtual void queueLinkStatisticsPacket() = 0;
+    virtual void queueMSPFrameTransmission(uint8_t* data) = 0;
+
+    virtual uint32_t sendRCFrame(bool frameAvailable, uint32_t *channelData) = 0;
+
+    virtual void sendQueuedData(uint32_t maxBytesToSend);
+    virtual void processSerialInput();
+    virtual int getMaxSerialWriteSize() { return defaultMaxSerialWriteSize; }
 
 protected:
     const int defaultMaxSerialReadSize = 64;
+    const int defaultMaxSerialWriteSize = 128;
 
     Stream *_outputPort;
     Stream *_inputPort;
     bool failsafe = false;
+
+    static const uint32_t SERIAL_OUTPUT_FIFO_SIZE = 256U;
+    FIFO<SERIAL_OUTPUT_FIFO_SIZE> _fifo;
 
     virtual int getMaxSerialReadSize() { return defaultMaxSerialReadSize; }
     virtual void processBytes(uint8_t *bytes, uint16_t size) = 0;

--- a/src/src/rx-serial/SerialIO.h
+++ b/src/src/rx-serial/SerialIO.h
@@ -3,34 +3,126 @@
 #include "targets.h"
 #include "FIFO.h"
 
+/**
+ * @brief Abstract class that is to be extended by implementqtion classes for different serial protocols on the recevier side.
+ *
+ * At a minimum, a new protocol extension class should implement the following functions
+ *
+ * * queueLinkStatisticsPacket
+ * * queueMSPFrameTransmission
+ * * sendRCFrame
+ * * sendQueuedData
+ * * processBytes
+ */
 class SerialIO {
 public:
 
     SerialIO(Stream *output, Stream *input) : _outputPort(output), _inputPort(input) {}
     virtual ~SerialIO() {}
 
+    /**
+     * @brief Set the Failsafe flag
+     *
+     * This allows the serial protocol implementation to react accordingly.
+     * e.g. if it needs to set a flag in the serial messages, or stop sending over
+     * serial port.
+     *
+     * @param failsafe true when the firmware has detected a failsafe condition.
+     */
     void setFailsafe(bool failsafe);
 
+    /**
+     * @brief Signals the protocol to queue a link statistics packet
+     *
+     * The packet should be queued into the `_fifo` member variable as RC packets
+     * are prioritised and ancilliary data is sent after the RC data when the
+     * `sendQueuedData` function is called.
+     */
     virtual void queueLinkStatisticsPacket() = 0;
+
+    /**
+     * @brief Signals that the MSP frame should be queued for transmision.
+     *
+     * The MSP frame should be queued as in `queueLinkStatisticsPacket` so it can be
+     * sent after any RC data.
+     *
+     * @param data pointer to the MSP packet
+     */
     virtual void queueMSPFrameTransmission(uint8_t* data) = 0;
 
+    /**
+     * @brief send the RC channel data to the serial port stream `_outputPort` member
+     * variable.
+     *
+     * If the function whishes to be called as fast as possible, then it should return
+     * DURATION_IMMEDIATE, otherwise is should return the number of milliseconds delay
+     * before this method is called again.
+     *
+     * @param frameAvailable indicates that a new OTA frame of data has been received
+     * since the last call to this function
+     * @param channelData pointer to the 16 channels of data
+     * @return number of milliseconds to delay before this method is called again
+     */
     virtual uint32_t sendRCFrame(bool frameAvailable, uint32_t *channelData) = 0;
 
+    /**
+     * @brief send any previsouly queued data to the serial port stream `_outputPort`
+     * member varialbe.
+     */
     virtual void sendQueuedData(uint32_t maxBytesToSend);
+
+    /**
+     * @brief read bytes from the serial port and process them.
+     *
+     * The maximum number of bytes to read per call is obtained
+     * from the `getMaxSerialReadSize` method call.
+     *
+     * This method *should* not be overridden by custom implementatinos, it is
+     * only overridden by the `SerialNOOP` implementation.
+     */
     virtual void processSerialInput();
+
+    /**
+     * @brief Get the maximum number of bytes to write to the serial port in each call.
+     *
+     * @return maximum number of bytes to write
+     */
     virtual int getMaxSerialWriteSize() { return defaultMaxSerialWriteSize; }
 
 protected:
-    const int defaultMaxSerialReadSize = 64;
-    const int defaultMaxSerialWriteSize = 128;
-
+    /// @brief the output stream for the serial port
     Stream *_outputPort;
-    Stream *_inputPort;
+    /// @brief flag that indicates the receiver is in the failsafe state
     bool failsafe = false;
 
     static const uint32_t SERIAL_OUTPUT_FIFO_SIZE = 256U;
+
+
+    /**
+     * @brief the FIFO that should be used to queue serial data to in the
+     * `queueLinkStatisticsPacket` and `queueMSPFrameTransmission` method implementations.
+     */
     FIFO<SERIAL_OUTPUT_FIFO_SIZE> _fifo;
 
+    /**
+     * @brief Get the maximum number of bytes to read from teh serial port per call
+     *
+     * @return the maximum number of bytes to read
+     */
     virtual int getMaxSerialReadSize() { return defaultMaxSerialReadSize; }
+
+    /**
+     * @brief Protocol specific method to process the bytes that have been read
+     * from the serial port by the framework calling the `processSerialInput` method.
+     *
+     * @param bytes pointer to the byte array that contains the serial data
+     * @param size number of bytes in the buffer
+     */
     virtual void processBytes(uint8_t *bytes, uint16_t size) = 0;
+
+private:
+    const int defaultMaxSerialReadSize = 64;
+    const int defaultMaxSerialWriteSize = 128;
+
+    Stream *_inputPort;
 };

--- a/src/src/rx-serial/SerialIO.h
+++ b/src/src/rx-serial/SerialIO.h
@@ -10,7 +10,6 @@ public:
     SerialIO(Stream *output, Stream *input) : _outputPort(output), _inputPort(input) {}
     virtual ~SerialIO() {}
 
-    virtual void setLinkQualityStats(uint16_t lq, uint16_t rssi) = 0;
     virtual void sendLinkStatisticsToFC() = 0;
     virtual void sendMSPFrameToFC(uint8_t* data) = 0;
     virtual uint32_t sendRCFrameToFC(bool frameAvailable, uint32_t *channelData) = 0;

--- a/src/src/rx-serial/SerialNOOP.h
+++ b/src/src/rx-serial/SerialNOOP.h
@@ -8,7 +8,6 @@ public:
 
     virtual ~SerialNOOP() {}
 
-    void setLinkQualityStats(uint16_t lq, uint16_t rssi) override {}
     void sendLinkStatisticsToFC() override {}
     void sendMSPFrameToFC(uint8_t* data) override {}
 

--- a/src/src/rx-serial/SerialNOOP.h
+++ b/src/src/rx-serial/SerialNOOP.h
@@ -15,7 +15,6 @@ public:
     uint32_t sendRCFrameToFC(bool frameAvailable, uint32_t *channelData) override { return  10; }
 
     void handleUARTin() override {}
-    void handleUARTout() override { _fifo.flush(); }
 
 private:
     void processByte(uint8_t byte) override {}

--- a/src/src/rx-serial/SerialNOOP.h
+++ b/src/src/rx-serial/SerialNOOP.h
@@ -7,11 +7,11 @@ public:
     explicit SerialNOOP() : SerialIO(nullptr, nullptr) {}
     virtual ~SerialNOOP() {}
 
-    void sendLinkStatisticsToFC() override {}
-    void sendMSPFrameToFC(uint8_t* data) override {}
-    uint32_t sendRCFrameToFC(bool frameAvailable, uint32_t *channelData) override { return  DURATION_NEVER; }
+    void queueLinkStatisticsPacket() override {}
+    void queueMSPFrameTransmission(uint8_t* data) override {}
+    uint32_t sendRCFrame(bool frameAvailable, uint32_t *channelData) override { return  DURATION_NEVER; }
 
-    void handleUARTin() override {}
+    void processSerialInput() override {}
 
 private:
     void processBytes(uint8_t *bytes, uint16_t size) override {}

--- a/src/src/rx-serial/SerialNOOP.h
+++ b/src/src/rx-serial/SerialNOOP.h
@@ -5,16 +5,14 @@
 class SerialNOOP : public SerialIO {
 public:
     explicit SerialNOOP() : SerialIO(nullptr, nullptr) {}
-
     virtual ~SerialNOOP() {}
 
     void sendLinkStatisticsToFC() override {}
     void sendMSPFrameToFC(uint8_t* data) override {}
-
-    uint32_t sendRCFrameToFC(bool frameAvailable, uint32_t *channelData) override { return  10; }
+    uint32_t sendRCFrameToFC(bool frameAvailable, uint32_t *channelData) override { return  DURATION_NEVER; }
 
     void handleUARTin() override {}
 
 private:
-    void processByte(uint8_t byte) override {}
+    void processBytes(uint8_t *bytes, uint16_t size) override {}
 };

--- a/src/src/rx-serial/SerialSBUS.cpp
+++ b/src/src/rx-serial/SerialSBUS.cpp
@@ -12,11 +12,6 @@ extern RxConfig config;
 
 const auto SBUS_CALLBACK_INTERVAL_MS = 9;
 
-void SerialSBUS::sendLinkStatisticsToFC()
-{
-    // unsupported
-}
-
 uint32_t SerialSBUS::sendRCFrameToFC(bool frameAvailable, uint32_t *channelData)
 {
     static auto sendPackets = false;
@@ -77,11 +72,6 @@ uint32_t SerialSBUS::sendRCFrameToFC(bool frameAvailable, uint32_t *channelData)
     _outputPort->write((uint8_t)extraData);    // ch 17, 18, lost packet, failsafe
     _outputPort->write((uint8_t)0x00);    // FOOTER
     return SBUS_CALLBACK_INTERVAL_MS;
-}
-
-void SerialSBUS::sendMSPFrameToFC(uint8_t* data)
-{
-    // unsupported
 }
 
 #endif

--- a/src/src/rx-serial/SerialSBUS.cpp
+++ b/src/src/rx-serial/SerialSBUS.cpp
@@ -12,11 +12,6 @@ extern RxConfig config;
 
 const auto SBUS_CALLBACK_INTERVAL_MS = 9;
 
-void SerialSBUS::setLinkQualityStats(uint16_t lq, uint16_t rssi)
-{
-    // unsupported
-}
-
 void SerialSBUS::sendLinkStatisticsToFC()
 {
     // unsupported
@@ -33,7 +28,7 @@ uint32_t SerialSBUS::sendRCFrameToFC(bool frameAvailable, uint32_t *channelData)
 
     // TODO: if failsafeMode == FAILSAFE_SET_POSITION then we use the set positions rather than the last values
     crsf_channels_s PackedRCdataOut;
-    
+
     if (config.GetSerialProtocol() == PROTOCOL_DJI_RS_PRO)
     {
         PackedRCdataOut.ch0 = fmap(channelData[0], CRSF_CHANNEL_VALUE_MIN, CRSF_CHANNEL_VALUE_MAX, 352, 1696);

--- a/src/src/rx-serial/SerialSBUS.cpp
+++ b/src/src/rx-serial/SerialSBUS.cpp
@@ -12,7 +12,7 @@ extern RxConfig config;
 
 const auto SBUS_CALLBACK_INTERVAL_MS = 9;
 
-uint32_t SerialSBUS::sendRCFrameToFC(bool frameAvailable, uint32_t *channelData)
+uint32_t SerialSBUS::sendRCFrame(bool frameAvailable, uint32_t *channelData)
 {
     static auto sendPackets = false;
     if ((failsafe && config.GetFailsafeMode() == FAILSAFE_NO_PULSES) || (!sendPackets && connectionState != connected))

--- a/src/src/rx-serial/SerialSBUS.h
+++ b/src/src/rx-serial/SerialSBUS.h
@@ -3,13 +3,12 @@
 class SerialSBUS : public SerialIO {
 public:
     explicit SerialSBUS(Stream &out, Stream &in) : SerialIO(&out, &in) {}
-
     virtual ~SerialSBUS() {}
 
+    void sendLinkStatisticsToFC() override {}
+    void sendMSPFrameToFC(uint8_t* data) override {}
     uint32_t sendRCFrameToFC(bool frameAvailable, uint32_t *channelData) override;
-    void sendMSPFrameToFC(uint8_t* data) override;
-    void sendLinkStatisticsToFC() override;
 
 private:
-    void processByte(uint8_t byte) override {};
+    void processBytes(uint8_t *bytes, uint16_t size) override {};
 };

--- a/src/src/rx-serial/SerialSBUS.h
+++ b/src/src/rx-serial/SerialSBUS.h
@@ -6,7 +6,6 @@ public:
 
     virtual ~SerialSBUS() {}
 
-    void setLinkQualityStats(uint16_t lq, uint16_t rssi) override;
     uint32_t sendRCFrameToFC(bool frameAvailable, uint32_t *channelData) override;
     void sendMSPFrameToFC(uint8_t* data) override;
     void sendLinkStatisticsToFC() override;

--- a/src/src/rx-serial/SerialSBUS.h
+++ b/src/src/rx-serial/SerialSBUS.h
@@ -5,9 +5,9 @@ public:
     explicit SerialSBUS(Stream &out, Stream &in) : SerialIO(&out, &in) {}
     virtual ~SerialSBUS() {}
 
-    void sendLinkStatisticsToFC() override {}
-    void sendMSPFrameToFC(uint8_t* data) override {}
-    uint32_t sendRCFrameToFC(bool frameAvailable, uint32_t *channelData) override;
+    void queueLinkStatisticsPacket() override {}
+    void queueMSPFrameTransmission(uint8_t* data) override {}
+    uint32_t sendRCFrame(bool frameAvailable, uint32_t *channelData) override;
 
 private:
     void processBytes(uint8_t *bytes, uint16_t size) override {};

--- a/src/src/rx-serial/SerialSUMD.cpp
+++ b/src/src/rx-serial/SerialSUMD.cpp
@@ -76,18 +76,3 @@ uint32_t SerialSUMD::sendRCFrameToFC(bool frameAvailable, uint32_t *channelData)
 
     return DURATION_IMMEDIATELY;
 }
-
-void SerialSUMD::sendLinkStatisticsToFC()
-{
-    // unsupported
-}
-
-void SerialSUMD::sendMSPFrameToFC(uint8_t* data)
-{
-    (void)data;
-    // unsupported
-}
-
-void processByte(uint8_t byte) {
-    // unsupported
-}

--- a/src/src/rx-serial/SerialSUMD.cpp
+++ b/src/src/rx-serial/SerialSUMD.cpp
@@ -7,7 +7,7 @@
 #define SUMD_CRC_SIZE			2														// 16 bit CRC
 #define SUMD_FRAME_16CH_LEN		(SUMD_HEADER_SIZE+SUMD_DATA_SIZE_16CH+SUMD_CRC_SIZE)
 
-uint32_t SerialSUMD::sendRCFrameToFC(bool frameAvailable, uint32_t *channelData)
+uint32_t SerialSUMD::sendRCFrame(bool frameAvailable, uint32_t *channelData)
 {
     if (!frameAvailable) {
         return DURATION_IMMEDIATELY;

--- a/src/src/rx-serial/SerialSUMD.cpp
+++ b/src/src/rx-serial/SerialSUMD.cpp
@@ -5,13 +5,7 @@
 #define SUMD_HEADER_SIZE		3														// 3 Bytes header
 #define SUMD_DATA_SIZE_16CH		(16*2)													// 2 Bytes per channel
 #define SUMD_CRC_SIZE			2														// 16 bit CRC
-#define SUMD_FRAME_16CH_LEN		(SUMD_HEADER_SIZE+SUMD_DATA_SIZE_16CH+SUMD_CRC_SIZE)	
-
-void SerialSUMD::setLinkQualityStats(uint16_t lq, uint16_t rssi)
-{
-    linkQuality = lq;
-    rssiDBM = rssi;
-}
+#define SUMD_FRAME_16CH_LEN		(SUMD_HEADER_SIZE+SUMD_DATA_SIZE_16CH+SUMD_CRC_SIZE)
 
 uint32_t SerialSUMD::sendRCFrameToFC(bool frameAvailable, uint32_t *channelData)
 {
@@ -23,69 +17,69 @@ uint32_t SerialSUMD::sendRCFrameToFC(bool frameAvailable, uint32_t *channelData)
 
 	outBuffer[0] = 0xA8;		//Graupner
 	outBuffer[1] = 0x01;	    //SUMD
-	outBuffer[2] = 0x10;		//16CH	
+	outBuffer[2] = 0x10;		//16CH
 
-    uint16_t us = (CRSF_to_US(ChannelData[0]) << 3);
-    outBuffer[3] = us >> 8;		
+    uint16_t us = (CRSF_to_US(channelData[0]) << 3);
+    outBuffer[3] = us >> 8;
     outBuffer[4] = us & 0x00ff;
-    us = (CRSF_to_US(ChannelData[1]) << 3);
-    outBuffer[5] = us >> 8;		
+    us = (CRSF_to_US(channelData[1]) << 3);
+    outBuffer[5] = us >> 8;
     outBuffer[6] = us & 0x00ff;
-    us = (CRSF_to_US(ChannelData[2]) << 3);
-    outBuffer[7] = us >> 8;		
+    us = (CRSF_to_US(channelData[2]) << 3);
+    outBuffer[7] = us >> 8;
     outBuffer[8] = us & 0x00ff;
-    us = (CRSF_to_US(ChannelData[3]) << 3);
-    outBuffer[9] = us >> 8;		
+    us = (CRSF_to_US(channelData[3]) << 3);
+    outBuffer[9] = us >> 8;
     outBuffer[10] = us & 0x00ff;
-    us = (CRSF_to_US(ChannelData[7]) << 3); //channel 8 mapped to 5 to move arm channel away from the aileron function
-    outBuffer[11] = us >> 8;		
+    us = (CRSF_to_US(channelData[7]) << 3); //channel 8 mapped to 5 to move arm channel away from the aileron function
+    outBuffer[11] = us >> 8;
     outBuffer[12] = us & 0x00ff;
-    us = (CRSF_to_US(ChannelData[5]) << 3);
-    outBuffer[13] = us >> 8;		
+    us = (CRSF_to_US(channelData[5]) << 3);
+    outBuffer[13] = us >> 8;
     outBuffer[14] = us & 0x00ff;
-    us = (CRSF_to_US(ChannelData[6]) << 3);
-    outBuffer[15] = us >> 8;		
+    us = (CRSF_to_US(channelData[6]) << 3);
+    outBuffer[15] = us >> 8;
     outBuffer[16] = us & 0x00ff;
-    us = (CRSF_to_US(ChannelData[4]) << 3); //channel 5 mapped to 8
-    outBuffer[17] = us >> 8;		
+    us = (CRSF_to_US(channelData[4]) << 3); //channel 5 mapped to 8
+    outBuffer[17] = us >> 8;
     outBuffer[18] = us & 0x00ff;
-    us = (CRSF_to_US(ChannelData[8]) << 3);
-    outBuffer[19] = us >> 8;		
+    us = (CRSF_to_US(channelData[8]) << 3);
+    outBuffer[19] = us >> 8;
     outBuffer[20] = us & 0x00ff;
-    us = (CRSF_to_US(ChannelData[9]) << 3);
-    outBuffer[21] = us >> 8;		
+    us = (CRSF_to_US(channelData[9]) << 3);
+    outBuffer[21] = us >> 8;
     outBuffer[22] = us & 0x00ff;
-    us = (CRSF_to_US(ChannelData[10]) << 3);
-    outBuffer[23] = us >> 8;		
+    us = (CRSF_to_US(channelData[10]) << 3);
+    outBuffer[23] = us >> 8;
     outBuffer[24] = us & 0x00ff;
-    us = (CRSF_to_US(ChannelData[11]) << 3);
-    outBuffer[25] = us >> 8;		
+    us = (CRSF_to_US(channelData[11]) << 3);
+    outBuffer[25] = us >> 8;
     outBuffer[26] = us & 0x00ff;
-    us = (CRSF_to_US(ChannelData[12]) << 3);
-    outBuffer[27] = us >> 8;		
+    us = (CRSF_to_US(channelData[12]) << 3);
+    outBuffer[27] = us >> 8;
     outBuffer[28] = us & 0x00ff;
-    us = (CRSF_to_US(ChannelData[13]) << 3);
-    outBuffer[29] = us >> 8;		
+    us = (CRSF_to_US(channelData[13]) << 3);
+    outBuffer[29] = us >> 8;
     outBuffer[30] = us & 0x00ff;
-    us = (CRSF_to_US(ChannelData[14]) << 3);
-    outBuffer[31] = us >> 8;		
+    us = (CRSF_to_US(channelData[14]) << 3);
+    outBuffer[31] = us >> 8;
     outBuffer[32] = us & 0x00ff;
-    us = (CRSF_to_US(ChannelData[15]) << 3);
-    outBuffer[33] = us >> 8;		
+    us = (CRSF_to_US(channelData[15]) << 3);
+    outBuffer[33] = us >> 8;
     outBuffer[34] = us & 0x00ff;
-	  
+
 	uint16_t crc = crc2Byte.calc(outBuffer, (SUMD_HEADER_SIZE + SUMD_DATA_SIZE_16CH), 0);
 	outBuffer[35] = (uint8_t)(crc >> 8);
-	outBuffer[36] = (uint8_t)(crc & 0x00ff);	  	
-	
+	outBuffer[36] = (uint8_t)(crc & 0x00ff);
+
 	_outputPort->write(outBuffer, sizeof(outBuffer));
-	
+
     return DURATION_IMMEDIATELY;
 }
 
 void SerialSUMD::sendLinkStatisticsToFC()
 {
-    // unsupported	
+    // unsupported
 }
 
 void SerialSUMD::sendMSPFrameToFC(uint8_t* data)

--- a/src/src/rx-serial/SerialSUMD.h
+++ b/src/src/rx-serial/SerialSUMD.h
@@ -4,15 +4,13 @@
 class SerialSUMD : public SerialIO {
 public:
     explicit SerialSUMD(Stream &out, Stream &in) : SerialIO(&out, &in) { crc2Byte.init(16, 0x1021); }
-
     virtual ~SerialSUMD() {}
 
-    Crc2Byte crc2Byte;
-
+    void sendLinkStatisticsToFC() override {}
+    void sendMSPFrameToFC(uint8_t* data) override {}
     uint32_t sendRCFrameToFC(bool frameAvailable, uint32_t *channelData) override;
-    void sendMSPFrameToFC(uint8_t* data) override;
-    void sendLinkStatisticsToFC() override;
 
 private:
-    void processByte(uint8_t byte) override {};
+    Crc2Byte crc2Byte;
+    void processBytes(uint8_t *bytes, uint16_t size) override {};
 };

--- a/src/src/rx-serial/SerialSUMD.h
+++ b/src/src/rx-serial/SerialSUMD.h
@@ -6,9 +6,9 @@ public:
     explicit SerialSUMD(Stream &out, Stream &in) : SerialIO(&out, &in) { crc2Byte.init(16, 0x1021); }
     virtual ~SerialSUMD() {}
 
-    void sendLinkStatisticsToFC() override {}
-    void sendMSPFrameToFC(uint8_t* data) override {}
-    uint32_t sendRCFrameToFC(bool frameAvailable, uint32_t *channelData) override;
+    void queueLinkStatisticsPacket() override {}
+    void queueMSPFrameTransmission(uint8_t* data) override {}
+    uint32_t sendRCFrame(bool frameAvailable, uint32_t *channelData) override;
 
 private:
     Crc2Byte crc2Byte;

--- a/src/src/rx-serial/SerialSUMD.h
+++ b/src/src/rx-serial/SerialSUMD.h
@@ -9,14 +9,10 @@ public:
 
     Crc2Byte crc2Byte;
 
-    void setLinkQualityStats(uint16_t lq, uint16_t rssi) override;
     uint32_t sendRCFrameToFC(bool frameAvailable, uint32_t *channelData) override;
     void sendMSPFrameToFC(uint8_t* data) override;
     void sendLinkStatisticsToFC() override;
 
 private:
-    uint16_t linkQuality = 0;
-    uint16_t rssiDBM = 0;
-
     void processByte(uint8_t byte) override {};
 };

--- a/src/src/rx-serial/devSerialIO.cpp
+++ b/src/src/rx-serial/devSerialIO.cpp
@@ -44,8 +44,8 @@ static int timeout()
     }
     frameAvailable = false;
     // still get telemetry and send link stats if theres no model match
-    serialIO->handleUARTout();
     serialIO->handleUARTin();
+    serialIO->handleUARTout();
     return duration;
 }
 

--- a/src/src/rx-serial/devSerialIO.cpp
+++ b/src/src/rx-serial/devSerialIO.cpp
@@ -40,12 +40,12 @@ static int timeout()
     // only send frames if we have a model match
     if (connectionHasModelMatch)
     {
-        duration = serialIO->sendRCFrameToFC(frameAvailable, ChannelData);
+        duration = serialIO->sendRCFrame(frameAvailable, ChannelData);
     }
     frameAvailable = false;
     // still get telemetry and send link stats if theres no model match
-    serialIO->handleUARTin();
-    serialIO->handleUARTout();
+    serialIO->processSerialInput();
+    serialIO->sendQueuedData(serialIO->getMaxSerialWriteSize());
     return duration;
 }
 

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1096,7 +1096,7 @@ void UpdateModelMatch(uint8_t model)
 
 void SendMSPFrameToFC(uint8_t *mspData)
 {
-    serialIO->sendMSPFrameToFC(mspData);
+    serialIO->queueMSPFrameTransmission(mspData);
 }
 
 /**
@@ -1156,7 +1156,7 @@ void MspReceiveComplete()
         // No MSP data to the FC if no model match
         if (connectionHasModelMatch && (receivedHeader->dest_addr == CRSF_ADDRESS_BROADCAST || receivedHeader->dest_addr == CRSF_ADDRESS_FLIGHT_CONTROLLER))
         {
-            serialIO->sendMSPFrameToFC(MspData);
+            serialIO->queueMSPFrameTransmission(MspData);
         }
     }
 
@@ -1505,7 +1505,7 @@ static void checkSendLinkStatsToFc(uint32_t now)
         if ((connectionState != disconnected && connectionHasModelMatch) ||
             SendLinkStatstoFCForcedSends)
         {
-            serialIO->sendLinkStatisticsToFC();
+            serialIO->queueLinkStatisticsPacket();
             SendLinkStatstoFCintervalLastSent = now;
             if (SendLinkStatstoFCForcedSends)
                 --SendLinkStatstoFCForcedSends;

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -301,11 +301,6 @@ void ICACHE_RAM_ATTR getRFlinkInfo()
         CRSF::LinkStatistics.uplink_RSSI_2 = -rssiDBM;
     }
 
-    serialIO->setLinkQualityStats(
-        UINT10_to_CRSF(fmap(uplinkLQ, 0, 100, 0, 1023)),
-        UINT10_to_CRSF(map(constrain(rssiDBM, ExpressLRS_currAirRate_RFperfParams->RXsensitivity, -50),
-                                                   ExpressLRS_currAirRate_RFperfParams->RXsensitivity, -50, 0, 1023))
-    );
     SnrMean.add(Radio.LastPacketSNRRaw);
 
     CRSF::LinkStatistics.active_antenna = antenna;


### PR DESCRIPTION
As part of documenting the Serial API for receivers I noticed there was a couple of extra cleanups that could be done along with a simplification of the API.

1. Move CRSF specific code from `SerialIO` to `SerialCRSF`
2. Remove the `setLinkQualityStats` method as it's really only for CRSF
3. Add empty default methods in the `SerialIO` class so subclasses don't need to implement them
4. Renaming some of the methods based on their actual/expected usage
5. Document the API so it's clear what is expected for a protocol implementor
6. Resurrect the LQ/RSSI behaviour (shoving in on channel 14/15) on the CRSF protocol if it's not using 16-Channel Mode, as it was in 3.2