### PR TITLE
Feature: PWM failsafe modes, like no-pulse, hold, and custom set position

### DIFF
--- a/src/html/elrs.css
+++ b/src/html/elrs.css
@@ -348,12 +348,23 @@ body, input, select, textarea {
   }
 
     /* Custom code for ExpressLRS PWM Output table */
+  .pwmpnl {
+	overflow-x: auto;
+	min-width: fit-content;
+  }
+  .pwmtbl table {
+	overflow-x: auto;
+  }
   .pwmtbl th {
 	text-align: center;
 	font-weight: bold;
   }
   .pwmtbl td {
 	text-align: center;
+  }
+  .pwmitm {
+	min-width: 6em;
+	white-space: nowrap;
   }
 
   /*==========================*/

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -189,20 +189,20 @@
 							<li><b>750us:</b> Use half pulse width (494-1006us) with center 750us instead of 988-2012us</li>
 							<li><b>Failsafe</b>
 								<ul>
-									<li>Set Position - Absolute position to set the servo on failsafe
+									<li>"Set Position" sets the servo to an absolute "Failsafe Pos"
 										<ul>
 											<li>Does not use "Invert" flag</li>
 											<li>Value will be halved if "750us" flag is set</li>
 											<li>Will be converted to binary for "On/Off" mode (>1500us = HIGH)</li>
 										</ul>
 									</li>
-									<li>No Pulse - Stop pulsing
+									<li>"No Pulses" stops sending pulses
 										<ul>
 											<li>Unpowers servos</li>
 											<li>May disarm ESCs</li>
 										</ul>
 									</li>
-									<li>Hold Position - Uses last received channel position</li>
+									<li>"Last Position" continues sending last received channel position</li>
 								</ul>
 							</li>
 						</ul>

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -187,11 +187,22 @@
 							<li><b>Input:</b> Input channel from the handset</li>
 							<li><b>Invert:</b> Invert input channel position</li>
 							<li><b>750us:</b> Use half pulse width (494-1006us) with center 750us instead of 988-2012us</li>
-							<li><b>Failsafe:</b> Absolute position to set the servo on failsafe
+							<li><b>Failsafe</b>
 								<ul>
