### PR TITLE
Fix ESP32 S3 CRSF/PPM autodetect

### DIFF
--- a/src/lib/Handset/AutoDetect.cpp
+++ b/src/lib/Handset/AutoDetect.cpp
@@ -9,7 +9,11 @@
 
 #include <driver/rmt.h>
 
+#if defined(PLATFORM_ESP32_S3)
+constexpr rmt_channel_t PPM_RMT_CHANNEL = RMT_CHANNEL_4;
+#else
 constexpr rmt_channel_t PPM_RMT_CHANNEL = RMT_CHANNEL_0;
+#endif
 constexpr auto RMT_TICKS_PER_US = 10;
 
 void AutoDetect::Begin()

--- a/src/lib/Handset/AutoDetect.cpp
+++ b/src/lib/Handset/AutoDetect.cpp
@@ -9,11 +9,6 @@
 
 #include <driver/rmt.h>
 
-#if defined(PLATFORM_ESP32_S3)
-constexpr rmt_channel_t PPM_RMT_CHANNEL = RMT_CHANNEL_4;
-#else
-constexpr rmt_channel_t PPM_RMT_CHANNEL = RMT_CHANNEL_0;
-#endif
 constexpr auto RMT_TICKS_PER_US = 10;
 
 void AutoDetect::Begin()

--- a/src/lib/Handset/PPMHandset.cpp
+++ b/src/lib/Handset/PPMHandset.cpp
@@ -9,11 +9,6 @@
 
 #include <driver/rmt.h>
 
-#if defined(PLATFORM_ESP32_S3)
-constexpr rmt_channel_t PPM_RMT_CHANNEL = RMT_CHANNEL_4;
-#else
-constexpr rmt_channel_t PPM_RMT_CHANNEL = RMT_CHANNEL_0;
-#endif
 constexpr auto RMT_TICKS_PER_US = 10;
 
 void PPMHandset::Begin()

--- a/src/lib/Handset/PPMHandset.cpp
+++ b/src/lib/Handset/PPMHandset.cpp
@@ -9,7 +9,11 @@
 
 #include <driver/rmt.h>
 
+#if defined(PLATFORM_ESP32_S3)
+constexpr rmt_channel_t PPM_RMT_CHANNEL = RMT_CHANNEL_4;
+#else
 constexpr rmt_channel_t PPM_RMT_CHANNEL = RMT_CHANNEL_0;
+#endif
 constexpr auto RMT_TICKS_PER_US = 10;
 
 void PPMHandset::Begin()

--- a/src/lib/Handset/PPMHandset.h
+++ b/src/lib/Handset/PPMHandset.h
@@ -16,3 +16,9 @@ private:
     size_t numChannels = 0;
     RingbufHandle_t rb = nullptr;
 };
+
+#if defined(PLATFORM_ESP32_S3)
+constexpr rmt_channel_t PPM_RMT_CHANNEL = RMT_CHANNEL_4;
+#else
+constexpr rmt_channel_t PPM_RMT_CHANNEL = RMT_CHANNEL_0;
+#endif


### PR DESCRIPTION
The ESP32S3 has 4 TX and 4 RX RMT channels. The RX channels start at channel 4.
So we have to have a different RMT channel for the autodetect/PPM on S3 vs regular ESP32.

Fixes #2585 