### PR TITLE
Add LinkStats to ESPNOW MSP Backpack Telemetry

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -191,35 +191,17 @@ void CRSF::flush_port_input(void)
     }
 }
 
-void ICACHE_RAM_ATTR CRSF::sendLinkStatisticsToTX()
+void ICACHE_RAM_ATTR CRSF::makeLinkStatisticsPacket(uint8_t buffer[LinkStatisticsFrameLength + 4])
 {
-    if (!CRSF::CRSFstate)
+    buffer[0] = CRSF_ADDRESS_RADIO_TRANSMITTER;
+    buffer[1] = LinkStatisticsFrameLength + 2;
+    buffer[2] = CRSF_FRAMETYPE_LINK_STATISTICS;
+    for (uint8_t i = 0; i < LinkStatisticsFrameLength; i++)
     {
-        return;
+        buffer[i + 3] = ((uint8_t *)&LinkStatistics)[i];
     }
-
-    constexpr uint8_t outBuffer[4] = {
-        LinkStatisticsFrameLength + 4,
-        CRSF_ADDRESS_RADIO_TRANSMITTER,
-        LinkStatisticsFrameLength + 2,
-        CRSF_FRAMETYPE_LINK_STATISTICS
-    };
-
-    uint8_t crc = crsf_crc.calc(outBuffer[3]);
-    crc = crsf_crc.calc((byte *)&LinkStatistics, LinkStatisticsFrameLength, crc);
-
-#ifdef PLATFORM_ESP32
-    portENTER_CRITICAL(&FIFOmux);
-#endif
-    if (SerialOutFIFO.ensure(outBuffer[0] + 1))
-    {
-        SerialOutFIFO.pushBytes(outBuffer, sizeof(outBuffer));
-        SerialOutFIFO.pushBytes((byte *)&LinkStatistics, LinkStatisticsFrameLength);
-        SerialOutFIFO.push(crc);
-    }
-#ifdef PLATFORM_ESP32
-    portEXIT_CRITICAL(&FIFOmux);
-#endif
+    uint8_t crc = crsf_crc.calc(buffer[2]);
+    buffer[LinkStatisticsFrameLength + 3] = crsf_crc.calc((byte *)&LinkStatistics, LinkStatisticsFrameLength, crc);
 }
 
 /**

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -62,7 +62,7 @@ public:
 
     #ifdef CRSF_TX_MODULE
     static bool IsArmed() { return CRSF_to_BIT(ChannelData[4]); } // AUX1
-    static void ICACHE_RAM_ATTR sendLinkStatisticsToTX();
+    static void ICACHE_RAM_ATTR makeLinkStatisticsPacket(uint8_t buffer[LinkStatisticsFrameLength + 4]);
     static void ICACHE_RAM_ATTR sendTelemetryToTX(uint8_t *data);
 
     static void packetQueueExtended(uint8_t type, void *data, uint8_t len);

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1358,7 +1358,11 @@ void loop()
    * is elapsed. This keeps handset happy dispite of the telemetry ratio */
   if ((connectionState == connected) && (LastTLMpacketRecvMillis != 0) &&
       (now >= (uint32_t)(firmwareOptions.tlm_report_interval + TLMpacketReported))) {
-    crsf.sendLinkStatisticsToTX();
+    // 3 byte header + 1 byte CRC
+    uint8_t linkStatisticsFrame[LinkStatisticsFrameLength + 4];
+    crsf.makeLinkStatisticsPacket(linkStatisticsFrame);
+    crsf.sendTelemetryToTX(linkStatisticsFrame);
+    crsfTelemToMSPOut(linkStatisticsFrame);
     TLMpacketReported = now;
   }
 


### PR DESCRIPTION
This PR accomplishes one thing when stacked on top of https://github.com/ExpressLRS/ExpressLRS/pull/2370: Include linkstats in the ESPNOW telemetry frames sent for trackers, etc. This permits fancy stuff like sending telemetry to the TBS Fusion OSD so raw PWM models such as spec wings, etc, can have RSSI, LQ, and battery OSD. There's a PR on the Backpack repo following this PR which accomplishes just that.