### PR TITLE
Allow flashing of the backpack on S3 via USB

### DIFF
--- a/src/lib/Backpack/devBackpack.cpp
+++ b/src/lib/Backpack/devBackpack.cpp
@@ -10,7 +10,6 @@
 #define BACKPACK_TIMEOUT 20    // How often to check for backpack commands
 
 extern bool InBindingMode;
-extern Stream *TxBackpack;
 extern char backpackVersion[];
 extern bool headTrackingEnabled;
 
@@ -29,33 +28,55 @@ bool lastRecordingState = false;
 #include "CRSF.h"
 #include "hwTimer.h"
 
-void startPassthrough()
+[[noreturn]] void startPassthrough()
 {
-    // stop everyhting
+    // stop everything
     devicesStop();
     Radio.End();
     hwTimer::stop();
     CRSF::End();
 
+    Stream *uplink = &CRSF::Port;
+
     uint32_t baud = PASSTHROUGH_BAUD == -1 ? BACKPACK_LOGGING_BAUD : PASSTHROUGH_BAUD;
     // get ready for passthrough
     if (GPIO_PIN_RCSIGNAL_RX == GPIO_PIN_RCSIGNAL_TX)
+    {
         #if defined(PLATFORM_ESP32_S3)
-            CRSF::Port.begin(baud, SERIAL_8N1, 44, 43);  // 如果PLATFORM_ESP32_S3宏定义，则将引脚配置为44和43，If PLATFORM_ESP32_S3 macro is defined, pins are configured as 44 and 43
+        // if UART0 is connected to the backpack then use the USB for the uplink
+        if (GPIO_PIN_DEBUG_RX == 44 && GPIO_PIN_DEBUG_TX == 43)
+        {
+            uplink = &Serial;
+            Serial.setTxBufferSize(1024);
+            Serial.setRxBufferSize(16384);
+        }
+        else
+        {
+            CRSF::Port.begin(baud, SERIAL_8N1, 44, 43);  // pins are configured as 44 and 43
+            CRSF::Port.setTxBufferSize(1024);
+            CRSF::Port.setRxBufferSize(16384);
+        }
         #else
-            CRSF::Port.begin(baud, SERIAL_8N1, 3, 1);  // 否则继续使用默认引脚配置3和1，Otherwise continue to use default pin configuration 3 and 1
+        CRSF::Port.begin(baud, SERIAL_8N1, 3, 1);  // default pin configuration 3 and 1
+        CRSF::Port.setTxBufferSize(1024);
+        CRSF::Port.setRxBufferSize(16384);
         #endif
+    }
     else
     {
         CRSF::Port.begin(baud, SERIAL_8N1, GPIO_PIN_RCSIGNAL_RX, GPIO_PIN_RCSIGNAL_TX);
+        CRSF::Port.setTxBufferSize(1024);
+        CRSF::Port.setRxBufferSize(16384);
     }
     disableLoopWDT();
 
-    HardwareSerial &backpack = *(HardwareSerial*)TxBackpack;
+    auto backpack = (HardwareSerial*)TxBackpack;
     if (baud != BACKPACK_LOGGING_BAUD)
     {
-        backpack.begin(PASSTHROUGH_BAUD, SERIAL_8N1, GPIO_PIN_DEBUG_RX, GPIO_PIN_DEBUG_TX);
+        backpack->begin(PASSTHROUGH_BAUD, SERIAL_8N1, GPIO_PIN_DEBUG_RX, GPIO_PIN_DEBUG_TX);
     }
+    backpack->setRxBufferSize(1024);
+    backpack->setTxBufferSize(16384);
 
     // reset ESP8285 into bootloader mode
     digitalWrite(GPIO_PIN_BACKPACK_BOOT, HIGH);
@@ -65,27 +86,29 @@ void startPassthrough()
     digitalWrite(GPIO_PIN_BACKPACK_EN, HIGH);
     delay(50);
 
-    CRSF::Port.flush();
-    backpack.flush();
+    uplink->flush();
+    backpack->flush();
 
     uint8_t buf[64];
-    while (backpack.available())
-        backpack.readBytes(buf, sizeof(buf));
+    while (backpack->available())
+    {
+        backpack->readBytes(buf, sizeof(buf));
+    }
 
     // go hard!
     for (;;)
     {
-        int r = CRSF::Port.available();
-        if (r > sizeof(buf))
-            r = sizeof(buf);
-        r = CRSF::Port.readBytes(buf, r);
-        backpack.write(buf, r);
+        int available_bytes = uplink->available();
+        if (available_bytes > sizeof(buf))
+            available_bytes = sizeof(buf);
+        auto bytes_read = uplink->readBytes(buf, available_bytes);
+        backpack->write(buf, bytes_read);
 
-        r = backpack.available();
-        if (r > sizeof(buf))
-            r = sizeof(buf);
-        r = backpack.readBytes(buf, r);
-        CRSF::Port.write(buf, r);
+        available_bytes = backpack->available();
+        if (available_bytes > sizeof(buf))
+            available_bytes = sizeof(buf);
+        bytes_read = backpack->readBytes(buf, available_bytes);
+        uplink->write(buf, bytes_read);
     }
 }
 #endif
