### PR TITLE
Pass through handset channels if headtracking switch is off

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -452,11 +452,13 @@ void injectBackpackPanTiltRollData(uint32_t const now)
       enable |= !chan;
     }
   }
+
   if (enable != headTrackingEnabled)
   {
     headTrackingEnabled = enable;
     HTEnableFlagReadyToSend = true;
   }
+
   // If enabled and this packet is less that 1 second old then use it
   if (enable && now - lastPTRValidTimeMs < 1000)
   {
@@ -464,12 +466,7 @@ void injectBackpackPanTiltRollData(uint32_t const now)
     ChannelData[ptrStartChannel + 5] = ptrChannelData[1];
     ChannelData[ptrStartChannel + 6] = ptrChannelData[2];
   }
-  else
-  {
-    ChannelData[ptrStartChannel + 4] = CRSF_CHANNEL_VALUE_MID;
-    ChannelData[ptrStartChannel + 5] = CRSF_CHANNEL_VALUE_MID;
-    ChannelData[ptrStartChannel + 6] = CRSF_CHANNEL_VALUE_MID;
-  }
+  // else if not enabled or PTR is old, do not override ChannelData from handset
 #endif
 }
 


### PR DESCRIPTION
If headtracking is set to to be enabled with a switch and the switch is NOT in the enabled position...
* Current behavior: Set the channels to MID (1500us)
* PR behavior: Use the channels sent by the handset. User sets what position they want the headtracking channels to be when the switch is disabled in the handset's mixer.

As discussed on #2255. There's no way for the user to avoid forcing all the headtracking channels to 1500us if there's no headtracking available or the switch is off, which is undesirable.