### PR TITLE
Add optional secondary serial device to ESP32 receivers

### DIFF
--- a/src/html/hardware.html
+++ b/src/html/hardware.html
@@ -86,6 +86,20 @@ td img.icon-pwm {
 					<tr><td width="30"></td><td>RX pin<img class="icon-input"/></td><td><input size='3' id='serial_rx' name='serial_rx' type='text'/></td><td>Pin used to receive CRSF signal from the handset</td></tr>
 					<tr><td></td><td>TX pin<img class="icon-output"/></td><td><input size='3' id='serial_tx' name='serial_tx' type='text'/></td><td>Pin used to transmit CRSF telemetry to the handset (may be the same as the RX PIN)</td></tr>
 
+					<tr><td colspan='2'><b>Secondary Serial Pins</td></tr>
+					<tr><td width="30"></td><td>RX pin<img class="icon-input"/></td><td><input size='3' id='serial1_rx' name='serial1_rx' type='text'/></td><td>Secondary serial RX - ESP32 targets only</td></tr>
+					<tr><td></td><td>TX pin<img class="icon-output"/></td><td><input size='3' id='serial1_tx' name='serial1_tx' type='text'/></td><td>Secondary serial TX - ESP32 targets only</td></tr>
+					<tr><td></td><td>Secondary Serial protocol</td><td>
+						<select id='serial1_protocol' name='serial1_protocol'>
+							<option value='-1'>None</option>
+							<option value='0'>CRSF</option>
+							<option value='2'>SBUS</option>
+							<option value='3'>SBUS Inverted</option>
+							<option value='4'>SUMD</option>
+							<option value='6'>HoTT Telemetry</option>
+						</select>
+					</td><td>Secondary serial protocol</td></tr>					
+
 					<tr><td colspan='2'><b>Radio Chip Pins & Options</td></tr>
 					<tr><td></td><td>BUSY pin<img class="icon-input"/></td><td><input size='3' id='radio_busy' name='radio_busy' type='text'/></td><td>GPIO Input connected to SX128x busy pin</td></tr>
 					<tr><td></td><td>DIO0 pin<img class="icon-input"/></td><td><input size='3' id='radio_dio0' name='radio_dio0' type='text'/></td><td>Unused on SX128x, Interrupt pin for SX127x</td></tr>

--- a/src/html/hardware.html
+++ b/src/html/hardware.html
@@ -89,16 +89,6 @@ td img.icon-pwm {
 					<tr><td colspan='2'><b>Secondary Serial Pins</td></tr>
 					<tr><td width="30"></td><td>RX pin<img class="icon-input"/></td><td><input size='3' id='serial1_rx' name='serial1_rx' type='text'/></td><td>Secondary serial RX - ESP32 targets only</td></tr>
 					<tr><td></td><td>TX pin<img class="icon-output"/></td><td><input size='3' id='serial1_tx' name='serial1_tx' type='text'/></td><td>Secondary serial TX - ESP32 targets only</td></tr>
-					<tr><td></td><td>Secondary Serial protocol</td><td>
-						<select id='serial1_protocol' name='serial1_protocol'>
-							<option value='-1'>None</option>
-							<option value='0'>CRSF</option>
-							<option value='2'>SBUS</option>
-							<option value='3'>SBUS Inverted</option>
-							<option value='4'>SUMD</option>
-							<option value='6'>HoTT Telemetry</option>
-						</select>
-					</td><td>Secondary serial protocol</td></tr>					
 
 					<tr><td colspan='2'><b>Radio Chip Pins & Options</td></tr>
 					<tr><td></td><td>BUSY pin<img class="icon-input"/></td><td><input size='3' id='radio_busy' name='radio_busy' type='text'/></td><td>GPIO Input connected to SX128x busy pin</td></tr>

--- a/src/html/hardware.html
+++ b/src/html/hardware.html
@@ -86,9 +86,9 @@ td img.icon-pwm {
 					<tr><td width="30"></td><td>RX pin<img class="icon-input"/></td><td><input size='3' id='serial_rx' name='serial_rx' type='text'/></td><td>Pin used to receive CRSF signal from the handset</td></tr>
 					<tr><td></td><td>TX pin<img class="icon-output"/></td><td><input size='3' id='serial_tx' name='serial_tx' type='text'/></td><td>Pin used to transmit CRSF telemetry to the handset (may be the same as the RX PIN)</td></tr>
 
-					<tr><td colspan='2'><b>Secondary Serial Pins</td></tr>
-					<tr><td width="30"></td><td>RX pin<img class="icon-input"/></td><td><input size='3' id='serial1_rx' name='serial1_rx' type='text'/></td><td>Secondary serial RX - ESP32 targets only</td></tr>
-					<tr><td></td><td>TX pin<img class="icon-output"/></td><td><input size='3' id='serial1_tx' name='serial1_tx' type='text'/></td><td>Secondary serial TX - ESP32 targets only</td></tr>
+					<tr><td colspan='2'><b>Serial2 Pins</td></tr>
+					<tr><td width="30"></td><td>RX pin<img class="icon-input"/></td><td><input size='3' id='serial1_rx' name='serial1_rx' type='text'/></td><td>Serial2 RX - ESP32 targets only</td></tr>
+					<tr><td></td><td>TX pin<img class="icon-output"/></td><td><input size='3' id='serial1_tx' name='serial1_tx' type='text'/></td><td>Serial2 TX - ESP32 targets only</td></tr>
 
 					<tr><td colspan='2'><b>Radio Chip Pins & Options</td></tr>
 					<tr><td></td><td>BUSY pin<img class="icon-input"/></td><td><input size='3' id='radio_busy' name='radio_busy' type='text'/></td><td>GPIO Input connected to SX128x busy pin</td></tr>

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -258,7 +258,7 @@
 								<label for='serial-protocol'>Serial Protocol</label>
 							</div>
 						</div>
-						<div id="serial1-config"></div>
+						<div id="serial1-config">
 							<div class="mui-select">
 								<select id='serial1-protocol' name='serial1-protocol'>
 									<option value='0'>NONE</option>

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -270,7 +270,7 @@
 									<option value='6'>DJI RS Pro</option>
 									<option value='7'>HoTT Telemetry</option>
 								</select>
-								<label for='serial1-protocol'>Secondary Serial Protocol</label>
+								<label for='serial1-protocol'>Serial2 Protocol</label>
 							</div>
 						</div>
 						<div id="sbus-config" style="display: none;">

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -258,6 +258,21 @@
 								<label for='serial-protocol'>Serial Protocol</label>
 							</div>
 						</div>
+						<div id="serial1-config"></div>
+							<div class="mui-select">
+								<select id='serial1-protocol' name='serial1-protocol'>
+									<option value='0'>NONE</option>
+									<option value='1'>CRSF</option>
+									<option value='2'>Inverted CRSF</option>
+									<option value='3'>SBUS</option>
+									<option value='4'>Inverted SBUS</option>
+									<option value='5'>SUMD</option>
+									<option value='6'>DJI RS Pro</option>
+									<option value='7'>HoTT Telemetry</option>
+								</select>
+								<label for='serial1-protocol'>Secondary Serial Protocol</label>
+							</div>
+						</div>
 						<div id="sbus-config" style="display: none;">
 							<h2>SBUS Failsafe</h2>
 							Set the failsafe behaviour when using the SBUS protocol:<br/>

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -212,8 +212,6 @@ function updatePwmSettings(arPwm) {
   
   modeSelectionInit = false;
 
-  modeSelectionInit = false;
-
   // put some constraints on pinRx/Tx mode selects
   if (pinRxIndex !== undefined && pinTxIndex !== undefined) {
     const pinRxMode = _(`pwm_${pinRxIndex}_mode`);

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -75,6 +75,7 @@ function updatePwmSettings(arPwm) {
   }
   var pinRxIndex = undefined;
   var pinTxIndex = undefined;
+  var pinTx2Index = undefined;
   var pinModes = []
   // arPwm is an array of raw integers [49664,50688,51200]. 10 bits of failsafe position, 4 bits of input channel, 1 bit invert, 4 bits mode, 1 bit for narrow/750us
   const htmlFields = ['<div class="mui-panel pwmpnl"><table class="pwmtbl mui-table"><tr><th class="fixed-column">Output</th><th class="mui--text-center fixed-column">Features</th><th>Mode</th><th>Input</th><th class="mui--text-center fixed-column">Invert?</th><th class="mui--text-center fixed-column">750us?</th><th class="mui--text-center fixed-column pwmitm">Failsafe Mode</th><th class="mui--text-center fixed-column pwmitm">Failsafe Pos</th></tr>'];
@@ -126,6 +127,7 @@ function updatePwmSettings(arPwm) {
     }
     if (features & 64) {
       modes.push('Serial2 TX');
+      pinTx2Index = index;
     } else {
       modes.push(undefined);
     }
@@ -245,6 +247,22 @@ function updatePwmSettings(arPwm) {
     pinRxMode.onchange();
     if(pinRxMode.value != 9) pinTxMode.value = pinTx;
   }
+
+
+  // put some constraints on Serial 1 pin Rx/Tx mode selects
+  if (pinTx2Index !== undefined) {
+    const pinTx2Mode = _(`pwm_${pinTx2Index}_mode`);
+
+    pinTx2Mode.onchange = () => {
+      if (pinTx2Mode.value == 14) { // Serial2 TX
+        _('serial1-config').style.display = 'block';
+      } else {
+        _('serial1-config').style.display = 'none';
+      }
+    }
+    pinTx2Mode.onchange();
+  }
+
 }
 @@end
 

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -59,6 +59,11 @@ function generateFeatureBadges(features) {
   if ((features & 12) === 12) str += `<span style="color: #696969; background-color: #fab4a8" class="badge">I2C</span>`;
   else if (!!(features & 4)) str += `<span style="color: #696969; background-color: #fab4a8" class="badge">SCL</span>`;
   else if (!!(features & 8)) str += `<span style="color: #696969; background-color: #fab4a8" class="badge">SDA</span>`;
+  
+  // Serial2
+  if (!!(features & 32) || !!(features & 64)) 
+    str += `<span style="color: #696969; background-color: #36b5ff" class="badge">Serial2</span>`;
+
   return str;
 }
 
@@ -202,7 +207,7 @@ function updatePwmSettings(arPwm) {
   
   modeSelectionInit = false;
 
-  // put some contraints on pinRx/Tx mode selects
+  // put some constraints on pinRx/Tx mode selects
   if (pinRxIndex !== undefined && pinTxIndex !== undefined) {
     const pinRxMode = _(`pwm_${pinRxIndex}_mode`);
     const pinTxMode = _(`pwm_${pinTxIndex}_mode`);

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -113,7 +113,18 @@ function updatePwmSettings(arPwm) {
       }
       modes.push(undefined);  // true PWM
     }
-    modes.push(undefined);  // true PWM
+  
+    if (features & 32) {
+      modes.push('SERIAL1 RX');
+    } else {
+      modes.push(undefined);
+    }
+    if (features & 64) {
+      modes.push('SERIAL1 TX');
+    } else {
+      modes.push(undefined);
+    }
+
     const modeSelect = enumSelectGenerate(`pwm_${index}_mode`, mode, modes);
     const inputSelect = enumSelectGenerate(`pwm_${index}_ch`, ch,
         ['ch1', 'ch2', 'ch3', 'ch4',
@@ -375,9 +386,23 @@ function updateConfig(data, options) {
       _('sbus-config').style.display = 'none';
     }
   }
+
+  _('serial1-protocol').onchange = () => {
+    const proto = Number(_('serial1-protocol').value);
+    if (_('is-airport').checked) {
+      _('rcvr-uart-baud').disabled = false;
+      _('rcvr-uart-baud').value = options['rcvr-uart-baud'];
+      _('serial1-config').style.display = 'none';
+      _('sbus-config').style.display = 'none';
+      return;
+    }
+  }
+
   updatePwmSettings(data.pwm);
   _('serial-protocol').value = data['serial-protocol'];
   _('serial-protocol').onchange();
+  _('serial1-protocol').value = data['serial1-protocol'];
+  _('serial1-protocol').onchange();
   _('is-airport').onchange = _('serial-protocol').onchange;
   _('vbind').checked = data.hasOwnProperty('vbind') && data['vbind'];
   _('vbind').onchange = () => {
@@ -686,6 +711,7 @@ if (_('config')) {
         return JSON.stringify({
           "pwm": getPwmFormData(),
           "serial-protocol": +_('serial-protocol').value,
+          "serial1-protocol": +_('serial1-protocol').value,
           "sbus-failsafe": +_('sbus-failsafe').value,
           "modelid": +_('modelid').value,
           "force-tlm": +_('force-tlm').checked,

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -115,12 +115,12 @@ function updatePwmSettings(arPwm) {
     }
   
     if (features & 32) {
-      modes.push('Serial1 RX');
+      modes.push('Serial2 RX');
     } else {
       modes.push(undefined);
     }
     if (features & 64) {
-      modes.push('Serial1 TX');
+      modes.push('Serial2 TX');
     } else {
       modes.push(undefined);
     }

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -115,12 +115,12 @@ function updatePwmSettings(arPwm) {
     }
   
     if (features & 32) {
-      modes.push('SERIAL1 RX');
+      modes.push('Serial1 RX');
     } else {
       modes.push(undefined);
     }
     if (features & 64) {
-      modes.push('SERIAL1 TX');
+      modes.push('Serial1 TX');
     } else {
       modes.push(undefined);
     }

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -414,7 +414,11 @@ function updateConfig(data, options) {
   _('serial-protocol').onchange();
   _('serial1-protocol').value = data['serial1-protocol'];
   _('serial1-protocol').onchange();
-  _('is-airport').onchange = _('serial-protocol').onchange;
+  _('is-airport').onchange = () => {
+    _('serial-protocol').onchange();
+    _('serial1-protocol').onchange();
+  } 
+  _('is-airport').onchange;
   _('vbind').checked = data.hasOwnProperty('vbind') && data['vbind'];
   _('vbind').onchange = () => {
     _('bindphrase').style.display = _('vbind').checked ? 'none' : 'block';

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -61,8 +61,9 @@ function generateFeatureBadges(features) {
   else if (!!(features & 8)) str += `<span style="color: #696969; background-color: #fab4a8" class="badge">SDA</span>`;
   
   // Serial2
-  if (!!(features & 32) || !!(features & 64)) 
-    str += `<span style="color: #696969; background-color: #36b5ff" class="badge">Serial2</span>`;
+  if ((features & 96) === 96) str += `<span style="color: #696969; background-color: #36b5ff" class="badge">Serial2</span>`;
+  else if (!!(features & 32)) str += `<span style="color: #696969; background-color: #36b5ff" class="badge">RX2</span>`;
+  else if (!!(features & 64)) str += `<span style="color: #696969; background-color: #36b5ff" class="badge">TX2</span>`;
 
   return str;
 }

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -207,6 +207,8 @@ function updatePwmSettings(arPwm) {
   
   modeSelectionInit = false;
 
+  modeSelectionInit = false;
+
   // put some constraints on pinRx/Tx mode selects
   if (pinRxIndex !== undefined && pinTxIndex !== undefined) {
     const pinRxMode = _(`pwm_${pinRxIndex}_mode`);

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -175,19 +175,21 @@ typedef enum : uint8_t {
 
 enum eServoOutputMode : uint8_t
 {
-    som50Hz,    // Hz modes are "Servo PWM" where the signal is 988-2012us
-    som60Hz,    // and the mode sets the refresh interval
-    som100Hz,   // 50Hz must be mode=0 for default in config
-    som160Hz,
-    som333Hz,
-    som400Hz,
-    som10KHzDuty,
-    somOnOff,   // Digital 0/1 mode
-    somDShot,   // DShot300
-    somSerial,  // Serial TX or RX depending on pin
-    somSCL,     // I2C clock signal
-    somSDA,     // I2C data line
-    somPwm,     // True PWM mode (NOT SUPPORTED)
+    som50Hz = 0,    // 0:  50 Hz  | modes are "Servo PWM" where the signal is 988-2012us
+    som60Hz,        // 1:  60 Hz  | and the mode sets the refresh interval
+    som100Hz,       // 2:  100 Hz | must be mode=0 for default in config
+    som160Hz,       // 3:  160Hz
+    som333Hz,       // 4:  333Hz
+    som400Hz,       // 5:  400Hz
+    som10KHzDuty,   // 6:  10kHz duty
+    somOnOff,       // 7:  Digital 0/1 mode
+    somDShot,       // 8:  DShot300
+    somSerial,      // 9:  primary Serial
+    somSCL,         // 10: I2C clock signal
+    somSDA,         // 11: I2C data line
+    somPwm,         // 12: true PWM mode (NOT SUPPORTED)
+    somSerial1RX,   // 13: secondary Serial RX
+    somSerial1TX,   // 14: secondary Serial TX
 };
 
 enum eServoOutputFailsafeMode : uint8_t
@@ -206,6 +208,18 @@ enum eSerialProtocol : uint8_t
 	PROTOCOL_SUMD,
     PROTOCOL_DJI_RS_PRO,
     PROTOCOL_HOTT_TLM
+};
+
+enum eSerial1Protocol : uint8_t
+{
+    PROTOCOL_SERIAL1_NONE,
+    PROTOCOL_SERIAL1_CRSF,
+    PROTOCOL_SERIAL1_INVERTED_CRSF,
+    PROTOCOL_SERIAL1_SBUS,
+    PROTOCOL_SERIAL1_INVERTED_SBUS,
+	PROTOCOL_SERIAL1_SUMD,
+    PROTOCOL_SERIAL1_DJI_RS_PRO,
+    PROTOCOL_SERIAL1_HOTT_TLM
 };
 
 enum eFailsafeMode : uint8_t

--- a/src/include/hardware.h
+++ b/src/include/hardware.h
@@ -6,7 +6,6 @@ typedef enum {
     HARDWARE_serial_tx,
     HARDWARE_serial1_rx,
     HARDWARE_serial1_tx,
-    HARDWARE_serial1_protocol,
 
     // Radio
     HARDWARE_radio_busy,

--- a/src/include/hardware.h
+++ b/src/include/hardware.h
@@ -4,6 +4,9 @@ typedef enum {
     // Serial
     HARDWARE_serial_rx,
     HARDWARE_serial_tx,
+    HARDWARE_serial1_rx,
+    HARDWARE_serial1_tx,
+    HARDWARE_serial1_protocol,
 
     // Radio
     HARDWARE_radio_busy,

--- a/src/include/target/Unified_ESP_RX.h
+++ b/src/include/target/Unified_ESP_RX.h
@@ -39,7 +39,6 @@
 #define GPIO_PIN_RCSIGNAL_TX hardware_pin(HARDWARE_serial_tx)
 #define GPIO_PIN_SERIAL1_RX hardware_pin(HARDWARE_serial1_rx)
 #define GPIO_PIN_SERIAL1_TX hardware_pin(HARDWARE_serial1_tx)
-#define SERIAL1_PROTOCOL hardware_pin(HARDWARE_serial1_protocol)
 
 // Radio
 #define GPIO_PIN_BUSY hardware_pin(HARDWARE_radio_busy)

--- a/src/include/target/Unified_ESP_RX.h
+++ b/src/include/target/Unified_ESP_RX.h
@@ -37,6 +37,9 @@
 // Serial
 #define GPIO_PIN_RCSIGNAL_RX hardware_pin(HARDWARE_serial_rx)
 #define GPIO_PIN_RCSIGNAL_TX hardware_pin(HARDWARE_serial_tx)
+#define GPIO_PIN_SERIAL1_RX hardware_pin(HARDWARE_serial1_rx)
+#define GPIO_PIN_SERIAL1_TX hardware_pin(HARDWARE_serial1_tx)
+#define SERIAL1_PROTOCOL hardware_pin(HARDWARE_serial1_protocol)
 
 // Radio
 #define GPIO_PIN_BUSY hardware_pin(HARDWARE_radio_busy)

--- a/src/lib/CONFIG/config.cpp
+++ b/src/lib/CONFIG/config.cpp
@@ -1114,6 +1114,15 @@ void RxConfig::SetSerialProtocol(eSerialProtocol serialProtocol)
     }
 }
 
+void RxConfig::SetSerial1Protocol(eSerial1Protocol serialProtocol)
+{
+    if (m_config.serial1Protocol != serialProtocol)
+    {
+        m_config.serial1Protocol = serialProtocol;
+        m_modified = true;
+    }
+}
+
 void RxConfig::SetTeamraceChannel(uint8_t teamraceChannel)
 {
     if (m_config.teamraceChannel != teamraceChannel)

--- a/src/lib/CONFIG/config.cpp
+++ b/src/lib/CONFIG/config.cpp
@@ -1031,6 +1031,8 @@ RxConfig::SetDefaults(bool commit)
     m_config.serialProtocol = PROTOCOL_CRSF;
 #endif
 
+    m_config.serial1Protocol = PROTOCOL_SERIAL1_NONE;
+
     if (commit)
     {
         // Prevent rebinding to the flashed UID on first boot

--- a/src/lib/CONFIG/config.h
+++ b/src/lib/CONFIG/config.h
@@ -220,6 +220,8 @@ typedef struct __attribute__((packed)) {
     uint8_t     teamraceChannel:4,
                 teamracePosition:3,
                 teamracePitMode:1;  // FUTURE: Enable pit mode when disabling model
+    uint8_t     serial1Protocol:4,  // secondary serial protocol
+                serial1Protocol_unused:4;
 } rx_config_t;
 
 class RxConfig
@@ -244,6 +246,7 @@ public:
     bool GetForceTlmOff() const { return m_config.forceTlmOff; }
     uint8_t GetRateInitialIdx() const { return m_config.rateInitialIdx; }
     eSerialProtocol GetSerialProtocol() const { return (eSerialProtocol)m_config.serialProtocol; }
+    eSerial1Protocol GetSerial1Protocol() const { return (eSerial1Protocol)m_config.serial1Protocol; }
     uint8_t GetTeamraceChannel() const { return m_config.teamraceChannel; }
     uint8_t GetTeamracePosition() const { return m_config.teamracePosition; }
     eFailsafeMode GetFailsafeMode() const { return (eFailsafeMode)m_config.failsafeMode; }
@@ -264,6 +267,7 @@ public:
     void SetForceTlmOff(bool forceTlmOff);
     void SetRateInitialIdx(uint8_t rateInitialIdx);
     void SetSerialProtocol(eSerialProtocol serialProtocol);
+    void SetSerial1Protocol(eSerial1Protocol serial1Protocol);
     void SetTeamraceChannel(uint8_t teamraceChannel);
     void SetTeamracePosition(uint8_t teamracePosition);
     void SetFailsafeMode(eFailsafeMode failsafeMode);

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -3,20 +3,28 @@
 #include "rxtx_devLua.h"
 #include "helpers.h"
 #include "devServoOutput.h"
-#include "deferred.h"
 
+extern void deferExecution(uint32_t ms, std::function<void()> f);
 extern void reconfigureSerial();
+extern void reconfigureSerial1();
 extern bool BindingModeRequest;
 
 static char modelString[] = "000";
 #if defined(GPIO_PIN_PWM_OUTPUTS)
-static char pwmModes[] = "50Hz;60Hz;100Hz;160Hz;333Hz;400Hz;10kHzDuty;On/Off;DShot;Serial RX;Serial TX;I2C SCL;I2C SDA";
+static char pwmModes[] = "50Hz;60Hz;100Hz;160Hz;333Hz;400Hz;10kHzDuty;On/Off;DShot;Serial RX;Serial TX;I2C SCL;I2C SDA;SERIAL1_RX;SERIAL1_TX";
 #endif
 
 static struct luaItem_selection luaSerialProtocol = {
-    {"Protocol", CRSF_TEXT_SELECTION},
+    {"Protocol 1", CRSF_TEXT_SELECTION},
     0, // value
     "CRSF;Inverted CRSF;SBUS;Inverted SBUS;SUMD;DJI RS Pro;HoTT Telemetry",
+    STR_EMPTYSPACE
+};
+
+static struct luaItem_selection luaSerial1Protocol = {
+    {"Protocol 2", CRSF_TEXT_SELECTION},
+    0, // value
+    "NONE;CRSF;Inverted CRSF;SBUS;Inverted SBUS;SUMD;DJI RS Pro;HoTT Telemetry",
     STR_EMPTYSPACE
 };
 
@@ -163,36 +171,6 @@ static struct luaItem_command luaBindMode = {
 #if defined(GPIO_PIN_PWM_OUTPUTS)
 static void luaparamMappingChannelOut(struct luaPropertiesCommon *item, uint8_t arg)
 {
-    bool sclAssigned = false;
-    bool sdaAssigned = false;
-
-    const char *no1Option    = ";";
-    const char *no2Options   = ";;";
-    const char *dshot        = ";DShot";
-    const char *serial_RX    = ";Serial RX";
-    const char *serial_TX    = ";Serial TX";
-    const char *i2c_SCL      = ";I2C SCL;";
-    const char *i2c_SDA      = ";;I2C SDA";
-    const char *i2c_BOTH     = ";I2C SCL;I2C SDA";
-
-    const char *pModeString;
-
-
-    // find out if use once only modes have already been assigned
-    for (uint8_t ch = 0; ch < GPIO_PIN_PWM_OUTPUTS_COUNT; ch++)
-    {
-      if (ch == (arg -1))
-        continue;
-
-      eServoOutputMode mode = (eServoOutputMode)config.GetPwmChannel(ch)->val.mode;
-      
-      if (mode == somSCL)
-        sclAssigned = true;
-
-      if (mode == somSDA)
-        sdaAssigned = true;
-    }
-
     setLuaUint8Value(&luaMappingChannelOut, arg);
 
     // When the selected output channel changes, update the available PWM modes for that pin
@@ -203,72 +181,65 @@ static void luaparamMappingChannelOut(struct luaPropertiesCommon *item, uint8_t 
     // DShot output (1 option)
     // ;DShot
     // ESP8266 enum skips this, so it is never present
-    if (GPIO_PIN_PWM_OUTPUTS[arg-1] != 0)   // DShot doesn't work with GPIO0, exclude it
+    if (GPIO_PIN_PWM_OUTPUTS[arg-1] != UNDEF_PIN)
     {
-        pModeString = dshot;
+        strcat(pwmModes, ";DShot");
     }
     else
 #endif
     {
-        pModeString = no1Option;
+        strcat(pwmModes, ";");
     }
-    strcat(pwmModes, pModeString);
 
     // SerialIO outputs (1 option)
     // ;[Serial RX] | [Serial TX]
-    if (GPIO_PIN_PWM_OUTPUTS[arg-1] == U0RXD_GPIO_NUM)
+    if (GPIO_PIN_PWM_OUTPUTS[arg-1] == 3)
     {
-        pModeString = serial_RX;
+        strcat(pwmModes, ";Serial RX");
     }
-    else if (GPIO_PIN_PWM_OUTPUTS[arg-1] == U0TXD_GPIO_NUM)
+    else if (GPIO_PIN_PWM_OUTPUTS[arg-1] == 1)
     {
-        pModeString = serial_TX;
+        strcat(pwmModes, ";Serial TX");
     }
     else
     {
-        pModeString = no1Option;
+        strcat(pwmModes, ";");
     }
-    strcat(pwmModes, pModeString);
 
     // I2C pins (2 options)
     // ;[I2C SCL] ;[I2C SDA]
-    if (GPIO_PIN_SCL != UNDEF_PIN || GPIO_PIN_SDA != UNDEF_PIN)
+    // If the target defines SCL/SDA then those pins MUST be used,
+    // otherwise allow any pin to be either SCL or SDA
+    if (GPIO_PIN_PWM_OUTPUTS[arg-1] == GPIO_PIN_SCL)
     {
-        // If the target defines SCL/SDA then those pins MUST be used
-        if (GPIO_PIN_PWM_OUTPUTS[arg-1] == GPIO_PIN_SCL)
-        {
-            pModeString = i2c_SCL;
-        }
-        else if (GPIO_PIN_PWM_OUTPUTS[arg-1] == GPIO_PIN_SDA)
-        {
-            pModeString = i2c_SDA;
-        }
-        else
-        {
-            pModeString = no2Options;
-        }
-    } 
-    else
-    {  
-        // otherwise allow any pin to be either SCL or SDA but only once
-        if (sclAssigned && !sdaAssigned)
-        {
-            pModeString = i2c_SDA;
-        }
-        else if (sdaAssigned && !sclAssigned)
-        {
-            pModeString = i2c_SCL;
-        }
-        else if (!sclAssigned && !sdaAssigned)
-        {
-            pModeString = i2c_BOTH;
-        }
-        else
-        {
-            pModeString = no2Options;
-        }
+        strcat(pwmModes, ";I2C SCL;");
     }
-    strcat(pwmModes, pModeString);
+    else if (GPIO_PIN_PWM_OUTPUTS[arg-1] == GPIO_PIN_SDA)
+    {
+        strcat(pwmModes, ";;I2C SDA");
+    }
+    else if (GPIO_PIN_SCL == UNDEF_PIN || GPIO_PIN_SDA == UNDEF_PIN)
+    {
+        strcat(pwmModes, ";I2C SCL;I2C SDA");
+    }
+    else
+        strcat(pwmModes, ";;");
+    
+    strcat(pwmModes, ";");
+
+    // secondary Serial pins (2 options)
+    // ;[SERIAL1 RX] ;[SERIAL1_TX]
+    // allow any pin to be either SERIAL1 RX or SERIAL1 TX
+#if defined(PLATFORM_ESP32)
+    if (GPIO_PIN_PWM_OUTPUTS[arg-1] != UNDEF_PIN)
+    {
+        strcat(pwmModes, ";SERIAL1 RX;SERIAL1 TX");
+    }
+    else
+#endif
+    {
+        strcat(pwmModes, ";;");
+    }
 
     // trim off trailing semicolons (assumes pwmModes has at least 1 non-semicolon)
     for (auto lastPos = strlen(pwmModes)-1; pwmModes[lastPos] == ';'; lastPos--)
@@ -318,7 +289,7 @@ static void configureSerialPin(uint8_t sibling, uint8_t oldMode, uint8_t newMode
 
   if (oldMode != newMode)
   {
-    deferExecutionMillis(100, [](){
+    deferExecution(100, [](){
       reconfigureSerial();
     });
   }
@@ -415,13 +386,26 @@ static void registerLuaParameters()
   registerLUAParameter(&luaSerialProtocol, [](struct luaPropertiesCommon* item, uint8_t arg){
     config.SetSerialProtocol((eSerialProtocol)arg);
     if (config.IsModified()) {
-      deferExecutionMillis(100, [](){
+      deferExecution(100, [](){
         reconfigureSerial();
       });
     }
   });
 
-  if (config.GetSerialProtocol() == PROTOCOL_SBUS || config.GetSerialProtocol() == PROTOCOL_INVERTED_SBUS || config.GetSerialProtocol() == PROTOCOL_DJI_RS_PRO)
+  registerLUAParameter(&luaSerial1Protocol, [](struct luaPropertiesCommon* item, uint8_t arg){
+    config.SetSerial1Protocol((eSerial1Protocol)arg);
+    if (config.IsModified()) {
+      deferExecution(100, [](){
+        reconfigureSerial1();
+      });
+    }
+  });
+
+  eSerialProtocol prot0 = config.GetSerialProtocol();
+  eSerial1Protocol prot1 = config.GetSerial1Protocol();
+
+  if (prot0 == PROTOCOL_SBUS || prot0 == PROTOCOL_INVERTED_SBUS || prot0 == PROTOCOL_DJI_RS_PRO ||
+      prot1 == PROTOCOL_SERIAL1_SBUS || prot1 == PROTOCOL_SERIAL1_INVERTED_SBUS || prot1 == PROTOCOL_SERIAL1_DJI_RS_PRO)
   {
     registerLUAParameter(&luaFailsafeMode, [](struct luaPropertiesCommon* item, uint8_t arg){
       config.SetFailsafeMode((eFailsafeMode)arg);
@@ -476,7 +460,7 @@ static void registerLuaParameters()
   registerLUAParameter(&luaBindMode, [](struct luaPropertiesCommon* item, uint8_t arg){
     // Complete when TX polls for status i.e. going back to idle, because we're going to lose connection
     if (arg == lcsQuery) {
-      deferExecutionMillis(200, [](){ BindingModeRequest = true; });
+      deferExecution(200, [](){ BindingModeRequest = true; });
     }
     sendLuaCommandResponse(&luaBindMode, arg < 5 ? lcsExecuting : lcsIdle, arg < 5 ? "Entering..." : "");
   });
@@ -489,6 +473,7 @@ static void registerLuaParameters()
 static int event()
 {
   setLuaTextSelectionValue(&luaSerialProtocol, config.GetSerialProtocol());
+  setLuaTextSelectionValue(&luaSerial1Protocol, config.GetSerial1Protocol());
   setLuaTextSelectionValue(&luaFailsafeMode, config.GetFailsafeMode());
 
   if (GPIO_PIN_ANT_CTRL != UNDEF_PIN)

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -488,7 +488,7 @@ static void registerLuaParameters()
   registerLUAParameter(&luaSerial1Protocol, [](struct luaPropertiesCommon* item, uint8_t arg){
     config.SetSerial1Protocol((eSerial1Protocol)arg);
     if (config.IsModified()) {
-      deferExecution(100, [](){
+      deferExecutionMillis(100, [](){
         reconfigureSerial1();
       });
     }

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -229,9 +229,21 @@ static void luaparamMappingChannelOut(struct luaPropertiesCommon *item, uint8_t 
 
 #if defined(PLATFORM_ESP32)
     // secondary Serial pins (2 options)
-    // ;[SERIAL1 RX] ;[SERIAL1_TX]
-    // allow any pin to be either SERIAL1 RX or SERIAL1 TX
-    strcat(pwmModes, ";Serial2 RX;Serial2 TX");
+    // ;[SERIAL2 RX] ;[SERIAL2_TX]
+    // If the target defines Serial2 RX/TX then those pins MUST be used,
+    // otherwise allow any pin to be either RX or TX
+    if (GPIO_PIN_PWM_OUTPUTS[arg-1] == GPIO_PIN_SERIAL1_RX)
+    {
+        strcat(pwmModes, ";SERIAL2 RX;");
+    }
+    else if (GPIO_PIN_PWM_OUTPUTS[arg-1] == GPIO_PIN_SERIAL1_TX)
+    {
+        strcat(pwmModes, ";;SERIAL2 TX");
+    }
+    else if (GPIO_PIN_SERIAL1_RX == UNDEF_PIN || GPIO_PIN_SERIAL1_TX == UNDEF_PIN)
+    {
+      strcat(pwmModes, ";Serial2 RX;Serial2 TX");
+    }
 #else
     strcat(pwmModes, ";;");
 #endif

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -11,7 +11,7 @@ extern bool BindingModeRequest;
 
 static char modelString[] = "000";
 #if defined(GPIO_PIN_PWM_OUTPUTS)
-static char pwmModes[] = "50Hz;60Hz;100Hz;160Hz;333Hz;400Hz;10kHzDuty;On/Off;DShot;Serial RX;Serial TX;I2C SCL;I2C SDA;SERIAL1_RX;SERIAL1_TX";
+static char pwmModes[] = "50Hz;60Hz;100Hz;160Hz;333Hz;400Hz;10kHzDuty;On/Off;DShot;Serial RX;Serial TX;I2C SCL;I2C SDA;Serial1 RX;Serial1 TX";
 #endif
 
 static struct luaItem_selection luaSerialProtocol = {
@@ -181,7 +181,7 @@ static void luaparamMappingChannelOut(struct luaPropertiesCommon *item, uint8_t 
     // DShot output (1 option)
     // ;DShot
     // ESP8266 enum skips this, so it is never present
-    if (GPIO_PIN_PWM_OUTPUTS[arg-1] != UNDEF_PIN)
+    if (GPIO_PIN_PWM_OUTPUTS[arg-1] != 0)   // DShot doesn't work with GPIO0, exclude it
     {
         strcat(pwmModes, ";DShot");
     }
@@ -227,19 +227,14 @@ static void luaparamMappingChannelOut(struct luaPropertiesCommon *item, uint8_t 
     
     strcat(pwmModes, ";");
 
+#if defined(PLATFORM_ESP32)
     // secondary Serial pins (2 options)
     // ;[SERIAL1 RX] ;[SERIAL1_TX]
     // allow any pin to be either SERIAL1 RX or SERIAL1 TX
-#if defined(PLATFORM_ESP32)
-    if (GPIO_PIN_PWM_OUTPUTS[arg-1] != UNDEF_PIN)
-    {
-        strcat(pwmModes, ";SERIAL1 RX;SERIAL1 TX");
-    }
-    else
+    strcat(pwmModes, ";Serial1 RX;Serial1 TX");
+#else
+    strcat(pwmModes, ";;");
 #endif
-    {
-        strcat(pwmModes, ";;");
-    }
 
     // trim off trailing semicolons (assumes pwmModes has at least 1 non-semicolon)
     for (auto lastPos = strlen(pwmModes)-1; pwmModes[lastPos] == ';'; lastPos--)

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -11,18 +11,18 @@ extern bool BindingModeRequest;
 
 static char modelString[] = "000";
 #if defined(GPIO_PIN_PWM_OUTPUTS)
-static char pwmModes[] = "50Hz;60Hz;100Hz;160Hz;333Hz;400Hz;10kHzDuty;On/Off;DShot;Serial RX;Serial TX;I2C SCL;I2C SDA;Serial1 RX;Serial1 TX";
+static char pwmModes[] = "50Hz;60Hz;100Hz;160Hz;333Hz;400Hz;10kHzDuty;On/Off;DShot;Serial RX;Serial TX;I2C SCL;I2C SDA;Serial2 RX;Serial2 TX";
 #endif
 
 static struct luaItem_selection luaSerialProtocol = {
-    {"Protocol 1", CRSF_TEXT_SELECTION},
+    {"Protocol", CRSF_TEXT_SELECTION},
     0, // value
     "CRSF;Inverted CRSF;SBUS;Inverted SBUS;SUMD;DJI RS Pro;HoTT Telemetry",
     STR_EMPTYSPACE
 };
 
 static struct luaItem_selection luaSerial1Protocol = {
-    {"Protocol 2", CRSF_TEXT_SELECTION},
+    {"Protocol2", CRSF_TEXT_SELECTION},
     0, // value
     "NONE;CRSF;Inverted CRSF;SBUS;Inverted SBUS;SUMD;DJI RS Pro;HoTT Telemetry",
     STR_EMPTYSPACE
@@ -231,7 +231,7 @@ static void luaparamMappingChannelOut(struct luaPropertiesCommon *item, uint8_t 
     // secondary Serial pins (2 options)
     // ;[SERIAL1 RX] ;[SERIAL1_TX]
     // allow any pin to be either SERIAL1 RX or SERIAL1 TX
-    strcat(pwmModes, ";Serial1 RX;Serial1 TX");
+    strcat(pwmModes, ";Serial2 RX;Serial2 TX");
 #else
     strcat(pwmModes, ";;");
 #endif

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -3,8 +3,8 @@
 #include "rxtx_devLua.h"
 #include "helpers.h"
 #include "devServoOutput.h"
+#include "deferred.h"
 
-extern void deferExecutionMillis(uint32_t ms, std::function<void()> f);
 extern void reconfigureSerial();
 extern void reconfigureSerial1();
 extern bool BindingModeRequest;
@@ -235,11 +235,11 @@ static void luaparamMappingChannelOut(struct luaPropertiesCommon *item, uint8_t 
 
     // SerialIO outputs (1 option)
     // ;[Serial RX] | [Serial TX]
-    if (GPIO_PIN_PWM_OUTPUTS[arg-1] == 3)
+    if (GPIO_PIN_PWM_OUTPUTS[arg-1] == U0RXD_GPIO_NUM)
     {
         pModeString = serial_RX;
     }
-    else if (GPIO_PIN_PWM_OUTPUTS[arg-1] == 1)
+    else if (GPIO_PIN_PWM_OUTPUTS[arg-1] == U0TXD_GPIO_NUM)
     {
         pModeString = serial_TX;
     }

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -4,7 +4,7 @@
 #include "helpers.h"
 #include "devServoOutput.h"
 
-extern void deferExecution(uint32_t ms, std::function<void()> f);
+extern void deferExecutionMillis(uint32_t ms, std::function<void()> f);
 extern void reconfigureSerial();
 extern void reconfigureSerial1();
 extern bool BindingModeRequest;
@@ -382,7 +382,7 @@ static void configureSerialPin(uint8_t sibling, uint8_t oldMode, uint8_t newMode
 
   if (oldMode != newMode)
   {
-    deferExecution(100, [](){
+    deferExecutionMillis(100, [](){
       reconfigureSerial();
     });
   }
@@ -479,7 +479,7 @@ static void registerLuaParameters()
   registerLUAParameter(&luaSerialProtocol, [](struct luaPropertiesCommon* item, uint8_t arg){
     config.SetSerialProtocol((eSerialProtocol)arg);
     if (config.IsModified()) {
-      deferExecution(100, [](){
+      deferExecutionMillis(100, [](){
         reconfigureSerial();
       });
     }
@@ -553,7 +553,7 @@ static void registerLuaParameters()
   registerLUAParameter(&luaBindMode, [](struct luaPropertiesCommon* item, uint8_t arg){
     // Complete when TX polls for status i.e. going back to idle, because we're going to lose connection
     if (arg == lcsQuery) {
-      deferExecution(200, [](){ BindingModeRequest = true; });
+      deferExecutionMillis(200, [](){ BindingModeRequest = true; });
     }
     sendLuaCommandResponse(&luaBindMode, arg < 5 ? lcsExecuting : lcsIdle, arg < 5 ? "Entering..." : "");
   });

--- a/src/lib/OPTIONS/hardware.cpp
+++ b/src/lib/OPTIONS/hardware.cpp
@@ -25,6 +25,9 @@ static const struct {
 } fields[] = {
     {HARDWARE_serial_rx, "serial_rx", INT},
     {HARDWARE_serial_tx, "serial_tx", INT},
+    {HARDWARE_serial1_rx, "serial1_rx", INT},
+    {HARDWARE_serial1_tx, "serial1_tx", INT},
+    {HARDWARE_serial1_protocol, "serial1_protocol", INT},
     {HARDWARE_radio_busy, "radio_busy", INT},
     {HARDWARE_radio_busy_2, "radio_busy_2", INT},
     {HARDWARE_radio_dio0, "radio_dio0", INT},

--- a/src/lib/OPTIONS/hardware.cpp
+++ b/src/lib/OPTIONS/hardware.cpp
@@ -27,7 +27,6 @@ static const struct {
     {HARDWARE_serial_tx, "serial_tx", INT},
     {HARDWARE_serial1_rx, "serial1_rx", INT},
     {HARDWARE_serial1_tx, "serial1_tx", INT},
-    {HARDWARE_serial1_protocol, "serial1_protocol", INT},
     {HARDWARE_radio_busy, "radio_busy", INT},
     {HARDWARE_radio_busy_2, "radio_busy_2", INT},
     {HARDWARE_radio_dio0, "radio_dio0", INT},

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -381,7 +381,8 @@ static void GetConfiguration(AsyncWebServerRequest *request)
       if (pin != 0) features |= 16; // DShot supported on all pins but GPIO0 
       if (pin == GPIO_PIN_SERIAL1_RX) features |= 32;  // SERIAL1 RX supported (only on this pin)
       else if (pin == GPIO_PIN_SERIAL1_TX) features |= 64;  // SERIAL1 TX supported (only on this pin)
-      else if (GPIO_PIN_SERIAL1_RX == UNDEF_PIN || GPIO_PIN_SERIAL1_TX == UNDEF_PIN) features |= 96; // Both Serial1 RX/TX supported (on any pin)
+      else if ((GPIO_PIN_SERIAL1_RX == UNDEF_PIN || GPIO_PIN_SERIAL1_TX == UNDEF_PIN) && 
+               (!(features & 1) && !(features & 2))) features |= 96; // Both Serial1 RX/TX supported (on any pin if not already featured for Serial 1)
       #endif
       json["config"]["pwm"][ch]["features"] = features;
     }

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -379,8 +379,9 @@ static void GetConfiguration(AsyncWebServerRequest *request)
       else if (GPIO_PIN_SCL == UNDEF_PIN || GPIO_PIN_SDA == UNDEF_PIN) features |= 12; // Both I2C SCL/SDA supported (on any pin)
       #if defined(PLATFORM_ESP32)
       if (pin != 0) features |= 16; // DShot supported on all pins but GPIO0 
-      if (GPIO_PIN_SERIAL1_RX == UNDEF_PIN)  features |= 32;  // Serial1RX supported
-      if (GPIO_PIN_SERIAL1_TX == UNDEF_PIN)  features |= 64;  // Serial1TX supported
+      if (pin == GPIO_PIN_SERIAL1_RX) features |= 32;  // SERIAL1 RX supported (only on this pin)
+      else if (pin == GPIO_PIN_SERIAL1_TX) features |= 64;  // SERIAL1 TX supported (only on this pin)
+      else if (GPIO_PIN_SERIAL1_RX == UNDEF_PIN || GPIO_PIN_SERIAL1_TX == UNDEF_PIN) features |= 96; // Both Serial1 RX/TX supported (on any pin)
       #endif
       json["config"]["pwm"][ch]["features"] = features;
     }

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -360,6 +360,7 @@ static void GetConfiguration(AsyncWebServerRequest *request)
     json["config"]["mode"] = wifiMode == WIFI_STA ? "STA" : "AP";
     #if defined(TARGET_RX)
     json["config"]["serial-protocol"] = config.GetSerialProtocol();
+    json["config"]["serial1-protocol"] = config.GetSerial1Protocol();
     json["config"]["sbus-failsafe"] = config.GetFailsafeMode();
     json["config"]["modelid"] = config.GetModelId();
     json["config"]["force-tlm"] = config.GetForceTlmOff();
@@ -378,6 +379,8 @@ static void GetConfiguration(AsyncWebServerRequest *request)
       else if (GPIO_PIN_SCL == UNDEF_PIN || GPIO_PIN_SDA == UNDEF_PIN) features |= 12; // Both I2C SCL/SDA supported (on any pin)
       #if defined(PLATFORM_ESP32)
       if (pin != 0) features |= 16; // DShot supported
+      if (GPIO_PIN_SERIAL1_RX == UNDEF_PIN)  features |= 32;  // Serial1RX supported
+      if (GPIO_PIN_SERIAL1_TX == UNDEF_PIN)  features |= 64;  // Serial1TX supported
       #endif
       json["config"]["pwm"][ch]["features"] = features;
     }
@@ -504,6 +507,9 @@ static void UpdateConfiguration(AsyncWebServerRequest *request, JsonVariant &jso
 {
   uint8_t protocol = json["serial-protocol"] | 0;
   config.SetSerialProtocol((eSerialProtocol)protocol);
+
+  uint8_t protocol1 = json["serial1-protocol"] | 0;
+  config.SetSerial1Protocol((eSerial1Protocol)protocol1);
 
   uint8_t failsafe = json["sbus-failsafe"] | 0;
   config.SetFailsafeMode((eFailsafeMode)failsafe);

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -378,7 +378,7 @@ static void GetConfiguration(AsyncWebServerRequest *request)
       else if (pin == GPIO_PIN_SDA) features |= 8;  // I2C SCL supported (only on this pin)
       else if (GPIO_PIN_SCL == UNDEF_PIN || GPIO_PIN_SDA == UNDEF_PIN) features |= 12; // Both I2C SCL/SDA supported (on any pin)
       #if defined(PLATFORM_ESP32)
-      if (pin != 0) features |= 16; // DShot supported
+      if (pin != 0) features |= 16; // DShot supported on all pins but GPIO0 
       if (GPIO_PIN_SERIAL1_RX == UNDEF_PIN)  features |= 32;  // Serial1RX supported
       if (GPIO_PIN_SERIAL1_TX == UNDEF_PIN)  features |= 64;  // Serial1TX supported
       #endif

--- a/src/src/rx-serial/SerialHoTT_TLM.cpp
+++ b/src/src/rx-serial/SerialHoTT_TLM.cpp
@@ -43,7 +43,7 @@ void SerialHoTT_TLM::setTXMode()
 #if defined(PLATFORM_ESP32)
     pinMode(halfDuplexPin, OUTPUT);                                 // set half duplex GPIO to OUTPUT
     digitalWrite(halfDuplexPin, HIGH);                              // set half duplex GPIO to high level
-    pinMatrixOutAttach(halfDuplexPin, U0TXD_OUT_IDX, false, false); // attach GPIO as output of UART0 TX
+    pinMatrixOutAttach(halfDuplexPin, UTXDoutIdx, false, false);    // attach GPIO as output of UART TX
 #endif
 }
 
@@ -51,7 +51,7 @@ void SerialHoTT_TLM::setRXMode()
 {
 #if defined(PLATFORM_ESP32)
     pinMode(halfDuplexPin, INPUT_PULLUP);                           // set half duplex GPIO to INPUT
-    pinMatrixInAttach(halfDuplexPin, U0RXD_IN_IDX, false);          // attach half duplex GPIO as input to UART0 RX
+    pinMatrixInAttach(halfDuplexPin, URXDinIdx, false);             // attach half duplex GPIO as input to UART RX
 #endif
 }
 

--- a/src/src/rx-serial/SerialHoTT_TLM.h
+++ b/src/src/rx-serial/SerialHoTT_TLM.h
@@ -263,11 +263,25 @@ enum {
 class SerialHoTT_TLM : public SerialIO
 {
 public:
-    explicit SerialHoTT_TLM(Stream &out, Stream &in)
+    explicit SerialHoTT_TLM(Stream &out, Stream &in, int8_t serial1TXpin = UNDEF_PIN)
         : SerialIO(&out, &in)
-    {
-        // use UART0 default TX pin for half duplex if not defined otherwise
-        halfDuplexPin = GPIO_PIN_RCSIGNAL_TX == UNDEF_PIN ? U0TXD_GPIO_NUM : GPIO_PIN_RCSIGNAL_TX;
+    {       
+#if defined(PLATFORM_ESP32)
+        if (serial1TXpin == UNDEF_PIN)
+        {
+            // we are on UART0, use default TX pin for half duplex if not defined otherwise
+            UTXDoutIdx = U0TXD_OUT_IDX;
+            URXDinIdx = U0RXD_IN_IDX;
+            halfDuplexPin = GPIO_PIN_RCSIGNAL_TX == UNDEF_PIN ? U0TXD_GPIO_NUM : GPIO_PIN_RCSIGNAL_TX;
+        }
+        else
+        {   
+            // we are on UART1, use Serial1 TX assigned pin for half duplex
+            UTXDoutIdx = U1TXD_OUT_IDX;
+            URXDinIdx = U1RXD_IN_IDX;
+            halfDuplexPin = serial1TXpin;
+        } 
+#endif
 
         uint32_t now = millis();
 
@@ -287,6 +301,12 @@ public:
     void sendQueuedData(uint32_t maxBytesToSend) override;
 
 private:
+#if defined(PLATFORM_ESP32)
+    int8_t halfDuplexPin;
+    uint8_t UTXDoutIdx;
+    uint8_t URXDinIdx;
+#endif
+
     void setTXMode();
     void setRXMode();
 
@@ -335,8 +355,6 @@ private:
         {SENSOR_ID_VARIO_B, false}};
 
     FIFO<HOTT_MAX_BUF_LEN> hottInputBuffer;
-
-    uint8_t halfDuplexPin;
 
     bool discoveryMode = true;
     uint8_t nextDevice = FIRST_DEVICE;

--- a/src/src/rx-serial/SerialSBUS.cpp
+++ b/src/src/rx-serial/SerialSBUS.cpp
@@ -5,6 +5,9 @@
 
 #if defined(TARGET_RX)
 
+extern Stream* serial_protocol_tx;
+extern Stream* serial1_protocol_tx;
+
 #define SBUS_FLAG_SIGNAL_LOSS       (1 << 2)
 #define SBUS_FLAG_FAILSAFE_ACTIVE   (1 << 3)
 
@@ -29,8 +32,8 @@ uint32_t SerialSBUS::sendRCFrame(bool frameAvailable, bool frameMissed, uint32_t
     // TODO: if failsafeMode == FAILSAFE_SET_POSITION then we use the set positions rather than the last values
     crsf_channels_s PackedRCdataOut;
 
-    if (config.GetSerialProtocol() == PROTOCOL_DJI_RS_PRO ||
-        config.GetSerial1Protocol() == PROTOCOL_SERIAL1_DJI_RS_PRO)
+    if (((config.GetSerialProtocol() == PROTOCOL_DJI_RS_PRO) && streamOut == serial_protocol_tx)||
+        ((config.GetSerial1Protocol() == PROTOCOL_SERIAL1_DJI_RS_PRO) && streamOut == serial1_protocol_tx))
     {
         PackedRCdataOut.ch0 = fmap(channelData[0], CRSF_CHANNEL_VALUE_MIN, CRSF_CHANNEL_VALUE_MAX, 352, 1696);
         PackedRCdataOut.ch1 = fmap(channelData[1], CRSF_CHANNEL_VALUE_MIN, CRSF_CHANNEL_VALUE_MAX, 352, 1696);

--- a/src/src/rx-serial/SerialSBUS.cpp
+++ b/src/src/rx-serial/SerialSBUS.cpp
@@ -29,7 +29,8 @@ uint32_t SerialSBUS::sendRCFrame(bool frameAvailable, bool frameMissed, uint32_t
     // TODO: if failsafeMode == FAILSAFE_SET_POSITION then we use the set positions rather than the last values
     crsf_channels_s PackedRCdataOut;
 
-    if (config.GetSerialProtocol() == PROTOCOL_DJI_RS_PRO)
+    if (config.GetSerialProtocol() == PROTOCOL_DJI_RS_PRO ||
+        config.GetSerial1Protocol() == PROTOCOL_DJI_RS_PRO)
     {
         PackedRCdataOut.ch0 = fmap(channelData[0], CRSF_CHANNEL_VALUE_MIN, CRSF_CHANNEL_VALUE_MAX, 352, 1696);
         PackedRCdataOut.ch1 = fmap(channelData[1], CRSF_CHANNEL_VALUE_MIN, CRSF_CHANNEL_VALUE_MAX, 352, 1696);

--- a/src/src/rx-serial/SerialSBUS.cpp
+++ b/src/src/rx-serial/SerialSBUS.cpp
@@ -5,9 +5,6 @@
 
 #if defined(TARGET_RX)
 
-extern Stream* serial_protocol_tx;
-extern Stream* serial1_protocol_tx;
-
 #define SBUS_FLAG_SIGNAL_LOSS       (1 << 2)
 #define SBUS_FLAG_FAILSAFE_ACTIVE   (1 << 3)
 
@@ -32,8 +29,15 @@ uint32_t SerialSBUS::sendRCFrame(bool frameAvailable, bool frameMissed, uint32_t
     // TODO: if failsafeMode == FAILSAFE_SET_POSITION then we use the set positions rather than the last values
     crsf_channels_s PackedRCdataOut;
 
+#if defined(PLATFORM_ESP32)
+    extern Stream* serial_protocol_tx;
+    extern Stream* serial1_protocol_tx;
+    
     if (((config.GetSerialProtocol() == PROTOCOL_DJI_RS_PRO) && streamOut == serial_protocol_tx)||
         ((config.GetSerial1Protocol() == PROTOCOL_SERIAL1_DJI_RS_PRO) && streamOut == serial1_protocol_tx))
+#else
+    if (config.GetSerialProtocol() == PROTOCOL_DJI_RS_PRO)
+#endif
     {
         PackedRCdataOut.ch0 = fmap(channelData[0], CRSF_CHANNEL_VALUE_MIN, CRSF_CHANNEL_VALUE_MAX, 352, 1696);
         PackedRCdataOut.ch1 = fmap(channelData[1], CRSF_CHANNEL_VALUE_MIN, CRSF_CHANNEL_VALUE_MAX, 352, 1696);

--- a/src/src/rx-serial/SerialSBUS.cpp
+++ b/src/src/rx-serial/SerialSBUS.cpp
@@ -30,7 +30,7 @@ uint32_t SerialSBUS::sendRCFrame(bool frameAvailable, bool frameMissed, uint32_t
     crsf_channels_s PackedRCdataOut;
 
     if (config.GetSerialProtocol() == PROTOCOL_DJI_RS_PRO ||
-        config.GetSerial1Protocol() == PROTOCOL_DJI_RS_PRO)
+        config.GetSerial1Protocol() == PROTOCOL_SERIAL1_DJI_RS_PRO)
     {
         PackedRCdataOut.ch0 = fmap(channelData[0], CRSF_CHANNEL_VALUE_MIN, CRSF_CHANNEL_VALUE_MAX, 352, 1696);
         PackedRCdataOut.ch1 = fmap(channelData[1], CRSF_CHANNEL_VALUE_MIN, CRSF_CHANNEL_VALUE_MAX, 352, 1696);

--- a/src/src/rx-serial/SerialSBUS.h
+++ b/src/src/rx-serial/SerialSBUS.h
@@ -2,7 +2,11 @@
 
 class SerialSBUS : public SerialIO {
 public:
-    explicit SerialSBUS(Stream &out, Stream &in) : SerialIO(&out, &in) {}
+    explicit SerialSBUS(Stream &out, Stream &in) : SerialIO(&out, &in)
+    {
+        streamOut = &out;
+    }
+
     ~SerialSBUS() override = default;
 
     void queueLinkStatisticsPacket() override {}
@@ -11,4 +15,6 @@ public:
 
 private:
     void processBytes(uint8_t *bytes, uint16_t size) override {};
+
+    Stream *streamOut;
 };

--- a/src/src/rx-serial/devSerial1IO.cpp
+++ b/src/src/rx-serial/devSerial1IO.cpp
@@ -29,6 +29,10 @@ static int start()
 
 static int event()
 {
+<<<<<<< HEAD
+=======
+
+>>>>>>> 7b0659cf (initial commit)
     static connectionState_e lastConnectionState = disconnected;
     
     if (serial1IO != nullptr) 
@@ -39,6 +43,7 @@ static int event()
     return DURATION_IGNORE;
 }
 
+<<<<<<< HEAD
 static bool confirmFrameAvailable()
 {
     if (!frameAvailable)
@@ -52,6 +57,8 @@ static bool confirmFrameAvailable()
     return true;
 }
 
+=======
+>>>>>>> 7b0659cf (initial commit)
 static int timeout()
 {
     if (connectionState == serialUpdate || serial1IO == nullptr)
@@ -59,6 +66,7 @@ static int timeout()
         return DURATION_NEVER;  // stop callbacks when doing serial update or serial1 not used
     }
 
+<<<<<<< HEAD
     noInterrupts();
     bool missed = frameMissed;
     frameMissed = false;
@@ -68,6 +76,16 @@ static int timeout()
     bool sendChannels = confirmFrameAvailable();
     uint32_t duration = serial1IO->sendRCFrame(sendChannels, missed, ChannelData);
 
+=======
+    uint32_t duration = 10; // 10ms callback (i.e. when no theres no model match)
+    // only send frames if we have a model match
+    if (connectionHasModelMatch)
+    {
+        duration = serial1IO->sendRCFrame(frameAvailable, frameMissed, ChannelData);
+    }
+    frameAvailable = false;
+    frameMissed = false;
+>>>>>>> 7b0659cf (initial commit)
     // still get telemetry and send link stats if theres no model match
     serial1IO->processSerialInput();
     serial1IO->sendQueuedData(serial1IO->getMaxSerialWriteSize());

--- a/src/src/rx-serial/devSerial1IO.cpp
+++ b/src/src/rx-serial/devSerial1IO.cpp
@@ -1,0 +1,71 @@
+#include "targets.h"
+
+#if defined(TARGET_RX)
+
+#include "common.h"
+#include "device.h"
+#include "SerialIO.h"
+#include "CRSF.h"
+
+extern SerialIO *serial1IO;
+
+static volatile bool frameAvailable = false;
+static volatile bool frameMissed = false;
+
+void ICACHE_RAM_ATTR crsfRCFrameAvailableSerial1()
+{
+    frameAvailable = true;
+}
+
+void ICACHE_RAM_ATTR crsfRCFrameMissedSerial1()
+{
+    frameMissed = true;
+}
+
+static int start()
+{
+    return DURATION_IMMEDIATELY;
+}
+
+static int event()
+{
+
+    static connectionState_e lastConnectionState = disconnected;
+    
+    if (serial1IO != nullptr) 
+    {
+        serial1IO->setFailsafe(connectionState == disconnected && lastConnectionState == connected);
+        lastConnectionState = connectionState;
+    }
+    return DURATION_IGNORE;
+}
+
+static int timeout()
+{
+    if (connectionState == serialUpdate || serial1IO == nullptr)
+    {
+        return DURATION_NEVER;  // stop callbacks when doing serial update or serial1 not used
+    }
+
+    uint32_t duration = 10; // 10ms callback (i.e. when no theres no model match)
+    // only send frames if we have a model match
+    if (connectionHasModelMatch)
+    {
+        duration = serial1IO->sendRCFrame(frameAvailable, frameMissed, ChannelData);
+    }
+    frameAvailable = false;
+    frameMissed = false;
+    // still get telemetry and send link stats if theres no model match
+    serial1IO->processSerialInput();
+    serial1IO->sendQueuedData(serial1IO->getMaxSerialWriteSize());
+    return duration;
+}
+
+device_t Serial1_device = {
+    .initialize = nullptr,
+    .start = start,
+    .event = event,
+    .timeout = timeout
+};
+
+#endif

--- a/src/src/rx-serial/devSerial1IO.cpp
+++ b/src/src/rx-serial/devSerial1IO.cpp
@@ -29,10 +29,6 @@ static int start()
 
 static int event()
 {
-<<<<<<< HEAD
-=======
-
->>>>>>> 7b0659cf (initial commit)
     static connectionState_e lastConnectionState = disconnected;
     
     if (serial1IO != nullptr) 
@@ -43,7 +39,6 @@ static int event()
     return DURATION_IGNORE;
 }
 
-<<<<<<< HEAD
 static bool confirmFrameAvailable()
 {
     if (!frameAvailable)
@@ -57,8 +52,6 @@ static bool confirmFrameAvailable()
     return true;
 }
 
-=======
->>>>>>> 7b0659cf (initial commit)
 static int timeout()
 {
     if (connectionState == serialUpdate || serial1IO == nullptr)
@@ -66,7 +59,6 @@ static int timeout()
         return DURATION_NEVER;  // stop callbacks when doing serial update or serial1 not used
     }
 
-<<<<<<< HEAD
     noInterrupts();
     bool missed = frameMissed;
     frameMissed = false;
@@ -76,16 +68,6 @@ static int timeout()
     bool sendChannels = confirmFrameAvailable();
     uint32_t duration = serial1IO->sendRCFrame(sendChannels, missed, ChannelData);
 
-=======
-    uint32_t duration = 10; // 10ms callback (i.e. when no theres no model match)
-    // only send frames if we have a model match
-    if (connectionHasModelMatch)
-    {
-        duration = serial1IO->sendRCFrame(frameAvailable, frameMissed, ChannelData);
-    }
-    frameAvailable = false;
-    frameMissed = false;
->>>>>>> 7b0659cf (initial commit)
     // still get telemetry and send link stats if theres no model match
     serial1IO->processSerialInput();
     serial1IO->sendQueuedData(serial1IO->getMaxSerialWriteSize());

--- a/src/src/rx-serial/devSerial1IO.h
+++ b/src/src/rx-serial/devSerial1IO.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "device.h"
+
+extern device_t Serial1_device;
+extern void crsfRCFrameAvailableSerial1();
+extern void crsfRCFrameMissedSerial1();

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -381,7 +381,7 @@ bool ICACHE_RAM_ATTR HandleFHSS()
 
     if (geminiMode)
     {
-        if ((((OtaNonce + 1)/ExpressLRS_currAirRate_Modparams->FHSShopInterval) % 2 == 0) || FHSSuseDualBand) // When in DualBand do not switch between radios.  The OTA modulation paramters and HighFreq/LowFreq Tx amps are set during Config.
+        if ((((OtaNonce + 1)/ExpressLRS_currAirRate_Modparams->FHSShopInterval) % 2 == 0) || FHSSuseDualBand) // When in DualBand do not switch between radios.  The OTA modulation paramters and HighFreq/LowFreq Tx amps are set during Config. 
         {
             Radio.SetFrequencyReg(FHSSgetNextFreq(), SX12XX_Radio_1);
             Radio.SetFrequencyReg(FHSSgetGeminiFreq(), SX12XX_Radio_2);

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -133,6 +133,10 @@ uint32_t serialBaud;
 SerialIO *serialIO = nullptr;
 SerialIO *serial1IO = nullptr;
 
+// SBUS driver needs to distinguish stream for SBUS/DJI protocol 
+const Stream *serial_protocol_tx = &(SERIAL_PROTOCOL_TX);
+const Stream *serial1_protocol_tx = &(SERIAL1_PROTOCOL_TX);
+
 /* SERIAL_PROTOCOL_RX is used by telemetry receiver and can be on a different peripheral */
 #if defined(TARGET_RX_GHOST_ATTO_V1) /* !TARGET_RX_GHOST_ATTO_V1 */
     #define SERIAL_PROTOCOL_RX CrsfRxSerial
@@ -1421,11 +1425,11 @@ static void setupSerial1()
             break;
         case PROTOCOL_SERIAL1_SBUS:
         case PROTOCOL_SERIAL1_DJI_RS_PRO:
-            Serial1.begin(100000, SERIAL_8N2, UNDEF_PIN, serial1TXpin, true);
+            Serial1.begin(100000, SERIAL_8E2, UNDEF_PIN, serial1TXpin, true);
             serial1IO = new SerialSBUS(SERIAL1_PROTOCOL_TX, SERIAL1_PROTOCOL_RX);
             break;
         case PROTOCOL_SERIAL1_INVERTED_SBUS:
-            Serial1.begin(100000, SERIAL_8N2, UNDEF_PIN, serial1TXpin, false);
+            Serial1.begin(100000, SERIAL_8E2, UNDEF_PIN, serial1TXpin, false);
             serial1IO = new SerialSBUS(SERIAL1_PROTOCOL_TX, SERIAL1_PROTOCOL_RX);
             break;
         case PROTOCOL_SERIAL1_SUMD:

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -381,7 +381,7 @@ bool ICACHE_RAM_ATTR HandleFHSS()
 
     if (geminiMode)
     {
-        if ((((OtaNonce + 1)/ExpressLRS_currAirRate_Modparams->FHSShopInterval) % 2 == 0) || FHSSuseDualBand) // When in DualBand do not switch between radios.  The OTA modulation paramters and HighFreq/LowFreq Tx amps are set during Config. 
+        if ((((OtaNonce + 1)/ExpressLRS_currAirRate_Modparams->FHSShopInterval) % 2 == 0) || FHSSuseDualBand) // When in DualBand do not switch between radios.  The OTA modulation paramters and HighFreq/LowFreq Tx amps are set during Config.
         {
             Radio.SetFrequencyReg(FHSSgetNextFreq(), SX12XX_Radio_1);
             Radio.SetFrequencyReg(FHSSgetGeminiFreq(), SX12XX_Radio_2);

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -328,7 +328,7 @@ void SetRFLinkRate(uint8_t index, bool bindMode) // Set speed of RF link
 #endif
 
     hwTimer::updateInterval(interval);
-    
+
     FHSSusePrimaryFreqBand = !(ModParams->radio_type == RADIO_TYPE_LR1121_LORA_2G4);
     FHSSuseDualBand = ModParams->radio_type == RADIO_TYPE_LR1121_LORA_DUAL;
 
@@ -381,7 +381,7 @@ bool ICACHE_RAM_ATTR HandleFHSS()
 
     if (geminiMode)
     {
-        if ((((OtaNonce + 1)/ExpressLRS_currAirRate_Modparams->FHSShopInterval) % 2 == 0) || FHSSuseDualBand) // When in DualBand do not switch between radios.  The OTA modulation paramters and HighFreq/LowFreq Tx amps are set during Config. 
+        if ((((OtaNonce + 1)/ExpressLRS_currAirRate_Modparams->FHSShopInterval) % 2 == 0) || FHSSuseDualBand) // When in DualBand do not switch between radios.  The OTA modulation paramters and HighFreq/LowFreq Tx amps are set during Config.
         {
             Radio.SetFrequencyReg(FHSSgetNextFreq(), SX12XX_Radio_1);
             Radio.SetFrequencyReg(FHSSgetGeminiFreq(), SX12XX_Radio_2);
@@ -749,7 +749,8 @@ void ICACHE_RAM_ATTR HWtimerCallbackTock()
         else
         {
             crsfRCFrameMissed();
-            crsfRCFrameMissedSerial1();        }
+            crsfRCFrameMissedSerial1();
+        }
     }
     else if (ExpressLRS_currAirRate_Modparams->numOfSends == 1)
     {
@@ -878,7 +879,8 @@ static void ICACHE_RAM_ATTR ProcessRfPacket_RC(OTA_Packet_s const * const otaPkt
             // teamrace is only checked for servos because the teamrace model select logic only runs
             // when new frames are available, and will decide later if the frame will be forwarded
             if (teamraceHasModelMatch)
-                servoNewChannelsAvailable();        }
+                servoNewChannelsAvailable();
+        }
         else if (!LQCalcDVDA.currentIsSet())
         {
             LQCalcDVDA.add();
@@ -1212,7 +1214,7 @@ void MspReceiveComplete()
 static void setupSerial()
 {
     bool sbusSerialOutput = false;
-	bool sumdSerialOutput = false;
+    bool sumdSerialOutput = false;
 
 #if defined(PLATFORM_ESP8266) || defined(PLATFORM_ESP32)
     bool hottTlmSerial = false;
@@ -1242,7 +1244,7 @@ static void setupSerial()
         sbusSerialOutput = true;
         serialBaud = 100000;
     }
-	else if (config.GetSerialProtocol() == PROTOCOL_SUMD)
+    else if (config.GetSerialProtocol() == PROTOCOL_SUMD)
     {
         sumdSerialOutput = true;
         serialBaud = 115200;

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1369,6 +1369,7 @@ static void setupSerial()
 #endif
 }
 
+#if defined(PLATFORM_ESP32)
 static void serial1Shutdown()
 {
     if(serial1IO != nullptr)
@@ -1381,7 +1382,6 @@ static void serial1Shutdown()
 
 static void setupSerial1()
 {
-#if defined(PLATFORM_ESP32)
     //
     // init secondary serial and protocol
     //
@@ -1437,7 +1437,6 @@ static void setupSerial1()
             serial1IO = new SerialHoTT_TLM(SERIAL1_PROTOCOL_TX, SERIAL1_PROTOCOL_RX);
             break;
     }
-#endif
 }
 
 void reconfigureSerial1()
@@ -1445,7 +1444,10 @@ void reconfigureSerial1()
     serial1Shutdown();
     setupSerial1();
 }
-
+#else
+    void setupSerial1() {};
+    void reconfigureSerial1() {}; 
+#endif
 
 static void serialShutdown()
 {

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -128,14 +128,19 @@ uint32_t serialBaud;
     HardwareSerial SERIAL_PROTOCOL_TX(USART1);
 #else
     #define SERIAL_PROTOCOL_TX Serial
-    #define SERIAL1_PROTOCOL_TX Serial1
-#endif
-SerialIO *serialIO = nullptr;
-SerialIO *serial1IO = nullptr;
+    
+    #if defined(PLATFORM_ESP32)
+        #define SERIAL1_PROTOCOL_TX Serial1
 
-// SBUS driver needs to distinguish stream for SBUS/DJI protocol 
-const Stream *serial_protocol_tx = &(SERIAL_PROTOCOL_TX);
-const Stream *serial1_protocol_tx = &(SERIAL1_PROTOCOL_TX);
+        // SBUS driver needs to distinguish stream for SBUS/DJI protocol 
+        const Stream *serial_protocol_tx = &(SERIAL_PROTOCOL_TX);
+        const Stream *serial1_protocol_tx = &(SERIAL1_PROTOCOL_TX);
+        
+        SerialIO *serial1IO = nullptr;
+    #endif
+#endif
+
+SerialIO *serialIO = nullptr;
 
 /* SERIAL_PROTOCOL_RX is used by telemetry receiver and can be on a different peripheral */
 #if defined(TARGET_RX_GHOST_ATTO_V1) /* !TARGET_RX_GHOST_ATTO_V1 */

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1454,7 +1454,7 @@ static void setupSerial1()
             break;
         case PROTOCOL_SERIAL1_HOTT_TLM:
             Serial1.begin(19200, SERIAL_8N2, serial1RXpin, serial1TXpin, false);
-            serial1IO = new SerialHoTT_TLM(SERIAL1_PROTOCOL_TX, SERIAL1_PROTOCOL_RX);
+            serial1IO = new SerialHoTT_TLM(SERIAL1_PROTOCOL_TX, SERIAL1_PROTOCOL_RX, serial1TXpin);
             break;
     }
 }


### PR DESCRIPTION
This PR intends to enable more possible use cases mostly for but not limited to fixed wing and helicopter pilots.

As an example consider the classical use cases:
- a fixed wing setup with external CRSF telemetry and an external gyro connected to a receiver
- a helicopter setup with a flybarless unit and external telemetry sensors (e.g. a telemetry capable ESC)

Currently ELRS receivers only allow using one serial interface (I call it the primary one) for the implemented set of protocols (CRSF, CRSF INV, SBUS, SBUS INV, DJI RS PRO HoTT Telemetry) making the above use cases impossible. This PR adds a secondary serial device on ESP32 receivers which enables running an additional protocol. This opens up the possibility to run two different protocols concurrently. In the above uses cases a setup could look like:
- primary serial CRSF, secondary serial SBUS
- primary serial HoTT Telemetry, secondary serial SUMD

Here's an example using a Radiomaster ER6 receiver showing protocol HoTT Telemetry with a GPS/Vario connected on the primary serial (RX and TX used) and SBUS on the secondary serial (only TX used) configured to use the signal pin of channel connector 6 which might be used to feed channel data to a flybarless unit or gyro. ER6 channels 1 to 5 still output PWM data.

![pr](https://github.com/ExpressLRS/ExpressLRS/assets/5615068/cb300439-ead1-4104-8873-7f6f582da4b0)

The secondary serial device can be configured using the WebUI or LUA script

Extensions to the code base:
- added an additional serial device
- added configuration options to WebUI and LUA
- added logic to run any of the known serial protocols on the secondary serial device