-									<li>Does not use "Invert" flag</li>
-									<li>Value will be halved if "750us" flag is set</li>
-									<li>Will be converted to binary for "On/Off" mode (>1500us = HIGH)</li>
+									<li>Set Position - Absolute position to set the servo on failsafe
+										<ul>
+											<li>Does not use "Invert" flag</li>
+											<li>Value will be halved if "750us" flag is set</li>
+											<li>Will be converted to binary for "On/Off" mode (>1500us = HIGH)</li>
+										</ul>
+									</li>
+									<li>No Pulse - Stop pulsing
+										<ul>
+											<li>Unpowers servos</li>
+											<li>May disarm ESCs</li>
+										</ul>
+									</li>
+									<li>Hold Position - Uses last received channel position</li>
 								</ul>
 							</li>
 						</ul>

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -120,7 +120,7 @@ function updatePwmSettings(arPwm) {
           'ch9 (AUX5)', 'ch10 (AUX6)', 'ch11 (AUX7)', 'ch12 (AUX8)',
           'ch13 (AUX9)', 'ch14 (AUX10)', 'ch15 (AUX11)', 'ch16 (AUX12)']);
     const failsafeModeSelect = enumSelectGenerate(`pwm_${index}_fsmode`, failsafeMode,
-        ['Set Position', 'No Pulses', 'Hold Position']); // match eServoOutputFailsafeMode
+        ['Set Position', 'No Pulses', 'Last Position']); // match eServoOutputFailsafeMode
     htmlFields.push(`<tr><td class="mui--text-center mui--text-title">${index + 1}</td>
             <td>${generateFeatureBadges(features)}</td>
             <td>${modeSelect}</td>

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -43,7 +43,7 @@ function getPwmFormData() {
 
 function enumSelectGenerate(id, val, arOptions) {
   // Generate a <select> item with every option in arOptions, and select the val element (0-based)
-  const retVal = `<div class="mui-select compact"><select id="${id}">` +
+  const retVal = `<div class="mui-select compact"><select id="${id}" class="pwmitm">` +
         arOptions.map((item, idx) => {
           if (item) return `<option value="${idx}"${(idx === val) ? ' selected' : ''} ${item === 'Disabled' ? 'disabled' : ''}>${item}</option>`;
           return '';
@@ -71,7 +71,7 @@ function updatePwmSettings(arPwm) {
   var pinTxIndex = undefined;
   var pinModes = []
   // arPwm is an array of raw integers [49664,50688,51200]. 10 bits of failsafe position, 4 bits of input channel, 1 bit invert, 4 bits mode, 1 bit for narrow/750us
-  const htmlFields = ['<div class="mui-panel"><table class="pwmtbl mui-table"><tr><th class="fixed-column">Output</th><th class="mui--text-center fixed-column">Features</th><th>Mode</th><th>Input</th><th class="mui--text-center fixed-column">Invert?</th><th class="mui--text-center fixed-column">750us?</th><th>Failsafe Mode</th><th>Failsafe Pos</th></tr>'];
+  const htmlFields = ['<div class="mui-panel pwmpnl"><table class="pwmtbl mui-table"><tr><th class="fixed-column">Output</th><th class="mui--text-center fixed-column">Features</th><th>Mode</th><th>Input</th><th class="mui--text-center fixed-column">Invert?</th><th class="mui--text-center fixed-column">750us?</th><th class="mui--text-center fixed-column pwmitm">Failsafe Mode</th><th class="mui--text-center fixed-column pwmitm">Failsafe Pos</th></tr>'];
   arPwm.forEach((item, index) => {
     const failsafe = (item.config & 1023) + 988; // 10 bits
     const failsafeMode = (item.config >> 20) & 3; // 2 bits
@@ -120,7 +120,7 @@ function updatePwmSettings(arPwm) {
           'ch9 (AUX5)', 'ch10 (AUX6)', 'ch11 (AUX7)', 'ch12 (AUX8)',
           'ch13 (AUX9)', 'ch14 (AUX10)', 'ch15 (AUX11)', 'ch16 (AUX12)']);
     const failsafeModeSelect = enumSelectGenerate(`pwm_${index}_fsmode`, failsafeMode,
-        ['Set Pos', 'No Pulse', 'Hold Pos']); // match eServoOutputFailsafeMode
+        ['Set Position', 'No Pulses', 'Hold Position']); // match eServoOutputFailsafeMode
     htmlFields.push(`<tr><td class="mui--text-center mui--text-title">${index + 1}</td>
             <td>${generateFeatureBadges(features)}</td>
             <td>${modeSelect}</td>
@@ -128,7 +128,7 @@ function updatePwmSettings(arPwm) {
             <td><div class="mui-checkbox mui--text-center"><input type="checkbox" id="pwm_${index}_inv"${(inv) ? ' checked' : ''}></div></td>
             <td><div class="mui-checkbox mui--text-center"><input type="checkbox" id="pwm_${index}_nar"${(narrow) ? ' checked' : ''}></div></td>
             <td>${failsafeModeSelect}</td>
-            <td><div class="mui-textfield compact"><input id="pwm_${index}_fs" value="${failsafe}" size="6"/></div></td></tr>`);
+            <td><div class="mui-textfield compact"><input id="pwm_${index}_fs" value="${failsafe}" size="6" class="pwmitm" /></div></td></tr>`);
     pinModes[index] = mode;
   });
   htmlFields.push('</table></div>');

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -186,7 +186,7 @@ enum eServoOutputFailsafeMode : uint8_t
 {
     PWMFAILSAFE_SET_POSITION,  // user customizable pulse value
     PWMFAILSAFE_NO_PULSES,     // stop pulsing
-    PWMFAILSAFE_HOLD_POSITION, // continue to pulse last used value
+    PWMFAILSAFE_LAST_POSITION, // continue to pulse last used value
 };
 
 enum eSerialProtocol : uint8_t

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -185,7 +185,7 @@ enum eServoOutputMode : uint8_t
 enum eServoOutputFailsafeMode : uint8_t
 {
     PWMFAILSAFE_SET_POSITION,  // user customizable pulse value
-    PWMFAILSAFE_NO_PULSE,      // stop pulsing
+    PWMFAILSAFE_NO_PULSES,     // stop pulsing
     PWMFAILSAFE_HOLD_POSITION, // continue to pulse last used value
 };
 

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -182,6 +182,13 @@ enum eServoOutputMode : uint8_t
     somPwm,     // True PWM mode (NOT SUPPORTED)
 };
 
