### PR TITLE
Hide lua backpack items if the backpack is disabled

### DIFF
--- a/src/lib/LUA/lua.h
+++ b/src/lib/LUA/lua.h
@@ -21,7 +21,7 @@ enum lua_Flags{
 
 struct luaPropertiesCommon {
     const char* const name;    // display name
-    const crsf_value_type_e type;
+    crsf_value_type_e type;
     uint8_t id;         // Sequential id assigned by enumeration
     uint8_t parent;     // id of parent folder
 } PACKED;
@@ -115,12 +115,12 @@ struct luaItem_float {
 } PACKED;
 
 struct luaItem_string {
-    const struct luaPropertiesCommon common;
+    struct luaPropertiesCommon common;
     const char* value;
 } PACKED;
 
 struct luaItem_folder {
-    const struct luaPropertiesCommon common;
+    struct luaPropertiesCommon common;
     char* dyn_name;
 } PACKED;
 
@@ -137,6 +137,9 @@ uint8_t getLuaWarningFlags(void);
 
 void luaRegisterDevicePingCallback(void (*callback)());
 #endif
+
+#define LUA_FIELD_HIDE(fld) { fld.common.type = (crsf_value_type_e)((uint8_t)fld.common.type | CRSF_FIELD_HIDDEN); }
+#define LUA_FIELD_SHOW(fld) { fld.common.type = (crsf_value_type_e)((uint8_t)fld.common.type & ~CRSF_FIELD_HIDDEN); }
 
 void sendLuaCommandResponse(struct luaItem_command *cmd, luaCmdStep_e step, const char *message);
 

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -31,8 +31,6 @@ static const char luastrHeadTrackingEnable[] = "Off;On;" STR_LUA_ALLAUX_UPDOWN;
 static const char luastrHeadTrackingStart[] = STR_LUA_ALLAUX;
 static const char luastrOffOn[] = "Off;On";
 
-static const char luastrDisabled[] = "Disabled";
-
 #define HAS_RADIO (GPIO_PIN_SCK != UNDEF_PIN)
 
 static struct luaItem_selection luaAirRate = {
@@ -343,21 +341,23 @@ static void luadevUpdateBackpackOpts()
   if (config.GetBackpackDisable())
   {
     // If backpack is disabled, set all the Backpack select options to "Disabled"
-    luaDvrAux.options = luastrDisabled;
-    luaDvrStartDelay.options = luastrDisabled;
-    luaDvrStopDelay.options = luastrDisabled;
-    luaHeadTrackingEnableChannel.options = luastrDisabled;
-    luaHeadTrackingStartChannel.options = luastrDisabled;
-    luaBackpackTelemetry.options = luastrDisabled;
+    LUA_FIELD_HIDE(luaDvrAux);
+    LUA_FIELD_HIDE(luaDvrStartDelay);
+    LUA_FIELD_HIDE(luaDvrStopDelay);
+    LUA_FIELD_HIDE(luaHeadTrackingEnableChannel);
+    LUA_FIELD_HIDE(luaHeadTrackingStartChannel);
+    LUA_FIELD_HIDE(luaBackpackTelemetry);
+    LUA_FIELD_HIDE(luaBackpackVersion);
   }
   else
   {
-    luaDvrAux.options = luastrDvrAux;
-    luaDvrStartDelay.options = luastrDvrDelay;
-    luaDvrStopDelay.options = luastrDvrDelay;
-    luaHeadTrackingEnableChannel.options = luastrHeadTrackingEnable;
-    luaHeadTrackingStartChannel.options = luastrHeadTrackingStart;
-    luaBackpackTelemetry.options = luastrOffOn;
+    LUA_FIELD_SHOW(luaDvrAux);
+    LUA_FIELD_SHOW(luaDvrStartDelay);
+    LUA_FIELD_SHOW(luaDvrStopDelay);
+    LUA_FIELD_SHOW(luaHeadTrackingEnableChannel);
+    LUA_FIELD_SHOW(luaHeadTrackingStartChannel);
+    LUA_FIELD_SHOW(luaBackpackTelemetry);
+    LUA_FIELD_SHOW(luaBackpackVersion);
   }
 }
 

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -29,6 +29,7 @@ static const char luastrDvrAux[] = "Off;" STR_LUA_ALLAUX_UPDOWN;
 static const char luastrDvrDelay[] = "0s;5s;15s;30s;45s;1min;2min";
 static const char luastrHeadTrackingEnable[] = "Off;On;" STR_LUA_ALLAUX_UPDOWN;
 static const char luastrHeadTrackingStart[] = STR_LUA_ALLAUX;
+static const char luastrOffOn[] = "Off;On";
 
 static const char luastrDisabled[] = "Disabled";
 
@@ -104,7 +105,7 @@ static struct luaItem_selection luaSwitch = {
 static struct luaItem_selection luaModelMatch = {
     {"Model Match", CRSF_TEXT_SELECTION},
     0, // value
-    "Off;On",
+    luastrOffOn,
     modelMatchUnit
 };
 
@@ -209,7 +210,7 @@ static struct luaItem_command luaVtxSend = {
 struct luaItem_selection luaBluetoothTelem = {
     {"BT Telemetry", CRSF_TEXT_SELECTION},
     0, // value
-    "Off;On",
+    luastrOffOn,
     STR_EMPTYSPACE
 };
 #endif
@@ -223,7 +224,7 @@ static struct luaItem_folder luaBackpackFolder = {
 static struct luaItem_selection luaBackpackEnable = {
     {"Backpack", CRSF_TEXT_SELECTION},
     0, // value
-    "Off;On",
+    luastrOffOn,
     STR_EMPTYSPACE};
 #endif
 
@@ -260,7 +261,7 @@ static struct luaItem_selection luaHeadTrackingStartChannel = {
 static struct luaItem_selection luaBackpackTelemetry = {
     {"Telemetry", CRSF_TEXT_SELECTION},
     0, // value
-    "Off;On",
+    luastrOffOn,
     STR_EMPTYSPACE};
 
 static struct luaItem_string luaBackpackVersion = {
@@ -347,6 +348,7 @@ static void luadevUpdateBackpackOpts()
     luaDvrStopDelay.options = luastrDisabled;
     luaHeadTrackingEnableChannel.options = luastrDisabled;
     luaHeadTrackingStartChannel.options = luastrDisabled;
+    luaBackpackTelemetry.options = luastrDisabled;
   }
   else
   {
@@ -355,6 +357,7 @@ static void luadevUpdateBackpackOpts()
     luaDvrStopDelay.options = luastrDvrDelay;
     luaHeadTrackingEnableChannel.options = luastrHeadTrackingEnable;
     luaHeadTrackingStartChannel.options = luastrHeadTrackingStart;
+    luaBackpackTelemetry.options = luastrOffOn;
   }
 }
 

--- a/src/lua/elrsV3.lua
+++ b/src/lua/elrsV3.lua
@@ -657,9 +657,10 @@ local function reloadRelatedFields(field)
   for fieldId = fields_count, 1, -1 do
     -- Skip this field, will be added to end
     local fldTest = fields[fieldId]
+    local fldType = fldTest.type or 99 -- type could be nil if still loading
     if fieldId ~= field.id
       and fldTest.parent == field.parent
-      and (fldTest.type or 99) < 11 then -- type could be nil if still loading
+      and fldType ~= 11 and fldType ~= 13 then -- ignores FOLDER/COMMAND
       fldTest.nc = true -- "no cache" the options
       loadQ[#loadQ+1] = fieldId
     end

--- a/src/lua/elrsV3.lua
+++ b/src/lua/elrsV3.lua
@@ -660,7 +660,7 @@ local function reloadRelatedFields(field)
     local fldType = fldTest.type or 99 -- type could be nil if still loading
     if fieldId ~= field.id
       and fldTest.parent == field.parent
-      and fldType ~= 11 and fldType ~= 13 then -- ignores FOLDER/COMMAND
+      and (fldType < 11 or fldType == 12) then -- ignores FOLDER/COMMAND/devices/EXIT
       fldTest.nc = true -- "no cache" the options
       loadQ[#loadQ+1] = fieldId
     end


### PR DESCRIPTION
Instead of setting backpack items to display "Disabled", when the backpack is off, this just hides them. In a future update to the Lua (already complete), hidden items take less RAM because they do not fully load until they are shown.

I was in this code because #2370 didn't respect the Disabled flag and therefore always shows `Telemetry` regardless of if the backpack is enabled or disabled. However, this now hides that as well as the `Version` field.

### Other Bugs
Note that the Version field still displays after changing the backpack state to off and vice versa, but that's due to the Lua not reloading it on change properly, but I have also fixed that in another set of changes. Exiting the script and coming back loads it properly.

I didn't include the Lua in this because if anyone had to review another lua update for 3.4 they'd probably murder me 😅 