### PR TITLE
For MacOS, prioritise the `wchusbserial` devices

### DIFF
--- a/src/python/serials_find.py
+++ b/src/python/serials_find.py
@@ -42,6 +42,7 @@ def serial_ports():
             ports = glob.glob('/dev/tty.usbmodem*')
             ports.extend(glob.glob('/dev/tty.SLAB*'))
             ports.extend(glob.glob('/dev/tty.usbserial*'))
+            ports.extend(glob.glob('/dev/tty.wchusbserial*'))
         else:
             raise Exception('Unsupported platform')
 
@@ -52,7 +53,7 @@ def serial_ports():
             result.append(port)
         except (OSError, serial.SerialException) as error:
             if "permission denied" in str(error).lower():
-                raise Exception("You don't have persmission to use serial port!")
+                raise Exception("You don't have permission to use serial port!")
             pass
     result.reverse()
     return result


### PR DESCRIPTION
We have some devices that are starting to use the WCH USB-to-SERIAL chip and under macOS thse do not work in the default usbserial driver in the kernel, you must install the driver from https://github.com/WCHSoftGroup/ch34xser_macos

If the driver is not installed you get an error such as the following...
```
Configuring upload protocol...
AVAILABLE: cmsis-dap, esp-bridge, esp-prog, espota, esptool, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa
CURRENT: upload_protocol = esptool
Looking for upload port...
Auto-detected: /dev/cu.usbmodem57190356161
Uploading .pio/build/Unified_ESP32_LR1121_TX_via_UART/firmware.bin
esptool.py v4.2.1
Serial port /dev/cu.usbmodem57190356161
Connecting....
Chip is ESP32-PICO-D4 (revision 1)
Features: WiFi, BT, Dual Core, 240MHz, Embedded Flash, VRef calibration in efuse, Coding Scheme None
Crystal is 40MHz
MAC: 64:b7:08:9e:af:f0
Uploading stub...

A fatal error occurred: Failed to write to target RAM (result was 01070000: Operation timed out)
*** [upload] Error 2
```