### PR TITLE
Fix "Not set" UID badge in web UI

### DIFF
--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -271,7 +271,7 @@ function updateUIDType(uidtype) {
     bg = '#1976D2'; // blue/white
     desc = 'The binding UID was generated from a binding phrase set at flash time';
   }
-  if (uidtype === 'Overridden') // TX
+  else if (uidtype === 'Overridden') // TX
   {
     bg = '#689F38'; // green/black
     fg = 'black';


### PR DESCRIPTION
When completely resetting or with a fresh new TX module, the UID badge in the web UI was wrongly saying "Bound".
This was a simple missing `else` in the code path.