### PR TITLE
ppm decode using esp32 RMT hardware

### DIFF
--- a/src/html/hardware.html
+++ b/src/html/hardware.html
@@ -86,6 +86,10 @@ td img.icon-pwm {
 					<tr><td width="30"></td><td>RX pin<img class="icon-input"/></td><td><input size='3' id='serial_rx' name='serial_rx' type='text'/></td><td>Pin used to receive CRSF signal from the handset</td></tr>
 					<tr><td></td><td>TX pin<img class="icon-output"/></td><td><input size='3' id='serial_tx' name='serial_tx' type='text'/></td><td>Pin used to transmit CRSF telemetry to the handset (may be the same as the RX PIN)</td></tr>
 
+					<tr><td colspan='2'><b>PPM Pin</td></tr>
+					<tr><td width="30"></td><td>PPM pin<img class="icon-input"/></td><td><input size='3' id='input_ppm' name='input_ppm' type='text'/></td><td>Pin used to receive PPM signal from the handset</td></tr>
+
+						
 					<tr><td colspan='2'><b>Radio Chip Pins & Options</td></tr>
 					<tr><td></td><td>BUSY pin<img class="icon-input"/></td><td><input size='3' id='radio_busy' name='radio_busy' type='text'/></td><td>GPIO Input connected to SX128x busy pin</td></tr>
 					<tr><td></td><td>DIO0 pin<img class="icon-input"/></td><td><input size='3' id='radio_dio0' name='radio_dio0' type='text'/></td><td>Unused on SX128x, Interrupt pin for SX127x</td></tr>

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -72,6 +72,13 @@
 							<label for="wifi-on-interval">WiFi "auto on" interval in seconds (leave blank to disable)</label>
 						</div>
 @@if isTX:
+						<div class="mui-select">
+							<select id='input_mode' name='input_mode'>
+								<option value='0'>PPM</option>
+								<option value='1'>CRSF</option>
+							</select>
+							<label for="domain">Input mode ppm/crsf </label>
+						</div>
 						<div class="mui-textfield">
 							<input size='5' id='tlm-interval' name='tlm-interval' type='text'/>
 							<label for="tlm-interval">TLM report interval (ms)</label>

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -200,6 +200,11 @@ enum eFailsafeMode : uint8_t
     FAILSAFE_SET_POSITION
 };
 
+enum eInputMode: uint8_t{
+    INPUT_PPM,
+    INPUT_CRSF
+};
+
 #ifndef UNIT_TEST
 #if defined(RADIO_SX127X)
 #define RATE_MAX 6

--- a/src/include/hardware.h
+++ b/src/include/hardware.h
@@ -138,6 +138,8 @@ typedef enum {
     HARDWARE_vtx_amp_vpd_25mW,
     HARDWARE_vtx_amp_vpd_100mW,
 
+    HARDWARE_input_ppm,
+
     HARDWARE_LAST
 } nameType;
 

--- a/src/include/target/Unified_ESP32_TX.h
+++ b/src/include/target/Unified_ESP32_TX.h
@@ -191,6 +191,13 @@
 #define OPT_HAS_THERMAL_LM75A hardware_flag(HARDWARE_thermal_lm75a)
 #define OPT_HAS_THERMAL OPT_HAS_THERMAL_LM75A // If any of the sensors are present
 
