### PR TITLE
Optimize and fix broken FM30 target

### DIFF
--- a/src/include/target/FM30_TX.h
+++ b/src/include/target/FM30_TX.h
@@ -5,7 +5,7 @@
 // There is some special handling for this target
 #define TARGET_TX_FM30
 #define USE_SX1280_DCDC
-//#define CRITICAL_FLASH
+#define CRITICAL_FLASH
 
 // GPIO pin definitions
 #define GPIO_PIN_NSS            PB12

--- a/src/lib/BUTTON/button.h
+++ b/src/lib/BUTTON/button.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <functional>
-
 class Button
 {
 private:
@@ -26,8 +24,8 @@ private:
     uint8_t _pressCount; // number of short presses before timeout
 public:
     // Callbacks
-    std::function<void ()>OnShortPress;
-    std::function<void ()>OnLongPress;
+    void (*OnShortPress)();
+    void (*OnLongPress)();
     // Properties
     uint8_t getCount() const { return _pressCount; }
     uint8_t getLongCount() const { return _longCount; }

--- a/src/lib/LUA/lua.h
+++ b/src/lib/LUA/lua.h
@@ -3,7 +3,6 @@
 
 #include "targets.h"
 #include "crsf_protocol.h"
-#include <functional>
 
 enum lua_Flags{
     //bit 0 and 1 are status flags, show up as the little icon in the lua top right corner

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -352,25 +352,28 @@ static void luadevUpdateBackpackOpts()
 }
 
 #if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
+static void setBleJoystickMode()
+{
+  connectionState = bleJoystick;
+}
+
 static void luahandWifiBle(struct luaPropertiesCommon *item, uint8_t arg)
 {
   struct luaItem_command *cmd = (struct luaItem_command *)item;
-  std::function<void()> setTargetState;
+  void (*setTargetState)();
   connectionState_e targetState;
   const char *textConfirm;
   const char *textRunning;
   if ((void *)item == (void *)&luaWebUpdate)
   {
-    setTargetState = setWifiUpdateMode;
+    setTargetState = &setWifiUpdateMode;
     textConfirm = "Enter WiFi Update?";
     textRunning = "WiFi Running...";
     targetState = wifiUpdate;
   }
   else
   {
-    setTargetState = []() {
-      connectionState = bleJoystick;
-    };
+    setTargetState = &setBleJoystickMode;
     textConfirm = "Start BLE Joystick?";
     textRunning = "Joystick Running...";
     targetState = bleJoystick;

--- a/src/lib/OTA/OTA.h
+++ b/src/lib/OTA/OTA.h
@@ -1,7 +1,6 @@
 #ifndef H_OTA
 #define H_OTA
 
-#include <functional>
 #include <cstddef>
 #include "crc.h"
 #include "devCRSF.h"
@@ -164,8 +163,8 @@ void OtaUpdateSerializers(OtaSwitchMode_e const mode, uint8_t packetSize);
 extern OtaSwitchMode_e OtaSwitchModeCurrent;
 
 // CRC
-typedef std::function<bool (OTA_Packet_s * const otaPktPtr)> ValidatePacketCrc_t;
-typedef std::function<void (OTA_Packet_s * const otaPktPtr)> GeneratePacketCrc_t;
+typedef bool (*ValidatePacketCrc_t)(OTA_Packet_s * const otaPktPtr);
+typedef void (*GeneratePacketCrc_t)(OTA_Packet_s * const otaPktPtr);
 extern ValidatePacketCrc_t OtaValidatePacketCrc;
 extern GeneratePacketCrc_t OtaGeneratePacketCrc;
 // Value is implicit leading 1, comment is Koopman formatting (implicit trailing 1) https://users.ece.cmu.edu/~koopman/crc/
@@ -174,7 +173,7 @@ extern GeneratePacketCrc_t OtaGeneratePacketCrc;
 #define ELRS_CRC16_POLY 0x3D65 // 0x9eb2
 
 #if defined(TARGET_TX) || defined(UNIT_TEST)
-typedef std::function<void (OTA_Packet_s * const otaPktPtr, const uint32_t *channelData, bool TelemetryStatus, uint8_t tlmDenom)> PackChannelData_t;
+typedef void (*PackChannelData_t)(OTA_Packet_s * const otaPktPtr, const uint32_t *channelData, bool TelemetryStatus, uint8_t tlmDenom);
 extern PackChannelData_t OtaPackChannelData;
 #if defined(UNIT_TEST)
 void OtaSetHybrid8NextSwitchIndex(uint8_t idx);
@@ -183,7 +182,7 @@ void OtaSetFullResNextChannelSet(bool next);
 #endif
 
 #if defined(TARGET_RX) || defined(UNIT_TEST)
-typedef std::function<bool (OTA_Packet_s const * const otaPktPtr, uint32_t *channelData, uint8_t tlmDenom)> UnpackChannelData_t;
+typedef bool (*UnpackChannelData_t)(OTA_Packet_s const * const otaPktPtr, uint32_t *channelData, uint8_t tlmDenom);
 extern UnpackChannelData_t OtaUnpackChannelData;
 #endif
 

--- a/src/lib/SCREEN/fsm.h
+++ b/src/lib/SCREEN/fsm.h
@@ -1,4 +1,3 @@
-#include <functional>
 #include <deque>
 
 #include "targets.h"
@@ -37,8 +36,8 @@ typedef struct fsm_state_event_s
 typedef struct fsm_state_entry_s
 {
     fsm_state_t state;
-    std::function<bool()> available;
-    std::function<void(bool init)> entry;
+    bool (*available)();
+    void (*entry)(bool init);
     uint16_t timeout;
     fsm_state_event_t const *events;
     uint8_t event_count;

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -68,9 +68,9 @@ uint8_t MSPDataPackage[5];
 static uint8_t BindingSendCount;
 bool RxWiFiReadyToSend = false;
 
+bool headTrackingEnabled = false;
 #if !defined(CRITICAL_FLASH)
 static uint16_t ptrChannelData[3] = {CRSF_CHANNEL_VALUE_MID, CRSF_CHANNEL_VALUE_MID, CRSF_CHANNEL_VALUE_MID};
-bool headTrackingEnabled = false;
 static uint32_t lastPTRValidTimeMs;
 #endif
 

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -68,9 +68,11 @@ uint8_t MSPDataPackage[5];
 static uint8_t BindingSendCount;
 bool RxWiFiReadyToSend = false;
 
+#if !defined(CRITICAL_FLASH)
 static uint16_t ptrChannelData[3] = {CRSF_CHANNEL_VALUE_MID, CRSF_CHANNEL_VALUE_MID, CRSF_CHANNEL_VALUE_MID};
 bool headTrackingEnabled = false;
 static uint32_t lastPTRValidTimeMs;
+#endif
 
 static TxTlmRcvPhase_e TelemetryRcvPhase = ttrpTransmitting;
 StubbornReceiver TelemetryReceiver;
@@ -414,6 +416,7 @@ void ICACHE_RAM_ATTR HandlePrepareForTLM()
 
 void injectBackpackPanTiltRollData(uint32_t const now)
 {
+#if !defined(CRITICAL_FLASH)
   // Do not override channels if the backpack is NOT communicating or PanTiltRoll is disabled
   if (config.GetPTREnableChannel() == HT_OFF || backpackVersion[0] == 0)
   {
@@ -452,6 +455,7 @@ void injectBackpackPanTiltRollData(uint32_t const now)
     ChannelData[ptrStartChannel + 5] = CRSF_CHANNEL_VALUE_MID;
     ChannelData[ptrStartChannel + 6] = CRSF_CHANNEL_VALUE_MID;
   }
+#endif
 }
 
 void ICACHE_RAM_ATTR SendRCdataToRF()
@@ -1019,18 +1023,18 @@ void ProcessMSPPacket(uint32_t now, mspPacket_t *packet)
 
     VtxTriggerSend();
   }
-#endif
-  if (packet->function == MSP_ELRS_GET_BACKPACK_VERSION)
-  {
-    memset(backpackVersion, 0, sizeof(backpackVersion));
-    memcpy(backpackVersion, packet->payload, min((size_t)packet->payloadSize, sizeof(backpackVersion)-1));
-  }
   else if (packet->function == MSP_ELRS_BACKPACK_SET_PTR && packet->payloadSize == 6)
   {
     ptrChannelData[0] = packet->payload[0] + (packet->payload[1] << 8);
     ptrChannelData[1] = packet->payload[2] + (packet->payload[3] << 8);
     ptrChannelData[2] = packet->payload[4] + (packet->payload[5] << 8);
     lastPTRValidTimeMs = now;
+  }
+#endif
+  if (packet->function == MSP_ELRS_GET_BACKPACK_VERSION)
+  {
+    memset(backpackVersion, 0, sizeof(backpackVersion));
+    memcpy(backpackVersion, packet->payload, min((size_t)packet->payloadSize, sizeof(backpackVersion)-1));
   }
 }
 
@@ -1098,8 +1102,12 @@ static void setupSerial()
     serialPort = new NullStream();
   }
 #elif defined(TARGET_TX_FM30)
-  USBSerial *serialPort = &SerialUSB; // No way to disable creating SerialUSB global, so use it
-  serialPort->begin();
+  #if defined(PIO_FRAMEWORK_ARDUINO_ENABLE_CDC)
+    USBSerial *serialPort = &SerialUSB; // No way to disable creating SerialUSB global, so use it
+    serialPort->begin();
+  #else
+    Stream *serialPort = new NullStream();
+  #endif
 #elif (defined(GPIO_PIN_DEBUG_RX) && GPIO_PIN_DEBUG_RX != UNDEF_PIN) || (defined(GPIO_PIN_DEBUG_TX) && GPIO_PIN_DEBUG_TX != UNDEF_PIN)
   HardwareSerial *serialPort = new HardwareSerial(2);
   #if defined(GPIO_PIN_DEBUG_RX) && GPIO_PIN_DEBUG_RX != UNDEF_PIN
@@ -1127,6 +1135,9 @@ static void setupSerial()
   }
 #else
   TxUSB = new NullStream();
