### PR TITLE
Add to .gitignore files that are modified or created during the building by the configurator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ src/.vscode
 src/data/*.ini
 src/data/*.json
 src/hardware
+src/VERSION
+src/firmware.bin.gz
+src/user_defines.txt

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,5 @@ src/.vscode
 src/data/*.ini
 src/data/*.json
 src/hardware
-src/VERSION
 src/firmware.bin.gz
 src/user_defines.txt


### PR DESCRIPTION
Hi there!

During the process of developing custom firmware, I noticed that git indexes certain files that are modified or created while building by the ExpressLRS configurator. This became inconvenient when checking for updates on my custom firmware. Therefore, I decided to add these files to the .gitignore.