### PR TITLE
Ability to set Semtech output power when using DAC for PA power control

### DIFF
--- a/src/hardware/RX/DIY 900 TTGO V1.json
+++ b/src/hardware/RX/DIY 900 TTGO V1.json
@@ -12,6 +12,6 @@
     "power_max": 2,
     "power_default": 2,
     "power_control": 0,
-    "power_values": [8,12,15],
+    "power_values": [120,124,127],
     "led": 2
 }

--- a/src/hardware/RX/DIY 900 TTGO V2.json
+++ b/src/hardware/RX/DIY 900 TTGO V2.json
@@ -12,6 +12,6 @@
     "power_max": 2,
     "power_default": 2,
     "power_control": 0,
-    "power_values": [8,12,15],
+    "power_values": [120,124,127],
     "led": 25
 }

--- a/src/hardware/RX/DIY Huzzah RFM95.json
+++ b/src/hardware/RX/DIY Huzzah RFM95.json
@@ -13,6 +13,6 @@
     "power_max": 0,
     "power_default": 0,
     "power_control": 0,
-    "power_values": [15],
+    "power_values": [127],
     "led": 0
 }

--- a/src/hardware/RX/Generic 900 PWMP.json
+++ b/src/hardware/RX/Generic 900 PWMP.json
@@ -10,7 +10,7 @@
     "power_max": 2,
     "power_default": 2,
     "power_control": 0,
-    "power_values": [8,12,15],
+    "power_values": [120,124,127],
     "led": 16,
     "pwm_outputs": [0,1,3,5,9,10]
 }

--- a/src/hardware/RX/Generic 900 True Diversity PA.json
+++ b/src/hardware/RX/Generic 900 True Diversity PA.json
@@ -25,7 +25,7 @@
     "power_max": 2,
     "power_default": 2,
     "power_control": 0,
-    "power_values": [8,12,15],
+    "power_values": [120,124,127],
 
     "led_rgb": 22,
     "led_rgb_isgrb": true,

--- a/src/hardware/RX/Generic 900 True Diversity PWM 16.json
+++ b/src/hardware/RX/Generic 900 True Diversity PWM 16.json
@@ -17,7 +17,7 @@
     "power_max": 2,
     "power_default": 2,
     "power_control": 0,
-    "power_values": [8,12,15],
+    "power_values": [120,124,127],
 
     "led_rgb":21,
     "led_rgb_isgrb":true,

--- a/src/hardware/RX/Generic 900.json
+++ b/src/hardware/RX/Generic 900.json
@@ -13,7 +13,7 @@
     "power_max": 2,
     "power_default": 2,
     "power_control": 0,
-    "power_values": [8,12,15],
+    "power_values": [120,124,127],
     "led": 16,
     "button": 0
 }

--- a/src/hardware/RX/Namimno VOYAGER 900.json
+++ b/src/hardware/RX/Namimno VOYAGER 900.json
@@ -13,7 +13,7 @@
     "power_max": 2,
     "power_default": 2,
     "power_control": 0,
-    "power_values": [8,12,15],
+    "power_values": [120,124,127],
     "button": 0,
     "led": 16
 }

--- a/src/hardware/TX/DIY 900 E19.json
+++ b/src/hardware/TX/DIY 900 E19.json
@@ -15,6 +15,6 @@
     "power_max": 6,
     "power_default": 2,
     "power_control": 0,
-    "power_values": [2,5,8,12,15],
+    "power_values": [114,117,120,124,127],
     "led": 27
 }

--- a/src/hardware/TX/DIY 900 RFM95.json
+++ b/src/hardware/TX/DIY 900 RFM95.json
@@ -15,6 +15,6 @@
     "power_max": 2,
     "power_default": 2,
     "power_control": 0,
-    "power_values": [8,12,15],
+    "power_values": [120,124,127],
     "led": 27
 }

--- a/src/hardware/TX/DIY 900 TTGO V1.json
+++ b/src/hardware/TX/DIY 900 TTGO V1.json
@@ -12,7 +12,7 @@
     "power_max": 2,
     "power_default": 2,
     "power_control": 0,
-    "power_values": [8,12,15],
+    "power_values": [120,124,127],
     "button": 0,
     "led": 2,
     "screen_rst": 16,

--- a/src/hardware/TX/DIY 900 TTGO V2.json
+++ b/src/hardware/TX/DIY 900 TTGO V2.json
@@ -12,7 +12,7 @@
     "power_max": 2,
     "power_default": 2,
     "power_control": 0,
