### PR TITLE
Oops, undo setting the out directory

### DIFF
--- a/src/python/binary_configurator.py
+++ b/src/python/binary_configurator.py
@@ -348,7 +348,7 @@ def main():
     # Flashing options
     parser.add_argument("--flash", type=UploadMethod, choices=list(UploadMethod), help="Flashing Method")
     parser.add_argument("--erase", action='store_true', default=False, help="Full chip erase before flashing on ESP devices")
-    parser.add_argument('--out', action=writeable_dir, default=".")
+    parser.add_argument('--out', action=writeable_dir, default=None)
     parser.add_argument("--port", type=str, help="SerialPort or WiFi address to flash firmware to")
     parser.add_argument("--baud", type=int, default=0, help="Baud rate for serial communication")
     parser.add_argument("--force", action='store_true', default=False, help="Force upload even if target does not match")
@@ -372,10 +372,10 @@ def main():
             firmware_dir = '' if args.fdir is None else args.fdir + '/'
             srcdir = firmware_dir + ('LBT/' if args.lbt else 'FCC/') + file
             dst = 'firmware.bin'
-            shutil.copy2(srcdir + '/firmware.bin', args.out)
-            if os.path.exists(srcdir + '/bootloader.bin'): shutil.copy2(srcdir + '/bootloader.bin', args.out)
-            if os.path.exists(srcdir + '/partitions.bin'): shutil.copy2(srcdir + '/partitions.bin', args.out)
-            if os.path.exists(srcdir + '/boot_app0.bin'): shutil.copy2(srcdir + '/boot_app0.bin', args.out)
+            shutil.copy2(srcdir + '/firmware.bin', ".")
+            if os.path.exists(srcdir + '/bootloader.bin'): shutil.copy2(srcdir + '/bootloader.bin', ".")
+            if os.path.exists(srcdir + '/partitions.bin'): shutil.copy2(srcdir + '/partitions.bin', ".")
+            if os.path.exists(srcdir + '/boot_app0.bin'): shutil.copy2(srcdir + '/boot_app0.bin', ".")
             args.file = open(dst, 'r+b')
         except FileNotFoundError:
             print("Firmware files not found, did you download and unpack them in this directory?")


### PR DESCRIPTION
The previous PR was not 100% backwards compatible! This one fixes that and is also compatible with the upcoming changes in Configurator which uses the separated hardware targets artifacts from the firmware artefacts; which enables us to add new targets an any time and configurator will check the modification time of the artifact and make them available immediately.

This has been tested with a 1.6.0 release of Configurator and a local build of PR [#566](https://github.com/ExpressLRS/ExpressLRS-Configurator/pull/566) 