### PR TITLE
Update the wifi power levels

### DIFF
--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -899,12 +899,6 @@ static void startWiFi(unsigned long now)
   WiFi.persistent(false);
   WiFi.disconnect();
   WiFi.mode(WIFI_OFF);
-  #if defined(PLATFORM_ESP8266)
-    WiFi.setOutputPower(13);
-    WiFi.setPhyMode(WIFI_PHY_MODE_11N);
-  #elif defined(PLATFORM_ESP32)
-    WiFi.setTxPower(WIFI_POWER_13dBm);
-  #endif
   strcpy(station_ssid, firmwareOptions.home_wifi_ssid);
   strcpy(station_password, firmwareOptions.home_wifi_password);
   if (station_ssid[0] == 0) {
@@ -1116,6 +1110,12 @@ static void HandleWebUpdate()
         WiFi.setHostname(wifi_hostname); // hostname must be set before the mode is set to STA
         #endif
         changeTime = now;
+        #if defined(PLATFORM_ESP8266)
+        WiFi.setOutputPower(20.5);
+        WiFi.setPhyMode(WIFI_PHY_MODE_11N);
+        #elif defined(PLATFORM_ESP32)
+        WiFi.setTxPower(WIFI_POWER_19_5dBm);
+        #endif
         WiFi.softAPConfig(ipAddress, ipAddress, netMsk);
         WiFi.softAP(wifi_ap_ssid, wifi_ap_password);
         startServices();
@@ -1131,7 +1131,11 @@ static void HandleWebUpdate()
         WiFi.setHostname(wifi_hostname); // hostname must be set after the mode is set to STA
         #endif
         changeTime = now;
-        #if defined(PLATFORM_ESP32)
+        #if defined(PLATFORM_ESP8266)
+        WiFi.setOutputPower(20.5);
+        WiFi.setPhyMode(WIFI_PHY_MODE_11N);
+        #elif defined(PLATFORM_ESP32)
+        WiFi.setTxPower(WIFI_POWER_19_5dBm);
         WiFi.setSortMethod(WIFI_CONNECT_AP_BY_SIGNAL);
         WiFi.setScanMethod(WIFI_ALL_CHANNEL_SCAN);
         #endif


### PR DESCRIPTION
Increase the wifi power output on the ESP devices from 13dBm to 19.5dBm on the ESP32, and 20.5dBm on the ESP8285.

| Device | Version | Measured Power | Measured Current |
| --- | --- | --- | --- |
| NBD 8285 RX | 3.3.2 | -44dBm Phone next to RX | 85mA |
|  | PR | -35dBm | 89mA |
| Bandit ESP32 Module | 3.3.2 | -55dBm Phone ~500mm away | 130mA @ 8V |
|  | PR | -50dBm | 137mA @ 8V |

So for a small increase in power consumption we can get a small but noticeable increase in wifi output power.