### PR TITLE
common.ini: update MAVLink version

### DIFF
--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -10,6 +10,8 @@ extra_scripts =
 monitor_dtr = 0
 monitor_rts = 0
 
+mavlink_lib_dep = https://github.com/mavlink/c_library_v2.git#e54a8d2e8cf7985e689ad1c8c8f37dc0800ea87b
+
 [common_env_data]
 build_src_filter = +<*> -<.git/> -<svn/> -<example/> -<examples/> -<test/> -<tests/> -<*.py> -<*test*.*>
 build_flags = -Wall -Iinclude
@@ -94,7 +96,7 @@ lib_deps =
 	ottowinter/ESPAsyncWebServer-esphome @ 3.0.0
 	esphome/AsyncTCP-esphome @ 2.0.1 # use specific version - an update to this library breaks the build
 	bblanchon/ArduinoJson @ 6.19.4
-	duracopter/MAVLink v2 C library@^2.0
+	${env.mavlink_lib_dep}
 
 [env_common_esp32s3rx]
 platform = espressif32@6.3.2
@@ -127,7 +129,7 @@ lib_deps =
 	makuna/NeoPixelBus @ 2.7.0
 	ottowinter/ESPAsyncWebServer-esphome @ 3.0.0
 	bblanchon/ArduinoJson @ 6.19.4
-	duracopter/MAVLink v2 C library@^2.0
+	${env.mavlink_lib_dep}
 upload_speed = 460800
 monitor_speed = 420000
 monitor_filters = esp8266_exception_decoder
@@ -147,7 +149,7 @@ build_flags =
 build_src_filter = ${common_env_data.build_src_filter} -<ESP32*.*> -<ESP8266*.*> -<WS281B*.*>
 lib_deps =
 	paolop74/extEEPROM @ 3.4.1
-	duracopter/MAVLink v2 C library@^2.0
+	${env.mavlink_lib_dep}
 oled_lib_deps =
 	${env_common_stm32.lib_deps}
 	olikraus/U8g2 @ 2.34.4


### PR DESCRIPTION
I will warn that I really have no idea what I'm doing with platform.io, but this updates the MAVlink version. I added `mavlink_lib_dep` as a `env` varable so the version only have to be changed in one spot in the future.

MAVLink provides the built lib here: https://github.com/mavlink/c_library_v2

`duracopter/MAVLink v2 C library@^2.0` was just pointing to the same thing I think, but its very out of date, no updates for 5 years, its not clear to me how we can tell exactly what commit we were on  (https://registry.platformio.org/libraries/duracopter/MAVLink%20v2%20C%20library)?

The new repo is kept upto date with MAVLink master automatically. There are not really MAVlink releases and just grabbing master might be a bad idea, so this jumps to the current latest commit (https://github.com/mavlink/c_library_v2/commit/e54a8d2e8cf7985e689ad1c8c8f37dc0800ea87b), we will probably want to update it occasionally.

I was hoping this would fix some of the build warnings, but it does not seem to. 