### PR TITLE
Retain PWM channel setting when switching a serial pin function

### DIFF
--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -185,45 +185,38 @@ static void luaparamMappingChannelIn(struct luaPropertiesCommon *item, uint8_t a
   config.SetPwmChannelRaw(ch, newPwmCh.raw);
 }
 
-static uint8_t configureSerialPin(uint8_t pin, uint8_t sibling, uint8_t oldMode, uint8_t newMode)
+static void configureSerialPin(uint8_t pin, uint8_t sibling, uint8_t oldMode, uint8_t newMode)
 {
   for (int ch=0 ; ch<GPIO_PIN_PWM_OUTPUTS_COUNT ; ch++)
   {
     if (GPIO_PIN_PWM_OUTPUTS[ch] == sibling)
     {
-      // set sibling pin channel settings based on this pins settings
-      rx_config_pwm_t newPin3Config;
+      // Retain as much of the sibling's current config as possible
+      rx_config_pwm_t siblingPinConfig;
+      siblingPinConfig.raw = config.GetPwmChannel(ch)->raw;
+
+      // If the new mode is serial, the sibling is also forced to serial
       if (newMode == somSerial)
       {
-        newPin3Config.val.mode = somSerial;
+        siblingPinConfig.val.mode = somSerial;
       }
-      else
+      // If the new mode is not serial, and the sibling is serial, set the sibling to PWM (50Hz)
+      else if (siblingPinConfig.val.mode == somSerial)
       {
-          rx_config_pwm_t oldSiblingConfig;
-          oldSiblingConfig.raw = config.GetPwmChannel(ch)->raw;
-
-          // Only when the old port was serial, switch it to PWM at the default 50Hz.
-          if (oldSiblingConfig.val.mode == somSerial)
-          {
-              newPin3Config.val.mode = som50Hz;
-          }
-          else
-          {
-              // retain the channel configuration if the sibiling is already in PWM mode
-              newPin3Config.raw = oldSiblingConfig.raw;
-          }
+        siblingPinConfig.val.mode = som50Hz;
       }
-      config.SetPwmChannelRaw(ch, newPin3Config.raw);
+
+      config.SetPwmChannelRaw(ch, siblingPinConfig.raw);
       break;
     }
   }
+
   if (oldMode != newMode)
   {
     deferExecution(100, [](){
       reconfigureSerial();
     });
   }
-  return newMode;
 }
 
 static void luaparamMappingOutputMode(struct luaPropertiesCommon *item, uint8_t arg)
@@ -237,11 +230,11 @@ static void luaparamMappingOutputMode(struct luaPropertiesCommon *item, uint8_t 
   // Check if pin == 1/3 and do other pin adjustment accordingly
   if (GPIO_PIN_PWM_OUTPUTS[ch] == 1)
   {
-    newPwmCh.val.mode = configureSerialPin(1, 3, oldMode, arg);
+    configureSerialPin(1, 3, oldMode, arg);
   }
   else if (GPIO_PIN_PWM_OUTPUTS[ch] == 3)
   {
-    newPwmCh.val.mode = configureSerialPin(3, 1, oldMode, arg);
+    configureSerialPin(3, 1, oldMode, arg);
   }
   else if (arg == somSerial)
   {


### PR DESCRIPTION
A continuation of #2486 and Issue #2485! This is simpler code that accomplishes the same thing as #2486, except also retains the Input Channel setting.

### Issue

1. On 3.3.x-maint, all PWM output channels default still (2=2 50Hz, 3=3 50Hz) enter the lua -> Other Devices -> Output Mapping -> Output Channel = 2
2. Set Output Mode to Serial TX
3. Select Output Channel = 3
4. Note that Input Channel has changed to from 3 to 1 and Mode to Serial RX.

This PR retains Output 3's original channel mapping, which is important because the user might change Output 2 to Serial, then change it back, which would result in Output 3 still outputting PWM, but from Input 1 instead of 3. This would not be apparent to the user. They'll still lose the output rate if it isn't 50Hz though, but I don't think we can do anything about that.

EDIT: Or would it be better to set Output 3's mode to the new mode instead of 50Hz? That could easily be changed in the code from som50Hz: `siblingPinConfig.val.mode = newMode`

### Redundant Code

`configureSerialPin()` always returns the new mode value, which means the `newPwmCh.val.mode` is set twice in a round about way. I've removed this extra code to prevent having to follow it to see it doesn't do anything.

Sorry to come late with this. I actually fixed this after Thanksgiving but hadn't committed or submitted it. I was about to tag deadbyte about the fix, saw there was an issue, then also a merged PR. 😖 Someone organize my life for me!