### PR TITLE
stlink flash fix bootloader path

### DIFF
--- a/src/python/binary_flash.py
+++ b/src/python/binary_flash.py
@@ -62,7 +62,7 @@ def upload_stm32_stlink(args, options: FirmwareOptions):
     app_start = flash_start + offset
 
     if options.bootloader is not None:
-        stlink.program_flash('bootloader/' + options.bootloader, flash_start, erase=True, verify=True, initialize_comms=True)
+        stlink.program_flash(args.fdir + '/bootloader/' + options.bootloader, flash_start, erase=True, verify=True, initialize_comms=True)
 
     stlink.program_flash(args.file.name, app_start, erase=True, verify=True, initialize_comms=True)
 

--- a/src/python/binary_flash.py
+++ b/src/python/binary_flash.py
@@ -62,7 +62,8 @@ def upload_stm32_stlink(args, options: FirmwareOptions):
     app_start = flash_start + offset
 
     if options.bootloader is not None:
-        stlink.program_flash(args.fdir + '/bootloader/' + options.bootloader, flash_start, erase=True, verify=True, initialize_comms=True)
+        bootloader_dir = '' if args.fdir is None else args.fdir + '/'
+        stlink.program_flash(bootloader_dir + 'bootloader/' + options.bootloader, flash_start, erase=True, verify=True, initialize_comms=True)
 
     stlink.program_flash(args.file.name, app_start, erase=True, verify=True, initialize_comms=True)
 


### PR DESCRIPTION
fixes https://github.com/ExpressLRS/ExpressLRS/issues/2482
related to https://github.com/ExpressLRS/ExpressLRS/issues/2468

This uses args.fdir to set the bootloader path.
This works on my machine running ubuntu 22.04