### PR TITLE
Fix error when radio chip failed to read

### DIFF
--- a/src/include/common.h
+++ b/src/include/common.h
@@ -43,9 +43,10 @@ typedef enum
     MODE_STATES,
     // States below here are special mode states
     noCrossfire,
+    bleJoystick,
+    NO_CONFIG_SAVE_STATES,
     wifiUpdate,
     serialUpdate,
-    bleJoystick,
     // Failure states go below here to display immediately
     FAILURE_STATES,
     radioFailed,

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1745,7 +1745,7 @@ static void updateSwitchMode()
 
 static void CheckConfigChangePending()
 {
-    if (config.IsModified() && !InBindingMode && connectionState != wifiUpdate)
+    if (config.IsModified() && !InBindingMode && connectionState < NO_CONFIG_SAVE_STATES)
     {
         LostConnection(false);
         config.Commit();


### PR DESCRIPTION
Fixes the LED when going into "bad radio" state.
I found this when working on a new target.

I've introduced a new NO_CONFIG_SAVE_STATES "level" in the `connectionState` enum, which "states" after that do not allow committing to the config.
The `bleJoystick` state as moved to be before the new state so the states after the NO_CONFIG_SAVE_STATES are 
- `wifiUpdate` which does it's own committing to the config
- `serialUpdate` which should not do any committing
- `radioFailed` which is an error state, and the hardware.html should be updated (i.e. not config)
- `hardwareUndefined` as for `radioFailed`