### PR TITLE
[LR1121] Decrease PACKET_TO_TOCK_SLACK

### DIFF
--- a/src/lib/LR1121Driver/LR1121.cpp
+++ b/src/lib/LR1121Driver/LR1121.cpp
@@ -41,7 +41,7 @@ LR1121Driver::LR1121Driver(): SX12xxDriverCommon()
     instance = this;
     timeout = 0xFFFFFF;
     lastSuccessfulPacketRadio = SX12XX_Radio_1;
-    fallBackMode = LR1121_MODE_STDBY_XOSC;
+    fallBackMode = LR1121_MODE_FS;
     ignoreSecondIRQ = false;
 }
 
@@ -101,14 +101,6 @@ transitioning from FS mode and the other from Standby mode. This causes the tx d
     // 7.2.5 SetRxTxFallbackMode
     uint8_t FBbuf[1] = {LR11XX_RADIO_FALLBACK_FS};
     fallBackMode = LR1121_MODE_FS;
-#if defined(TARGET_TX)
-    if (GPIO_PIN_NSS_2 != UNDEF_PIN)
-    {
-        FBbuf[0] = {LR11XX_RADIO_FALLBACK_STDBY_XOSC};
-        fallBackMode = LR1121_MODE_STDBY_XOSC;
-    }
-#endif
-    // 7.2.5 SetRxTxFallbackMode
     hal.WriteCommand(LR11XX_RADIO_SET_RX_TX_FALLBACK_MODE_OC, FBbuf, sizeof(FBbuf), SX12XX_Radio_All);
 
     // 7.2.12 SetRxBoosted
@@ -739,7 +731,6 @@ void ICACHE_RAM_ATTR LR1121Driver::IsrCallback(SX12XX_Radio_Number_t radioNumber
     {
         if (instance->RXnbISR(radioNumber))
         {
-            instance->ClearIrqStatus(SX12XX_Radio_All);
             instance->ignoreSecondIRQ = true;  
         }
 #if defined(DEBUG_RCVR_SIGNAL_STATS)

--- a/src/lib/LR1121Driver/LR1121.h
+++ b/src/lib/LR1121Driver/LR1121.h
@@ -18,7 +18,6 @@ public:
 
     ///////////Radio Variables////////
     uint32_t timeout;
-    bool ignoreSecondIRQ;
 
     ///////////////////////////////////
 

--- a/src/lib/LR1121Driver/LR1121.h
+++ b/src/lib/LR1121Driver/LR1121.h
@@ -18,6 +18,7 @@ public:
 
     ///////////Radio Variables////////
     uint32_t timeout;
+    bool ignoreSecondIRQ;
 
     ///////////////////////////////////
 

--- a/src/lib/SX12xxDriverCommon/SX12xxDriverCommon.h
+++ b/src/lib/SX12xxDriverCommon/SX12xxDriverCommon.h
@@ -56,6 +56,7 @@ public:
     int8_t FuzzySNRThreshold;
 
     bool isFirstRxIrq = true;
+    bool ignoreSecondIRQ = false;
 
 #if defined(DEBUG_RCVR_SIGNAL_STATS)
     typedef struct rxSignalStats_s

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -52,7 +52,7 @@
 #define DIVERSITY_ANTENNA_INTERVAL 5
 #define DIVERSITY_ANTENNA_RSSI_TRIGGER 5
 #if defined(RADIO_LR1121)
-#define PACKET_TO_TOCK_SLACK 280 // Desired buffer time between Packet ISR and Tock ISR. Increase slack due to the LR1121s slow processing time.  Mainly required for 500Hz mode.
+#define PACKET_TO_TOCK_SLACK 260 // Desired buffer time between Packet ISR and Tock ISR. Increase slack due to the LR1121s slow processing time.  Mainly required for 500Hz mode.
 #else
 #define PACKET_TO_TOCK_SLACK 200 // Desired buffer time between Packet ISR and Tock ISR
 #endif
@@ -388,8 +388,10 @@ bool ICACHE_RAM_ATTR HandleFHSS()
         }
         else
         {
-            Radio.SetFrequencyReg(FHSSgetNextFreq(), SX12XX_Radio_2);
+            // Write radio1 first. This optimises the SPI traffic order.
+            uint32_t freqRadio2 = FHSSgetNextFreq();
             Radio.SetFrequencyReg(FHSSgetGeminiFreq(), SX12XX_Radio_1);
+            Radio.SetFrequencyReg(freqRadio2, SX12XX_Radio_2);
         }
     }
     else
@@ -1964,6 +1966,7 @@ void loop()
     DynamicPower_UpdateRx(false);
     debugRcvrLinkstats();
     debugRcvrSignalStats(now);
+    Radio.ignoreSecondIRQ = false;
 }
 
 struct bootloader {

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -52,7 +52,7 @@
 #define DIVERSITY_ANTENNA_INTERVAL 5
 #define DIVERSITY_ANTENNA_RSSI_TRIGGER 5
 #if defined(RADIO_LR1121)
-#define PACKET_TO_TOCK_SLACK 260 // Desired buffer time between Packet ISR and Tock ISR. Increase slack due to the LR1121s slow processing time.  Mainly required for 500Hz mode.
+#define PACKET_TO_TOCK_SLACK 240 // Desired buffer time between Packet ISR and Tock ISR. Increase slack due to the LR1121s slow processing time.  Mainly required for 500Hz mode.
 #else
 #define PACKET_TO_TOCK_SLACK 200 // Desired buffer time between Packet ISR and Tock ISR
 #endif

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1362,6 +1362,8 @@ void setup()
 void loop()
 {
   uint32_t now = millis();
+  
+  Radio.ignoreSecondIRQ = false;
 
   HandleUARTout(); // Only used for non-CRSF output
 


### PR DESCRIPTION
2.4G 500Hz 1:2 was not working due to not enough time for the slow ass LR1121 SPI operations.

 Summary
- Saves another 40us on the rx
- LR11XX_RADIO_FALLBACK_STDBY_XOSC has been removed because its faster to use FS

Firstly the unnecessary ClearIrqStatus(SX12XX_Radio_All) was removed from the LR1121_IRQ_RX_DONE IRQ.  Both radios dio pins are reset during GetLastPacketStats().  ignoreSecondIRQ has also been introduced to prevent the second redundant IRQ from being called with Gemini hardware.  This removes another unnecessary GetIrqStatus() call.  ignoreSecondIRQ is reset in the loop() and to absolutely guaranty it is reset.  There is no race condition here since the loop is not run between 2 back to back IRQs.

The use of LR1121_MODE_STDBY_XOSC was incorrect and should have been LR1121_MODE_STDBY_RC.  But that is soooo slow.  Using just FS as the fallback is faster and the difference between changing modes between FS or RC (after a tlm reception timeout) is only 15us.  This is fine and better than the incorrect LR1121_MODE_STDBY_XOSC .

Calls to SetFrequencyReg() have also been optimised to reduce wait times in the SPI traffic.

Finally, isFirstRxIrq was missing for the TX.  This resulted in the 2nd radios TLM packet stats not being read.  Not a huge deal but it should be done... and ETX should display TRSS2 and TSNR2 😄 