+/* for ppm input*/
+#define HAS_PPM_INPUT
+
+#define GPIO_PIN_INPUT_PPM hardware_pin(HARDWARE_input_ppm)
+
+
+
 /*
 // These are RX settings
 

--- a/src/include/target/Unified_ESP8285_TX.h
+++ b/src/include/target/Unified_ESP8285_TX.h
@@ -67,3 +67,5 @@
 #define WS2812_BOOT_LEDS_COUNT hardware_int(HARDWARE_ledidx_rgb_boot_count)
 
 #define GPIO_PIN_FAN_EN hardware_pin(HARDWARE_misc_fan_en)
+
+#define GPIO_PIN_INPUT_PPM hardware_pin(HARDWARE_input_ppm);

--- a/src/lib/OPTIONS/hardware.cpp
+++ b/src/lib/OPTIONS/hardware.cpp
@@ -129,6 +129,8 @@ static const struct {
     {HARDWARE_vtx_sck, "vtx_sck", INT},
     {HARDWARE_vtx_amp_vpd_25mW, "vtx_amp_vpd_25mW", ARRAY},
     {HARDWARE_vtx_amp_vpd_100mW, "vtx_amp_vpd_100mW", ARRAY},
+    {HARDWARE_input_ppm, "input_ppm", INT},
+
 };
 
 typedef union {

--- a/src/lib/OPTIONS/options.cpp
+++ b/src/lib/OPTIONS/options.cpp
@@ -127,6 +127,11 @@ __attribute__ ((used)) static firmware_options_t flashedOptions = {
 #else
     .is_airport = false,
 #endif
+#if defined(HAS_PPM_INPUT)
+    .input_mode = 0, //for ppm default
+#else 
+    .input_mode = 1,//for crsf default 
+#endif
 #if defined(GPIO_PIN_BUZZER)
     #if defined(DISABLE_ALL_BEEPS)
     .buzzer_mode = buzzerQuiet,
@@ -221,6 +226,7 @@ void saveOptions(Stream &stream, bool customised)
     doc["fan-runtime"] = firmwareOptions.fan_min_runtime;
     doc["unlock-higher-power"] = firmwareOptions.unlock_higher_power;
     doc["airport-uart-baud"] = firmwareOptions.uart_baud;
+    doc["input_mode"] = firmwareOptions.input_mode;
     #else
     doc["rcvr-uart-baud"] = firmwareOptions.uart_baud;
     doc["lock-on-first-connection"] = firmwareOptions.lock_on_first_connection;
@@ -321,6 +327,7 @@ static void options_LoadFromFlashOrFile(EspFlashStream &strmFlash)
     firmwareOptions.tlm_report_interval = doc["tlm-interval"] | 240U;
     firmwareOptions.fan_min_runtime = doc["fan-runtime"] | 30U;
     firmwareOptions.unlock_higher_power = doc["unlock-higher-power"] | false;
+    firmwareOptions.input_mode = doc["input_mode"] | 0;
     #if defined(USE_AIRPORT_AT_BAUD)
     firmwareOptions.uart_baud = doc["airport-uart-baud"] | USE_AIRPORT_AT_BAUD;
     firmwareOptions.is_airport = doc["is-airport"] | true;

--- a/src/lib/OPTIONS/options.h
+++ b/src/lib/OPTIONS/options.h
@@ -42,6 +42,7 @@ typedef struct _options {
     bool        _unused1:1;
     bool        unlock_higher_power:1;
     bool        is_airport:1;
+    uint8_t     input_mode:1; 
 #if defined(GPIO_PIN_BUZZER)
     uint8_t     buzzer_mode;            // 0 = disable all, 1 = beep once, 2 = disable startup beep, 3 = default tune, 4 = custom tune
     uint16_t    buzzer_melody[32][2];

--- a/src/lib/PPM/PPMReader.h
+++ b/src/lib/PPM/PPMReader.h
@@ -1,0 +1,79 @@
+#ifndef H_PPM
+#define H_PPM
+
+#include "targets.h"
+#include "crsf_protocol.h"
+#include "common.h"
+#include "Arduino.h"
+#include "esp32-hal.h"
+
+#include <stdio.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+#include "logging.h"
+
+
+#define PPM_RESOLUTION_NS 1000 // 1uS TICK
+#define PPM_MIN_SYMBOL_TICKS  10  //   10us
+#define PPM_MAX_SYMBOL_TICKS  2200 //  3ms max
+
+extern "C" void receive_process(uint32_t *data, size_t len, void * arg);
+
+class PPMReader {
+  private:
+    rmt_obj_t* rmt_recv = NULL;
+    float realNanoTick;
+    uint32_t lastActiveMS=0;
+  public:
+    int8_t gpio = -1;
+
+    PPMReader(uint8_t pin, float rmtFreqHz) 
+    {
+        if ((rmt_recv = rmtInit(pin, RMT_RX_MODE, RMT_MEM_192)) == NULL)
+        {
+            DBGLN("init receiver failed\n");        
+            return;
+        }
+        gpio = pin;
+        realNanoTick = rmtSetTick(rmt_recv, rmtFreqHz);
+        rmtSetFilter(rmt_recv, true,PPM_MIN_SYMBOL_TICKS);
+        rmtSetRxThreshold(rmt_recv,PPM_MAX_SYMBOL_TICKS);
+        DBGLN("PPM INIT OK");
+    }
+    void begin() {
+        // Creating RMT RX Callback Task
+      DBGLN("BEGIN PPM RECV TASK");
+      rmtRead(rmt_recv, receive_process, this);
+    }
+
+
+    void process(rmt_data_t *data, size_t len)
+    {
+        // DBGLN("RECV PPM SIG [%d] realTick[%f]",len,realNanoTick);
+        if(len>7 ){//has good packet
+          lastActiveMS=millis();
+        }
+        for (size_t i = 0; i<len-1; i++) {
+        // DBGLN("PPM CHANNEL VALUE %d [%d | %d | %d | %d]",i,data[i].level0 ,data[i].duration0,data[i].level1,data[i].duration1);
+        uint16_t value= (data[i].duration1 + data[i+1].duration0);
+        if(value > 900 && value < 2250){
+            ChannelData[i]=fmap(value,1000,2000,CRSF_CHANNEL_VALUE_MIN,CRSF_CHANNEL_VALUE_MAX);
+        }
+      }
+
+    }
+    bool isActive(){
+      uint32_t check=millis() - lastActiveMS;
+      return (check>500)? false:true;
+    }
+
+};
+
+
+void receive_process(uint32_t *data, size_t len, void * arg)
+{
+  PPMReader * p = (PPMReader *)arg;
+  p->process((rmt_data_t*) data, len);
+}
+#endif

--- a/src/lib/PPM/devPPM.h
+++ b/src/lib/PPM/devPPM.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "device.h"
+
+extern device_t PPM_device;

--- a/src/lib/PPM/devPPM_rx.cpp
+++ b/src/lib/PPM/devPPM_rx.cpp
@@ -1,0 +1,56 @@
+#include "targets.h"
+#include "devPPM.h"
+#include "logging.h"
+#include "PPMReader.h"
+ 
+#if defined( HAS_PPM_INPUT) && defined(PLATFORM_ESP32)
+static PPMReader *ppmReader=nullptr;
+extern bool webserverPreventAutoStart;
+
+static void initPPM()
+{
+    pinMode(GPIO_PIN_INPUT_PPM, INPUT_PULLUP);//input
+}
+
+/* at the end of setup call this to init dev ppm 
+return the timeout period in */
+static int start()
+{
+    if(ppmReader ==nullptr){
+        ppmReader=new PPMReader(GPIO_PIN_INPUT_PPM,PPM_RESOLUTION_NS);
+    }
+    DBGLN("START PPM ");
+    ppmReader->begin();
+    return DURATION_IMMEDIATELY;
+}
+
+//time out update connection status
+static int timeout()
+{
+
+    return DURATION_IGNORE;
+}
+
+//event triger by main ,recv & parse ppm data 
+static int  event()
+{
+    if(!ppmReader->isActive())
+    {
+        DBGLN("PPM lost set wifi on ");
+        webserverPreventAutoStart=false;
+    }else{
+        webserverPreventAutoStart=true;
+        DBGLN("PPM ACTIVE");
+    }
+    return DURATION_IGNORE;
+  //get value from ppmreader to ChannelData
+}
+
+device_t PPM_device = {
+    .initialize = initPPM,
+    .start = start,
+    .event = event,
+    .timeout = nullptr
+};
+
+#endif

--- a/src/python/serve_html.py
+++ b/src/python/serve_html.py
@@ -22,6 +22,7 @@ sx127x = False
 config = {
         "options": {
             "uid": [1,2,3,4,5,6],   # this is the 'flashed' UID and may be empty if using traditional binding on an RX.
+            "input_mode": 0, # input mode 0 for ppm 1 for crsf
             "tlm-interval": 240,
             "fan-runtime": 30,
             "no-sync-on-arm": False,


### PR DESCRIPTION
ppm decode using  hardware RMT timer to capture ppm, turn on wifi without ppm input in 60s , user can change input mode(ppm/crsf)  in web config page. working and test well on DIY esp32+E28 Tx hardware 