-    "power_values": [8,12,15],
+    "power_values": [120,124,127],
     "screen_sck": 22,
     "screen_sda": 21,
     "screen_type": 1,

--- a/src/hardware/TX/Generic 900 Gemini.json
+++ b/src/hardware/TX/Generic 900 Gemini.json
@@ -19,13 +19,13 @@
     "power_txen": 14,
     "power_rxen_2": 9,
     "power_txen_2": 15,
-    
+
     "power_min": 0,
     "power_high": 2,
     "power_max": 2,
     "power_default": 2,
     "power_control": 0,
-    "power_values": [8,12,15],
+    "power_values": [120,124,127],
 
     "led_rgb": 22,
     "led_rgb_isgrb": true,

--- a/src/hardware/TX/Jumper T-20 900.json
+++ b/src/hardware/TX/Jumper T-20 900.json
@@ -15,5 +15,5 @@
     "power_max": 6,
     "power_default": 4,
     "power_control": 0,
-    "power_values": [0,3,15]
+    "power_values": [112,115,127]
 }

--- a/src/html/hardware.html
+++ b/src/html/hardware.html
@@ -174,7 +174,8 @@ td img.icon-pwm {
 							<option value='3'>via ESP DACWRITE</option>
 						</select>
 					</td><td>How the power level is set</td></tr>
-					<tr><td></td><td>Level Value(s)</td><td><input size='40' id='power_values' name='power_values' type='text' class='array'/></td><td>Comma-separated list of values that set the power output</td></tr>
+					<tr><td></td><td>Power Value(s)</td><td><input size='40' id='power_values' name='power_values' type='text' class='array'/></td><td>Comma-separated list of values that set the power output (if using a DAC these are the DAC values)</td></tr>
+					<tr><td></td><td>Secondary Power Value(s)</td><td><input size='40' id='power_values2' name='power_values2' type='text' class='array'/></td><td>Comma-separated list of values that set the power output (if using a DAC then these set the Semtech power output)</td></tr>
 
 					<tr><td colspan='2'><b>Radio Power Detection</td></tr>
 					<tr><td></td><td>PDET pin<img class="icon-analog"/></td><td><input size='3' id='power_pdet' name='power_pdet' type='text'/></td><td>Analog input (up to 1.1V) connected to 'power detect' pin on PA for adjustment of the power output</td></tr>

--- a/src/include/hardware.h
+++ b/src/include/hardware.h
@@ -47,6 +47,7 @@ typedef enum {
 
     HARDWARE_power_control,
     HARDWARE_power_values,
+    HARDWARE_power_values2,
 
     // Input
     HARDWARE_joystick,

--- a/src/include/target/DIY_900_RX_STM32.h
+++ b/src/include/target/DIY_900_RX_STM32.h
@@ -28,4 +28,4 @@
 #define MinPower                PWR_10mW
 #define MaxPower                PWR_50mW
 #define DefaultPower            PWR_50mW
-#define POWER_OUTPUT_VALUES     {8,12,15}
+#define POWER_OUTPUT_VALUES     {120,124,127}

--- a/src/include/target/DIY_900_RX_STM32_SX1272.h
+++ b/src/include/target/DIY_900_RX_STM32_SX1272.h
@@ -35,4 +35,4 @@
 #define MinPower                PWR_10mW
 #define MaxPower                PWR_50mW
 #define DefaultPower            PWR_50mW
-#define POWER_OUTPUT_VALUES     {8,12,15}
+#define POWER_OUTPUT_VALUES     {120,124,127}

--- a/src/include/target/DIY_900_TX_STM32_SX1272.h
+++ b/src/include/target/DIY_900_TX_STM32_SX1272.h
@@ -37,4 +37,4 @@
 #define MinPower                PWR_10mW
 #define MaxPower                PWR_50mW
 #define DefaultPower            PWR_50mW
-#define POWER_OUTPUT_VALUES     {8,12,15}
+#define POWER_OUTPUT_VALUES     {120,124,127}

--- a/src/include/target/Frsky_RX_R9M.h
+++ b/src/include/target/Frsky_RX_R9M.h
@@ -71,7 +71,7 @@ https://github.com/jaxxzer
     #define GPIO_PIN_BUTTON         PC13 // pullup e.g. LOW when pressed
 #endif
 
-#define POWER_OUTPUT_FIXED 15 //MAX power for 900 RXes
+#define POWER_OUTPUT_FIXED 127 //MAX power for 900 RXes
 // External pads
 // #define R9m_Ch1    PA8
 // #define R9m_Ch2    PA11

--- a/src/include/target/Frsky_TX_R9M_LITE.h
+++ b/src/include/target/Frsky_TX_R9M_LITE.h
@@ -31,4 +31,4 @@
 // Output Power
 #define MinPower                    PWR_10mW
 #define MaxPower                    PWR_50mW
-#define POWER_OUTPUT_VALUES         {8,11,15}
+#define POWER_OUTPUT_VALUES         {120,124,127}

--- a/src/include/target/NamimnoRC_VOYAGER_900_RX.h
+++ b/src/include/target/NamimnoRC_VOYAGER_900_RX.h
@@ -18,4 +18,4 @@
 #define GPIO_PIN_RCSIGNAL_TX    PA9
 
 // Output Power - default for SX127x
-#define POWER_OUTPUT_FIXED 15 //MAX power for 900 RXes
+#define POWER_OUTPUT_FIXED 127 //MAX power for 900 RXes

--- a/src/include/target/Unified_ESP32_TX.h
+++ b/src/include/target/Unified_ESP32_TX.h
@@ -88,6 +88,7 @@
 #define POWER_OUTPUT_DACWRITE (hardware_int(HARDWARE_power_control)==3)
 #define POWER_OUTPUT_FIXED -99
 #define POWER_OUTPUT_VALUES hardware_i16_array(HARDWARE_power_values)
+#define POWER_OUTPUT_VALUES2 hardware_i16_array(HARDWARE_power_values2)
 
 // Input
 #define HAS_FIVE_WAY_BUTTON

--- a/src/include/target/Unified_ESP_RX.h
+++ b/src/include/target/Unified_ESP_RX.h
@@ -87,6 +87,7 @@
 #define POWER_OUTPUT_DACWRITE (hardware_int(HARDWARE_power_control)==3)
 #define POWER_OUTPUT_FIXED -99
 #define POWER_OUTPUT_VALUES hardware_i16_array(HARDWARE_power_values)
+#define POWER_OUTPUT_VALUES2 hardware_i16_array(HARDWARE_power_values2)
 
 // Input
 #define GPIO_PIN_BUTTON hardware_pin(HARDWARE_button)

--- a/src/lib/OPTIONS/hardware.cpp
+++ b/src/lib/OPTIONS/hardware.cpp
@@ -60,6 +60,7 @@ static const struct {
     {HARDWARE_power_pdet_slope, "power_pdet_slope", FLOAT},
     {HARDWARE_power_control, "power_control", INT},
     {HARDWARE_power_values, "power_values", ARRAY},
+    {HARDWARE_power_values2, "power_values2", ARRAY},
     {HARDWARE_joystick, "joystick", INT},
     {HARDWARE_joystick_values, "joystick_values", ARRAY},
     {HARDWARE_five_way1, "five_way1", INT},

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -277,7 +277,18 @@ void POWERMGNT::setPower(PowerLevels_e Power)
     #if defined(PLATFORM_ESP32)
     if (POWER_OUTPUT_DACWRITE)
     {
-        Radio.SetOutputPower(0b0000);
+        if (POWER_OUTPUT_VALUES2 != nullptr)
+        {
+#if defined(RADIO_SX127X)
+            Radio.SetOutputPowerRaw(POWER_OUTPUT_VALUES2[Power - MinPower]);
+#else
+            Radio.SetOutputPower(POWER_OUTPUT_VALUES2[Power - MinPower]);
+#endif
+        }
+        else
+        {
+            Radio.SetOutputPower(0b0000);
+        }
         dacWrite(GPIO_PIN_RFamp_APC2, powerValues[Power - MinPower]);
     }
     else

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -262,32 +262,19 @@ void POWERMGNT::setPower(PowerLevels_e Power)
     }
 #if defined(POWER_OUTPUT_DAC)
     // DAC is used e.g. for R9M, ES915TX and Voyager
-    Radio.SetOutputPower(0b0000);
     int mV = isDomain868() ? powerValues868[Power - MinPower] :powerValues[Power - MinPower];
     TxDAC.setPower(mV);
 #elif defined(POWER_OUTPUT_ANALOG)
-    Radio.SetOutputPower(0b0000);
     //Set DACs PA5 & PA4
     analogWrite(GPIO_PIN_RFamp_APC1, 3350); //0-4095 2.7V
     analogWrite(GPIO_PIN_RFamp_APC2, powerValues[Power - MinPower]);
-#elif defined(POWER_OUTPUT_DACWRITE) && !defined(TARGET_UNIFIED_TX) && !defined(TARGET_UNIFIED_RX)
-    Radio.SetOutputPower(0b0000);
-    dacWrite(GPIO_PIN_RFamp_APC2, powerValues[Power - MinPower]);
 #else
     #if defined(PLATFORM_ESP32)
     if (POWER_OUTPUT_DACWRITE)
     {
         if (POWER_OUTPUT_VALUES2 != nullptr)
         {
-#if defined(RADIO_SX127X)
-            Radio.SetOutputPowerRaw(POWER_OUTPUT_VALUES2[Power - MinPower]);
-#else
             Radio.SetOutputPower(POWER_OUTPUT_VALUES2[Power - MinPower]);
-#endif
-        }
-        else
-        {
-            Radio.SetOutputPower(0b0000);
         }
         dacWrite(GPIO_PIN_RFamp_APC2, powerValues[Power - MinPower]);
     }

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -217,20 +217,34 @@ void SX127xDriver::SetSyncWord(uint8_t syncWord)
   currSyncWord = _syncWord;
 }
 
+void SX127xDriver::SetOutputPower(uint8_t Power)
+{
+  Power &= 0x0F;
+  if (OPT_USE_SX1276_RFO_HF)
+  {
+    SetOutputPowerRaw(SX127X_MAX_OUTPUT_POWER_RFO_HF | Power);
+  }
+  else
+  {
+    SetOutputPowerRaw(SX127X_MAX_OUTPUT_POWER | Power);
+  }
+}
+
 /***
  * @brief: Schedule an output power change after the next transmit
  * The radio must be in SX127x_OPMODE_STANDBY to change the power
  ***/
-void SX127xDriver::SetOutputPower(uint8_t Power)
+void SX127xDriver::SetOutputPowerRaw(uint8_t Power)
 {
   uint8_t pwrNew;
+  Power &= 0x7F;
   if (OPT_USE_SX1276_RFO_HF)
   {
-    pwrNew = SX127X_PA_SELECT_RFO | SX127X_MAX_OUTPUT_POWER_RFO_HF | Power;
+    pwrNew = SX127X_PA_SELECT_RFO | Power;
   }
   else
   {
-    pwrNew = SX127X_PA_SELECT_BOOST | SX127X_MAX_OUTPUT_POWER | Power;
+    pwrNew = SX127X_PA_SELECT_BOOST | Power;
   }
 
   if ((pwrPending == PWRPENDING_NONE && pwrCurrent != pwrNew) || pwrPending != pwrNew)
@@ -390,7 +404,7 @@ void ICACHE_RAM_ATTR SX127xDriver::TXnb(uint8_t * data, uint8_t size, SX12XX_Rad
   // }
 
   transmittingRadio = radioNumber;
-  
+
   SetMode(SX127x_OPMODE_STANDBY, SX12XX_Radio_All);
 
   if (radioNumber == SX12XX_Radio_NONE)

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -88,7 +88,7 @@ bool SX127xDriver::Begin()
   ConfigLoraDefaults();
   // Force the next power update, and use the defaults for RFO_HF or PA_BOOST
   pwrCurrent = PWRPENDING_NONE;
-  SetOutputPower(OPT_USE_SX1276_RFO_HF ? SX127X_MAX_OUTPUT_POWER_RFO_HF : SX127X_MAX_OUTPUT_POWER);
+  SetOutputPower(0);
   CommitOutputPower();
 
   return true;

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -224,7 +224,8 @@ void SX127xDriver::SetSyncWord(uint8_t syncWord)
 void SX127xDriver::SetOutputPower(uint8_t Power)
 {
   uint8_t pwrNew;
-  Power &= 0x7F;
+  Power &= SX127X_PA_POWER_MASK;
+
   if (OPT_USE_SX1276_RFO_HF)
   {
     pwrNew = SX127X_PA_SELECT_RFO | Power;

--- a/src/lib/SX127xDriver/SX127x.h
+++ b/src/lib/SX127xDriver/SX127x.h
@@ -39,7 +39,6 @@ public:
     void SetCRCMode(bool on); //false for off
     void SetSyncWord(uint8_t syncWord);
     void SetOutputPower(uint8_t Power);
-    void SetOutputPowerRaw(uint8_t Power);
     void SetPreambleLength(uint8_t PreambleLen);
     void SetSpreadingFactor(SX127x_SpreadingFactor sf);
     void SetRxTimeoutUs(uint32_t interval);
@@ -79,7 +78,7 @@ public:
 private:
     // constant used for no power change pending
     // must not be a valid power register value
-    static const uint8_t PWRPENDING_NONE = SX127X_MAX_OUTPUT_POWER_INVALID;
+    static const int16_t PWRPENDING_NONE = -1;
 
     SX127x_Bandwidth currBW;
     SX127x_SpreadingFactor currSF;
@@ -89,7 +88,7 @@ private:
     uint8_t currSyncWord;
     uint8_t currPreambleLen;
     uint8_t pwrCurrent;
-    uint8_t pwrPending;
+    int16_t pwrPending;
     uint8_t lowFrequencyMode;
 
     static void IsrCallback_1();

--- a/src/lib/SX127xDriver/SX127x.h
+++ b/src/lib/SX127xDriver/SX127x.h
@@ -39,6 +39,7 @@ public:
     void SetCRCMode(bool on); //false for off
     void SetSyncWord(uint8_t syncWord);
     void SetOutputPower(uint8_t Power);
+    void SetOutputPowerRaw(uint8_t Power);
     void SetPreambleLength(uint8_t PreambleLen);
     void SetSpreadingFactor(SX127x_SpreadingFactor sf);
     void SetRxTimeoutUs(uint32_t interval);

--- a/src/lib/SX127xDriver/SX127xRegs.h
+++ b/src/lib/SX127xDriver/SX127xRegs.h
@@ -125,9 +125,6 @@ typedef enum
 // SX127X_REG_PA_CONFIG
 #define SX127X_PA_SELECT_RFO 0b00000000    //  7     7     RFO pin output, power limited to +14 dBm
 #define SX127X_PA_SELECT_BOOST 0b10000000  //  7     7     PA_BOOST pin output, power limited to +20 dBm
-#define SX127X_OUTPUT_POWER 0b00001111     //  3     0     output power: P_out = 17 - (15 - OUTPUT_POWER) [dBm] for PA_SELECT_BOOST
-#define SX127X_MAX_OUTPUT_POWER_RFO_HF 0b00000000 //       Max output power when using RFO_HF
-#define SX127X_MAX_OUTPUT_POWER 0b01110000 //              Enable max output power
 // SX127X_REG_OCP
 #define SX127X_OCP_OFF 0b00000000   //  5     5     PA overload current protection disabled
 #define SX127X_OCP_ON 0b00100000    //  5     5     PA overload current protection enabled

--- a/src/lib/SX127xDriver/SX127xRegs.h
+++ b/src/lib/SX127xDriver/SX127xRegs.h
@@ -125,6 +125,7 @@ typedef enum
 // SX127X_REG_PA_CONFIG
 #define SX127X_PA_SELECT_RFO 0b00000000    //  7     7     RFO pin output, power limited to +14 dBm
 #define SX127X_PA_SELECT_BOOST 0b10000000  //  7     7     PA_BOOST pin output, power limited to +20 dBm
+#define SX127X_PA_POWER_MASK 0b01111111    //  6     0     PA MAX_POWER and OUTPUT_POWER combined bit mask
 // SX127X_REG_OCP
 #define SX127X_OCP_OFF 0b00000000   //  5     5     PA overload current protection disabled
 #define SX127X_OCP_ON 0b00100000    //  5     5     PA overload current protection enabled

--- a/src/lib/SX127xDriver/SX127xRegs.h
+++ b/src/lib/SX127xDriver/SX127xRegs.h
@@ -128,7 +128,6 @@ typedef enum
 #define SX127X_OUTPUT_POWER 0b00001111     //  3     0     output power: P_out = 17 - (15 - OUTPUT_POWER) [dBm] for PA_SELECT_BOOST
 #define SX127X_MAX_OUTPUT_POWER_RFO_HF 0b00000000 //       Max output power when using RFO_HF
 #define SX127X_MAX_OUTPUT_POWER 0b01110000 //              Enable max output power
-#define SX127X_MAX_OUTPUT_POWER_INVALID 0b00010000 //      A value for the MaxPower field that is not used by ExpressLRS
 // SX127X_REG_OCP
 #define SX127X_OCP_OFF 0b00000000   //  5     5     PA overload current protection disabled
 #define SX127X_OCP_ON 0b00100000    //  5     5     PA overload current protection enabled


### PR DESCRIPTION
This allows us to not only control the output power of the PA by way of the DAC pin, but also to control the input power into the PA by controlling the output power of the Semtech chip simultaneously.

Theres a new hardware element for this, `power_values2` which is also an array which has a one-to-one relationship to the the `power_values` element. The values in this table are used to control the `MaxPower` and `OutputPower` bits for the SX127x and the `OutputPower` for the SX128x chipsets.

EDIT: After discussions, when in non-DAC mode, `power_values` array has the `MaxPower` & `OutputPower` for SX127x as well. This simplifies the code at the expense of a change to a few target files. 