### PR TITLE
Add file drag-and-drop to webui update tab

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -145,7 +145,7 @@
 					<button id="upload_btn" class="mui-btn mui-btn--primary upload" style="margin: 0 auto; display:block;">
 						<label>
 							Select firmware file
-							<input type="file" id="firmware_file" name="update" />
+							<input type="file" id="firmware_file" name="update[]" />
 						</label>
 					</button>
 					<div id="filedrag">or drop firmware file here</div>

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -142,12 +142,13 @@
 					If this happens you will need to recover via USB/Serial. You may also download the
 					<a href="firmware.bin" title="Click to download firmware">currently running firmware</a>.
 					<br/><br/>
-					<button id="upload_btn" class="mui-btn mui-btn--primary upload">
+					<button id="upload_btn" class="mui-btn mui-btn--primary upload" style="margin: 0 auto; display:block;">
 						<label>
-							Flash firmware file
+							Select firmware file
 							<input type="file" id="firmware_file" name="update" />
 						</label>
 					</button>
+					<div id="filedrag">or drop firmware file here</div>
 					<br/>
 					<h3 id="status"></h3>
 					<progress id="progressBar" value="0" max="100" style="width:100%;"></progress>

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -16,6 +16,50 @@ function _(el) {
   return document.getElementById(el);
 }
 
+function initFiledrag() {
+  const fileselect = _('firmware_file');
+  const filedrag = _('filedrag');
+
+  fileselect.addEventListener('change', fileSelectHandler, false);
+
+  const xhr = new XMLHttpRequest();
+  if (xhr.upload) {
+    filedrag.addEventListener('dragover', fileDragHover, false);
+    filedrag.addEventListener('dragleave', fileDragHover, false);
+    filedrag.addEventListener('drop', fileSelectHandler, false);
+    filedrag.style.display = 'block';
+  }
+}
+
+function fileDragHover(e) {
+  e.stopPropagation();
+  e.preventDefault();
+  if (e.target === _('filedrag')) e.target.className = (e.type === 'dragover' ? 'hover' : '');
+}
+
+function fileSelectHandler(e) {
+  fileDragHover(e);
+  const files = e.target.files || e.dataTransfer.files;
+  for (const f of files) {
+    _('upload_btn').disabled = true
+    try {
+      const formdata = new FormData();
+      formdata.append('upload', f, f.name);
+      const ajax = new XMLHttpRequest();
+      ajax.upload.addEventListener('progress', progressHandler, false);
+      ajax.addEventListener('load', completeHandler, false);
+      ajax.addEventListener('error', errorHandler, false);
+      ajax.addEventListener('abort', abortHandler, false);
+      ajax.open('POST', '/update');
+      ajax.setRequestHeader('X-FileSize', f.size);
+      ajax.send(formdata);
+    }
+    catch (e) {
+      _('upload_btn').disabled = false
+    }
+  }
+}
+
 function getPwmFormData() {
   let ch = 0;
   let inField;
@@ -251,6 +295,7 @@ function init() {
   // Start on the options tab
   mui.tabs.activate('pane-justified-1');
 @@end
+  initFiledrag();
   initOptions();
 }
 

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -16,50 +16,6 @@ function _(el) {
   return document.getElementById(el);
 }
 
-function initFiledrag() {
-  const fileselect = _('firmware_file');
-  const filedrag = _('filedrag');
-
-  fileselect.addEventListener('change', fileSelectHandler, false);
-
-  const xhr = new XMLHttpRequest();
-  if (xhr.upload) {
-    filedrag.addEventListener('dragover', fileDragHover, false);
-    filedrag.addEventListener('dragleave', fileDragHover, false);
-    filedrag.addEventListener('drop', fileSelectHandler, false);
-    filedrag.style.display = 'block';
-  }
-}
-
-function fileDragHover(e) {
-  e.stopPropagation();
-  e.preventDefault();
-  if (e.target === _('filedrag')) e.target.className = (e.type === 'dragover' ? 'hover' : '');
-}
-
-function fileSelectHandler(e) {
-  fileDragHover(e);
-  const files = e.target.files || e.dataTransfer.files;
-  for (const f of files) {
-    _('upload_btn').disabled = true
-    try {
-      const formdata = new FormData();
-      formdata.append('upload', f, f.name);
-      const ajax = new XMLHttpRequest();
-      ajax.upload.addEventListener('progress', progressHandler, false);
-      ajax.addEventListener('load', completeHandler, false);
-      ajax.addEventListener('error', errorHandler, false);
-      ajax.addEventListener('abort', abortHandler, false);
-      ajax.open('POST', '/update');
-      ajax.setRequestHeader('X-FileSize', f.size);
-      ajax.send(formdata);
-    }
-    catch (e) {
-      _('upload_btn').disabled = false
-    }
-  }
-}
-
 function getPwmFormData() {
   let ch = 0;
   let inField;
@@ -480,10 +436,36 @@ _('network-tab').addEventListener('mui.tabs.showstart', getNetworks);
 
 // =========================================================
 
-function uploadFile() {
+function initFiledrag() {
+  const fileselect = _('firmware_file');
+  const filedrag = _('filedrag');
+
+  fileselect.addEventListener('change', fileSelectHandler, false);
+
+  const xhr = new XMLHttpRequest();
+  if (xhr.upload) {
+    filedrag.addEventListener('dragover', fileDragHover, false);
+    filedrag.addEventListener('dragleave', fileDragHover, false);
+    filedrag.addEventListener('drop', fileSelectHandler, false);
+    filedrag.style.display = 'block';
+  }
+}
+
+function fileDragHover(e) {
+  e.stopPropagation();
+  e.preventDefault();
+  if (e.target === _('filedrag')) e.target.className = (e.type === 'dragover' ? 'hover' : '');
+}
+
+function fileSelectHandler(e) {
+  fileDragHover(e);
+  const files = e.target.files || e.dataTransfer.files;
+  uploadFile(files[0]);
+}
+
+function uploadFile(file) {
   _('upload_btn').disabled = true
   try {
-    const file = _('firmware_file').files[0];
     const formdata = new FormData();
     formdata.append('upload', file, file.name);
     const ajax = new XMLHttpRequest();
@@ -597,11 +579,6 @@ function abortHandler(event) {
     message: event.target.responseText
   });
 }
-
-_('firmware_file').addEventListener('change', (e) => {
-  e.preventDefault();
-  uploadFile();
-});
 
 @@if isTX:
 _('fileselect').addEventListener('change', (e) => {


### PR DESCRIPTION
![NewFirmwareUpload](https://github.com/ExpressLRS/ExpressLRS/assets/83231715/d485dee7-b561-40af-9608-208650065869)

I hope it's much clearer now you can drag-and-drop the firmware file to update.

Selecting or Dropping the Firmware File starts the upload automatically and if the file is a valid firmware file, firmware update should start as normal.

Tested with a Vantac TX and RX.
Test Method:
Build new firmware to be flashed into the devices.
Activate wifi mode on device. Load their WebUI. Go into Update Tab. Build a firmware (version doesn't matter much).
Failure mode tested by uploading a TX firmware into RX device, and RX firmware into a TX device. User should still be able to reupload file.
Success mode tested by uploading the appropriate firmware file into their respective device. Terminates as before.
