### PR TITLE
Allow setting the destination for CRSF MSP packets

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -461,7 +461,7 @@ void CRSF::UnlockMspMessage()
     }
 }
 
-void ICACHE_RAM_ATTR CRSF::AddMspMessage(mspPacket_t* packet)
+void ICACHE_RAM_ATTR CRSF::AddMspMessage(mspPacket_t* packet, uint8_t destination)
 {
     if (packet->payloadSize > ENCAPSULATED_MSP_MAX_PAYLOAD_SIZE)
     {
@@ -475,7 +475,7 @@ void ICACHE_RAM_ATTR CRSF::AddMspMessage(mspPacket_t* packet)
     outBuffer[0] = CRSF_ADDRESS_BROADCAST;                                      // address
     outBuffer[1] = packet->payloadSize + ENCAPSULATED_MSP_HEADER_CRC_LEN + CRSF_FRAME_LENGTH_EXT_TYPE_CRC; // length
     outBuffer[2] = CRSF_FRAMETYPE_MSP_WRITE;                                    // packet type
-    outBuffer[3] = CRSF_ADDRESS_FLIGHT_CONTROLLER;                              // destination
+    outBuffer[3] = destination;                                                 // destination
     outBuffer[4] = CRSF_ADDRESS_RADIO_TRANSMITTER;                              // origin
 
     // Encapsulated MSP payload

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -80,7 +80,7 @@ public:
     static void GetMspMessage(uint8_t **data, uint8_t *len);
     static void UnlockMspMessage();
     static void AddMspMessage(const uint8_t length, uint8_t* data);
-    static void AddMspMessage(mspPacket_t* packet, uint8_t destination = CRSF_ADDRESS_FLIGHT_CONTROLLER);
+    static void AddMspMessage(mspPacket_t* packet, uint8_t destination);
     static void ResetMspQueue();
     static uint32_t OpenTXsyncLastSent;
     static uint8_t GetMaxPacketBytes() { return maxPacketBytes; }

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -80,7 +80,7 @@ public:
     static void GetMspMessage(uint8_t **data, uint8_t *len);
     static void UnlockMspMessage();
     static void AddMspMessage(const uint8_t length, uint8_t* data);
-    static void AddMspMessage(mspPacket_t* packet);
+    static void AddMspMessage(mspPacket_t* packet, uint8_t destination = CRSF_ADDRESS_FLIGHT_CONTROLLER);
     static void ResetMspQueue();
     static uint32_t OpenTXsyncLastSent;
     static uint8_t GetMaxPacketBytes() { return maxPacketBytes; }

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -639,7 +639,7 @@ static void registerLuaParameters()
           msp.function = MSP_SET_RX_CONFIG;
           msp.addByte(MSP_ELRS_MODEL_ID);
           msp.addByte(newModelMatch ? CRSF::getModelID() : 0xff);
-          CRSF::AddMspMessage(&msp);
+          CRSF::AddMspMessage(&msp, CRSF_ADDRESS_CRSF_RECEIVER);
         }
         luadevUpdateModelID();
       });

--- a/src/lib/VTX/devVTX.cpp
+++ b/src/lib/VTX/devVTX.cpp
@@ -60,7 +60,7 @@ static void eepromWriteToMSPOut()
     packet.reset();
     packet.function = MSP_EEPROM_WRITE;
 
-    CRSF::AddMspMessage(&packet);
+    CRSF::AddMspMessage(&packet, CRSF_ADDRESS_FLIGHT_CONTROLLER);
 }
 
 static void VtxConfigToMSPOut()
@@ -87,7 +87,7 @@ static void VtxConfigToMSPOut()
         }
     }
 
-    CRSF::AddMspMessage(&packet);
+    CRSF::AddMspMessage(&packet, CRSF_ADDRESS_FLIGHT_CONTROLLER);
 
     if (!CRSF::IsArmed()) // Do not send while armed.  There is no need to change the video frequency while armed.  It can also cause VRx modules to flash up their OSD menu e.g. Rapidfire.
     {

--- a/src/test/test_msp/encapsulated_msp_tests.cpp
+++ b/src/test/test_msp/encapsulated_msp_tests.cpp
@@ -28,7 +28,7 @@ void test_encapsulated_msp_send(void)
     packet.addByte(0x00);   // don't enable pitmode
 
     // Ask the CRSF class to send the encapsulated packet to the stream
-    CRSF::AddMspMessage(&packet);
+    CRSF::AddMspMessage(&packet, CRSF_ADDRESS_FLIGHT_CONTROLLER);
 
     uint8_t* data;
     uint8_t len;
@@ -79,7 +79,7 @@ void test_encapsulated_msp_send_too_long(void)
     packet.addByte(0x05);
 
     // Ask the CRSF class to send the encapsulated packet to the stream
-    CRSF::AddMspMessage(&packet);
+    CRSF::AddMspMessage(&packet, CRSF_ADDRESS_FLIGHT_CONTROLLER);
 
     uint8_t* data;
     uint8_t len;


### PR DESCRIPTION
Also target the RX when sending set_rx_config command so it's not also sent to the FC.
Apparently sending an unexpected command to Rotorflight causes it to corrupt it's config! 🤷‍♂️ 

Fixes #2549 