### PR TITLE
Fix frameAvailable race condition

### DIFF
--- a/src/src/rx-serial/devSerialIO.cpp
+++ b/src/src/rx-serial/devSerialIO.cpp
@@ -44,12 +44,16 @@ static int timeout()
 
     uint32_t duration = 10; // 10ms callback (i.e. when no theres no model match)
     // only send frames if we have a model match
-    if (connectionHasModelMatch)
-    {
-        duration = serialIO->sendRCFrame(frameAvailable, frameMissed, ChannelData);
-    }
+    noInterrupts();
+    bool available = frameAvailable;
+    bool missed = frameMissed;
     frameAvailable = false;
     frameMissed = false;
+    interrupts();
+    if (connectionHasModelMatch)
+    {
+        duration = serialIO->sendRCFrame(available, missed, ChannelData);
+    }
     // still get telemetry and send link stats if theres no model match
     serialIO->processSerialInput();
     serialIO->sendQueuedData(serialIO->getMaxSerialWriteSize());


### PR DESCRIPTION
Thanks to @pkendall64 for the code 😍 

This PR fixes a race condition with frameAvailable.  Currently it is possible for frameAvailable to be cleared before the RC data has been written to the UART.  