### PR TITLE
Add ESP32-S3 support

### DIFF
--- a/src/include/target/Unified_ESP_RX.h
+++ b/src/include/target/Unified_ESP_RX.h
@@ -127,6 +127,7 @@
 #define ANALOG_VBAT_OFFSET hardware_int(HARDWARE_vbat_offset)
 #define ANALOG_VBAT_SCALE hardware_int(HARDWARE_vbat_scale)
 
+#if defined(PLATFORM_ESP32)
 // VTX
 #define HAS_VTX_SPI
 #define HAS_MSP_VTX
@@ -140,3 +141,4 @@
 #define GPIO_PIN_SPI_VTX_SCK hardware_pin(HARDWARE_vtx_sck)
 #define VPD_VALUES_25MW hardware_u16_array(HARDWARE_vtx_amp_vpd_25mW)
 #define VPD_VALUES_100MW hardware_u16_array(HARDWARE_vtx_amp_vpd_100mW)
+#endif

--- a/src/lib/AnalogVbat/devAnalogVbat.cpp
+++ b/src/lib/AnalogVbat/devAnalogVbat.cpp
@@ -43,7 +43,7 @@ static int start()
     }
     vbatUpdateScale = 1;
 #if defined(PLATFORM_ESP32)
-    analogSetWidth(12);
+    analogReadResolution(12);
 
     int atten = hardware_int(HARDWARE_vbat_atten);
     if (atten != -1)

--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -754,13 +754,60 @@ void ICACHE_RAM_ATTR CRSF::adjustMaxPacketSize()
     DBGLN("Adjusted max packet size %u-%u", maxPacketBytes, maxPeriodBytes);
 }
 
