### PR TITLE
Fix ESP8285 RX as TX

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -120,8 +120,6 @@ void CRSF::Begin()
         if (RecvModelUpdate) RecvModelUpdate();
     }
 #elif defined(PLATFORM_ESP8266)
-    // Kill of the default serial port
-    Serial.end();
     // Uses default UART pins
     CRSF::Port.begin(UARTrequestedBaud);
     // Invert RX/TX (not done, connection is full duplex uninverted)

--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -120,6 +120,8 @@ void CRSF::Begin()
         if (RecvModelUpdate) RecvModelUpdate();
     }
 #elif defined(PLATFORM_ESP8266)
+    // Kill of the default serial port
+    Serial.end();
     // Uses default UART pins
     CRSF::Port.begin(UARTrequestedBaud);
     // Invert RX/TX (not done, connection is full duplex uninverted)

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1635,10 +1635,6 @@ void resetConfigAndReboot()
 void setup()
 {
     #if defined(TARGET_UNIFIED_RX)
-    // Setup default logging in case of failure, or no layout
-    Serial.begin(115200);
-    SerialLogger = &Serial;
-
     hardwareConfigured = options_init();
     if (!hardwareConfigured)
     {

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1173,10 +1173,6 @@ static void setupTarget()
 bool setupHardwareFromOptions()
 {
 #if defined(TARGET_UNIFIED_TX)
-  // Setup default logging in case of failure, or no layout
-  Serial.begin(115200);
-  TxBackpack = &Serial;
-
   if (!options_init())
   {
     // Register the WiFi with the framework


### PR DESCRIPTION
# Problem
In 3.3.0 the RX as TX for ESP8285 was broken.
The underlying problem is that the built-in serial device interferes with the CRSF serial connection once it is created.

# Solution
Kill the build-in Serial by call the `end` method on it before starting the CRSF serial connection.
Fixes #2381 

# Tested
Tested using a TX16S MKII with a DIY 8285 RX in place of the internal module.

# Future
Ideally we should disable all the built-in serial stuff from the framework and be in complete control of this stuff our selves to avoid these problems in the future!