### PR TITLE
hadling div/0 condition in `fuzzy_snr()`

### DIFF
--- a/src/lib/SX12xxDriverCommon/SX12xxDriverCommon.h
+++ b/src/lib/SX12xxDriverCommon/SX12xxDriverCommon.h
@@ -98,6 +98,11 @@ protected:
      */
     int8_t fuzzy_snr(int16_t snr1, int16_t snr2, int16_t threshold)
     {
+        if (threshold == 0)
+        {
+            return (int8_t)(snr1 < snr2 ? snr1 : snr2);
+        }
+
         int16_t diff = (int16_t)abs(snr1 - snr2) << 4;
         int16_t lower_value = (int16_t)(snr1 < snr2 ? snr1 : snr2) << 4;
         int16_t average_value = ((int16_t)snr1 + snr2) << 3;
@@ -106,15 +111,15 @@ protected:
 
         if (diff < threshold_scaled)
         {
-            return lower_value >> 4;
+            return (int8_t)lower_value >> 4;
         }
         else if (diff > threshold_scaled * 2)
         {
-            return average_value >> 4;
+            return (int8_t)average_value >> 4;
         }
         else
         {
-            int16_t transition_value = (diff - threshold_scaled) / threshold;
+            int16_t transition_value = (diff - threshold_scaled) / threshold_scaled;
             return (int8_t)((lower_value * (16 - transition_value) + average_value * transition_value) >> 8);
         }
     }


### PR DESCRIPTION
When in FLRC mode, threshold for `fuzzy_snr()` is given zero, which caused div/0 cases.

This PR handles this condition, + a few more mistaken condition fix.