### PR TITLE
Remove the UART_INVERTED option

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -74,9 +74,6 @@
 							<input size='5' id='tlm-interval' name='tlm-interval' type='text'/>
 							<label>TLM report interval (ms)</label>
 						</div>
-						<div class="mui-checkbox">
-							<label><input id='uart-inverted' name='uart-inverted' type='checkbox'/>UART inverted</label>
-						</div>
 						<div class="mui-textfield">
 							<input size='3' id='fan-runtime' name='fan-runtime' type='text'/>
 							<label>Fan runtime (s)</label>

--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -85,7 +85,7 @@ uint32_t CRSF::TxToHandsetBauds[] = {400000, 115200, 5250000, 3750000, 1870000, 
 uint8_t CRSF::UARTcurrentBaudIdx = 0;
 uint32_t CRSF::UARTrequestedBaud = 5250000;
 #if defined(PLATFORM_ESP32)
-bool CRSF::UARTinverted = false;
+bool CRSF::UARTinverted = true; // default to start looking for an inverted signal
 #endif
 
 bool CRSF::CRSFstate = false;
@@ -104,7 +104,10 @@ void CRSF::Begin()
 
 #if defined(PLATFORM_ESP32)
     portDISABLE_INTERRUPTS();
-    UARTinverted = firmwareOptions.uart_inverted;
+    if (GPIO_PIN_RCSIGNAL_RX != GPIO_PIN_RCSIGNAL_TX)
+    {
+        UARTinverted = false; // on a full UART we will start uninverted checking first
+    }
     CRSF::Port.begin(TxToHandsetBauds[UARTcurrentBaudIdx], SERIAL_8N1,
                      GPIO_PIN_RCSIGNAL_RX, GPIO_PIN_RCSIGNAL_TX,
                      false, 500);

--- a/src/lib/OPTIONS/options.cpp
+++ b/src/lib/OPTIONS/options.cpp
@@ -111,11 +111,7 @@ __attribute__ ((used)) static firmware_options_t flashedOptions = {
 #else
     .fan_min_runtime = 30,
 #endif
-#if defined(UART_INVERTED) // Only on ESP32
-    .uart_inverted = true,
-#else
-    .uart_inverted = false,
-#endif
+    ._unused1 = false,
 #if defined(UNLOCK_HIGHER_POWER)
     .unlock_higher_power = true,
 #else
@@ -215,7 +211,6 @@ void saveOptions(Stream &stream, bool customised)
     #if defined(TARGET_UNIFIED_TX)
     doc["tlm-interval"] = firmwareOptions.tlm_report_interval;
     doc["fan-runtime"] = firmwareOptions.fan_min_runtime;
-    doc["uart-inverted"] = firmwareOptions.uart_inverted;
     doc["unlock-higher-power"] = firmwareOptions.unlock_higher_power;
     doc["airport-uart-baud"] = firmwareOptions.uart_baud;
     #else
@@ -317,7 +312,6 @@ static void options_LoadFromFlashOrFile(EspFlashStream &strmFlash)
     #if defined(TARGET_UNIFIED_TX)
     firmwareOptions.tlm_report_interval = doc["tlm-interval"] | 240U;
     firmwareOptions.fan_min_runtime = doc["fan-runtime"] | 30U;
-    firmwareOptions.uart_inverted = doc["uart-inverted"] | true;
     firmwareOptions.unlock_higher_power = doc["unlock-higher-power"] | false;
     #if defined(USE_AIRPORT_AT_BAUD)
     firmwareOptions.uart_baud = doc["airport-uart-baud"] | USE_AIRPORT_AT_BAUD;

--- a/src/lib/OPTIONS/options.h
+++ b/src/lib/OPTIONS/options.h
@@ -39,7 +39,7 @@ typedef struct _options {
 #if defined(TARGET_TX) || defined(UNIT_TEST)
     uint32_t    tlm_report_interval;
     uint32_t    fan_min_runtime;
-    bool        uart_inverted:1;
+    bool        _unused1:1;
     bool        unlock_higher_power:1;
     bool        is_airport:1;
 #if defined(GPIO_PIN_BUZZER)

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -859,10 +859,6 @@ static void startMDNS()
   {
     options += " -DUNLOCK_HIGHER_POWER";
   }
-  if (firmwareOptions.uart_inverted)
-  {
-    options += " -DUART_INVERTED";
-  }
   options += " -DTLM_REPORT_INTERVAL_MS=" + String(firmwareOptions.tlm_report_interval);
   options += " -DFAN_MIN_RUNTIME=" + String(firmwareOptions.fan_min_runtime);
   #endif

--- a/src/python/binary_configurator.py
+++ b/src/python/binary_configurator.py
@@ -114,9 +114,7 @@ def patch_tx_params(mm, pos, args, options):
     pos = write32(mm, pos, args.tlm_report)
     pos = write32(mm, pos, args.fan_min_runtime)
     val = mm[pos]
-    if args.uart_inverted != None:
-        val &= ~1
-        val |= args.uart_inverted
+    val &= ~1   # unused1 - ex uart_inverted
     if args.unlock_higher_power != None:
         val &= ~2
         val |= (args.unlock_higher_power << 1)
@@ -226,8 +224,6 @@ def patch_unified(args, options):
         json_flags['unlock-higher-power'] = args.unlock_higher_power
     if args.fan_min_runtime is not None:
         json_flags['fan-runtime'] = args.fan_min_runtime
-    if args.uart_inverted is not None:
-        json_flags['uart-inverted'] = args.uart_inverted
 
     if args.airport_baud is not None:
         json_flags['is-airport'] = True
@@ -331,9 +327,6 @@ def main():
     # TX Params
     parser.add_argument('--tlm-report', type=int, const=240, nargs='?', action='store', help='The interval (in milliseconds) between telemetry packets')
     parser.add_argument('--fan-min-runtime', type=int, const=30, nargs='?', action='store', help='The minimum amount of time the fan should run for (in seconds) if it turns on')
-    parser.add_argument('--uart-inverted', dest='uart_inverted', action='store_true', help='For most OpenTX based radios, this is the default')
-    parser.add_argument('--no-uart-inverted', dest='uart_inverted', action='store_false', help='If your radio is T8SG V2 or you use Deviation firmware set this flag.')
-    parser.set_defaults(uart_inverted=None)
     parser.add_argument('--unlock-higher-power', dest='unlock_higher_power', action='store_true', help='DANGER: Unlocks the higher power on modules that do not normally have sufficient cooling e.g. 1W on R9M')
     parser.add_argument('--no-unlock-higher-power', dest='unlock_higher_power', action='store_false', help='Set the max power level at the safe maximum level')
     parser.set_defaults(unlock_higher_power=None)

--- a/src/python/binary_configurator.py
+++ b/src/python/binary_configurator.py
@@ -306,6 +306,10 @@ class writeable_dir(argparse.Action):
         else:
             raise argparse.ArgumentTypeError("readable_dir:{0} is not a writeable dir".format(prospective_dir))
 
+class deprecate_action(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        delattr(namespace, self.dest)
+
 def main():
     parser = argparse.ArgumentParser(description="Configure Binary Firmware")
     # firmware/targets directory
@@ -347,6 +351,9 @@ def main():
     parser.add_argument("--confirm", action='store_true', default=False, help="Confirm upload if a mismatched target was previously uploaded")
     parser.add_argument("--tx", action='store_true', default=False, help="Flash a TX module, RX if not specified")
     parser.add_argument("--lbt", action='store_true', default=False, help="Use LBT firmware, default is FCC (onl for 2.4GHz firmware)")
+    # Deprecated options, left for backward compatibility
+    parser.add_argument('--uart-inverted', action=deprecate_action, nargs=0, help='Deprecated')
+    parser.add_argument('--no-uart-inverted', action=deprecate_action, nargs=0, help='Deprecated')
 
     #
     # Firmware file to patch/configure

--- a/src/python/build_flags.py
+++ b/src/python/build_flags.py
@@ -63,8 +63,6 @@ def process_json_flag(define):
                 json_flags['rcvr-uart-baud'] = int(dequote(parts.group(2)))
             else:
                 json_flags['airport-uart-baud'] = int(dequote(parts.group(2)))
-    if define == "-DUART_INVERTED" and not isRX:
-        json_flags['uart-inverted'] = True
     if define == "-DUNLOCK_HIGHER_POWER"  and not isRX:
         json_flags['unlock-higher-power'] = True
     if define == "-DLOCK_ON_FIRST_CONNECTION" and isRX:

--- a/src/user_defines.txt
+++ b/src/user_defines.txt
@@ -41,10 +41,6 @@
 
 ### COMPATIBILITY OPTIONS: ###
 
-# Invert the TX/RX half-duplex pin in the transmitter code. Handset external
-# modules are almost all inverted. ESP32/8286 targets only
--DUART_INVERTED
-
 # Use a custom baud rate on the receiver for a KISS v1 FC (which runs at 400000) or any other oddball baud
 # If not defined, will default to 420000
 #-DRCVR_UART_BAUD=400000


### PR DESCRIPTION
It's not actually used any more. It just sets whether the (ESP32) TX starts in inverted mode or not!
