### PR TITLE
Get thermal info from S3 if no LM75A

### DIFF
--- a/src/include/targets.h
+++ b/src/include/targets.h
@@ -65,6 +65,7 @@
 
 #ifndef HAS_THERMAL
 #define OPT_HAS_THERMAL false
+#define OPT_HAS_THERMAL_LM75A false
 #elif !defined(OPT_HAS_THERMAL)
 #define OPT_HAS_THERMAL true
 #endif

--- a/src/lib/THERMAL/devThermal.cpp
+++ b/src/lib/THERMAL/devThermal.cpp
@@ -60,10 +60,14 @@ uint32_t get_rpm();
 static void initialize()
 {
 #if defined(HAS_THERMAL)
+#if defined(PLATFORM_ESP32_S3)
+    thermal.init();
+#else
     if (OPT_HAS_THERMAL_LM75A && GPIO_PIN_SCL != UNDEF_PIN && GPIO_PIN_SDA != UNDEF_PIN)
     {
         thermal.init();
     }
+#endif
 #endif
     if (GPIO_PIN_FAN_EN != UNDEF_PIN)
     {
@@ -71,10 +75,12 @@ static void initialize()
     }
 }
 
-#if defined(HAS_THERMAL)
 static void timeoutThermal()
 {
+#if defined(HAS_THERMAL)
+#if !defined(PLATFORM_ESP32_S3)
     if(OPT_HAS_THERMAL_LM75A)
+#endif
     {
         thermal.handle();
 #ifdef HAS_SMART_FAN
@@ -90,8 +96,8 @@ static void timeoutThermal()
         }
 #endif
     }
-}
 #endif
+}
 
 #if defined(PLATFORM_ESP32)
 static void setFanSpeed()
@@ -258,12 +264,7 @@ static int event()
 
 static int timeout()
 {
-#if defined(HAS_THERMAL)
-    if (OPT_HAS_THERMAL_LM75A && GPIO_PIN_SCL != UNDEF_PIN && GPIO_PIN_SDA != UNDEF_PIN)
-    {
-        timeoutThermal();
-    }
-#endif
+    timeoutThermal();
     timeoutFan();
     timeoutTacho();
     return THERMAL_DURATION;

--- a/src/lib/THERMAL/thermal.cpp
+++ b/src/lib/THERMAL/thermal.cpp
@@ -6,6 +6,9 @@
 #include "lm75a.h"
 LM75A lm75a;
 #endif
+#if defined(PLATFORM_ESP32_S3)
+#include "driver/temp_sensor.h"
+#endif
 
 uint8_t thermal_threshold_data[] = {
     THERMAL_FAN_DEFAULT_HIGH_THRESHOLD,
@@ -17,18 +20,32 @@ uint8_t thermal_threshold_data[] = {
 };
 
 int thermal_status = THERMAL_STATUS_FAIL;
+static bool use_internal_sensor = false;
 
 void Thermal::init()
 {
     int status = -1;
-#ifdef HAS_THERMAL_LM75A
-    status = lm75a.init();
-#endif
+    if (OPT_HAS_THERMAL_LM75A)
+    {
+        status = lm75a.init();
+    }
+#if defined(PLATFORM_ESP32_S3)
+    if (status == -1)
+    {
+        temp_sensor_config_t temp_sensor = TSENS_CONFIG_DEFAULT();
+        temp_sensor.dac_offset = TSENS_DAC_L2;  //TSENS_DAC_L2 is default   L4(-40℃ ~ 20℃), L2(-10℃ ~ 80℃) L1(20℃ ~ 100℃) L0(50℃ ~ 125℃)
+        temp_sensor_set_config(temp_sensor);
+        temp_sensor_start();
+        use_internal_sensor = true;
+    }
+#else
     if(status == -1)
     {
         ERRLN("Thermal failed!");
+        return;
     }
     else
+#endif
     {
         DBGLN("Thermal OK!");
         temp_value = 0;
@@ -49,8 +66,15 @@ uint8_t Thermal::read_temp()
         ERRLN("thermal not ready!");
         return 0;
     }
-#ifdef HAS_THERMAL_LM75A
-    return lm75a.read_lm75a();
+    if (OPT_HAS_THERMAL_LM75A)
+    {
+        return lm75a.read_lm75a();
+    }
+
+#if defined(PLATFORM_ESP32_S3)
+    float result = 0;
+    temp_sensor_read_celsius(&result);
+    return result;
 #else
     return 0;
 #endif
@@ -77,9 +101,10 @@ void Thermal::update_threshold(int index)
     }
     uint8_t high = thermal_threshold_data[2*index];
     uint8_t low = thermal_threshold_data[2*index+1];
-#ifdef HAS_THERMAL_LM75A
-    lm75a.update_lm75a_threshold(high, low);
-#endif
+    if (OPT_HAS_THERMAL_LM75A)
+    {
+        lm75a.update_lm75a_threshold(high, low);
+    }
 }
 
 #endif


### PR DESCRIPTION
The ESP32-S3 has a built-in thermal sensor, so we can utilise that if theres no LM75A on a TX module.