### PR TITLE
Add telemetry to backpack pins

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -222,6 +222,28 @@ void ICACHE_RAM_ATTR CRSF::sendLinkStatisticsToTX()
 #endif
 }
 
+void CRSF::printDebugLinkStats()
+{
+    // Wonder if I can "for i in crsfPayloadLinkStatistics"
+    char debug_hdr[] = "\nLinkStats: "
+    debugPrintf(&debug_hdr);
+
+    // Print UPLink stats
+    debugPrintf(LinkStatistics.uplink_RSSI_1);
+    debugPrintf(LinkStatistics.uplink_RSSI_2);
+    debugPrintf(LinkStatistics.uplink_Link_quality);
+    debugPrintf(LinkStatistics.uplink_SNR);
+    debugPrintf(LinkStatistics.active_antenna);
+    debugPrintf(LinkStatistics.rf_Mode);
+    debugPrintf(LinkStatistics.uplink_TX_Power);
+
+    // Print DOWNLink stats
+    debugPrintf(LinkStatistics.downlink_Link_quality);
+
+    char debug_ftr[] = "\n"
+    debugPrintf(&debug_ftr);
+}
+
 /**
  * Build a an extended type packet and queue it in the SerialOutFIFO
  * This is just a regular packet with 2 extra bytes with the sub src and target

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -60,9 +60,11 @@ public:
     static void SetExtendedHeaderAndCrc(uint8_t *frame, uint8_t frameType, uint8_t frameSize, uint8_t senderAddr, uint8_t destAddr);
     static uint32_t VersionStrToU32(const char *verStr);
 
+
     #ifdef CRSF_TX_MODULE
     static bool IsArmed() { return CRSF_to_BIT(ChannelData[4]); } // AUX1
     static void ICACHE_RAM_ATTR sendLinkStatisticsToTX();
+    static void printDebugLinkStats();
     static void ICACHE_RAM_ATTR sendTelemetryToTX(uint8_t *data);
 
     static void packetQueueExtended(uint8_t type, void *data, uint8_t len);

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1359,6 +1359,10 @@ void loop()
   if ((connectionState == connected) && (LastTLMpacketRecvMillis != 0) &&
       (now >= (uint32_t)(firmwareOptions.tlm_report_interval + TLMpacketReported))) {
     crsf.sendLinkStatisticsToTX();
+
+    // debug_print_statistics
+
+    
     TLMpacketReported = now;
   }
 


### PR DESCRIPTION
First attempt at adding printDebugLinkStats() to take over backpack pins as telemetry outputs