### PR TITLE
Allow binary flash of DUPLETX_ESP

### DIFF
--- a/src/python/binary_flash.py
+++ b/src/python/binary_flash.py
@@ -180,7 +180,12 @@ def upload(options: FirmwareOptions, args):
             elif args.flash == UploadMethod.stlink:      # untested
                 return upload_stm32_stlink(args, options)
     else:
-        if options.mcuType == MCUType.ESP32:
+        if options.mcuType == MCUType.ESP8266:
+            if args.flash == UploadMethod.uart:
+                return upload_esp8266_uart(args)
+            elif args.flash == UploadMethod.wifi:
+                return upload_wifi(args, options, ['elrs_tx', 'elrs_tx.local'], False)
+        elif options.mcuType == MCUType.ESP32:
             if args.flash == UploadMethod.edgetx:
                 return upload_esp32_etx(args)
             elif args.flash == UploadMethod.uart:


### PR DESCRIPTION
ESP-based RX as TX (DUPLETX_ESP) can't be flashed with the Configurator due to the binary_flasher not supported ESP-based TX. 
![image](https://github.com/ExpressLRS/ExpressLRS/assets/677183/51a7cdeb-6b46-481c-9c84-daddb31d6c63)

This PR enables the upload method for firmware!