### PR TITLE
ESP32 C3 RX support

### DIFF
--- a/src/lib/DEVICE/device.cpp
+++ b/src/lib/DEVICE/device.cpp
@@ -17,6 +17,11 @@
 #error Invalid radio configuration!
 #endif
 
+#if defined(PLATFORM_ESP32)
+#include <soc/soc_caps.h>
+#define MULTICORE (SOC_CPU_CORES_NUM > 1)
+#endif
+
 ///////////////////////////////////////
 
 extern bool connectionHasModelMatch;
@@ -30,7 +35,7 @@ static bool lastModelMatch[2] = {false, false};
 
 static unsigned long deviceTimeout[16] = {0};
 
-#if defined(PLATFORM_ESP32)
+#if MULTICORE
 static TaskHandle_t xDeviceTask = NULL;
 static SemaphoreHandle_t taskSemaphore;
 static SemaphoreHandle_t completeSemaphore;
@@ -45,7 +50,7 @@ void devicesRegister(device_affinity_t *devices, uint8_t count)
     uiDevices = devices;
     deviceCount = count;
 
-    #if defined(PLATFORM_ESP32)
+    #if MULTICORE
         taskSemaphore = xSemaphoreCreateBinary();
         completeSemaphore = xSemaphoreCreateBinary();
         disableCore0WDT();
@@ -64,7 +69,7 @@ void devicesInit()
             }
         }
     }
-    #if defined(PLATFORM_ESP32)
+    #if MULTICORE
     if (core == 1)
     {
         xSemaphoreGive(taskSemaphore);
@@ -89,7 +94,7 @@ void devicesStart()
             }
         }
     }
