### PR TITLE
Add MAVLink telemetry option in LUA & Prevent Wide mode when relevant.

### DIFF
--- a/src/include/common.h
+++ b/src/include/common.h
@@ -32,7 +32,7 @@ typedef enum : uint8_t
     TLM_RATIO_1_8,
     TLM_RATIO_1_4,
     TLM_RATIO_1_2,
-    TLM_RATIO_MAVLINK, // Force TLM_RATIO_1_2
+    TLM_RATIO_MAVLINK, // Forces TLM_RATIO_1_2 and enables MAVLink mode on the TX
     TLM_RATIO_DISARMED, // TLM_RATIO_STD when disarmed, TLM_RATIO_NO_TLM when armed
 } expresslrs_tlm_ratio_e;
 

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -32,6 +32,7 @@ typedef enum : uint8_t
     TLM_RATIO_1_8,
     TLM_RATIO_1_4,
     TLM_RATIO_1_2,
+    TLM_RATIO_MAVLINK, // Force TLM_RATIO_1_2
     TLM_RATIO_DISARMED, // TLM_RATIO_STD when disarmed, TLM_RATIO_NO_TLM when armed
 } expresslrs_tlm_ratio_e;
 

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -43,7 +43,7 @@ static struct luaItem_selection luaAirRate = {
 static struct luaItem_selection luaTlmRate = {
     {"Telem Ratio", CRSF_TEXT_SELECTION},
     0, // value
-    "Std;Off;1:128;1:64;1:32;1:16;1:8;1:4;1:2;Race",
+    "Std;Off;1:128;1:64;1:32;1:16;1:8;1:4;1:2;MAVLink;Race",
     tlmBandwidth
 };
 
@@ -302,6 +302,16 @@ static void luadevUpdateTlmBandwidth()
     // For Standard ratio, display the ratio instead of bps
     strcpy(tlmBandwidth, " (1:");
     uint8_t ratioDiv = TLMratioEnumToValue(ExpressLRS_currAirRate_Modparams->TLMinterval);
+    itoa(ratioDiv, &tlmBandwidth[4], 10);
+    strcat(tlmBandwidth, ")");
+  }
+
+  // TLM_RATIO_MAVLINK
+  else if (eRatio == TLM_RATIO_MAVLINK)
+  {
+    // For Standard ratio, display the ratio instead of bps
+    strcpy(tlmBandwidth, " (1:");
+    uint8_t ratioDiv = TLMratioEnumToValue(TLM_RATIO_1_2);
     itoa(ratioDiv, &tlmBandwidth[4], 10);
     strcat(tlmBandwidth, ")");
   }

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -296,22 +296,13 @@ static void luadevUpdateModelID() {
 static void luadevUpdateTlmBandwidth()
 {
   expresslrs_tlm_ratio_e eRatio = (expresslrs_tlm_ratio_e)config.GetTlm();
-  // TLM_RATIO_STD / TLM_RATIO_DISARMED
-  if (eRatio == TLM_RATIO_STD || eRatio == TLM_RATIO_DISARMED)
+  // TLM_RATIO_STD / TLM_RATIO_DISARMED / TLM_RATIO_MAVLINK
+  if (eRatio == TLM_RATIO_STD || eRatio == TLM_RATIO_DISARMED || eRatio == TLM_RATIO_MAVLINK)
   {
     // For Standard ratio, display the ratio instead of bps
     strcpy(tlmBandwidth, " (1:");
     uint8_t ratioDiv = TLMratioEnumToValue(ExpressLRS_currAirRate_Modparams->TLMinterval);
-    itoa(ratioDiv, &tlmBandwidth[4], 10);
-    strcat(tlmBandwidth, ")");
-  }
-
-  // TLM_RATIO_MAVLINK
-  else if (eRatio == TLM_RATIO_MAVLINK)
-  {
-    // For Standard ratio, display the ratio instead of bps
-    strcpy(tlmBandwidth, " (1:");
-    uint8_t ratioDiv = TLMratioEnumToValue(TLM_RATIO_1_2);
+    ratioDiv = eRatio == TLM_RATIO_MAVLINK ? 2 : ratioDiv; // MAVLink forces 1:2 ratio
     itoa(ratioDiv, &tlmBandwidth[4], 10);
     strcat(tlmBandwidth, ")");
   }
@@ -583,12 +574,17 @@ static void registerLuaParameters()
     {
       uint8_t selectedRate = RATE_MAX - 1 - arg;
       uint8_t actualRate = adjustPacketRateForBaud(selectedRate);
+      uint8_t packetSize = get_elrs_airRateConfig(actualRate)->PayloadLength;
       uint8_t newSwitchMode = adjustSwitchModeForAirRate(
-        (OtaSwitchMode_e)config.GetSwitchMode(), get_elrs_airRateConfig(actualRate)->PayloadLength);
+        (OtaSwitchMode_e)config.GetSwitchMode(), packetSize);
       // If the switch mode is going to change, block the change while connected
       if (newSwitchMode == OtaSwitchModeCurrent || connectionState == disconnected)
       {
         config.SetRate(actualRate);
+        if (config.GetTlm() == TLM_RATIO_MAVLINK && packetSize != OTA8_PACKET_SIZE)
+        {
+          newSwitchMode = 1; // Force Hybrid switch mode
+        }
         config.SetSwitchMode(newSwitchMode);
         if (actualRate != selectedRate)
         {
@@ -603,24 +599,26 @@ static void registerLuaParameters()
       expresslrs_tlm_ratio_e eRatio = (expresslrs_tlm_ratio_e)arg;
       if (eRatio <= TLM_RATIO_DISARMED)
       {
-        // Don't allow TLM ratio changes if using AIRPORT
-        if (!firmwareOptions.is_airport)
+        // Restart if ratio changed to/from TLM_MAVLINK_RATIO to enable/disable TX MAVLink mode
+        if (eRatio == TLM_RATIO_MAVLINK || config.GetTlm() == TLM_RATIO_MAVLINK)
         {
-          // If using MAVLink tlm ratio and not full res force Hybrid switch mode
-          if ((eRatio == TLM_RATIO_MAVLINK) && !OtaIsFullRes)
+          if (connectionState == disconnected)
           {
-            if (connectionState == disconnected)
-            {
-              config.SetTlm(eRatio);
-              config.SetSwitchMode(1);
-              OtaUpdateSerializers((OtaSwitchMode_e)1, ExpressLRS_currAirRate_Modparams->PayloadLength);
-            }
-            else
-              setLuaWarningFlag(LUA_FLAG_ERROR_CONNECTED, true);
+            if (eRatio == TLM_RATIO_MAVLINK && !OtaIsFullRes)
+              config.SetSwitchMode(1); // Force Hybrid switch mode
+            config.SetTlm(eRatio);
+            config.Commit();
+            delayMicroseconds(10000);
+            ESP.restart();
           }
           else
-            config.SetTlm(eRatio);
-          }
+            setLuaWarningFlag(LUA_FLAG_ERROR_CONNECTED, true);
+        }
+        // Don't allow TLM ratio changes if using AIRPORT
+        else if (!firmwareOptions.is_airport)
+        {
+          config.SetTlm(eRatio);
+        }
       }
     });
     #if defined(TARGET_TX_FM30)
@@ -636,10 +634,9 @@ static void registerLuaParameters()
         // the pack and unpack functions are matched
         if (connectionState == disconnected)
         {
-          // If using MAVLink tlm ratio and not full res force Hybrid switch mode
-          if ((config.GetTlm() == TLM_RATIO_MAVLINK) && !OtaIsFullRes)
+          if (config.GetTlm() == TLM_RATIO_MAVLINK && !OtaIsFullRes)
           {
-            arg = 1;
+            arg = 1; // Force Hybrid switch mode
           }
           config.SetSwitchMode(arg);
           OtaUpdateSerializers((OtaSwitchMode_e)arg, ExpressLRS_currAirRate_Modparams->PayloadLength);

--- a/src/lib/SCREEN/display.cpp
+++ b/src/lib/SCREEN/display.cpp
@@ -110,6 +110,7 @@ static const char *ratio_string[] = {
     "1:8",
     "1:4",
     "1:2",
+    "MAVLink",
     "Race"
 };
 

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -964,6 +964,7 @@ static bool ICACHE_RAM_ATTR ProcessRfPacket_SYNC(uint32_t const now, OTA_Sync_s 
 
     // Update TLM ratio, should never be TLM_RATIO_STD/DISARMED, the TX calculates the correct value for the RX
     expresslrs_tlm_ratio_e TLMrateIn = (expresslrs_tlm_ratio_e)(otaSync->newTlmRatio + (uint8_t)TLM_RATIO_NO_TLM);
+    TLMrateIn = (TLMrateIn == TLM_RATIO_MAVLINK) ? TLM_RATIO_1_2 : TLMrateIn;
     uint8_t TlmDenom = TLMratioEnumToValue(TLMrateIn);
     if (ExpressLRS_currTlmDenom != TlmDenom)
     {

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -280,6 +280,10 @@ expresslrs_tlm_ratio_e ICACHE_RAM_ATTR UpdateTlmRatioEffective()
   {
     retVal = ratioConfigured;
   }
+  else if (ratioConfigured == TLM_RATIO_MAVLINK)
+  {
+    retVal = TLM_RATIO_1_2;
+  }
 
   if (updateTelemDenom)
   {
@@ -1270,7 +1274,7 @@ void setup()
     config.SetStorageProvider(&eeprom); // Pass pointer to the Config class for access to storage
     config.Load(); // Load the stored values from eeprom
 
-    config.SetTlm(TLM_RATIO_1_2);
+    config.SetTlm(TLM_RATIO_MAVLINK); // Tester defaults DELETE ME LATER
 
     Radio.currFreq = GetInitialFreq(); //set frequency first or an error will occur!!!
     #if defined(RADIO_SX127X)

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -35,8 +35,8 @@ Stream *TxUSB;
 FIFO<AP_MAX_BUF_LEN> apInputBuffer;
 FIFO<AP_MAX_BUF_LEN> apOutputBuffer;
 
-// TODO: Remove this! Manual define for mavlink mode on TX
-bool mavlinkTX = true;
+// Variables / constants for MAVLink //
+bool mavlinkTX = false;
 uint8_t mavBuffer[64];
 
 #if defined(PLATFORM_ESP8266) || defined(PLATFORM_ESP32)
@@ -1250,6 +1250,13 @@ void setup()
   if (setupHardwareFromOptions())
   {
     initUID();
+
+    eeprom.Begin(); // Init the eeprom
+    config.SetStorageProvider(&eeprom); // Pass pointer to the Config class for access to storage
+    config.Load(); // Load the stored values from eeprom
+
+    mavlinkTX = config.GetTlm() == TLM_RATIO_MAVLINK ? true : false;
+
     setupTarget();
     // Register the devices with the framework
     devicesRegister(ui_devices, ARRAY_SIZE(ui_devices));
@@ -1269,12 +1276,6 @@ void setup()
     }
     CRSF::RecvModelUpdate = &ModelUpdateReq;
     DBGLN("ExpressLRS TX Module Booted...");
-
-    eeprom.Begin(); // Init the eeprom
-    config.SetStorageProvider(&eeprom); // Pass pointer to the Config class for access to storage
-    config.Load(); // Load the stored values from eeprom
-
-    config.SetTlm(TLM_RATIO_MAVLINK); // Tester defaults DELETE ME LATER
 
     Radio.currFreq = GetInitialFreq(); //set frequency first or an error will occur!!!
     #if defined(RADIO_SX127X)


### PR DESCRIPTION
MAVLink telemetry ratio option forces 1:2 and also forces Hybrid switch mode when using a packet rate that is not full res.

Note that I changed the tester default to be deleted from TLM_RATIO_1_2  to TLM_RATIO_MAVLINK.