### PR TITLE
Pin AsyncTCP to specific version

### DIFF
--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -51,6 +51,7 @@ build_flags =
 build_src_filter = ${common_env_data.build_src_filter} -<ESP8266*.*> -<STM32*.*>
 lib_deps =
 	ottowinter/ESPAsyncWebServer-esphome @ 3.0.0
+	esphome/AsyncTCP-esphome @ 2.0.1 # use specific version - an update to this library breaks the build
 	lemmingdev/ESP32-BLE-Gamepad @ 0.5.2
 	h2zero/NimBLE-Arduino @ 1.4.1
 	bblanchon/ArduinoJson @ 6.19.4
@@ -91,6 +92,7 @@ build_flags =
 build_src_filter = ${common_env_data.build_src_filter} -<ESP8266*.*> -<STM32*.*>
 lib_deps =
 	ottowinter/ESPAsyncWebServer-esphome @ 3.0.0
+	esphome/AsyncTCP-esphome @ 2.0.1 # use specific version - an update to this library breaks the build
 	bblanchon/ArduinoJson @ 6.19.4
 
 [env_common_esp32s3rx]


### PR DESCRIPTION
This fixes the build because an update to an unmanaged transitive dependency broke the build!