### PR TITLE
fix: SUMD not working at packet rates above 100Hz

### DIFF
--- a/src/src/rx-serial/SerialSUMD.cpp
+++ b/src/src/rx-serial/SerialSUMD.cpp
@@ -7,6 +7,8 @@
 #define SUMD_CRC_SIZE			2														// 16 bit CRC
 #define SUMD_FRAME_16CH_LEN		(SUMD_HEADER_SIZE+SUMD_DATA_SIZE_16CH+SUMD_CRC_SIZE)
 
+const auto SUMD_CALLBACK_INTERVAL_MS = 10;
+
 uint32_t SerialSUMD::sendRCFrame(bool frameAvailable, uint32_t *channelData)
 {
     if (!frameAvailable) {
@@ -74,5 +76,5 @@ uint32_t SerialSUMD::sendRCFrame(bool frameAvailable, uint32_t *channelData)
 
 	_outputPort->write(outBuffer, sizeof(outBuffer));
 
-    return DURATION_IMMEDIATELY;
+    return SUMD_CALLBACK_INTERVAL_MS;
 }


### PR DESCRIPTION
SUMD is supposed to run at a fixed 100Hz rate but is scheduled by DURATION_IMMEDIATELY leading to SUMD only working at 50Hz and 100Hz. Apologies, my bad.

Changes:
- schedule SUMD packets at SUMD_CALLBACK_INTERVAL_MS defined to be 10ms (100Hz)

