### PR TITLE
Automatically save the RX initial rate on disconnect

### DIFF
--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -45,13 +45,6 @@ static struct luaItem_selection luaTlmPower = {
 };
 #endif
 
-static struct luaItem_selection luaRateInitIdx = {
-    {"Init Rate", CRSF_TEXT_SELECTION},
-    0, // value
-    STR_LUA_PACKETRATES,
-    STR_EMPTYSPACE
-};
-
 #if defined(GPIO_PIN_ANT_CTRL)
 static struct luaItem_selection luaAntennaMode = {
     {"Ant. Mode", CRSF_TEXT_SELECTION},
@@ -351,10 +344,6 @@ static void registerLuaParameters()
   luadevGeneratePowerOpts(&luaTlmPower);
   registerLUAParameter(&luaTlmPower, &luaparamSetPower);
 #endif
-  registerLUAParameter(&luaRateInitIdx, [](struct luaPropertiesCommon* item, uint8_t arg) {
-    uint8_t newRate = RATE_MAX - 1 - arg;
-    config.SetRateInitialIdx(newRate);
-  });
   registerLUAParameter(&luaLoanModel, [](struct luaPropertiesCommon* item, uint8_t arg){
     // Do it when polling for status i.e. going back to idle, because we're going to lose conenction to the TX
     if (arg == 6) {
@@ -407,7 +396,6 @@ static int event()
   uint8_t luaPwrVal = (config.GetPower() == PWR_MATCH_TX) ? POWERMGNT::getMaxPower() + 1 : config.GetPower();
   setLuaTextSelectionValue(&luaTlmPower, luaPwrVal - POWERMGNT::getMinPower());
 #endif
-  setLuaTextSelectionValue(&luaRateInitIdx, RATE_MAX - 1 - config.GetRateInitialIdx());
 
 #if defined(GPIO_PIN_PWM_OUTPUTS)
   if (OPT_HAS_SERVO_OUTPUT)

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -759,6 +759,10 @@ void LostConnection(bool resumeRx)
 {
     DBGLN("lost conn fc=%d fo=%d", FreqCorrection, hwTimer::getFreqOffset());
 
+    // Use this rate as the initial rate next time if we connected on it
+    if (connectionState == connected)
+        config.SetRateInitialIdx(ExpressLRS_nextAirRateIndex);
+
     RFmodeCycleMultiplier = 1;
     connectionState = disconnected; //set lost connection
     RXtimerState = tim_disconnected;
@@ -1207,7 +1211,7 @@ static void setupSerial()
     {
         hottTlmSerial = true;
         serialBaud = 19200;
-    }    
+    }
 #endif
     bool invert = config.GetSerialProtocol() == PROTOCOL_SBUS || config.GetSerialProtocol() == PROTOCOL_INVERTED_CRSF || config.GetSerialProtocol() == PROTOCOL_DJI_RS_PRO;
 
@@ -1264,11 +1268,11 @@ static void setupSerial()
 
 #if defined(PLATFORM_ESP8266)
     SerialConfig config = SERIAL_8N1;
-    
+
     if(sbusSerialOutput)
     {
         config = SERIAL_8E2;
-    }    
+    }
     else if(hottTlmSerial)
     {
         config = SERIAL_8N2;
@@ -1280,14 +1284,14 @@ static void setupSerial()
     uint32_t config = SERIAL_8N1;
 
     if(sbusSerialOutput)
-    { 
+    {
         config = SERIAL_8E2;
     }
     else if(hottTlmSerial)
     {
         config = SERIAL_8N2;
     }
-    
+
     Serial.begin(serialBaud, config, GPIO_PIN_RCSIGNAL_RX, GPIO_PIN_RCSIGNAL_TX, invert);
 #endif
 


### PR DESCRIPTION
Automatically save the RX initial rate on disconnect! Did I stutter?!

We see this question a lot about how slowly ExpressLRS connects (or _binds_ 😡) and nobody knows about the setting to make it start faster. This PR just saves current packet rate when the receiver disconnects. This occurs every time the packet rate is changed via the Lua too, since that's a forced disconnect. I do not do it on connect, as that could cause the RX to stall during the flash write and lose connection.

I initially wrote InitRate as just a config item due to the danger of trying to do an flash write operation while flying and you just failsafed-- it is like the one time you need your receiver to be back up and running as fast as possible. However, I've been flying with this code for months now, with plenty of failsafe testing, and haven't experienced unexpected behavior.

### Unhappy case
In the case where:
* The receiver has a different InitRate than the handset, e.g. a new receiver on an existing EdgeTX model
* The receiver eventually connects, pilot flies, wheee! ✈
* The pilot does the right thing and unplugs the battery before turning off the handset
* RESULT: InitRate is not updated, next boot's connect takes just as long :(

Workaround: Turn off the handset while connected (haha what could go wrong), or set the packet rate again while the receiver is connected. 

## VOTE!
👍 we remove the Lua config item too
👎 leave the RX Lua "Init Rate" item even though we do not respect the user's choice and overwrite it all the time. This adds another workaround to the unhappy case, using the Lua to set it. However, I think people will get upset and confused if we leave it in how they "always change the InitRate and it **always** keeps resetting to some random value"