### PR TITLE
Fixes for LEDC driven PWM channels on ESP32

### DIFF
--- a/src/lib/PWM/PWM_ESP32.cpp
+++ b/src/lib/PWM/PWM_ESP32.cpp
@@ -89,9 +89,10 @@ static void ledcAttachPinEx(uint8_t pin, uint8_t chan, ledc_timer_t timer)
         .timer_sel = (ledc_timer_t)timer,
         .duty = 0,
         .hpoint = 0};
-    if (ledc_channel_config(&ledc_channel) != OK)
+    auto err = ledc_channel_config(&ledc_channel);
+    if (err != OK)
     {
-        ERRLN("ledc_channel_config failed");
+        ERRLN("ledc_channel_config failed with error 0x%x on pin %d", err, pin);
     }
 }
 
@@ -137,9 +138,10 @@ pwm_channel_t PWMController::allocate(uint8_t pin, uint32_t frequency)
             .duty_mode = MCPWM_DUTY_MODE_0,
             .counter_mode = MCPWM_UP_COUNTER,
         };
-        if (mcpwm_gpio_init(mcpwm_config[channel].unit, mcpwm_config[channel].signal, pin) != ESP_OK)
+        auto err = mcpwm_gpio_init(mcpwm_config[channel].unit, mcpwm_config[channel].signal, pin);
+        if (err != ESP_OK)
         {
-            DBGLN("failed %d", pin);
+            DBGLN("mcpwm_gpio_init failed with error 0x%x on pin %d", err, pin);
         }
         mcpwm_init(mcpwm_config[channel].unit, mcpwm_config[channel].timer, &pwm_config);
         mcpwm_frequencies[channel] = frequency;
@@ -190,7 +192,7 @@ void PWMController::release(pwm_channel_t channel)
         mcpwm_stop(mcpwm_config[ch].unit, mcpwm_config[ch].timer);
         mcpwm_frequencies[ch] = 0;
     }
-    else if (IS_MCPWM_CHANNEL(channel))
+    else if (IS_LEDC_CHANNEL(channel))
     {
         auto ch = LEDC_CHANNEL(channel);
         ledcDetachPin(ledc_config[ch].pin);

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -213,8 +213,6 @@ static int start()
         }
 #endif
     }
-    // set servo outputs to failsafe position on start in case they want to play silly buggers!
-    servosFailsafe();
     return DURATION_NEVER;
 }
 

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -141,6 +141,12 @@ static void initialize()
         return;
     }
 
+    for (int i=0 ; i<PWM_MAX_CHANNELS ; i++)
+    {
+        SERVO_PINS[i] = -1;
+        PWM_CHANNELS[i] = -1;
+    }
+
     for (int ch = 0; ch < GPIO_PIN_PWM_OUTPUTS_COUNT; ++ch)
     {
         int8_t pin = GPIO_PIN_PWM_OUTPUTS[ch];

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -219,6 +219,8 @@ static int start()
         }
 #endif
     }
+    // set servo outputs to failsafe position on start in case they want to play silly buggers!
+    servosFailsafe();
     return DURATION_NEVER;
 }
 

--- a/src/lib/ServoOutput/devServoOutput.h
+++ b/src/lib/ServoOutput/devServoOutput.h
@@ -13,9 +13,7 @@ extern device_t ServoOut_device;
 #define OPT_HAS_SERVO_OUTPUT (GPIO_PIN_PWM_OUTPUTS_COUNT > 0)
 
 // Notify this unit that new channel data has arrived
-void servoNewChannelsAvaliable();
-// Convert eServoOutputMode to microseconds, or 0 for non-servo modes
-uint16_t servoOutputModeToUs(eServoOutputMode mode);
+void servoNewChannelsAvailable();
 #else
-inline void servoNewChannelsAvaliable(){};
+inline void servoNewChannelsAvailable(){};
 #endif

--- a/src/lib/logging/logging.h
+++ b/src/lib/logging/logging.h
@@ -51,7 +51,7 @@ void debugFreeInitLogger();
       LOGGING_UART.print("ERROR: "); \
       debugPrintf(msg, ##__VA_ARGS__); \
       LOGGING_UART.println(); \
-  })(LOGGING_UART.println("ERROR: " msg))
+  },LOGGING_UART.println("ERROR: " msg))
 #endif
 
 #if defined(DEBUG_LOG) && !defined(CRITICAL_FLASH)

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -733,7 +733,7 @@ void ICACHE_RAM_ATTR HWtimerCallbackTock()
     if (ExpressLRS_currAirRate_Modparams->numOfSends > 1 && !(OtaNonce % ExpressLRS_currAirRate_Modparams->numOfSends) && LQCalcDVDA.currentIsSet())
     {
         crsfRCFrameAvailable();
-        servoNewChannelsAvaliable();
+        servoNewChannelsAvailable();
     }
 
     if (!didFHSS)
@@ -846,7 +846,7 @@ static void ICACHE_RAM_ATTR ProcessRfPacket_RC(OTA_Packet_s const * const otaPkt
         if (ExpressLRS_currAirRate_Modparams->numOfSends == 1)
         {
             crsfRCFrameAvailable();
-            servoNewChannelsAvaliable();
+            servoNewChannelsAvailable();
         }
         else if (!LQCalcDVDA.currentIsSet())
         {


### PR DESCRIPTION
As part of the PWM (ESP32-S3) refactor I broke the LEDC PWM support for regular ESP32 devices. This only affected channels > 12 as the first 12 are driven by the MCPWM module.

~Also, as a part of this I output the failsafe values at startup rather than no-signal as the ESP32 boot ROM outputs PWM signal on some pins and causes some servos to go mad and push into areas past the limits of the model they are connected to.~

EDIT: I removed the part where I set the failsafe positions on startup as this should really be a separate PR after discussion about the best way to achieve the desired outcome.