+  UNUSED(portConflict);
+  UNUSED(rxPin);
+  UNUSED(txPin);
 #endif
 }
 

--- a/src/targets/siyi.ini
+++ b/src/targets/siyi.ini
@@ -10,10 +10,10 @@ build_flags =
 	${env_common_stm32.build_flags}
 	${radio_2400.build_flags}
 	${common_env_data.build_flags_tx}
-	-flto
+	#-flto
+	#-DUSBCON
+	#-DPIO_FRAMEWORK_ARDUINO_ENABLE_CDC
 	-include target/FM30_TX.h
-	-DUSBCON
-	-DPIO_FRAMEWORK_ARDUINO_ENABLE_CDC
 	-DHSE_VALUE=16000000U
 	-DVECT_TAB_OFFSET=0x1000U
 	-Wl,--defsym=FLASH_APP_OFFSET=0x1000


### PR DESCRIPTION
`-flto` breaks FM30 target (#2382) for reasons I don't even want to debug into, so this PR disables LTO and gets the firmware size back down to fitting. The resulting firmware is now even smaller than it was with LTO enabled. _Things were bad, but now they're good and they will, forever!_ (just kidding, master eats up like 15% of the remaining space again)

Note that the `binary_configurator.py` / the Configurator does not support DFU flashing and I'm not sure I want to spend the time fixing that? It needs an external dfu-util.exe utility.

### Remove USB-CDC
The FM30 TX can't easily build with `DEBUG_LOG` anyway, so there's not much use for the USB-CDC serial port. I left some of the code in because you can actually cut out some other code temporarily to get it to fit again if something needs to be debugged.

### Enable CRITICAL_FLASH
`CRITICAL_FLASH` define doesn't take that much out but every bit is starting to help now

### Headtracking is out for CRITICAL_FLASH
It was easy to cut out a bit more by removing headtracking from flash-staved targets. More backpack stuff could be removed but the amount of changes needed after I messed with it wasn't worth how much work it would be. Still an option for later maybe.

### Remove std::function (all targets)
Wherever possible, I've removed the use of `std::function`. This C++ism is an extremely heavy **class** and not just an easier-to-read "pointer-to-a-function" and should be used only as a last resort. I'm the most guilty of overusing it too. The only one I couldn't easily take out were `deferExecutuion()` because 2 callers capture variables and I didn't want to get into refactoring that.

This benefits all targets in both RAM and Flash. Examples:
* FM30: 660B flash, 80B RAM
* Generic ESP RX: 632B flash, 80B RAM
* Ranger bling TX: 2,836B flash, 2,304 RAM

### Gemini and Airport
Gemini and TrueDiversity takes a ton of code. Airport isn't huge but does have a noticeable impact. I left both of these how they were though so any future developer who wants to keep FM30 kickin' could put these in their sights.