-#if defined(PLATFORM_ESP32)
+#if defined(PLATFORM_ESP32_S3)
 uint32_t CRSF::autobaud()
 {
     static enum { INIT, MEASURED, INVERTED } state;
 
-    uint32_t *autobaud_reg = (uint32_t *)UART_AUTOBAUD_REG(0);
-    uint32_t *rxd_cnt_reg = (uint32_t *)UART_RXD_CNT_REG(0);
+    if (state == MEASURED)
+    {
+        UARTinverted = !UARTinverted;
+        state = INVERTED;
+        return UARTrequestedBaud;
+    }
+    else if (state == INVERTED)
+    {
+        UARTinverted = !UARTinverted;
+        state = INIT;
+    }
+
+    if (REG_GET_BIT(UART_CONF0_REG(0), UART_AUTOBAUD_EN) == 0)
+    {
+        REG_WRITE(UART_RX_FILT_REG(0), (4 << UART_GLITCH_FILT_S) | UART_GLITCH_FILT_EN); // enable, glitch filter 4
+        REG_WRITE(UART_LOWPULSE_REG(0), 4095); // reset register to max value
+        REG_WRITE(UART_HIGHPULSE_REG(0), 4095); // reset register to max value
+        REG_SET_BIT(UART_CONF0_REG(0), UART_AUTOBAUD_EN); // enable autobaud
+        return 400000;
+    }
+    else if (REG_GET_BIT(UART_CONF0_REG(0), UART_AUTOBAUD_EN) && REG_READ(UART_RXD_CNT_REG(0)) < 300)
+    {
+        return 400000;
+    }
+
+    state = MEASURED;
+
+    uint32_t low_period  = REG_READ(UART_LOWPULSE_REG(0));
+    uint32_t high_period = REG_READ(UART_HIGHPULSE_REG(0));
+    REG_CLR_BIT(UART_CONF0_REG(0), UART_AUTOBAUD_EN); // disable autobaud
+    REG_CLR_BIT(UART_RX_FILT_REG(0), UART_GLITCH_FILT_EN); // disable glitch filtering
+
+    DBGLN("autobaud: low %d, high %d", low_period, high_period);
+    // According to the tecnnical reference
+    int32_t calulatedBaud = UART_CLK_FREQ / (low_period + high_period + 2);
+    int32_t bestBaud = (int32_t)TxToHandsetBauds[0];
+    for(int i=0 ; i<ARRAY_SIZE(TxToHandsetBauds) ; i++)
+    {
+        if (abs(calulatedBaud - bestBaud) > abs(calulatedBaud - (int32_t)TxToHandsetBauds[i]))
+        {
+            bestBaud = (int32_t)TxToHandsetBauds[i];
+        }
+    }
+    return bestBaud;
+}
+#elif defined(PLATFORM_ESP32)
+uint32_t CRSF::autobaud()
+{
+    static enum { INIT, MEASURED, INVERTED } state;
 
     if (state == MEASURED) {
         UARTinverted = !UARTinverted;
@@ -771,17 +818,17 @@ uint32_t CRSF::autobaud()
         state = INIT;
     }
 
-    if ((*autobaud_reg & 1) == 0) {
-        *autobaud_reg = (4 << 8) | 1;    // enable, glitch filter 4
+    if (REG_GET_BIT(UART_AUTOBAUD_REG(0), UART_AUTOBAUD_EN) == 0) {
+        REG_WRITE(UART_AUTOBAUD_REG(0), 4 << UART_GLITCH_FILT_S | UART_AUTOBAUD_EN);    // enable, glitch filter 4
         return 400000;
-    } else if ((*autobaud_reg & 1) && (*rxd_cnt_reg < 300))
+    } else if (REG_GET_BIT(UART_AUTOBAUD_REG(0), UART_AUTOBAUD_EN) && REG_READ(UART_RXD_CNT_REG(0)) < 300)
         return 400000;
 
     state = MEASURED;
 
-    uint32_t low_period  = *(uint32_t *)UART_LOWPULSE_REG(0);
-    uint32_t high_period = *(uint32_t *)UART_HIGHPULSE_REG(0);
-    *autobaud_reg = (4 << 8) | 0;
+    uint32_t low_period  = REG_READ(UART_LOWPULSE_REG(0));
+    uint32_t high_period = REG_READ(UART_HIGHPULSE_REG(0));
+    REG_CLR_BIT(UART_AUTOBAUD_REG(0), UART_AUTOBAUD_EN);   // disable autobaud
 
     DBGLN("autobaud: low %d, high %d", low_period, high_period);
     // sample code at https://github.com/espressif/esp-idf/issues/3336

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -1,4 +1,5 @@
 #include "targets.h"
+#include "logging.h"
 #include "POWERMGNT.h"
 
 uint8_t powerToCrsfPower(PowerLevels_e Power)
@@ -286,7 +287,11 @@ void POWERMGNT::setPower(PowerLevels_e Power)
         {
             Radio.SetOutputPower(POWER_OUTPUT_VALUES2[Power - MinPower]);
         }
+        #if defined(PLATFORM_ESP32_S3)
+        ERRLN("ESP32-S3 does not have a DAC");
+        #else
         dacWrite(GPIO_PIN_RFamp_APC2, powerValues[Power - MinPower]);
+        #endif
     }
     else
     #endif