-    #if defined(PLATFORM_ESP32)
+    #if MULTICORE
     if (core == 1)
     {
         xSemaphoreGive(taskSemaphore);
@@ -100,7 +105,7 @@ void devicesStart()
 
 void devicesStop()
 {
-    #if defined(PLATFORM_ESP32)
+    #if MULTICORE
     vTaskDelete(xDeviceTask);
     #endif
 }
@@ -109,7 +114,7 @@ void devicesTriggerEvent()
 {
     eventFired[0] = true;
     eventFired[1] = true;
-    #if defined(PLATFORM_ESP32)
+    #if MULTICORE
     // Release teh semaphore so the tasks on core 0 run now
     xSemaphoreGive(taskSemaphore);
     #endif
@@ -165,7 +170,7 @@ void devicesUpdate(unsigned long now)
     _devicesUpdate(now);
 }
 
-#if defined(PLATFORM_ESP32)
+#if MULTICORE
 static void deviceTask(void *pvArgs)
 {
     xSemaphoreTake(taskSemaphore, portMAX_DELAY);

--- a/src/lib/LED/esp32rgb.cpp
+++ b/src/lib/LED/esp32rgb.cpp
@@ -21,6 +21,9 @@
 #elif defined(CONFIG_IDF_TARGET_ESP32S3)
 #define SAMPLE_RATE (800000)
 #define MCLK 160000000
+#elif defined(CONFIG_IDF_TARGET_ESP32C3)
+#define SAMPLE_RATE (800000)
+#define MCLK 160000000
 #elif defined(CONFIG_IDF_TARGET_ESP32)
 #define SAMPLE_RATE (360000)
 #define MCLK 48000000
@@ -87,6 +90,8 @@ void ESP32S3LedDriver::ClearTo(RgbColor color, uint16_t first, uint16_t last)
 #if defined(CONFIG_IDF_TARGET_ESP32S2)
 static const int bitorder[] = {0x40, 0x80, 0x10, 0x20, 0x04, 0x08, 0x01, 0x02};
 #elif defined(CONFIG_IDF_TARGET_ESP32S3)
+static const int bitorder[] = {0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01};
+#elif defined(CONFIG_IDF_TARGET_ESP32C3)
 static const int bitorder[] = {0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01};
 #elif defined(CONFIG_IDF_TARGET_ESP32)
 static const int bitorder[] = {0x40, 0x80, 0x10, 0x20, 0x04, 0x08, 0x01, 0x02};

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -216,11 +216,11 @@ static void luaparamMappingChannelOut(struct luaPropertiesCommon *item, uint8_t 
 
     // SerialIO outputs (1 option)
     // ;[Serial RX] | [Serial TX]
-    if (GPIO_PIN_PWM_OUTPUTS[arg-1] == 3)
+    if (GPIO_PIN_PWM_OUTPUTS[arg-1] == U0RXD_GPIO_NUM)
     {
         pModeString = serial_RX;
     }
-    else if (GPIO_PIN_PWM_OUTPUTS[arg-1] == 1)
+    else if (GPIO_PIN_PWM_OUTPUTS[arg-1] == U0TXD_GPIO_NUM)
     {
         pModeString = serial_TX;
     }

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -292,7 +292,7 @@ void POWERMGNT::setPower(PowerLevels_e Power)
         {
             Radio.SetOutputPower(POWER_OUTPUT_VALUES2[Power - MinPower]);
         }
-        #if defined(PLATFORM_ESP32_S3)
+        #if defined(PLATFORM_ESP32_S3) || defined(PLATFORM_ESP32_C3)
         ERRLN("ESP32-S3 does not have a DAC");
         #else
         dacWrite(GPIO_PIN_RFamp_APC2, powerValues[Power - MinPower]);

--- a/src/lib/PWM/PWM_ESP32.cpp
+++ b/src/lib/PWM/PWM_ESP32.cpp
@@ -6,7 +6,7 @@
 
 #include "logging.h"
 
-#if defined(PLATFORM_ESP32_S3)
+#if defined(PLATFORM_ESP32_S3) || defined(PLATFORM_ESP32_C3)
 #define SPEED_MODE LEDC_LOW_SPEED_MODE
 #else
 #define SPEED_MODE LEDC_HIGH_SPEED_MODE
@@ -24,6 +24,7 @@
 #define LEDC_CHANNEL(ch) (ch & 0xFF)
 #define MCPWM_CHANNEL(ch) (ch & 0xFF)
 
+#if SOC_MCPWM_SUPPORTED
 static const struct
 {
     mcpwm_unit_t unit;
@@ -44,6 +45,7 @@ static const struct
     {MCPWM_UNIT_1, MCPWM2A, MCPWM_TIMER_2, MCPWM_GEN_A},
     {MCPWM_UNIT_1, MCPWM2B, MCPWM_TIMER_2, MCPWM_GEN_B},
 };
+#endif
 
 static uint32_t mcpwm_frequencies[MCPWM_CHANNELS] = {0};
 
@@ -95,8 +97,9 @@ static void ledcAttachPinEx(uint8_t pin, uint8_t chan, ledc_timer_t timer)
 
 pwm_channel_t PWMController::allocate(uint8_t pin, uint32_t frequency)
 {
-    // 1. see if we can allocate a MCPWM channel at this frequency
     int channel = -1;
+    // 1. see if we can allocate a MCPWM channel at this frequency
+#if SOC_MCPWM_SUPPORTED
     // 1a. see if theres a MCPWM already using this frequency we can piggy-back on
     for (int i = 0; i < MCPWM_CHANNELS; i++)
     {
@@ -144,7 +147,7 @@ pwm_channel_t PWMController::allocate(uint8_t pin, uint32_t frequency)
         mcpwm_frequencies[channel] = frequency;
         return channel | MCPWM_CHANNEL_FLAG;
     }
-
+#endif
     // 2. try for a LEDC channel
     for (int ch = 0; ch < LEDC_CHANNELS; ch++)
     {
@@ -188,13 +191,7 @@ pwm_channel_t PWMController::allocate(uint8_t pin, uint32_t frequency)
 
 void PWMController::release(pwm_channel_t channel)
 {
-    if (IS_MCPWM_CHANNEL(channel))
-    {
-        auto ch = MCPWM_CHANNEL(channel);
-        mcpwm_stop(mcpwm_config[ch].unit, mcpwm_config[ch].timer);
-        mcpwm_frequencies[ch] = 0;
-    }
-    else if (IS_LEDC_CHANNEL(channel))
+    if (IS_LEDC_CHANNEL(channel))
     {
         auto ch = LEDC_CHANNEL(channel);
         ledcDetachPin(ledc_config[ch].pin);
@@ -202,6 +199,14 @@ void PWMController::release(pwm_channel_t channel)
         ledc_config[ch].resolution_bits = 0;
         ledc_config[ch].interval = 0;
     }
+#if SOC_MCPWM_SUPPORTED
+    else if (IS_MCPWM_CHANNEL(channel))
+    {
+        auto ch = MCPWM_CHANNEL(channel);
+        mcpwm_stop(mcpwm_config[ch].unit, mcpwm_config[ch].timer);
+        mcpwm_frequencies[ch] = 0;
+    }
+#endif
     else
     {
         ERRLN("Invalid PWM channel %x", channel);
@@ -215,11 +220,13 @@ void PWMController::setDuty(pwm_channel_t channel, uint16_t duty)
         auto ch = LEDC_CHANNEL(channel);
         ledcWrite(ch, map(duty, 0, 1000, 0, (1 << ledc_config[ch].resolution_bits) - 1));
     }
+#if SOC_MCPWM_SUPPORTED
     else if (IS_MCPWM_CHANNEL(channel))
     {
         auto ch = MCPWM_CHANNEL(channel);
         mcpwm_set_duty(mcpwm_config[ch].unit, mcpwm_config[ch].timer, mcpwm_config[ch].generator, duty / 10.0f);
     }
+#endif
 }
 
 void PWMController::setMicroseconds(pwm_channel_t channel, uint16_t microseconds)
@@ -229,11 +236,13 @@ void PWMController::setMicroseconds(pwm_channel_t channel, uint16_t microseconds
         auto ch = LEDC_CHANNEL(channel);
         ledcWrite(ch, map(microseconds, 0, ledc_config[ch].interval, 0, (1 << ledc_config[ch].resolution_bits) - 1));
     }
+#if SOC_MCPWM_SUPPORTED
     else if (IS_MCPWM_CHANNEL(channel))
     {
         auto ch = MCPWM_CHANNEL(channel);
         mcpwm_set_duty_in_us(mcpwm_config[ch].unit, mcpwm_config[ch].timer, mcpwm_config[ch].generator, microseconds);
     }
+#endif
 }
 
 #endif

--- a/src/lib/RFAMP/RFAMP_hal.cpp
+++ b/src/lib/RFAMP/RFAMP_hal.cpp
@@ -94,10 +94,26 @@ void RFAMP_hal::init()
 
 void ICACHE_RAM_ATTR RFAMP_hal::TXenable(SX12XX_Radio_Number_t radioNumber)
 {
-#if defined(PLATFORM_ESP32)
+#if defined(PLATFORM_ESP32_C3)
     if (radioNumber == SX12XX_Radio_All)
     {
-        GPIO.out_w1ts = tx_all_enable_set_bits;
+        GPIO.out_w1ts.out_w1ts = tx_all_enable_set_bits;
+        GPIO.out_w1tc.out_w1tc = tx_all_enable_clr_bits;
+    }
+    else if (radioNumber == SX12XX_Radio_2)
+    {
+        GPIO.out_w1ts.out_w1ts = tx2_enable_set_bits;
+        GPIO.out_w1tc.out_w1tc = tx2_enable_clr_bits;
+    }
+    else
+    {
+        GPIO.out_w1ts.out_w1ts = tx1_enable_set_bits;
+        GPIO.out_w1tc.out_w1tc = tx1_enable_clr_bits;
+    }
+#elif defined(PLATFORM_ESP32)
+    if (radioNumber == SX12XX_Radio_All)
+    {
+        GPIO.out_w1ts = (uint32_t)tx_all_enable_set_bits;
         GPIO.out_w1tc = tx_all_enable_clr_bits;
 
         GPIO.out1_w1ts.data = tx_all_enable_set_bits >> 32;
@@ -170,7 +186,10 @@ void ICACHE_RAM_ATTR RFAMP_hal::TXenable(SX12XX_Radio_Number_t radioNumber)
 
 void ICACHE_RAM_ATTR RFAMP_hal::RXenable()
 {
-#if defined(PLATFORM_ESP32)
+#if defined(PLATFORM_ESP32_C3)
+    GPIO.out_w1ts.out_w1ts = rx_enable_set_bits;
+    GPIO.out_w1tc.out_w1tc = rx_enable_clr_bits;
+#elif defined(PLATFORM_ESP32)
     GPIO.out_w1ts = rx_enable_set_bits;
     GPIO.out_w1tc = rx_enable_clr_bits;
 
@@ -210,7 +229,9 @@ void ICACHE_RAM_ATTR RFAMP_hal::RXenable()
 
 void ICACHE_RAM_ATTR RFAMP_hal::TXRXdisable()
 {
-#if defined(PLATFORM_ESP32)
+#if defined(PLATFORM_ESP32_C3)
+    GPIO.out_w1tc.out_w1tc = txrx_disable_clr_bits;
+#elif defined(PLATFORM_ESP32)
     GPIO.out_w1tc = txrx_disable_clr_bits;
     GPIO.out1_w1tc.data = txrx_disable_clr_bits >> 32;
 #else

--- a/src/lib/SPIEx/SPIEx.cpp
+++ b/src/lib/SPIEx/SPIEx.cpp
@@ -15,7 +15,7 @@ void ICACHE_RAM_ATTR SPIExClass::_transfer(uint8_t cs_mask, uint8_t *data, uint3
     spiDisableSSPins(bus(), ~cs_mask);
     spiEnableSSPins(bus(), cs_mask);
 
-#if defined(PLATFORM_ESP32_S3)
+#if defined(PLATFORM_ESP32_S3) || defined(PLATFORM_ESP32_C3)
     spi->ms_dlen.ms_data_bitlen = (size*8)-1;
 #else
     spi->mosi_dlen.usr_mosi_dbitlen = ((size * 8) - 1);
@@ -30,9 +30,9 @@ void ICACHE_RAM_ATTR SPIExClass::_transfer(uint8_t cs_mask, uint8_t *data, uint3
         spi->data_buf[i] = wordsBuf[i]; //copy buffer to spi fifo
     }
 
-#if defined(PLATFORM_ESP32_S3)
+#if defined(PLATFORM_ESP32_S3) || defined(PLATFORM_ESP32_C3)
     spi->cmd.update = 1;
-    while (spi->cmd.update);
+    while (spi->cmd.update) {}
 #endif
     // start the SPI module
     spi->cmd.usr = 1;
@@ -89,7 +89,7 @@ void ICACHE_RAM_ATTR SPIExClass::_transfer(uint8_t cs_mask, uint8_t *data, uint3
 #endif
 }
 
-#if defined(PLATFORM_ESP32_S3)
+#if defined(PLATFORM_ESP32_S3) || defined(PLATFORM_ESP32_C3)
 SPIExClass SPIEx(FSPI);
 #elif defined(PLATFORM_ESP32)
 SPIExClass SPIEx(VSPI);

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -159,11 +159,7 @@ static void initialize()
         int8_t pin = GPIO_PIN_PWM_OUTPUTS[ch];
 #if (defined(DEBUG_LOG) || defined(DEBUG_RCVR_LINKSTATS)) && (defined(PLATFORM_ESP8266) || defined(PLATFORM_ESP32))
         // Disconnect the debug UART pins if DEBUG_LOG
-#if defined(PLATFORM_ESP32)
         if (pin == U0RXD_GPIO_NUM || pin == U0TXD_GPIO_NUM)
-#else
-        if (pin == 1 || pin == 3)
-#endif
         {
             pin = UNDEF_PIN;
         }

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -159,8 +159,8 @@ static void initialize()
         int8_t pin = GPIO_PIN_PWM_OUTPUTS[ch];
 #if (defined(DEBUG_LOG) || defined(DEBUG_RCVR_LINKSTATS)) && (defined(PLATFORM_ESP8266) || defined(PLATFORM_ESP32))
         // Disconnect the debug UART pins if DEBUG_LOG
-#if defined(PLATFORM_ESP32_S3)
-        if (pin == 43 || pin == 44)
+#if defined(PLATFORM_ESP32)
+        if (pin == U0RXD_GPIO_NUM || pin == U0TXD_GPIO_NUM)
 #else
         if (pin == 1 || pin == 3)
 #endif

--- a/src/lib/VTXSPI/devVTXSPI.cpp
+++ b/src/lib/VTXSPI/devVTXSPI.cpp
@@ -153,7 +153,7 @@ static void RfAmpVrefOff()
 
 static void setPWM()
 {
-#if defined(PLATFORM_ESP32_S3)
+#if defined(PLATFORM_ESP32_S3) || defined(PLATFORM_ESP32_C3)
     PWM.setDuty(rfAmpPwmChannel, vtxSPIPWM * 1000 / 4096);
 #elif defined(PLATFORM_ESP32)
     if (GPIO_PIN_RF_AMP_PWM == 25 || GPIO_PIN_RF_AMP_PWM == 26)

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -21,8 +21,6 @@
 #include <ESP8266WiFi.h>
 #include <ESP8266mDNS.h>
 #define wifi_mode_t WiFiMode_t
-#define U0TXD_GPIO_NUM  (1)
-#define U0RXD_GPIO_NUM  (3)
 #endif
 #include <DNSServer.h>
 

--- a/src/lib/logging/logging.h
+++ b/src/lib/logging/logging.h
@@ -21,6 +21,10 @@
   #endif
 #endif
 
+#if defined(TARGET_RX) && (defined(DEBUG_RCVR_LINKSTATS) || defined(DEBUG_RX_SCOREBOARD) || defined(DEBUG_RCVR_SIGNAL_STATS)) || defined(DEBUG_LOG)
+#define DEBUG_ENABLED
+#endif
+
 #if defined(TARGET_TX)
 extern Stream *TxBackpack;
 #if defined(PLATFORM_ESP32_S3)

--- a/src/python/UnifiedConfiguration.py
+++ b/src/python/UnifiedConfiguration.py
@@ -121,6 +121,8 @@ def appendConfiguration(source, target, env):
         platform = 'esp32'
         if 'esp32-s3' in env.get('BOARD', ''):
             platform = 'esp32-s3'
+        elif 'esp32-c3' in env.get('BOARD', ''):
+            platform = 'esp32-c3'
     else:
         platform = 'esp8285'
 

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1358,11 +1358,15 @@ static void setupSerial()
     {
         serialIO = new SerialCRSF(SERIAL_PROTOCOL_TX, SERIAL_PROTOCOL_RX);
     }
+#if defined(DEBUG_ENABLED)
 #if defined(PLATFORM_ESP32_S3) || defined(PLATFORM_ESP32_C3)
     USBSerial.begin(460800);
     SerialLogger = &USBSerial;
 #else
     SerialLogger = &Serial;
+#endif
+#else
+    SerialLogger = new NullStream();
 #endif
 }
 

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1358,7 +1358,7 @@ static void setupSerial()
     {
         serialIO = new SerialCRSF(SERIAL_PROTOCOL_TX, SERIAL_PROTOCOL_RX);
     }
-#if defined(PLATFORM_ESP32_S3)
+#if defined(PLATFORM_ESP32_S3) || defined(PLATFORM_ESP32_C3)
     USBSerial.begin(460800);
     SerialLogger = &USBSerial;
 #else

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -108,6 +108,15 @@ build_flags =
 	${env_common_esp32rx.build_flags}
 	-D PLATFORM_ESP32_S3=1
 
+[env_common_esp32c3rx]
+extends = env_common_esp32rx
+platform = espressif32@6.4.0
+board = esp32-c3-devkitm-1
+build_flags =
+	${env_common_esp32rx.build_flags}
+	-D PLATFORM_ESP32_C3=1
+	-D ARDUINO_USB_MODE
+
 # ------------------------- COMMON ESP82xx DEFINITIONS -----------------
 [env_common_esp82xx]
 platform = espressif8266@4.2.0

--- a/src/targets/unified.ini
+++ b/src/targets/unified.ini
@@ -259,3 +259,36 @@ extends = env:Unified_ESP32S3_900_RX_via_UART
 
 [env:Unified_ESP32S3_900_RX_via_WIFI]
 extends = env:Unified_ESP32S3_900_RX_via_UART
+
+
+# ESP32-C3
+
+[env:Unified_ESP32C3_2400_RX_via_UART]
+extends = env_common_esp32c3rx, radio_2400
+build_flags =
+	${env_common_esp32c3rx.build_flags}
+	${radio_2400.build_flags}
+	${common_env_data.build_flags_rx}
+	-include target/Unified_ESP_RX.h
+build_src_filter = ${env_common_esp32rx.build_src_filter} -<tx_*.cpp>
+
+[env:Unified_ESP32C3_2400_RX_via_BetaflightPassthrough]
+extends = env:Unified_ESP32C3_2400_RX_via_UART
+
+[env:Unified_ESP32C3_2400_RX_via_WIFI]
+extends = env:Unified_ESP32C3_2400_RX_via_UART
+
+[env:Unified_ESP32C3_900_RX_via_UART]
+extends = env_common_esp32c3rx, radio_900
+build_flags =
+	${env_common_esp32c3rx.build_flags}
+	${radio_900.build_flags}
+	${common_env_data.build_flags_rx}
+	-include target/Unified_ESP_RX.h
+build_src_filter = ${env_common_esp32rx.build_src_filter} -<tx_*.cpp>
+
+[env:Unified_ESP32C3_900_RX_via_BetaflightPassthrough]
+extends = env:Unified_ESP32C3_900_RX_via_UART
+
+[env:Unified_ESP32C3_900_RX_via_WIFI]
+extends = env:Unified_ESP32C3_900_RX_via_UART

--- a/src/targets/unified.ini
+++ b/src/targets/unified.ini
@@ -292,3 +292,18 @@ extends = env:Unified_ESP32C3_900_RX_via_UART
 
 [env:Unified_ESP32C3_900_RX_via_WIFI]
 extends = env:Unified_ESP32C3_900_RX_via_UART
+
+[env:Unified_ESP32C3_LR1121_RX_via_UART]
+extends = env_common_esp32c3rx, radio_LR1121
+build_flags =
+	${env_common_esp32c3rx.build_flags}
+	${radio_LR1121.build_flags}
+	${common_env_data.build_flags_rx}
+	-include target/Unified_ESP_RX.h
+build_src_filter = ${env_common_esp32rx.build_src_filter} -<tx_*.cpp>
+
+[env:Unified_ESP32C3_LR1121_RX_via_BetaflightPassthrough]
+extends = env:Unified_ESP32C3_LR1121_RX_via_UART
+
+[env:Unified_ESP32C3_LR1121_RX_via_WIFI]
+extends = env:Unified_ESP32C3_LR1121_RX_via_UART


### PR DESCRIPTION
Since the ESP8285 is aging and only has 2 more years of support from Espressif, the C3 is a good replacement.
The C3 has a few more GPIOs, does not do stupid things with to the IO pins during boot and has more flash/RAM etc.

The C3 also allows updates via USB (GPIO18/19) so if these pins are not used for anything then the firmware can be updated via direct USB connection. If the pins are used then the BOOT pin (GPIO 9) needs to be held low on power up. The C3 can also be updated via UART on GPIOs 20/21 as per other ESP32/ESP8285 chips, also by pulling GPIO9 low on power up.

The following is my janky setup for initial testing.
![IMG_0667](https://github.com/ExpressLRS/ExpressLRS/assets/512740/62e8ef00-fe53-4efc-a1ce-5d489423f61b)

And connected to my PWM testing bench.
![IMG_0668](https://github.com/ExpressLRS/ExpressLRS/assets/512740/4ddc2429-47c4-4825-a7d6-32ef0a43e49c)
