### PR TITLE
Fix GetLastPacketStats() and diversity packet crc check

### DIFF
--- a/src/lib/OTA/OTA.cpp
+++ b/src/lib/OTA/OTA.cpp
@@ -491,6 +491,8 @@ bool ICACHE_RAM_ATTR ValidatePacketCrcFull(OTA_Packet_s * const otaPktPtr)
 
 bool ICACHE_RAM_ATTR ValidatePacketCrcStd(OTA_Packet_s * const otaPktPtr)
 {
+    uint8_t backupCrcHigh = otaPktPtr->std.crcHigh;
+
     uint16_t const inCRC = ((uint16_t)otaPktPtr->std.crcHigh << 8) + otaPktPtr->std.crcLow;
     // For smHybrid the CRC only has the packet type in byte 0
     // For smWide the FHSS slot is added to the CRC in byte 0 on PACKET_TYPE_RCDATAs
@@ -506,6 +508,9 @@ bool ICACHE_RAM_ATTR ValidatePacketCrcStd(OTA_Packet_s * const otaPktPtr)
     }
     uint16_t const calculatedCRC =
         ota_crc.calc((uint8_t*)otaPktPtr, OTA4_CRC_CALC_LEN, OtaCrcInitializer);
+
+    otaPktPtr->std.crcHigh = backupCrcHigh;
+    
     return inCRC == calculatedCRC;
 }
 

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -473,9 +473,6 @@ void ICACHE_RAM_ATTR SX127xDriver::GetLastPacketStats()
       hal.writeRegister(SX127X_REG_FIFO_ADDR_PTR, FIFOaddr, radio[secondRadioIdx]);
       hal.readRegister(SX127X_REG_FIFO, RXdataBuffer_second, PayloadLength, radio[secondRadioIdx]);
 
-      // leaving only the type in the first byte (crcHigh was cleared)
-      RXdataBuffer[0] &= 0b11;
-      RXdataBuffer_second[0] &= 0b11;
       // if the second packet is same to the first, it's valid
       if (memcmp(RXdataBuffer, RXdataBuffer_second, PayloadLength) == 0)
       {

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -628,9 +628,6 @@ void ICACHE_RAM_ATTR SX1280Driver::GetLastPacketStats()
                 WORD_ALIGNED_ATTR uint8_t RXdataBuffer_second[RXBuffSize];
                 hal.ReadBuffer (FIFOaddr, RXdataBuffer_second, PayloadLength, radio[secondRadioIdx]);
 
-                // leaving only the type in the first byte (crcHigh was cleared)
-                RXdataBuffer[0] &= 0b11;
-                RXdataBuffer_second[0] &= 0b11;
                 // if the second packet is same to the first, it's valid
                 if(memcmp(RXdataBuffer, RXdataBuffer_second, PayloadLength) == 0)
                 {

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -196,11 +196,6 @@ bool ICACHE_RAM_ATTR ProcessTLMpacket(SX12xxDriverCommon::rx_status const status
   }
 
   LastTLMpacketRecvMillis = millis();
-  LQCalc.add();
-
-  Radio.GetLastPacketStats();
-  crsf.LinkStatistics.downlink_SNR = SNR_DESCALE(Radio.LastPacketSNRRaw);
-  crsf.LinkStatistics.downlink_RSSI = Radio.LastPacketRSSI;
 
   // Full res mode
   if (OtaIsFullRes)
@@ -248,6 +243,12 @@ bool ICACHE_RAM_ATTR ProcessTLMpacket(SX12xxDriverCommon::rx_status const status
         break;
     }
   }
+
+  LQCalc.add();
+  Radio.GetLastPacketStats();
+  crsf.LinkStatistics.downlink_SNR = SNR_DESCALE(Radio.LastPacketSNRRaw);
+  crsf.LinkStatistics.downlink_RSSI = Radio.LastPacketRSSI;
+
   return true;
 }
 


### PR DESCRIPTION
The current GetLastPacketStats() is only setup for performing diversity crc checks correctly with the STD packet.  When using a FULL packet type the below lines would zero data in the first byte.

```
// leaving only the type in the first byte (crcHigh was cleared)
RXdataBuffer[0] &= 0b11;
RXdataBuffer_second[0] &= 0b11;
```

What happens?  When the TX receives TLM GetLastPacketStats() is called before processing the packets, which means bits for containsLinkStats and airport.count are zeroed and lost.  This is not an issue on the RX because GetLastPacketStats() is called after processing the packet data.

This PR does a couple of things.

- Moves GetLastPacketStats() to be called after processing packet data for TLM packets, and follow the same sequence of calls as the rx_main.
- Changes OtaValidatePacketCrc() to not alter Radio.RXdataBuffer behinds the scene.  After the check crcHigh is restored.
- Finally the offending lines above can be removed from GetLastPacketStats() because OtaValidatePacketCrc() no sponger alters Radio.RXdataBuffer.

This affects all Gemini TX hardware.