### PR TITLE
Fix esp32s3 and backpack passthrough flashing settings

### DIFF
--- a/src/lib/Backpack/devBackpack.cpp
+++ b/src/lib/Backpack/devBackpack.cpp
@@ -41,9 +41,9 @@ void startPassthrough()
     // get ready for passthrough
     if (GPIO_PIN_RCSIGNAL_RX == GPIO_PIN_RCSIGNAL_TX)
         #if defined(PLATFORM_ESP32_S3)
-            CRSF::Port.begin(baud, SERIAL_8N1, 44, 43);  // 如果PLATFORM_ESP32_S3宏定义，则将引脚配置为44和43
+            CRSF::Port.begin(baud, SERIAL_8N1, 44, 43);  // 如果PLATFORM_ESP32_S3宏定义，则将引脚配置为44和43，If PLATFORM_ESP32_S3 macro is defined, pins are configured as 44 and 43
         #else
-            CRSF::Port.begin(baud, SERIAL_8N1, 3, 1);  // 否则继续使用默认引脚配置3和1
+            CRSF::Port.begin(baud, SERIAL_8N1, 3, 1);  // 否则继续使用默认引脚配置3和1，Otherwise continue to use default pin configuration 3 and 1
         #endif
     else
     {

--- a/src/lib/Backpack/devBackpack.cpp
+++ b/src/lib/Backpack/devBackpack.cpp
@@ -40,10 +40,11 @@ void startPassthrough()
     uint32_t baud = PASSTHROUGH_BAUD == -1 ? BACKPACK_LOGGING_BAUD : PASSTHROUGH_BAUD;
     // get ready for passthrough
     if (GPIO_PIN_RCSIGNAL_RX == GPIO_PIN_RCSIGNAL_TX)
-    {
-        // if we have a single S.PORT pin for RX then we assume the standard UART pins for passthrough
-        CRSF::Port.begin(baud, SERIAL_8N1, 3, 1);
-    }
+        #if defined(PLATFORM_ESP32_S3)
+            CRSF::Port.begin(baud, SERIAL_8N1, 44, 43);  // 如果PLATFORM_ESP32_S3宏定义，则将引脚配置为44和43
+        #else
+            CRSF::Port.begin(baud, SERIAL_8N1, 3, 1);  // 否则继续使用默认引脚配置3和1
+        #endif
     else
     {
         CRSF::Port.begin(baud, SERIAL_8N1, GPIO_PIN_RCSIGNAL_RX, GPIO_PIN_RCSIGNAL_TX);


### PR DESCRIPTION
The default U0RXT and U0TXD pins for ESP32 are 3 and 1 respectively.
The default U0RXT and U0TXD pins for ESP32S3 are 44 and 43 respectively.
So, when using ESP32S3, the passthrough burning may fail.