### PR TITLE
Fix TX module PPM input seeing spurious channels

### DIFF
--- a/src/lib/Handset/PPMHandset.cpp
+++ b/src/lib/Handset/PPMHandset.cpp
@@ -51,13 +51,20 @@ void PPMHandset::handleInput()
     if (items)
     {
         length /= 4; // one RMT = 4 Bytes
-        numChannels = length;
+        int channelCount = 0;
         for (int i = 0; i < length; i++)
         {
             const auto item = items[i];
+            // Stop if there is a 0 duration
+            if (item.duration0 == 0 || item.duration1 == 0)
+            {
+                break;
+            }
+            channelCount ++;
             const auto ppm = (item.duration0 + item.duration1) / RMT_TICKS_PER_US;
             ChannelData[i] = fmap(ppm, 988, 2012, CRSF_CHANNEL_VALUE_MIN, CRSF_CHANNEL_VALUE_MAX);
         }
+        numChannels = channelCount;
         vRingbufferReturnItem(rb, static_cast<void *>(items));
         lastPPM = now;
     }


### PR DESCRIPTION
Ignore trailing items with 0 duration. This fixes spurious channel data for inverted PPM and glitches.
Fixes #2596 