### PR TITLE
PWM testing/fixes

### DIFF
--- a/src/lib/PWM/PWM_ESP8266.cpp
+++ b/src/lib/PWM/PWM_ESP8266.cpp
@@ -43,15 +43,13 @@ void PWMController::setDuty(pwm_channel_t channel, uint16_t duty)
 void PWMController::setMicroseconds(pwm_channel_t channel, uint16_t microseconds)
 {
     int8_t pin = pwm_gpio[channel];
-    if (microseconds > 0) {
-        startWaveform8266(pin, microseconds, refreshInterval[channel] - microseconds);
-    }
-    else {
-        // startWaveform8266 does not handle 0 properly, there's still a 1.2 microsecond pulse
-        // so we have to explicitly stop the waveform generation
+    if (microseconds == 0 || microseconds==refreshInterval[channel])
+    {
         stopWaveform8266(pin);
-        digitalWrite(pin, LOW);
+        digitalWrite(pin, microseconds == 0 ? HIGH : LOW);
+        return;
     }
+    startWaveform8266(pin, microseconds, refreshInterval[channel] - microseconds);
 }
 
 #endif

--- a/src/lib/PWM/waveform_8266.cpp
+++ b/src/lib/PWM/waveform_8266.cpp
@@ -212,7 +212,7 @@ static inline IRAM_ATTR uint32_t earliest(uint32_t a, uint32_t b) {
 #endif
 
 // When the time to the next edge is greater than this, RTI and set another IRQ to minimize CPU usage
-#define MINIRQTIME microsecondsToClockCycles(4)
+#define MINIRQTIME microsecondsToClockCycles(10)
 
 static IRAM_ATTR void timer1Interrupt() {
   // Flag if the core is at 160 MHz, for use by adjust()

--- a/src/lib/PWM/waveform_8266.cpp
+++ b/src/lib/PWM/waveform_8266.cpp
@@ -128,7 +128,7 @@ static void disableIdleTimer() {
 // waveform smoothly on next low->high transition.  For immediate change, stopWaveform()
 // first, then it will immediately begin.
 void startWaveform8266(uint8_t pin, uint32_t timeHighUS, uint32_t timeLowUS) {
-   if ((pin > 16) || isFlashInterfacePin(pin) || (timeHighUS == 0)) {
+   if ((pin > 16) || isFlashInterfacePin(pin)) {
     return;
   }
   Waveform *wave = &wvfState.waveform[pin];

--- a/src/lib/PWM/waveform_8266.h
+++ b/src/lib/PWM/waveform_8266.h
@@ -1,7 +1,7 @@
 #pragma once
 
-void startWaveform8266(uint8_t pin, uint32_t timeHighUS, uint32_t timeLowUS);
-void stopWaveform8266(uint8_t pin);
+void startWaveform8266(uint8_t gpio, uint32_t timeHighUS, uint32_t timeLowUS);
+void stopWaveform8266(uint8_t gpio);
 
 #define startWaveform DO_NOT_USE
 #define startWaveformClockCycles DO_NOT_USE


### PR DESCRIPTION
This PR is for people that wish to test the fixes for EESP8285 based PWM receiver reboot issue. #2577

There are a couple of changes here...
1. revert the fix for 0/100% 10kHz as the second commit does it simpler, outside the NMI handler.
2. simpler fix for 0/100% 10kHz
3. Optimise some of the NMI hander code
4. Extend the 4uS minimum interrupt to 10uS (this alone fixed the issue for me on 3.3.2)

The final commit is to disable both the software and hardware watchdog timers so if the issue does present itself it will hard fail rather than reboot. This is temporary and only for testing this PR.

I am currently running a long test to ensure this problem is resolved. Currently at 48hrs at the time of opening this PR.
I will leave this running for at least 7 days, if it is still running after that time, I'll call it good.

As mentioned below a hi packet rate (F1000) and a high PWM update rate (333/400Hz) exacerbates the issue.