### PR TITLE
Fix LR1121 binding

### DIFF
--- a/src/include/common.h
+++ b/src/include/common.h
@@ -247,6 +247,7 @@ extern SX127xDriver Radio;
 #elif defined(RADIO_LR1121)
 #define RATE_MAX 14
 #define RATE_BINDING RATE_LORA_50HZ
+#define RATE_DUALBAND_BINDING 9 // 2.4GHz 50Hz
 
 extern LR1121Driver Radio;
 

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -976,6 +976,14 @@ static void EnterBindingMode()
   // Start attempting to bind
   // Lock the RF rate and freq while binding
   SetRFLinkRate(enumRatetoIndex(RATE_BINDING));
+
+#if defined(RADIO_LR1121)
+  FHSSuseDualBand = true;
+  expresslrs_mod_settings_s *const dualBandBindingModParams = get_elrs_airRateConfig(9); // 2.4GHz 50Hz
+  Radio.Config(dualBandBindingModParams->bw2, dualBandBindingModParams->sf2, dualBandBindingModParams->cr2, FHSSgetInitialGeminiFreq(),
+               dualBandBindingModParams->PreambleLen2, true, dualBandBindingModParams->PayloadLength, dualBandBindingModParams->interval, SX12XX_Radio_2);
+#endif
+
   Radio.SetFrequencyReg(FHSSgetInitialFreq());
   if (isDualRadio() && config.GetAntennaMode() == TX_RADIO_MODE_GEMINI) // Gemini mode
   {

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -979,7 +979,7 @@ static void EnterBindingMode()
 
 #if defined(RADIO_LR1121)
   FHSSuseDualBand = true;
-  expresslrs_mod_settings_s *const dualBandBindingModParams = get_elrs_airRateConfig(9); // 2.4GHz 50Hz
+  expresslrs_mod_settings_s *const dualBandBindingModParams = get_elrs_airRateConfig(RATE_DUALBAND_BINDING); // 2.4GHz 50Hz
   Radio.Config(dualBandBindingModParams->bw2, dualBandBindingModParams->sf2, dualBandBindingModParams->cr2, FHSSgetInitialGeminiFreq(),
                dualBandBindingModParams->PreambleLen2, true, dualBandBindingModParams->PayloadLength, dualBandBindingModParams->interval, SX12XX_Radio_2);
 #endif


### PR DESCRIPTION
Previously the LR1121 would only spam 50Hz 900M packets during traditional binding.  Now it simultaneously spams 900M and 2.4G 50 Hz packets and allows for traditional binding with sx1280 based receivers.