### PR TITLE
Pick SSID with strongest RSSI in mesh networks with multiple identical SSIDs

### DIFF
--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -1096,8 +1096,10 @@ static void HandleWebUpdate()
         WiFi.setHostname(wifi_hostname); // hostname must be set after the mode is set to STA
         #endif
         changeTime = now;
+        #if defined(PLATFORM_ESP32)
         WiFi.setSortMethod(WIFI_CONNECT_AP_BY_SIGNAL);
         WiFi.setScanMethod(WIFI_ALL_CHANNEL_SCAN);
+        #endif
         WiFi.begin(station_ssid, station_password);
         startServices();
       default:

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -1096,6 +1096,8 @@ static void HandleWebUpdate()
         WiFi.setHostname(wifi_hostname); // hostname must be set after the mode is set to STA
         #endif
         changeTime = now;
+        WiFi.setSortMethod(WIFI_CONNECT_AP_BY_SIGNAL);
+        WiFi.setScanMethod(WIFI_ALL_CHANNEL_SCAN);
         WiFi.begin(station_ssid, station_password);
         startServices();
       default:


### PR DESCRIPTION
Home networks in mesh configuration can have multiple identical SSIDs (with different BSSIDs). Connecting an ELRS device to a home network should pick the BSSID with the strongest RSSI for the SSID to be connected.

The underlying Arduino library defaults to the scan method `WIFI_FAST_SCAN `which picks the first matching SSID for `WiFi.begin(ssid,...)`. This can lead to WiFi.begin() randomly picking a device (e.g. router) which is further away than a close by other device (e.g. repeater) resulting in an unstable connection with connection losses. See also https://discord.com/channels/596350022191415318/1033101924494487582/threads/1197516934028218408

The fix is to change the default behavior for scanning network devices from the default `WIFI_FAST_SCAN `to `WIFI_ALL_CHANNEL_SCAN` which will take in account all devices on the network. In combination with sort method `WIFI_CONNECT_AP_BY_SIGNAL` (which is already default) the strongest BSSID for the given SSID will be connected.

https://github.com/espressif/arduino-esp32/blob/099b432d10fb4ca1529c52241bcadcb8a4386f17/libraries/WiFi/src/WiFiSTA.h#L74-L77