### PR TITLE
SPIEx on ESP32 was using the wrong underlying bus!

### DIFF
--- a/src/lib/SPIEx/SPIEx.cpp
+++ b/src/lib/SPIEx/SPIEx.cpp
@@ -12,8 +12,8 @@ void ICACHE_RAM_ATTR SPIExClass::_transfer(uint8_t cs_mask, uint8_t *data, uint3
     while(spi->cmd.usr) {}
 
     // Set the CS pins which we want controlled by the SPI module for this operation
-    spiDisableSSPins(SPIEx.bus(), ~cs_mask);
-    spiEnableSSPins(SPIEx.bus(), cs_mask);
+    spiDisableSSPins(bus(), ~cs_mask);
+    spiEnableSSPins(bus(), cs_mask);
 
 #if defined(PLATFORM_ESP32_S3)
     spi->ms_dlen.ms_data_bitlen = (size*8)-1;
@@ -89,4 +89,10 @@ void ICACHE_RAM_ATTR SPIExClass::_transfer(uint8_t cs_mask, uint8_t *data, uint3
 #endif
 }
 
+#if defined(PLATFORM_ESP32_S3)
+SPIExClass SPIEx(FSPI);
+#elif defined(PLATFORM_ESP32)
+SPIExClass SPIEx(VSPI);
+#else
 SPIExClass SPIEx;
+#endif

--- a/src/lib/VTXSPI/devVTXSPI.cpp
+++ b/src/lib/VTXSPI/devVTXSPI.cpp
@@ -273,11 +273,7 @@ static void initialize()
     {
         if (GPIO_PIN_SPI_VTX_SCK != UNDEF_PIN && GPIO_PIN_SPI_VTX_SCK != GPIO_PIN_SCK)
         {
-            #if defined(PLATFORM_ESP32_S3)
-            vtxSPI = new SPIClass(FSPI);
-            #else
-            vtxSPI = new SPIClass(VSPI);
-            #endif
+            vtxSPI = new SPIClass(HSPI);
             vtxSPI->begin(GPIO_PIN_SPI_VTX_SCK, GPIO_PIN_SPI_VTX_MISO, GPIO_PIN_SPI_VTX_MOSI, GPIO_PIN_SPI_VTX_NSS);
             vtxSPI->setHwCs(true);
             vtxSPI->setBitOrder(LSBFIRST);


### PR DESCRIPTION
Whilst making some additions to the OLED/TFT display code it was found that TFT was not working.
The problem is that the default constructor value for the SPI class is HSPI, and the default instance calls the constructor with a different bus ID! So when the SPIEx class was written the default HSPI was copied over and the default global instance of the class did NOT pass the correct value, so it used the wrong bus.

The default SPI bus for ESP32 is VSPI and for S3 it is FSPI.
The available SPI bus for other things, i.e. VTXSPI and OLED/TFT is HSPI in both cases.

Wi this fix in place the TFT display on the Axis is working again.