--- a/src/lib/SPIEx/SPIEx.cpp
+++ b/src/lib/SPIEx/SPIEx.cpp
@@ -8,25 +8,32 @@ void ICACHE_RAM_ATTR SPIExClass::_transfer(uint8_t cs_mask, uint8_t *data, uint3
 {
 #if defined(PLATFORM_ESP32)
     spi_dev_t *spi = *(reinterpret_cast<spi_dev_t**>(bus()));
-
     // wait for SPI to become non-busy
     while(spi->cmd.usr) {}
 
-    // Set the CS pins which we want crontrolled by the SPI module for this operation
+    // Set the CS pins which we want controlled by the SPI module for this operation
     spiDisableSSPins(SPIEx.bus(), ~cs_mask);
     spiEnableSSPins(SPIEx.bus(), cs_mask);
 
+#if defined(PLATFORM_ESP32_S3)
+    spi->ms_dlen.ms_data_bitlen = (size*8)-1;
+#else
     spi->mosi_dlen.usr_mosi_dbitlen = ((size * 8) - 1);
     spi->miso_dlen.usr_miso_dbitlen = ((size * 8) - 1);
+#endif
 
     // write the data to the SPI FIFO
     const uint32_t words = (size + 3) / 4;
-    uint32_t * const wordsBuf = reinterpret_cast<uint32_t *>(data);
+    auto * const wordsBuf = reinterpret_cast<uint32_t *>(data);
     for(int i=0; i<words; i++)
     {
         spi->data_buf[i] = wordsBuf[i]; //copy buffer to spi fifo
     }
 
+#if defined(PLATFORM_ESP32_S3)
+    spi->cmd.update = 1;
+    while (spi->cmd.update);
+#endif
     // start the SPI module
     spi->cmd.usr = 1;
 

--- a/src/lib/VTXSPI/devVTXSPI.cpp
+++ b/src/lib/VTXSPI/devVTXSPI.cpp
@@ -273,13 +273,12 @@ static void initialize()
     {
         if (GPIO_PIN_SPI_VTX_SCK != UNDEF_PIN && GPIO_PIN_SPI_VTX_SCK != GPIO_PIN_SCK)
         {
-            vtxSPI = new SPIClass();
-            #if defined(PLATFORM_ESP32)
-            vtxSPI->begin(GPIO_PIN_SPI_VTX_SCK, GPIO_PIN_SPI_VTX_MISO, GPIO_PIN_SPI_VTX_MOSI, GPIO_PIN_SPI_VTX_NSS);
+            #if defined(PLATFORM_ESP32_S3)
+            vtxSPI = new SPIClass(FSPI);
             #else
-            vtxSPI->pins(GPIO_PIN_SPI_VTX_SCK, GPIO_PIN_SPI_VTX_MISO, GPIO_PIN_SPI_VTX_MOSI, GPIO_PIN_SPI_VTX_NSS);
-            vtxSPI->begin();
+            vtxSPI = new SPIClass(VSPI);
             #endif
+            vtxSPI->begin(GPIO_PIN_SPI_VTX_SCK, GPIO_PIN_SPI_VTX_MISO, GPIO_PIN_SPI_VTX_MOSI, GPIO_PIN_SPI_VTX_NSS);
             vtxSPI->setHwCs(true);
             vtxSPI->setBitOrder(LSBFIRST);
         }

--- a/src/lib/VTXSPI/devVTXSPI.cpp
+++ b/src/lib/VTXSPI/devVTXSPI.cpp
@@ -7,6 +7,7 @@
 #include "hwTimer.h"
 #include "logging.h"
 #include <SPI.h>
+#include "PWM.h"
 
 #define SYNTHESIZER_REGISTER_A                  0x00
 #define SYNTHESIZER_REGISTER_B                  0x01
@@ -41,7 +42,7 @@
 #define BUF_PACKET_SIZE                         4 // 25b packet in 4 bytes
 
 #if defined(PLATFORM_ESP32)
-constexpr uint8_t rfAmpPwmChannel = 0;
+pwm_channel_t rfAmpPwmChannel = -1;
 #endif
 
 uint16_t vtxSPIFrequency = 6000;
@@ -140,14 +141,16 @@ static void RfAmpVrefOff()
 
 static void setPWM()
 {
-#if defined(PLATFORM_ESP32)
+#if defined(PLATFORM_ESP32_S3)
+    PWM.setDuty(rfAmpPwmChannel, vtxSPIPWM * 1000 / 4096);
+#elif defined(PLATFORM_ESP32)
     if (GPIO_PIN_RF_AMP_PWM == 25 || GPIO_PIN_RF_AMP_PWM == 26)
     {
         dacWrite(GPIO_PIN_RF_AMP_PWM, vtxSPIPWM >> 4);
     }
     else
     {
-        ledcWrite(rfAmpPwmChannel, vtxSPIPWM);
+        PWM.setDuty(rfAmpPwmChannel, vtxSPIPWM * 1000 / 4096);
     }
 #else
     analogWrite(GPIO_PIN_RF_AMP_PWM, vtxSPIPWM);
@@ -290,11 +293,9 @@ static void initialize()
         pinMode(GPIO_PIN_RF_AMP_VREF, OUTPUT);
         digitalWrite(GPIO_PIN_RF_AMP_VREF, LOW);
 
-        #if defined(PLATFORM_ESP8266)
-            pinMode(GPIO_PIN_RF_AMP_PWM, OUTPUT);
-            analogWriteFreq(10000); // 10kHz
-            analogWriteResolution(12); // 0 - 4095
-        #else
+        #if defined(PLATFORM_ESP32_S3)
+            rfAmpPwmChannel = PWM.allocate(GPIO_PIN_RF_AMP_PWM, 10000);
+        #elif defined(PLATFORM_ESP32)
             // If using a DAC pin then adjust min/max and initial value
             if (GPIO_PIN_RF_AMP_PWM == 25 || GPIO_PIN_RF_AMP_PWM == 26)
             {
@@ -304,9 +305,12 @@ static void initialize()
             }
             else
             {
-                ledcSetup(rfAmpPwmChannel, 10000, 12); // 12 bit 10khz
-                ledcAttachPin(GPIO_PIN_RF_AMP_PWM, rfAmpPwmChannel);
+                rfAmpPwmChannel = PWM.allocate(GPIO_PIN_RF_AMP_PWM, 10000);
             }
+        #else
+            pinMode(GPIO_PIN_RF_AMP_PWM, OUTPUT);
+            analogWriteFreq(10000); // 10kHz
+            analogWriteResolution(12); // 0 - 4095
         #endif
         setPWM();
 

--- a/src/lib/logging/logging.h
+++ b/src/lib/logging/logging.h
@@ -23,7 +23,11 @@
 
 #if defined(TARGET_TX)
 extern Stream *TxBackpack;
+#if defined(PLATFORM_ESP32_S3)
+#define LOGGING_UART (Serial)
+#else
 #define LOGGING_UART (*TxBackpack)
+#endif
 #else
 extern Stream *SerialLogger;
 #define LOGGING_UART (*SerialLogger)

--- a/src/python/UnifiedConfiguration.py
+++ b/src/python/UnifiedConfiguration.py
@@ -117,7 +117,13 @@ def appendConfiguration(source, target, env):
         moduletype = 'tx' if '_TX_' in target_name else 'rx'
         frequency = '2400' if '_2400_' in target_name else '900'
 
-    platform = 'esp32' if env.get('PIOPLATFORM', '') in ['espressif32'] else 'esp8285'
+    if env.get('PIOPLATFORM', '') == 'espressif32':
+        platform = 'esp32'
+        if 'esp32-s3' in env.get('BOARD', ''):
+            platform = 'esp32-s3'
+    else:
+        platform = 'esp8285'
+    print(platform)
 
     defines = json.JSONEncoder().encode(env['OPTIONS_JSON'])
 

--- a/src/python/binary_configurator.py
+++ b/src/python/binary_configurator.py
@@ -388,7 +388,7 @@ def main():
         options = FirmwareOptions(
             False if config['platform'] == 'stm32' else True,
             True if 'features' in config and 'buzzer' in config['features'] else False,
-            MCUType.STM32 if config['platform'] == 'stm32' else MCUType.ESP32 if config['platform'] == 'esp32' else MCUType.ESP8266,
+            MCUType.STM32 if config['platform'] == 'stm32' else MCUType.ESP32 if config['platform'].startswith('esp32') else MCUType.ESP8266,
             DeviceType.RX if '.rx_' in args.target else DeviceType.TX,
             RadioType.SX127X if '_900.' in args.target else RadioType.SX1280,
             config['lua_name'] if 'lua_name' in config else '',

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1172,8 +1172,13 @@ static void setupSerial()
     {
         // For PWM receivers with no serial pins defined, only turn on the Serial port if logging is on
         #if defined(DEBUG_LOG)
+        #if defined(PLATFORM_ESP32_S3)
+        USBSerial.begin(serialBaud);
+        SerialLogger = &USBSerial;
+        #else
         Serial.begin(serialBaud);
         SerialLogger = &Serial;
+        #endif
         #else
         SerialLogger = new NullStream();
         #endif

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1274,7 +1274,12 @@ static void setupSerial()
     {
         serialIO = new SerialCRSF(SERIAL_PROTOCOL_TX, SERIAL_PROTOCOL_RX);
     }
+#if defined(PLATFORM_ESP32_S3)
+    USBSerial.begin(460800);
+    SerialLogger = &USBSerial;
+#else
     SerialLogger = &Serial;
+#endif
 }
 
 static void serialShutdown()

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1172,7 +1172,8 @@ static void setupSerial()
     {
         // For PWM receivers with no serial pins defined, only turn on the Serial port if logging is on
         #if defined(DEBUG_LOG)
-        #if defined(PLATFORM_ESP32_S3)
+        #if defined(PLATFORM_ESP32_S3) && !defined(ESP32_S3_USB_JTAG_ENABLED)
+        // Requires pull-down on GPIO3.  If GPIO3 has a pull-up (for JTAG) this doesn't work.
         USBSerial.begin(serialBaud);
         SerialLogger = &USBSerial;
         #else

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1114,6 +1114,10 @@ static void setupSerial()
 #endif
   TxBackpack = serialPort;
 
+#if defined(PLATFORM_ESP32_S3)
+  Serial.begin(460800);
+#endif
+
 // Setup TxUSB
 #if defined(PLATFORM_ESP32)
   if (rxPin != UNDEF_PIN && txPin != UNDEF_PIN)

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -84,6 +84,14 @@ lib_deps =
 	ottowinter/ESPAsyncWebServer-esphome @ 3.0.0
 	bblanchon/ArduinoJson @ 6.19.4
 
+[env_common_esp32s3rx]
+platform = espressif32@6.3.2
+extends = env_common_esp32rx
+board = esp32-s3-devkitc-1
+build_flags =
+	${env_common_esp32rx.build_flags}
+	-D PLATFORM_ESP32_S3=1
+
 # ------------------------- COMMON ESP82xx DEFINITIONS -----------------
 [env_common_esp82xx]
 platform = espressif8266@4.2.0

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -61,6 +61,15 @@ tft_lib_deps =
 	${env_common_esp32.lib_deps}
 	moononournation/GFX Library for Arduino @ 1.2.8
 
+[env_common_esp32s3tx]
+platform = espressif32@6.3.2
+extends = env_common_esp32
+board = esp32-s3-devkitc-1
+build_flags =
+	${env_common_esp32.build_flags}
+	-D PLATFORM_ESP32_S3=1
+	-D ARDUINO_USB_CDC_ON_BOOT
+
 [env_common_esp32rx]
 platform = espressif32@6.3.2
 board = esp32dev

--- a/src/targets/unified.ini
+++ b/src/targets/unified.ini
@@ -64,6 +64,54 @@ board_build.ldscript = ./elrs.flash.1m64.ld
 [env:Unified_ESP8285_2400_TX_via_WIFI]
 extends = env:Unified_ESP8285_2400_TX_via_UART
 
+[env:Unified_ESP32S3_2400_TX_via_ETX]
+extends = env_common_esp32s3tx, radio_2400
+build_flags =
+	${env_common_esp32s3tx.build_flags}
+	${radio_2400.build_flags}
+	${common_env_data.build_flags_tx}
+	-include target/Unified_ESP32_TX.h
+	-D TARGET_AXIS_THOR_2400_TX=1
+	-D VTABLES_IN_FLASH=1
+	-O2
+build_src_filter = ${env_common_esp32s3tx.build_src_filter} -<rx_*.cpp>
+lib_deps =
+    ${env_common_esp32s3tx.tft_lib_deps}
+    ${env_common_esp32s3tx.oled_lib_deps}
+	SPIFFS
+upload_speed = 460800
+monitor_speed = 420000
+
+[env:Unified_ESP32S3_2400_TX_via_UART]
+extends = env:Unified_ESP32S3_2400_TX_via_ETX
+
+[env:Unified_ESP32S3_2400_TX_via_WIFI]
+extends = env:Unified_ESP32S3_2400_TX_via_ETX
+
+[env:Unified_ESP32S3_900_TX_via_ETX]
+extends = env_common_esp32s3tx, radio_900
+build_flags =
+	${env_common_esp32s3tx.build_flags}
+	${radio_900.build_flags}
+	${common_env_data.build_flags_tx}
+	-include target/Unified_ESP32_TX.h
+	-D TARGET_AXIS_THOR_2400_TX=1
+	-D VTABLES_IN_FLASH=1
+	-O2
+build_src_filter = ${env_common_esp32s3tx.build_src_filter} -<rx_*.cpp>
+lib_deps =
+    ${env_common_esp32s3tx.tft_lib_deps}
+    ${env_common_esp32s3tx.oled_lib_deps}
+	SPIFFS
+upload_speed = 460800
+monitor_speed = 460800
+
+[env:Unified_ESP32S3_900_TX_via_UART]
+extends = env:Unified_ESP32S3_900_TX_via_ETX
+
+[env:Unified_ESP32S3_900_TX_via_WIFI]
+extends = env:Unified_ESP32S3_900_TX_via_ETX
+
 
 # ********************************
 # Receiver targets

--- a/src/targets/unified.ini
+++ b/src/targets/unified.ini
@@ -131,3 +131,35 @@ extends = env:Unified_ESP32_900_RX_via_UART
 
 [env:Unified_ESP32_900_RX_via_WIFI]
 extends = env:Unified_ESP32_900_RX_via_UART
+
+# ESP32-S3
+
+[env:Unified_ESP32S3_2400_RX_via_UART]
+extends = env_common_esp32s3rx, radio_2400
+build_flags =
+	${env_common_esp32s3rx.build_flags}
+	${radio_2400.build_flags}
+	${common_env_data.build_flags_rx}
+	-include target/Unified_ESP_RX.h
+build_src_filter = ${env_common_esp32rx.build_src_filter} -<tx_*.cpp>
+
+[env:Unified_ESP32S3_2400_RX_via_BetaflightPassthrough]
+extends = env:Unified_ESP32S3_2400_RX_via_UART
+
+[env:Unified_ESP32S3_2400_RX_via_WIFI]
+extends = env:Unified_ESP32S3_2400_RX_via_UART
+
+[env:Unified_ESP32S3_900_RX_via_UART]
+extends = env_common_esp32s3rx, radio_900
+build_flags =
+	${env_common_esp32s3rx.build_flags}
+	${radio_900.build_flags}
+	${common_env_data.build_flags_rx}
+	-include target/Unified_ESP_RX.h
+build_src_filter = ${env_common_esp32rx.build_src_filter} -<tx_*.cpp>
+
+[env:Unified_ESP32S3_900_RX_via_BetaflightPassthrough]
+extends = env:Unified_ESP32S3_900_RX_via_UART
+
+[env:Unified_ESP32S3_900_RX_via_WIFI]
+extends = env:Unified_ESP32S3_900_RX_via_UART

--- a/src/user_defines.txt
+++ b/src/user_defines.txt
@@ -84,6 +84,12 @@
 
 # Turn on debug messages, if disabled then all debugging options (starting with DEBUG_) are disabled
 #-DDEBUG_LOG
+
+# For an ESP32S3 MCU, there are two options:
+# 1 - Pull-up on GPIO3, USB for JTAG (on MI_02), debug logging uses main UART.
+# 2 - Pull-down on GPIO3, Individual pins for JTAG (MTDI/MTMS/MTCK/MTDO), debug logging via USB for CDC UART (on MI_00)
+#-DESP32_S3_USB_JTAG_ENABLED
+
 # Use DEBUG_LOG_VERBOSE instead (or both) to see verbose debug logging (spammy stuff)
 #-DDEBUG_LOG_VERBOSE
 


### PR DESCRIPTION
Using an S3 allows us to have more GPIO pins available, 45 of them, 9 of them are reserved for Flash & PSRAM, leaving 37 usable IO pins!

The following features are available all at the same time!

1. Direct USB for updates and serial output (2 pins)
2. RGB LED (1 pin)
3. 16 PWM/IO pins configurable as DShot or other IO things (16 pins)
4. VBatt ADC input (1 pin)
5. Separate CRSF serial pins, for FC or CRSF sensors (2 pins)
6. Separate I2C pins, for Vario/Gyro etc (2 pins)
7. True Diversity/Gemini (11 pins)

And still 2 pins available!