### PR TITLE
Various web UI fixes and improvements

### DIFF
--- a/src/html/elrs.css
+++ b/src/html/elrs.css
@@ -13,7 +13,7 @@
     text-align: center;
 }
 
-.upload {
+.upload > label > input {
 	clip: rect(0 0 0 0);
 	clip-path: inset(50%);
 	height: 1px;
@@ -24,11 +24,11 @@
 	white-space: nowrap;
 	width: 1px;
 }
-label:has(.upload) {
+.upload > label {
 	cursor: pointer;
 	padding: 10px 16px 10px 16px;
 }
-button:has(label .upload) {
+.upload {
 	padding: 0;
 	tab-index: -1;
 }

--- a/src/html/elrs.css
+++ b/src/html/elrs.css
@@ -13,6 +13,26 @@
     text-align: center;
 }
 
+.upload {
+	clip: rect(0 0 0 0);
+	clip-path: inset(50%);
+	height: 1px;
+	overflow: hidden;
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	white-space: nowrap;
+	width: 1px;
+}
+label:has(.upload) {
+	cursor: pointer;
+	padding: 10px 16px 10px 16px;
+}
+button:has(label .upload) {
+	padding: 0;
+	tab-index: -1;
+}
+
 body, input, select, textarea {
     color: #666;
     font-family: "Source Sans Pro", Helvetica, sans-serif;

--- a/src/html/hardware.html
+++ b/src/html/hardware.html
@@ -1,6 +1,6 @@
 @@require(PLATFORM, VERSION, isTX, sx127x)
 <!DOCTYPE HTML>
-<html>
+<html lang="en">
 
 <head>
 	<title>Welcome to your ExpressLRS System</title>

--- a/src/html/hardware.html
+++ b/src/html/hardware.html
@@ -70,10 +70,10 @@ td img.icon-pwm {
 		</div>
 		<div class="mui-panel">
 			<label>Upload target configuration (remember to press "Save Target Configuration" below):</label>
-			<button class="mui-btn mui-btn--small mui-btn--primary">
+			<button class="mui-btn mui-btn--small mui-btn--primary upload">
 				<label>
 					Upload
-					<input type="file" id="fileselect" name="fileselect[]" class="upload" />
+					<input type="file" id="fileselect" name="fileselect[]" />
 				</label>
 			</button>
 			<div id="filedrag">or drop files here</div>

--- a/src/html/hardware.html
+++ b/src/html/hardware.html
@@ -69,16 +69,14 @@ td img.icon-pwm {
 			You can <a download href="/hardware.json">download</a> the configuration or <a href="/reset?hardware">reset</a> to pre-configured defaults and reboot.
 		</div>
 		<div class="mui-panel">
-			<form id="notused" action="" method="POST" enctype="multipart/form-data">
-				<fieldset>
-					<input type="hidden" id="MAX_FILE_SIZE" name="MAX_FILE_SIZE" value="10000" />
-					<div>
-						<label for="fileselect">Load target configuration (remember to press "Save Target Configuration" below):</label>
-						<input type="file" id="fileselect" name="fileselect[]" />
-						<div id="filedrag">or drop files here</div>
-					</div>
-				</fieldset>
-			</form>
+			<label>Upload target configuration (remember to press "Save Target Configuration" below):</label>
+			<button class="mui-btn mui-btn--small mui-btn--primary">
+				<label>
+					Upload
+					<input type="file" id="fileselect" name="fileselect[]" class="upload" />
+				</label>
+			</button>
+			<div id="filedrag">or drop files here</div>
 		</div>
 		<div class="mui-panel">
 			<form id='upload_hardware' method='POST' action="/hardware">

--- a/src/html/hardware.js
+++ b/src/html/hardware.js
@@ -26,7 +26,7 @@ function onReady() {
 function loadData() {
   xmlhttp = new XMLHttpRequest();
   xmlhttp.onreadystatechange = function() {
-    if (this.readyState == 4 && this.status == 200) {
+    if (this.readyState === 4 && this.status === 200) {
       const data = JSON.parse(this.responseText);
       updateHardwareSettings(data);
     }
@@ -43,19 +43,19 @@ function submitHardwareSettings() {
   const formData = new FormData(_('upload_hardware'));
   xhr.send(JSON.stringify(Object.fromEntries(formData), function(k, v) {
     if (v === '') return undefined;
-    if (_(k) && _(k).type == 'checkbox') {
-      return v == 'on' ? true : false;
+    if (_(k) && _(k).type === 'checkbox') {
+      return v === 'on';
     }
     if (_(k) && _(k).classList.contains('array')) {
       const arr = v.split(',').map((element) => {
         return Number(element);
       });
-      return arr.length == 0 ? undefined : arr;
+      return arr.length === 0 ? undefined : arr;
     }
     return isNaN(v) ? v : +v;
   }));
   xhr.onreadystatechange = function() {
-    if (this.readyState == 4 && this.status == 200) {
+    if (this.readyState === 4 && this.status === 200) {
       cuteAlert({
         type: 'question',
         title: 'Upload Succeeded',
@@ -63,7 +63,7 @@ function submitHardwareSettings() {
         confirmText: 'Reboot',
         cancelText: 'Close'
       }).then((e) => {
-        if (e == 'confirm') {
+        if (e === 'confirm') {
           const xhr = new XMLHttpRequest();
           xhr.open('POST', '/reboot');
           xhr.setRequestHeader('Content-Type', 'application/json');
@@ -79,7 +79,7 @@ function submitHardwareSettings() {
 function updateHardwareSettings(data) {
   for (const [key, value] of Object.entries(data)) {
     if (_(key)) {
-      if (_(key).type == 'checkbox') {
+      if (_(key).type === 'checkbox') {
         _(key).checked = value;
       } else {
         if (Array.isArray(value)) _(key).value = value.toString();
@@ -93,13 +93,13 @@ function updateHardwareSettings(data) {
 function fileDragHover(e) {
   e.stopPropagation();
   e.preventDefault();
-  e.target.className = (e.type == 'dragover' ? 'hover' : '');
+  if (e.target === _('filedrag')) e.target.className = (e.type === 'dragover' ? 'hover' : '');
 }
 
 function fileSelectHandler(e) {
   fileDragHover(e);
   const files = e.target.files || e.dataTransfer.files;
-  for (let i = 0, f; f = files[i]; i++) {
+  for (const f of files) {
     parseFile(f);
   }
 }

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -66,8 +66,8 @@
 						</div>
 @@end
 						<div class="mui-textfield">
-							<input size='3' id='wifi-on-interval' name='wifi-on-interval' type='text'/>
-							<label>WiFi "auto on" interval (s)</label>
+							<input size='3' id='wifi-on-interval' name='wifi-on-interval' type='text' placeholder="Disabled"/>
+							<label>WiFi "auto on" interval in seconds (leave blank to disable)</label>
 						</div>
 @@if isTX:
 						<div class="mui-textfield">

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -22,7 +22,7 @@
 
 			<ul class="mui-tabs__bar mui-tabs__bar--justified">
 				<li class="mui--is-active"><a data-mui-toggle="tab" data-mui-controls="pane-justified-1">Options</a></li>
-				<li><a data-mui-toggle="tab" data-mui-controls="pane-justified-4">WiFi</a></li>
+				<li><a id="network-tab" data-mui-toggle="tab" data-mui-controls="pane-justified-4">WiFi</a></li>
 @@if isTX:
 				<li id="button-tab"><a data-mui-toggle="tab" data-mui-controls="pane-justified-3">Buttons</a></li>
 @@end

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -1,6 +1,6 @@
 @@require(PLATFORM, VERSION, isTX, sx127x)
 <!DOCTYPE HTML>
-<html>
+<html lang="en">
 
 <head>
 	<title>Welcome to your ExpressLRS System</title>
@@ -47,9 +47,9 @@
 						<input type="hidden" id="flash-discriminator" name="flash-discriminator"/>
 						<input type="hidden" id="wifi-ssid" name="wifi-ssid"/>
 						<input type="hidden" id='wifi-password' name='wifi-password'/>
-						<span class="badge" id="uid-type"></span>&nbsp;<span id="uid-text"></span>
-						<br/>
 						<div class="mui-textfield">
+							<label for='uid'><span id="uid-text"></span></label>
+							<span class="badge" id="uid-type"></span>
 							<input size='40' id='uid' name='uid' type='text' class='array' readonly/>
 						</div>
 @@if sx127x:
@@ -62,42 +62,46 @@
 								<option value='4'>AU433</option>
 								<option value='5'>EU433</option>
 							</select>
-							<label>Regulatory domain</label>
+							<label for="domain">Regulatory domain</label>
 						</div>
 @@end
 						<div class="mui-textfield">
 							<input size='3' id='wifi-on-interval' name='wifi-on-interval' type='text' placeholder="Disabled"/>
-							<label>WiFi "auto on" interval in seconds (leave blank to disable)</label>
+							<label for="wifi-on-interval">WiFi "auto on" interval in seconds (leave blank to disable)</label>
 						</div>
 @@if isTX:
 						<div class="mui-textfield">
 							<input size='5' id='tlm-interval' name='tlm-interval' type='text'/>
-							<label>TLM report interval (ms)</label>
+							<label for="tlm-interval">TLM report interval (ms)</label>
 						</div>
 						<div class="mui-textfield">
 							<input size='3' id='fan-runtime' name='fan-runtime' type='text'/>
-							<label>Fan runtime (s)</label>
+							<label for="fan-runtime">Fan runtime (s)</label>
 						</div>
 						<div id="has-highpower" class="mui-checkbox" style="display: none;">
-							<label><input id='unlock-higher-power' name='unlock-higher-power' type='checkbox'/>Unlock higher power</label>
+							<input id='unlock-higher-power' name='unlock-higher-power' type='checkbox'/>
+							<label for="unlock-higher-power">Unlock higher power</label>
 						</div>
 						<div class="mui-checkbox">
-							<label><input id='is-airport' name='is-airport' type='checkbox'/>Use as AirPort Serial device</label>
+							<input id='is-airport' name='is-airport' type='checkbox'/>
+							<label for="is-airport">Use as AirPort Serial device</label>
 						</div>
 						<div class="mui-textfield">
 							<input size='7' id='airport-uart-baud' name='airport-uart-baud' type='text'/>
-							<label>AirPort UART baud</label>
+							<label for="airport-uart-baud">AirPort UART baud</label>
 						</div>
 @@else:
 						<div id="baud-config" class="mui-textfield"  style="display: block;">
 							<input size='7' id='rcvr-uart-baud' name='rcvr-uart-baud' type='text'/>
-							<label>UART baud</label>
+							<label for="rcvr-uart-baud">UART baud</label>
 						</div>
 						<div class="mui-checkbox">
-							<label><input id='lock-on-first-connection' name='lock-on-first-connection' type='checkbox'/>Lock on first connection</label>
+							<input id='lock-on-first-connection' name='lock-on-first-connection' type='checkbox'/>
+							<label for="lock-on-first-connection">Lock on first connection</label>
 						</div>
 						<div class="mui-checkbox">
-							<label><input id='is-airport' name='is-airport' type='checkbox'/>Use as AirPort Serial device</label>
+							<input id='is-airport' name='is-airport' type='checkbox'/>
+							<label for="is-airport">Use as AirPort Serial device</label>
 						</div>
 @@end
 						<button id='submit-options' class="mui-btn mui-btn--primary" disabled>Save</button>
@@ -154,11 +158,11 @@
 						</table>
 						<div id="button1-color-div" style="display: none;">
 							<input id='button1-color' name='button1-color' type='color'/>
-							<label>User button 1 color</label>
+							<label for="button1-color">User button 1 color</label>
 						</div>
 						<div id ="button2-color-div" style="display: none;">
 							<input id='button2-color' name='button2-color' type='color'/>
-							<label>User button 2 color</label>
+							<label for="button2-color">User button 2 color</label>
 						</div>
 						<button id="submit-actions" class="mui-btn mui-btn--primary">Save</button>
 					</form>
@@ -173,19 +177,21 @@
 						Set PWM output mode and failsafe positions.
 						<ul>
 							<li><b>Output:</b> Receiver output pin</li>
-							<li><b>Mode:</b> Output frequency, 10KHz 0-100% duty cycle, binary On/Off or Serial (for MCU pins 1 and 3 only) mode</li>
-							<ul>
-								<li>When enabling serial pins, be sure to select the <b>Serial Protocol</b>below and <b>UART baud</b> on the <b>Options</b> tab</li>
-							</ul>
+							<li><b>Mode:</b> Output frequency, 10KHz 0-100% duty cycle, binary On/Off or Serial (for MCU pins 1 and 3 only) mode
+								<ul>
+									<li>When enabling serial pins, be sure to select the <b>Serial Protocol</b>below and <b>UART baud</b> on the <b>Options</b> tab</li>
+								</ul>
+							</li>
 							<li><b>Input:</b> Input channel from the handset</li>
 							<li><b>Invert:</b> Invert input channel position</li>
 							<li><b>750us:</b> Use half pulse width (494-1006us) with center 750us instead of 988-2012us</li>
-							<li><b>Failsafe:</b> Absolute position to set the servo on failsafe</li>
-							<ul>
-								<li>Does not use "Invert" flag</li>
-								<li>Value will be halved if "750us" flag is set</li>
-								<li>Will be converted to binary for "On/Off" mode (>1500us = HIGH)</li>
-							</ul>
+							<li><b>Failsafe:</b> Absolute position to set the servo on failsafe
+								<ul>
+									<li>Does not use "Invert" flag</li>
+									<li>Value will be halved if "750us" flag is set</li>
+									<li>Will be converted to binary for "On/Off" mode (>1500us = HIGH)</li>
+								</ul>
+							</li>
 						</ul>
 						<br/><br/>
 						<form action="/pwm" id="pwm" method="POST">
@@ -206,7 +212,7 @@
 									<option value='5'>DJI RS Pro</option>
 									<option value='6'>HoTT Telemetry</option>
 								</select>
-								<label>Serial Protocol</label>
+								<label for='serial-protocol'>Serial Protocol</label>
 							</div>
 						</div>
 						<div id="sbus-config" style="display: none;">
@@ -222,7 +228,7 @@
 									<option value='0'>No Pulses</option>
 									<option value='1'>Last Position</option>
 								</select>
-								<label>SBUS Failsafe</label>
+								<label for="sbus-failsafe">SBUS Failsafe</label>
 							</div>
 						</div>
 
@@ -231,17 +237,19 @@
 						in the ExpressLRS Lua script for that model. 'Model Match' is between 0 and 63 inclusive.
 						<br/><br/>
 						<div class="mui-checkbox">
-							<label><input id='model-match' name='model-match' type='checkbox'/> Enable Model Match</label>
+							<input id='model-match' name='model-match' type='checkbox'/>
+							<label for="model-match">Enable Model Match</label>
 						</div>
 						<div class="mui-textfield">
 							<input id='modelid' type='text' name='modelid' value="255" required/>
-							<label>Model ID</label>
+							<label for="modelid">Model ID</label>
 						</div>
 						<h2>Force telemetry off</h2>
 						When running multiple receivers simultaneously from the same TX (to increase the number of PWM servo outputs), there can be at most one receiver with telemetry enabled.<br>Enable this option to ignore the "Telem Ratio" setting on the TX and never send telemetry from this receiver.
 						<br/><br/>
 						<div class="mui-checkbox">
-							<label><input id='force-tlm' name='force-tlm' type='checkbox' value="1"/> Force telemetry OFF on this receiver</label>
+							<input id='force-tlm' name='force-tlm' type='checkbox' value="1"/>
+							<label for="force-tlm">Force telemetry OFF on this receiver</label>
 						</div>
 						<button type='submit' class="mui-btn mui-btn--small mui-btn--primary">Save</button>
 					</form>
@@ -283,11 +291,11 @@
 							<div class="autocomplete mui-textfield" style="position:relative;">
 								<div id="loader" style="position:absolute;right:0;width: 28px;height: 28px;" class="loader"></div>
 								<input id="network" type="text" name="network" placeholder="SSID"/>
-								<label>WiFi SSID</label>
+								<label for="network">WiFi SSID</label>
 							</div>
 							<div class="mui-textfield">
 								<input size='64' id='password' name='password' type='password'/>
-								<label>WiFi password</label>
+								<label for="password">WiFi password</label>
 							</div>
 						</div>
 						<button type="submit" class="mui-btn mui-btn--primary">Confirm</button>

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -110,15 +110,15 @@
 					<h2>Import/Export</h2>
 					<br/>
 					<div>
-						<a href="/config?export" download="models.json" target="_blank" class="mui-btn mui-btn--small mui-btn--dark">Download model configuration file</a>
+						<a href="/config?export" download="models.json" target="_blank" class="mui-btn mui-btn--small mui-btn--dark">Save model configuration file</a>
 					</div>
 					<div>
-						<form action="" method="POST" enctype="multipart/form-data">
-							<div>
-								<label for="fileselect">Select a model configuration file to upload</label>
-								<input type="file" id="fileselect" name="fileselect[]" />
-							</div>
-						</form>
+						<button class="mui-btn mui-btn--small mui-btn--primary">
+							<label>
+								Upload model configuration file
+								<input type="file" id="fileselect" name="fileselect[]" class="upload" />
+							</label>
+						</button>
 					</div>
 				</div>
 			</div>
@@ -130,15 +130,15 @@
 					If this happens you will need to recover via USB/Serial. You may also download the
 					<a href="firmware.bin" title="Click to download firmware">currently running firmware</a>.
 					<br/><br/>
-					<form id='upload_form' method='POST' enctype='multipart/form-data'>
-						<div class="group">
-							<input id='firmware_file' type='file' name='update'>
-							<button id='upload_btn' type='submit' class="mui-btn mui-btn--primary">Update</button>
-						</div>
-						<br/>
-						<h3 id="status"></h3>
-						<progress id="progressBar" value="0" max="100" style="width:100%;"></progress>
-					</form>
+					<button id="upload_btn" class="mui-btn mui-btn--primary">
+						<label>
+							Flash firmware file
+							<input type="file" id="firmware_file" name="update" class="upload" />
+						</label>
+					</button>
+					<br/>
+					<h3 id="status"></h3>
+					<progress id="progressBar" value="0" max="100" style="width:100%;"></progress>
 				</div>
 			</div>
 

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -117,10 +117,10 @@
 						<a href="/config?export" download="models.json" target="_blank" class="mui-btn mui-btn--small mui-btn--dark">Save model configuration file</a>
 					</div>
 					<div>
-						<button class="mui-btn mui-btn--small mui-btn--primary">
+						<button class="mui-btn mui-btn--small mui-btn--primary upload">
 							<label>
 								Upload model configuration file
-								<input type="file" id="fileselect" name="fileselect[]" class="upload" />
+								<input type="file" id="fileselect" name="fileselect[]" />
 							</label>
 						</button>
 					</div>
@@ -134,10 +134,10 @@
 					If this happens you will need to recover via USB/Serial. You may also download the
 					<a href="firmware.bin" title="Click to download firmware">currently running firmware</a>.
 					<br/><br/>
-					<button id="upload_btn" class="mui-btn mui-btn--primary">
+					<button id="upload_btn" class="mui-btn mui-btn--primary upload">
 						<label>
 							Flash firmware file
-							<input type="file" id="firmware_file" name="update" class="upload" />
+							<input type="file" id="firmware_file" name="update" />
 						</label>
 					</button>
 					<br/>

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -173,42 +173,6 @@ function init() {
   initOptions();
 }
 
-function changeCurrentColors() {
-  if (colorTimer === undefined) {
-    sendCurrentColors();
-    colorTimer = setInterval(timeoutCurrentColors, 50);
-  } else {
-    colorUpdated = true;
-  }
-}
-
-function sendCurrentColors() {
-  const formData = new FormData(_('upload_options'));
-  const data = Object.fromEntries(formData);
-  colors = [];
-  for (const [k, v] of Object.entries(data)) {
-    if (_(k) && _(k).type == 'color') {
-      const index = parseInt(k.substring('6')) - 1;
-      if (_(k + '-div').style.display === 'none') colors[index] = -1;
-      else colors[index] = parseInt(v.substring(1), 16);
-    }
-  }
-  const xmlhttp = new XMLHttpRequest();
-  xmlhttp.open('POST', '/buttons', true);
-  xmlhttp.setRequestHeader('Content-type', 'application/json');
-  xmlhttp.send(JSON.stringify(colors));
-  colorUpdated = false;
-}
-
-function timeoutCurrentColors() {
-  if (colorUpdated) {
-    sendCurrentColors();
-  } else {
-    clearInterval(colorTimer);
-    colorTimer = undefined;
-  }
-}
-
 function updateConfig(data, options) {
   if (data.product_name) _('product_name').textContent = data.product_name;
   if (data.reg_domain) _('reg_domain').textContent = data.reg_domain;
@@ -676,8 +640,9 @@ _('submit-actions').addEventListener('click', submitButtonActions);
 
 function updateOptions(data) {
   for (const [key, value] of Object.entries(data)) {
+    if (key ==='wifi-on-interval' && value === -1) continue;
     if (_(key)) {
-      if (_(key).type == 'checkbox') {
+      if (_(key).type === 'checkbox') {
         _(key).checked = value;
       } else {
         if (Array.isArray(value)) _(key).value = value.toString();

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -311,7 +311,6 @@ function initOptions() {
       updateOptions(data['options']);
       updateConfig(data['config'], data['options']);
       initBindingPhraseGen();
-      setTimeout(getNetworks, 2000);
     }
   };
   xmlhttp.open('GET', '/config', true);
@@ -337,6 +336,8 @@ function getNetworks() {
   xmlhttp.open('GET', 'networks.json', true);
   xmlhttp.send();
 }
+
+_('network-tab').addEventListener('mui.tabs.showstart', getNetworks);
 
 // =========================================================
 

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -554,7 +554,7 @@ _('reset-options').addEventListener('click', callback('Reset Runtime Options', '
 
 _('sethome').addEventListener('submit', setupNetwork);
 _('connect').addEventListener('click', callback('Connect to Home Network', 'An error occurred connecting to the Home network', '/connect', null));
-if (_('config') !== undefined) {
+if (_('config')) {
   _('config').addEventListener('submit', callback('Set Configuration', 'An error occurred updating the configuration', '/config',
       (xmlhttp) => {
         xmlhttp.setRequestHeader('Content-Type', 'application/json');

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -458,7 +458,7 @@ function abortHandler(event) {
   });
 }
 
-_('upload_form').addEventListener('submit', (e) => {
+_('firmware_file').addEventListener('change', (e) => {
   e.preventDefault();
   uploadFile();
 });

--- a/src/lib/OPTIONS/options.cpp
+++ b/src/lib/OPTIONS/options.cpp
@@ -1,6 +1,5 @@
 #include "targets.h"
 #include "options.h"
-#include "helpers.h"
 
 #include "logging.h"
 
@@ -204,7 +203,10 @@ void saveOptions(Stream &stream, bool customised)
         JsonArray uid = doc.createNestedArray("uid");
         copyArray(firmwareOptions.uid, sizeof(firmwareOptions.uid), uid);
     }
-    doc["wifi-on-interval"] = firmwareOptions.wifi_auto_on_interval / 1000;
+    if (firmwareOptions.wifi_auto_on_interval != -1)
+    {
+        doc["wifi-on-interval"] = firmwareOptions.wifi_auto_on_interval / 1000;
+    }
     if (firmwareOptions.home_wifi_ssid[0])
     {
         doc["wifi-ssid"] = firmwareOptions.home_wifi_ssid;

--- a/src/python/serve_html.py
+++ b/src/python/serve_html.py
@@ -21,7 +21,7 @@ sx127x = False
 
 config = {
         "options": {
-            'uid': [1,2,3,4,5,6],
+            "uid": [1,2,3,4,5,6],   # this is the 'flashed' UID and may be empty if using traditional binding on an RX.
             "tlm-interval": 240,
             "fan-runtime": 30,
             "no-sync-on-arm": False,
@@ -37,6 +37,7 @@ config = {
             "wifi-ssid": "network-ssid"
         },
         "config": {
+            "uid": [1,2,3,4,5,6],   # this is the 'running' UID
             "uidtype": "On loan",
             "ssid":"network-ssid",
             "mode":"STA",
@@ -170,6 +171,11 @@ def update_config():
     if 'forcetlm' in request.json:
         config['config']['force-tlm'] = request.json['forcetlm']
     return "Config Updated"
+
+@route('/options.json', method='POST')
+def update_options():
+    config['options'] = request.json
+    return "Options Updated"
 
 @route('/import', method='POST')
 def import_config():

--- a/src/python/serve_html.py
+++ b/src/python/serve_html.py
@@ -32,7 +32,7 @@ config = {
             "rcvr-invert-tx": False,
             "lock-on-first-connection": True,
             "domain": 1,
-            "wifi-on-interval": 60,
+            # "wifi-on-interval": 60,
             "wifi-password": "w1f1-pAssw0rd",
             "wifi-ssid": "network-ssid"
         },

--- a/src/python/serve_html.py
+++ b/src/python/serve_html.py
@@ -194,6 +194,7 @@ def mode():
     net_counter = net_counter + 1
     if (net_counter > 3):
         return '["Test Network 1", "Test Network 2", "Test Network 3", "Test Network 4", "Test Network 5"]'
+    response.status = 204
     return '[]'
 
 if __name__ == '__main__':


### PR DESCRIPTION
# 1. Improve display of `WiFi "auto on" interval` in web UI
## Problem
When flashing with `AUTO_WIFI_ON_INTERVAL` off in the configurator then going to the web-UI it displays a zero; if you then make changes and save, it will set the wifi-on-interval to that zero and will auto boot into wifi mode!

## Solution
When the interval is off in configurator, the interval is left out of the JSON, which is correct. This was not respected in the `options.cpp` code where it maintains an in-memory copy, and a divide caused a zero to be in the field.

# 2. Nicer UX around the bind-phrase
When entering a bind-phrase we now change the badge above the UID to show that it has been `Modified` and not been saved.
After saving, the bind-phrase is cleared and UID badge is updated to `Flashed` as per usual.

# 3. Add missing serial protocols
The DJI, SUMD and HoTT telemetry protocols were not handled and some were not even in the list!
These have been added and a few other UX cleanups have been done.
1. When airport is selected, you don't get the choice of protocol as airport is the mode of operation.
2. The `SBUS failsafe` section is only shown when choosing SBUS modes. i.e. SBUS, SBUS inverted, or DJI RS Pro 

# 4. Styled the Upload buttons!
After discussions with my web designer team-mate, she showed my how to style the upload buttons so she doesn't make puking sounds when she sees the UI... well at least not for that anyway 😄 

# 5. Deferred WiFi scanning
Only scan wifi networks when entering the wifi tab.
Fixes #2402 