### PR TITLE
Transmit Betaflight MSP "SET_NAME" packets from tx to fc

### DIFF
--- a/src/lib/MSP/msptypes.h
+++ b/src/lib/MSP/msptypes.h
@@ -5,6 +5,7 @@
 #define MSP_SET_RX_CONFIG   45
 #define MSP_VTX_CONFIG      88   //out message         Get vtx settings - betaflight
 #define MSP_SET_VTX_CONFIG  89   //in message          Set vtx settings - betaflight
+#define MSP_SET_NAME        11   //in message          Set craft name - betaflight
 
 #define MSP_VTXTABLE_BAND               137 //out message         vtxTable band/channel data
 #define MSP_SET_VTXTABLE_BAND           227 //in message          set vtxTable band/channel data (one band at a time)
@@ -33,7 +34,7 @@
 
 // CRSF encapsulated msp defines
 #define ENCAPSULATED_MSP_HEADER_CRC_LEN     4
-#define ENCAPSULATED_MSP_MAX_PAYLOAD_SIZE   4
+#define ENCAPSULATED_MSP_MAX_PAYLOAD_SIZE   17
 #define ENCAPSULATED_MSP_MAX_FRAME_LEN      (ENCAPSULATED_MSP_HEADER_CRC_LEN + ENCAPSULATED_MSP_MAX_PAYLOAD_SIZE)
 
 // ELRS backpack protocol opcodes

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1043,6 +1043,9 @@ void ProcessMSPPacket(uint32_t now, mspPacket_t *packet)
     ptrChannelData[2] = packet->payload[4] + (packet->payload[5] << 8);
     lastPTRValidTimeMs = now;
   }
+  else if (packet->function == MSP_SET_NAME) {
+    CRSF::AddMspMessage(packet);
+  }
 #endif
   if (packet->function == MSP_ELRS_GET_BACKPACK_VERSION)
   {


### PR DESCRIPTION
### What does this add?

This PR enables the transmission of Betaflight SET_NAME MSP commands for setting the "Craft Name" field.

### Why should we add this?

In order to support (e.g.) racetimers sending lap time information and other messages to the OSD,
currently Betaflight does not (yet) support such information in a native way so we "abuse" the craft name field (like DJI V1 did ^^).
Once Betaflight supports this type of information we will refactor to use whatever new logic will be there...

### Any reference to how this will/is beeing used?

I am working on an extension/PR to this RotorHazard plugin, which displays lap time information in FPV Goggles using a variety of techniques.
[https://github.com/i-am-grub/VRxC_ELRS](https://github.com/i-am-grub/VRxC_ELRS)

This is my Fork, though its not yet 100% complete, therefore no PR exists yet.
[https://github.com/UAV-Painkillers/VRxC_ELRS](https://github.com/UAV-Painkillers/VRxC_ELRS)