### PR TITLE
Support CRSF bind command from betaflight

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -411,7 +411,7 @@ bool ICACHE_RAM_ATTR CRSF::ProcessPacket()
     {
         elrsLUAmode = SerialInBuffer[4] == CRSF_ADDRESS_ELRS_LUA;
 
-        if (packetType == CRSF_FRAMETYPE_COMMAND && SerialInBuffer[5] == SUBCOMMAND_CRSF && SerialInBuffer[6] == COMMAND_MODEL_SELECT_ID)
+        if (packetType == CRSF_FRAMETYPE_COMMAND && SerialInBuffer[5] == CRSF_COMMAND_SUBCMD_RX && SerialInBuffer[6] == CRSF_COMMAND_MODEL_SELECT_ID)
         {
             modelId = SerialInBuffer[7];
             #if defined(PLATFORM_ESP32)

--- a/src/lib/CrsfProtocol/crsf_protocol.h
+++ b/src/lib/CrsfProtocol/crsf_protocol.h
@@ -184,6 +184,7 @@ typedef struct crsf_ext_header_s
     // Extended fields
     uint8_t dest_addr;
     uint8_t orig_addr;
+    uint8_t payload[0];
 } PACKED crsf_ext_header_t;
 
 /**

--- a/src/lib/CrsfProtocol/crsf_protocol.h
+++ b/src/lib/CrsfProtocol/crsf_protocol.h
@@ -92,11 +92,12 @@ typedef enum
 } crsf_frame_type_e;
 
 typedef enum {
-    SUBCOMMAND_CRSF = 0x10
+    CRSF_COMMAND_SUBCMD_RX = 0x10
 } crsf_command_e;
 
 typedef enum {
-    COMMAND_MODEL_SELECT_ID = 0x05
+    CRSF_COMMAND_SUBCMD_RX_BIND = 0x01,
+    CRSF_COMMAND_MODEL_SELECT_ID = 0x05
 } crsf_subcommand_e;
 
 enum {

--- a/src/lib/Telemetry/telemetry.cpp
+++ b/src/lib/Telemetry/telemetry.cpp
@@ -245,6 +245,13 @@ bool Telemetry::AppendTelemetryPackage(uint8_t *package)
         callEnterBind = true;
         return true;
     }
+    if (header->frame_size == 7 && header->type == CRSF_FRAMETYPE_COMMAND &&
+        package[3] == CRSF_ADDRESS_CRSF_RECEIVER && package[4] == CRSF_ADDRESS_FLIGHT_CONTROLLER &&
+        package[5] == CRSF_COMMAND_SUBCMD_RX && package[6] == CRSF_COMMAND_SUBCMD_RX_BIND && package[7] == 0x9E)
+    {
+        callEnterBind = true;
+        return true;
+    }
     if (header->type == CRSF_FRAMETYPE_COMMAND && package[3] == 'm' && package[4] == 'm')
     {
         callUpdateModelMatch = true;
@@ -259,7 +266,6 @@ bool Telemetry::AppendTelemetryPackage(uint8_t *package)
 
     uint8_t targetIndex = 0;
     bool targetFound = false;
-
 
     if (header->type >= CRSF_FRAMETYPE_DEVICE_PING)
     {

--- a/src/lib/Telemetry/telemetry.h
+++ b/src/lib/Telemetry/telemetry.h
@@ -69,6 +69,7 @@ public:
     uint8_t ReceivedPackagesCount();
     bool AppendTelemetryPackage(uint8_t *package);
 private:
+    bool processInternalTelemetryPackage(uint8_t *package);
     void AppendToPackage(volatile crsf_telemetry_package_t *current);
     uint8_t CRSFinBuffer[CRSF_MAX_PACKET_LEN];
     telemetry_state_s telemetry_state;

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1541,7 +1541,6 @@ static void updateBindingMode(unsigned long now)
         config.Commit();
 
         DBGLN("Power on counter >=3, enter binding mode...");
-        config.SetIsBound(false);
         EnterBindingMode();
     }
 }

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1917,6 +1917,7 @@ void EnterBindingMode()
     UID[5] = BindingUID[5];
 
     OtaCrcInitializer = 0;
+    config.SetIsBound(false);
     InBindingMode = true;
 
     // Start attempting to bind


### PR DESCRIPTION
Add support for the CRSF bind command that can be sent via the betaflight `bind_rx` CLI command.
See https://github.com/betaflight/betaflight/pull/13119 and https://github.com/betaflight/betaflight/pull/13267

This allows a receiver that is bound using traditional binding (i.e. using the TX Lua command) to be rebound by entering the `bind_rx` CLI command in betaflight. This is useful for those receivers that manufacturers insist on sending out with the receiver pre-bound, despite being to informed that it should be reset prior to shipping.