### PR TITLE
Fix LBT fall back mode

### DIFF
--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -62,6 +62,7 @@ SX1280Driver::SX1280Driver(): SX12xxDriverCommon()
     timeout = 0xffff;
     currOpmode = SX1280_MODE_SLEEP;
     lastSuccessfulPacketRadio = SX12XX_Radio_1;
+    fallBackMode = SX1280_MODE_STDBY_RC;
 }
 
 void SX1280Driver::End()
@@ -114,6 +115,7 @@ bool SX1280Driver::Begin()
     }
 
 #if defined(TARGET_RX)
+    fallBackMode = SX1280_MODE_FS;
     hal.WriteCommand(SX1280_RADIO_SET_AUTOFS, 0x01, SX12XX_Radio_All); //Enable auto FS
 #else
 /*
@@ -124,6 +126,7 @@ transitioning from FS mode and the other from Standby mode. This causes the tx d
 */
     if (GPIO_PIN_NSS_2 == UNDEF_PIN)
     {
+        fallBackMode = SX1280_MODE_FS;
         hal.WriteCommand(SX1280_RADIO_SET_AUTOFS, 0x01, SX12XX_Radio_All); //Enable auto FS
     }
 #endif
@@ -480,7 +483,7 @@ void ICACHE_RAM_ATTR SX1280Driver::TXnb(uint8_t * data, uint8_t size, SX12XX_Rad
     if (currOpmode == SX1280_MODE_TX)
     {
         DBGLN("Timeout!");
-        SetMode(SX1280_MODE_FS, SX12XX_Radio_All);
+        SetMode(fallBackMode, SX12XX_Radio_All);
         ClearIrqStatus(SX1280_IRQ_RADIO_ALL, SX12XX_Radio_All);
         TXnbISR();
         return;
@@ -488,7 +491,7 @@ void ICACHE_RAM_ATTR SX1280Driver::TXnb(uint8_t * data, uint8_t size, SX12XX_Rad
 
     if (radioNumber == SX12XX_Radio_NONE)
     {
-        instance->SetMode(SX1280_MODE_FS, SX12XX_Radio_All);
+        instance->SetMode(fallBackMode, SX12XX_Radio_All);
         return;
     }
 
@@ -509,11 +512,11 @@ void ICACHE_RAM_ATTR SX1280Driver::TXnb(uint8_t * data, uint8_t size, SX12XX_Rad
         // Make sure the unused radio is in FS mode and will not receive the tx packet.
         if (radioNumber == SX12XX_Radio_1)
         {
-            instance->SetMode(SX1280_MODE_FS, SX12XX_Radio_2);
+            instance->SetMode(fallBackMode, SX12XX_Radio_2);
         }
         else
         {
-            instance->SetMode(SX1280_MODE_FS, SX12XX_Radio_1);
+            instance->SetMode(fallBackMode, SX12XX_Radio_1);
         }
     }
 

--- a/src/lib/SX1280Driver/SX1280.h
+++ b/src/lib/SX1280Driver/SX1280.h
@@ -62,6 +62,7 @@ private:
     bool modeSupportsFei;
     uint8_t pwrCurrent;
     uint8_t pwrPending;
+    SX1280_RadioOperatingModes_t fallBackMode;
 
     void SetMode(SX1280_RadioOperatingModes_t OPmode, SX12XX_Radio_Number_t radioNumber);
     void SetFIFOaddr(uint8_t txBaseAddr, uint8_t rxBaseAddr);


### PR DESCRIPTION
Normal tx modules and Gemini use different fallback modes after rxtx done.  This is set with SX1280_RADIO_SET_AUTOFS.  The current default fallback to FS mode will put Gemini tx modules out of step a little e.g. if radio1 did not pass channelclear for LBT, then it will be placed into FS, and radio2 will fallback to RC mode after txdone.  The following tx mode and IRQs will then be out of sync.

Needs testing!!!