+enum eServoOutputFailsafeMode : uint8_t
+{
+    PWMFAILSAFE_SET_POSITION,  // user customizable pulse value
+    PWMFAILSAFE_NO_PULSE,      // stop pulsing
+    PWMFAILSAFE_HOLD_POSITION, // continue to pulse last used value
+};
+
 enum eSerialProtocol : uint8_t
 {
     PROTOCOL_CRSF,

--- a/src/lib/CONFIG/config.h
+++ b/src/lib/CONFIG/config.h
@@ -187,7 +187,8 @@ typedef union {
                  inverted:1,     // invert channel output
                  mode:4,         // Output mode (eServoOutputMode)
                  narrow:1,       // Narrow output mode (half pulse width)
-                 unused:12;      // FUTURE: When someone complains "everyone" uses inverted polarity PWM or something :/
+                 failsafeMode:2, // failsafe output mode (eServoOutputFailsafeMode)
+                 unused:10;      // FUTURE: When someone complains "everyone" uses inverted polarity PWM or something :/
     } val;
     uint32_t raw;
 } rx_config_pwm_t;

--- a/src/lib/PWM/PWM_ESP8266.cpp
+++ b/src/lib/PWM/PWM_ESP8266.cpp
@@ -42,7 +42,16 @@ void PWMController::setDuty(pwm_channel_t channel, uint16_t duty)
 
 void PWMController::setMicroseconds(pwm_channel_t channel, uint16_t microseconds)
 {
-    startWaveform8266(pwm_gpio[channel], microseconds, refreshInterval[channel] - microseconds);
+    int8_t pin = pwm_gpio[channel];
+    if (microseconds > 0) {
+        startWaveform8266(pin, microseconds, refreshInterval[channel] - microseconds);
+    }
+    else {
+        // startWaveform8266 does not handle 0 properly, there's still a 1.2 microsecond pulse
+        // so we have to explicitly stop the waveform generation
+        stopWaveform8266(pin);
+        digitalWrite(pin, LOW);
+    }
 }
 
 #endif

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -95,7 +95,7 @@ static void servosFailsafe()
         else if (chConfig->val.failsafeMode == PWMFAILSAFE_NO_PULSES) {
             servoWrite(ch, 0);
         }
-        else if (chConfig->val.failsafeMode == PWMFAILSAFE_HOLD_POSITION) {
+        else if (chConfig->val.failsafeMode == PWMFAILSAFE_LAST_POSITION) {
             // do nothing
         }
     }

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -85,11 +85,19 @@ static void servosFailsafe()
     for (unsigned ch = 0 ; ch < GPIO_PIN_PWM_OUTPUTS_COUNT ; ++ch)
     {
         const rx_config_pwm_t *chConfig = config.GetPwmChannel(ch);
-        // Note: Failsafe values do not respect the inverted flag, failsafe values are absolute
-        uint16_t us = chConfig->val.failsafe + SERVO_FAILSAFE_MIN;
-        // Always write the failsafe position even if the servo has never been started,
-        // so all the servos go to their expected position
-        servoWrite(ch, us);
+        if (chConfig->val.failsafeMode == PWMFAILSAFE_SET_POSITION) {
+            // Note: Failsafe values do not respect the inverted flag, failsafe values are absolute
+            uint16_t us = chConfig->val.failsafe + SERVO_FAILSAFE_MIN;
+            // Always write the failsafe position even if the servo has never been started,
+            // so all the servos go to their expected position
+            servoWrite(ch, us);
+        }
+        else if (chConfig->val.failsafeMode == PWMFAILSAFE_NO_PULSE) {
+            servoWrite(ch, 0);
+        }
+        else if (chConfig->val.failsafeMode == PWMFAILSAFE_HOLD_POSITION) {
+            // do nothing
+        }
     }
 }
 

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -92,7 +92,7 @@ static void servosFailsafe()
             // so all the servos go to their expected position
             servoWrite(ch, us);
         }
-        else if (chConfig->val.failsafeMode == PWMFAILSAFE_NO_PULSE) {
+        else if (chConfig->val.failsafeMode == PWMFAILSAFE_NO_PULSES) {
             servoWrite(ch, 0);
         }
         else if (chConfig->val.failsafeMode == PWMFAILSAFE_HOLD_POSITION) {


### PR DESCRIPTION
Feature: PWM failsafe modes, like no-pulse, hold, and custom set position

Very useful for cases when servos needs to be de-energized, ESCs need to be disarmed, and other situations/hobbies that does not involve a drone flight controller.

For combat robotics, it means that the builder does not need to worry about changing the weapon failsafe setting when changing between a single-direction weapon vs a bi-directional weapon, and also not need to worry about a badly calibrated ESC when in bidirectional mode.

Addresses issue #1165

With the new slew of PWM surface receivers such as the RadioMaster ER3 and ER5 and such, and the new surface RadioMaster MT12 transmitter, it's about time the PWM receivers get the features they need.