### PR TITLE
Fix PWM channel reset on TX/RX serial port config change via LUA

### DIFF
--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -199,7 +199,19 @@ static uint8_t configureSerialPin(uint8_t pin, uint8_t sibling, uint8_t oldMode,
       }
       else
       {
-        newPin3Config.val.mode = som50Hz;
+          rx_config_pwm_t oldSiblingConfig;
+          oldSiblingConfig.raw = config.GetPwmChannel(ch)->raw;
+
+          // Only when the old port was serial, switch it to PWM at the default 50Hz.
+          if (oldSiblingConfig.val.mode == somSerial)
+          {
+              newPin3Config.val.mode = som50Hz;
+          }
+          else
+          {
+              // retain the channel configuration if the sibiling is already in PWM mode
+              newPin3Config.raw = oldSiblingConfig.raw;
+          }
       }
       config.SetPwmChannelRaw(ch, newPin3Config.raw);
       break;


### PR DESCRIPTION
Previously whenever one of the RX or TX pins (that are used for PWM channels) was reconfigured via the LUA script (from the TX) the corresponding sibling channel (in case of the RX pin, the TX pin and vice versa) would also be reconfigured. That is a sane approach when there is only serial and PWM modes available.

Fortunately ELRS allows us to change the PWM frequency of the outputs. So an output channel can be in either serial, on/off, PWM 50Hz, PWM 100Hz, 333Hz, 400Hz or 10kHzDuty modes. Whenever any of these modes are selected (for either of the serial pins) the entire port configuration is also done for the sibling port. The caveat with the previous implementation (before this commit) is that a sibling port could only be in either serial or PWM 50Hz mode. If you wanted to configure multiple ports for e.g. 333Hz PWM you'd not be able to configure both of the serial ports (pin 1 & 3) for anything but 50Hz PWM as that value was the hard coded PWM value in the serial configuration code.

With the code path for reconfiguring a serial pin into PWM has become a tiny bit more complex. When a port is supposed to be switched to PWM mode but already is in PWM mode the siblings configuration will be retained.

This now allows for sibling serial ports to have independent PWM frequencies configured via the ELRS lua script, just as it was possible via the webinterface already.

Fixes #2485