### PR TITLE
Add second reset pin to SX1276 for consistency with SX1280

### DIFF
--- a/src/lib/SX127xDriver/SX127xHal.cpp
+++ b/src/lib/SX127xDriver/SX127xHal.cpp
@@ -81,10 +81,18 @@ void SX127xHal::reset(void)
     if (GPIO_PIN_RST != UNDEF_PIN)
     {
         pinMode(GPIO_PIN_RST, OUTPUT);
-        delay(100);
         digitalWrite(GPIO_PIN_RST, LOW);
-        delay(100);
+        if (GPIO_PIN_RST_2 != UNDEF_PIN)
+        {
+            pinMode(GPIO_PIN_RST_2, OUTPUT);
+            digitalWrite(GPIO_PIN_RST_2, LOW);
+        }
+        delay(50); // Safety buffer. Busy takes longer to go low than the 1ms timeout in WaitOnBusy().
         pinMode(GPIO_PIN_RST, INPUT); // leave floating
+        if (GPIO_PIN_RST_2 != UNDEF_PIN)
+        {
+            pinMode(GPIO_PIN_RST_2, INPUT);
+        }
     }
 
     DBGLN("SX127x Ready!");


### PR DESCRIPTION
For consistency with SX1280 we should add an optional second reset pin for the SX127x devices.