### PR TITLE
Add SS for the uplink mav data

### DIFF
--- a/src/lib/MSP/msptypes.h
+++ b/src/lib/MSP/msptypes.h
@@ -31,6 +31,8 @@
 #define MSP_ELRS_POWER_CALI_GET             0x20
 #define MSP_ELRS_POWER_CALI_SET             0x21
 
+#define MSP_ELRS_MAVLINK_TLM                0xFD
+
 // CRSF encapsulated msp defines
 #define ENCAPSULATED_MSP_HEADER_CRC_LEN     4
 #define ENCAPSULATED_MSP_MAX_PAYLOAD_SIZE   4

--- a/src/lib/OTA/OTA.h
+++ b/src/lib/OTA/OTA.h
@@ -64,7 +64,9 @@ typedef struct {
         } PACKED dbg_linkstats;
         /** PACKET_TYPE_MSP **/
         struct {
-            uint8_t packageIndex;
+            uint8_t packageIndex:5,
+                    tlmFlag:1,
+                    spare:2;
             uint8_t payload[ELRS4_MSP_BYTES_PER_CALL];
         } msp_ul;
         /** PACKET_TYPE_SYNC **/
@@ -115,7 +117,8 @@ typedef struct {
         /** PACKET_TYPE_MSP **/
         struct {
             uint8_t packetType: 2,
-                    packageIndex: 6;
+                    packageIndex: 5,
+                    tlmFlag: 1;
             uint8_t payload[ELRS8_MSP_BYTES_PER_CALL];
         } msp_ul;
         /** PACKET_TYPE_SYNC **/

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1133,6 +1133,11 @@ void MspReceiveComplete()
         loanBindTimeout = LOAN_BIND_TIMEOUT_MSP;
         InLoanBindingMode = true;
         break;
+    case MSP_ELRS_MAVLINK_TLM: // 0xFD
+        // raw mavlink data
+        mavlinkOutputBuffer.atomicPushBytes(&MspData[2], MspData[1]);
+        MspReceiver.Unlock();
+        break;
     default:
         //handle received CRSF package
         crsf_ext_header_t *receivedHeader = (crsf_ext_header_t *) MspData;
@@ -1768,17 +1773,7 @@ void loop()
 
     if (MspReceiver.HasFinishedData())
     {
-        if (MspData[0] == MSP_ELRS_MAVLINK_TLM)
-        {
-            // raw mavlink data
-            uint8_t count = MspData[1];
-            mavlinkOutputBuffer.atomicPushBytes(&MspData[2], count);
-            MspReceiver.Unlock();
-        }
-        else
-        {
-            MspReceiveComplete();
-        }
+        MspReceiveComplete();
     }
 
     devicesUpdate(now);

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1136,7 +1136,6 @@ void MspReceiveComplete()
     case MSP_ELRS_MAVLINK_TLM: // 0xFD
         // raw mavlink data
         mavlinkOutputBuffer.atomicPushBytes(&MspData[2], MspData[1]);
-        MspReceiver.Unlock();
         break;
     default:
         //handle received CRSF package


### PR DESCRIPTION
This private branch PR adds the stubborn sender to the `mavlink-rc` feature for the uplink data.
This should make the uplink more resilient at long range, where we have significant packet loss OTA.