@@ -100,6 +123,28 @@ void checkBackpackUpdate()
             startPassthrough();
         }
     }
+#if defined(PLATFORM_ESP32_S3)
+    // Start passthrough mode if an Espressif resync packet is detected on the USB port
+    static const uint8_t resync[] = {
+        0xc0,0x00,0x08,0x24,0x00,0x00,0x00,0x00,0x00,0x07,0x07,0x12,0x20,0x55,0x55,0x55,0x55,
+        0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55, 0x55,0x55,
+        0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0xc0
+    };
+    static int resync_pos = 0;
+    while(Serial.available())
+    {
+        int byte = Serial.read();
+        if (byte == resync[resync_pos])
+        {
+            resync_pos++;
+            if (resync_pos == sizeof(resync)) startPassthrough();
+        }
+        else
+        {
+            resync_pos = 0;
+        }
+    }
+#endif
 #endif
 }
 

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -26,13 +26,8 @@ lib_ignore = SX127xDriver
 
 # ------------------------- COMMON ESP32 DEFINITIONS -----------------
 
-# platform 5.1.0 uses arduino core 2.0.4 which has a "major" problem with
-# requiring the QIO bootloader on PICO devices, so upgrading older firmware
-# will be problem using OTA, unless we have a mechanism for uploading a new
-# bootloader first!
-
 [env_common_esp32]
-platform = espressif32@6.3.2
+platform = espressif32@6.4.0
 board = esp32dev
 board_build.partitions = min_spiffs.csv
 upload_speed = 460800
@@ -62,7 +57,7 @@ tft_lib_deps =
 	moononournation/GFX Library for Arduino @ 1.2.8
 
 [env_common_esp32s3tx]
-platform = espressif32@6.3.2
+platform = espressif32@6.4.0
 extends = env_common_esp32
 board = esp32-s3-devkitc-1
 build_flags =
@@ -71,7 +66,7 @@ build_flags =
 	-D ARDUINO_USB_CDC_ON_BOOT
 
 [env_common_esp32rx]
-platform = espressif32@6.3.2
+platform = espressif32@6.4.0
 board = esp32dev
 board_build.partitions = min_spiffs.csv
 upload_speed = 460800
@@ -94,7 +89,7 @@ lib_deps =
 	bblanchon/ArduinoJson @ 6.19.4
 
 [env_common_esp32s3rx]
-platform = espressif32@6.3.2
+platform = espressif32@6.4.0
 extends = env_common_esp32rx
 board = esp32-s3-devkitc-1
 build_flags =


### PR DESCRIPTION
Refactoring the backpack passthrough flashing code for allowing the USB port to flash the backpack if the backpack is connected to UART0.  Because the USB does not control GPIO0 and the HWCDC Serial implementation does not allow the detection of line state changes, we have to detect the presence of a resync packet on the Serial port to start passthrough flashing.

Requires backpack PR https://github.com/ExpressLRS/Backpack/pull/120 and targets PR https://github.com/ExpressLRS/targets/pull/22