### PR TITLE
chore: adapt serial protocol labels in WebUI and LUA script

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -200,7 +200,7 @@
 					<form class="mui-form" action='/config' id='config' method='POST'>
 						<div id="serial-config" style="display: block;">
 							<h2>Serial Protocol</h2>
-							Set the protocol used to communicate with the flight controller.
+							Set the protocol used to communicate with the flight controller or other external devices.
 							<br/><br/>
 							<div class="mui-select">
 								<select id='serial-protocol' name='serial-protocol'>

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -23,7 +23,7 @@ static const char *rxModes = "50Hz;60Hz;100Hz;160Hz;333Hz;400Hz;10kHzDuty;On/Off
 #endif
 
 static struct luaItem_selection luaSerialProtocol = {
-    {"Protocol", CRSF_TEXT_SELECTION},
+    {"Serial Protocol", CRSF_TEXT_SELECTION},
     0, // value
     "CRSF;Inverted CRSF;SBUS;Inverted SBUS;SUMD;DJI RS Pro;HoTT Telemetry",
     STR_EMPTYSPACE

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -23,7 +23,7 @@ static const char *rxModes = "50Hz;60Hz;100Hz;160Hz;333Hz;400Hz;10kHzDuty;On/Off
 #endif
 
 static struct luaItem_selection luaSerialProtocol = {
-    {"Serial Protocol", CRSF_TEXT_SELECTION},
+    {"Protocol", CRSF_TEXT_SELECTION},
     0, // value
     "CRSF;Inverted CRSF;SBUS;Inverted SBUS;SUMD;DJI RS Pro;HoTT Telemetry",
     STR_EMPTYSPACE


### PR DESCRIPTION
This PR proposes a minor change to the WebUI serial protocol selection label after having serial protocols now not only meant  to be used with FC's. -> changed `Set the protocol used to communicate with the flight controller.` to `Set the protocol used to communicate with the flight controller or other external devices.`

It further proposes a minor change to the LUA RX protocol selection label to be more precise about the purpose of the selection and to establish a mental connection to the same WebUI selection. Changed `Protocol` to `Serial Protocol`

![image](https://github.com/ExpressLRS/ExpressLRS/assets/5615068/dbb0330e-202b-4138-96fb-53d11fbc40ba)
![image](https://github.com/ExpressLRS/ExpressLRS/assets/5615068/ff87b40a-9d7f-49bb-af87-8402aed4bffe)

 

