### PR TITLE
Allow choosing the domain for LR1121 modules

### DIFF
--- a/src/html/hardware.html
+++ b/src/html/hardware.html
@@ -1,4 +1,4 @@
-@@require(PLATFORM, VERSION, isTX, sx127x)
+@@require(PLATFORM, VERSION, isTX)
 <!DOCTYPE HTML>
 <html lang="en">
 

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -1,4 +1,4 @@
-@@require(PLATFORM, VERSION, isTX, sx127x)
+@@require(PLATFORM, VERSION, isTX, hasSubGHz)
 <!DOCTYPE HTML>
 <html lang="en">
 
@@ -53,7 +53,7 @@
 					<br/><br/>
 					<form id='upload_options' method='POST' action="/options">
 @@end
-@@if sx127x:
+@@if hasSubGHz:
 						<div class="mui-select">
 							<select id='domain' name='domain'>
 								<option value='0'>AU915</option>

--- a/src/python/build_html.py
+++ b/src/python/build_html.py
@@ -33,11 +33,12 @@ def build_html(mainfile, var, out, env, isTX=False):
         extensions=[CoreExtension("@@")]
     )
     template = engine.get_template(mainfile)
+    has_sub_ghz = '-DRADIO_SX127X=1' in env['BUILD_FLAGS'] or '-DRADIO_LR1121=1' in env['BUILD_FLAGS']
     data = template.render({
             'VERSION': get_version(env),
             'PLATFORM': re.sub("_via_.*", "", env['PIOENV']),
             'isTX': isTX,
-            'sx127x': '-DRADIO_SX127X=1' in env['BUILD_FLAGS']
+            'hasSubGHz': has_sub_ghz
         })
     if mainfile.endswith('.html'):
         data = html_minifier.html_minify(data)

--- a/src/python/serve_html.py
+++ b/src/python/serve_html.py
@@ -7,7 +7,7 @@ A simple http server for testing/debugging the web-UI
 open http://localhost:8080/
 add the following query params for TX and/or 900Mhz testing
     isTX
-    sx127x
+    hasSubGHz
 """
 
 from external.bottle import route, run, response, request
@@ -17,7 +17,7 @@ from external.wheezy.template.loader import FileLoader
 
 net_counter = 0
 isTX = False
-sx127x = False
+hasSubGHz = False
 
 config = {
         "options": {
@@ -111,7 +111,7 @@ config = {
     }
 
 def apply_template(mainfile):
-    global isTX, sx127x
+    global isTX, hasSubGHz
     engine = Engine(
         loader=FileLoader(["html"]),
         extensions=[CoreExtension("@@")]
@@ -121,16 +121,16 @@ def apply_template(mainfile):
             'VERSION': 'testing (xxxxxx)',
             'PLATFORM': '',
             'isTX': isTX,
-            'sx127x': sx127x
+            'hasSubGHz': hasSubGHz
         })
     return data
 
 @route('/')
 def index():
-    global net_counter, isTX, sx127x
+    global net_counter, isTX, hasSubGHz
     net_counter = 0
     isTX = 'isTX' in request.query
-    sx127x = 'sx127x' in request.query
+    hasSubGHz = 'hasSubGHz' in request.query
     response.content_type = 'text/html; charset=latin9'
     return apply_template('index.html')
 


### PR DESCRIPTION
Allow the user to change the regulatory domain from the web UI for devices using the LR1121.