### PR TITLE
Fix antenna value for Diversity/Gemini receivers

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -251,11 +251,6 @@ static uint8_t minLqForChaos()
 
 void ICACHE_RAM_ATTR getRFlinkInfo()
 {
-    if (GPIO_PIN_NSS_2 != UNDEF_PIN)
-    {
-        antenna = (Radio.GetProcessingPacketRadio() == SX12XX_Radio_1) ? 0 : 1;
-    }
-
     int32_t rssiDBM = Radio.LastPacketRSSI;
 
     if (GPIO_PIN_NSS_2 != UNDEF_PIN)
@@ -272,7 +267,7 @@ void ICACHE_RAM_ATTR getRFlinkInfo()
         // BetaFlight/iNav expect positive values for -dBm (e.g. -80dBm -> sent as 80)
         CRSF::LinkStatistics.uplink_RSSI_1 = -rssiDBM;
         CRSF::LinkStatistics.uplink_RSSI_2 = -rssiDBM2;
-        antenna = (rssiDBM > rssiDBM2)? 0 : 1; // report a better antenna for the reception
+        antenna = (Radio.GetProcessingPacketRadio() == SX12XX_Radio_1) ? 0 : 1;
     }
     else if (antenna == 0)
     {


### PR DESCRIPTION
Antenna should report the antenna that received the packet.  Diversity receivers report both RSSI values and are available for the user to see which antenna is performing better.  But there is value in seeing which antenna actually received the processed packet, in particularly with dual band systems.  The RSSI for 900M will always outperform 2.4G, even though the 2.4 packet has been received.  But currently antenna always reports the 900M antenna.