### PR TITLE
Add a new Link Mode option to LUA to select MAVLink

### DIFF
--- a/src/include/common.h
+++ b/src/include/common.h
@@ -113,6 +113,14 @@ typedef enum : uint8_t
     TX_RADIO_MODE_SWITCH = 3
 } tx_radio_mode_e;
 
+typedef enum : uint8_t
+{
+    TX_NORMAL_MODE      = 0,
+    TX_AIRPORT_MODE     = 1,
+    TX_MAVLINK_MODE     = 2,
+    TX_PARAM_DL_MODE    = 3
+} tx_transmission_mode_e;
+
 // Value used for expresslrs_rf_pref_params_s.DynpowerUpThresholdSnr if SNR should not be used
 #define DYNPOWER_SNR_THRESH_NONE -127
 

--- a/src/lib/CONFIG/config.cpp
+++ b/src/lib/CONFIG/config.cpp
@@ -431,6 +431,23 @@ TxConfig::SetAntennaMode(uint8_t txAntenna)
 }
 
 void
+TxConfig::SetLinkMode(uint8_t linkMode)
+{
+    if (GetLinkMode() != linkMode)
+    {
+        m_model->linkMode = linkMode;
+
+        if (linkMode == TX_AIRPORT_MODE ||
+            linkMode == TX_MAVLINK_MODE ||
+            linkMode == TX_PARAM_DL_MODE)
+        {
+            m_model->tlm = TLM_RATIO_1_2;
+        }
+        m_modified |= MODEL_CHANGED;
+    }
+}
+
+void
 TxConfig::SetModelMatch(bool modelMatch)
 {
     if (GetModelMatch() != modelMatch)

--- a/src/lib/CONFIG/config.h
+++ b/src/lib/CONFIG/config.h
@@ -52,8 +52,7 @@ typedef struct {
                 txAntenna:2,    // FUTURE: Which TX antenna to use, 0=Auto
                 ptrStartChannel:4,
                 ptrEnableChannel:5,
-                linkMode:2,
-                _unused:1;
+                linkMode:3;
 } model_config_t;
 
 typedef struct {

--- a/src/lib/CONFIG/config.h
+++ b/src/lib/CONFIG/config.h
@@ -52,7 +52,8 @@ typedef struct {
                 txAntenna:2,    // FUTURE: Which TX antenna to use, 0=Auto
                 ptrStartChannel:4,
                 ptrEnableChannel:5,
-                _unused:3;
+                linkMode:2,
+                _unused:1;
 } model_config_t;
 
 typedef struct {
@@ -106,6 +107,7 @@ public:
     uint8_t GetBoostChannel() const { return m_model->boostChannel; }
     uint8_t GetSwitchMode() const { return m_model->switchMode; }
     uint8_t GetAntennaMode() const { return m_model->txAntenna; }
+    uint8_t GetLinkMode() const { return m_model->linkMode; }
     bool GetModelMatch() const { return m_model->modelMatch; }
     bool     IsModified() const { return m_modified; }
     uint8_t  GetVtxBand() const { return m_config.vtxBand; }
@@ -133,6 +135,7 @@ public:
     void SetBoostChannel(uint8_t boostChannel);
     void SetSwitchMode(uint8_t switchMode);
     void SetAntennaMode(uint8_t txAntenna);
+    void SetLinkMode(uint8_t linkMode);
     void SetModelMatch(bool modelMatch);
     void SetDefaults(bool commit);
     void SetStorageProvider(ELRS_EEPROM *eeprom);

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -25,6 +25,7 @@ static const char folderNameSeparator[2] = {' ',':'};
 static const char switchmodeOpts4ch[] = "Wide;Hybrid";
 static const char switchmodeOpts8ch[] = "8ch;16ch Rate/2;12ch Mixed";
 static const char antennamodeOpts[] = "Gemini;Ant 1;Ant 2;Switch";
+static const char linkModeOpts[] = "Normal;AirPort;MAVLink;ParamDL";
 static const char luastrDvrAux[] = "Off;" STR_LUA_ALLAUX_UPDOWN;
 static const char luastrDvrDelay[] = "0s;5s;15s;30s;45s;1min;2min";
 static const char luastrHeadTrackingEnable[] = "Off;On;" STR_LUA_ALLAUX_UPDOWN;
@@ -96,6 +97,15 @@ static struct luaItem_selection luaSwitch = {
       {"Antenna Mode", CRSF_TEXT_SELECTION},
       0, // value
       antennamodeOpts,
+      STR_EMPTYSPACE
+  };
+#endif
+
+#if defined(GPIO_PIN_NSS_2)
+  static struct luaItem_selection luaLinkMode = {
+      {"Link Mode", CRSF_TEXT_SELECTION},
+      0, // value
+      linkModeOpts,
       STR_EMPTYSPACE
   };
 #endif
@@ -620,12 +630,15 @@ static void registerLuaParameters()
           setLuaWarningFlag(LUA_FLAG_ERROR_CONNECTED, true);
       });
     }
-      if (isDualRadio())
-      {
-        registerLUAParameter(&luaAntenna, [](struct luaPropertiesCommon *item, uint8_t arg) {
-          config.SetAntennaMode(arg);
-        });
-      }
+    if (isDualRadio())
+    {
+      registerLUAParameter(&luaAntenna, [](struct luaPropertiesCommon *item, uint8_t arg) {
+        config.SetAntennaMode(arg);
+      });
+    }
+    registerLUAParameter(&luaLinkMode, [](struct luaPropertiesCommon *item, uint8_t arg) {
+        config.SetLinkMode(arg);
+      });
     if (!firmwareOptions.is_airport)
     {
       registerLUAParameter(&luaModelMatch, [](struct luaPropertiesCommon *item, uint8_t arg) {
@@ -788,6 +801,7 @@ static int event()
   {
     setLuaTextSelectionValue(&luaAntenna, config.GetAntennaMode());
   }
+  setLuaTextSelectionValue(&luaLinkMode, config.GetLinkMode());
   luadevUpdateModelID();
   setLuaTextSelectionValue(&luaModelMatch, (uint8_t)config.GetModelMatch());
   setLuaTextSelectionValue(&luaPower, config.GetPower() - MinPower);


### PR DESCRIPTION
This PR is for the `mavlink-rc` branch, and adds a new item in the TX LUA menu that allows users to select between:
`Normal` the link behaves like a "regular" non-MAVLink ELRS setup, where telemetry is in CRSF flavour.
`AirPort` unused at the moment - reserved for future use - do not use
`MAVLink` configures the TX for MAVLink, which was previously hardcoded in this branch. The telem ratio is set to 1:2, and the uplink / downlink use the stubborn sender to relay MAVLink packets bi-directionally, with RC channels sideloaded.
`ParamDL` unused at the moment - reserved for future use - do not use.

This should allow users who have some CRSF based crafts (i.e. BF quads) as well as some MAVLink crafts (planes, etc.) to use the one TX module for both.

The `Link Mode` is part of the model-specific settings, so you can use one model for CRSF crafts, and another one for MAVLink and the param will auto change.

![Screenshot_8](https://github.com/ExpressLRS/ExpressLRS/assets/59873510/20b293d8-517a-48c1-ac25-30581b51f6b0)
