### PR TITLE
SerialMavlink: fix buffer overflow and unused variable

### DIFF
--- a/src/src/rx-serial/SerialMavlink.cpp
+++ b/src/src/rx-serial/SerialMavlink.cpp
@@ -53,7 +53,7 @@ uint32_t SerialMavlink::sendRCFrame(bool frameAvailable, uint32_t *channelData)
         chan16_raw: CRSF_to_US(channelData[15]),
     };
 
-    uint8_t buf[MAVLINK_MAX_PACKET_LEN];
+    uint8_t buf[MAVLINK_MSG_ID_RC_CHANNELS_OVERRIDE_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES];
     mavlink_message_t msg;
     mavlink_msg_rc_channels_override_encode(this_system_id, this_component_id, &msg, &rc_override);
     uint16_t len = mavlink_msg_to_send_buffer(buf, &msg);
@@ -98,7 +98,7 @@ void SerialMavlink::sendQueuedData(uint32_t maxBytesToSend)
             remnoise: 0,
         };
 
-        uint8_t buf[MAVLINK_MSG_ID_RADIO_STATUS_LEN];
+        uint8_t buf[MAVLINK_MSG_ID_RADIO_STATUS_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES];
         mavlink_message_t msg;
         mavlink_msg_radio_status_encode(this_system_id, this_component_id, &msg, &radio_status);
         uint16_t len = mavlink_msg_to_send_buffer(buf, &msg);
@@ -134,8 +134,8 @@ void SerialMavlink::sendQueuedData(uint32_t maxBytesToSend)
             {
                 // If it is, we want to deliberately hack the ftp url, so that the request fails
                 // Borrowed and modified from mLRS
-                uint8_t buf[MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL_LEN];
-                uint16_t len = mavlink_msg_file_transfer_protocol_get_payload(&msg, buf);
+                uint8_t buf[MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES];
+                mavlink_msg_file_transfer_protocol_get_payload(&msg, buf);
 
                 uint8_t target_component = buf[0];
                 uint8_t opcode = buf[3];
@@ -156,7 +156,7 @@ void SerialMavlink::sendQueuedData(uint32_t maxBytesToSend)
             }
             else
             {
-                uint8_t buf[MAVLINK_MAX_PAYLOAD_LEN];
+                uint8_t buf[MAVLINK_MAX_PACKET_LEN];
                 uint16_t len = mavlink_msg_to_send_buffer(buf, &msg);
                 _outputPort->write(buf, len);
             }


### PR DESCRIPTION
This fixes some potentially nasty overflows (I'm actually a bit surprised it was working at all). The payload length was being used for the buffer MAVLink messages are packed into. This results in a guaranteed write past the end of the buffer of 12 bytes (10 bytes of header and 2 bytes of checksum).

It is already correct in the for the `sendRCFrame` function. 

This also removes a unused length return. 

The compiler was warning about both:
```
src/rx-serial/SerialMavlink.cpp: In member function 'virtual void SerialMavlink::sendQueuedData(uint32_t)':
src/rx-serial/SerialMavlink.cpp:138:26: warning: unused variable 'len' [-Wunused-variable]
                 uint16_t len = mavlink_msg_file_transfer_protocol_get_payload(&msg, buf);
                          ^~~
Compiling .pio\build\Unified_ESP32_900_RX_via_UART\lib459\SX127xDriver\SX127x.cpp.o
In file included from .pio/libdeps/Unified_ESP32_900_RX_via_UART/c_library_v2/common/common.h:29,
                 from .pio/libdeps/Unified_ESP32_900_RX_via_UART/c_library_v2/common/mavlink.h:32,
                 from src/rx-serial/SerialMavlink.cpp:8:
In function 'void mav_array_memcpy(void*, const void*, size_t)',
    inlined from 'uint16_t mavlink_msg_file_transfer_protocol_pack(uint8_t, uint8_t, mavlink_message_t*, uint8_t, uint8_t, uint8_t, const uint8_t*)' at .pio/libdeps/Unified_ESP32_900_RX_via_UART/c_library_v2/common/./mavlink_msg_file_transfer_protocol.h:74:21,
    inlined from 'virtual void SerialMavlink::sendQueuedData(uint32_t)' at src/rx-serial/SerialMavlink.cpp:151:64:
.pio/libdeps/Unified_ESP32_900_RX_via_UART/c_library_v2/common/../protocol.h:178:9: warning: 'void* memcpy(void*, const void*, size_t)' forming offset [255, 263] is out of the bounds [0, 254] of object 'buf' with type 'uint8_t [254]' {aka 'unsigned char [254]'} [-Warray-bounds]
   memcpy(dest, src, n);
   ~~~~~~^~~~~~~~~~~~~~
src/rx-serial/SerialMavlink.cpp: In member function 'virtual void SerialMavlink::sendQueuedData(uint32_t)':
src/rx-serial/SerialMavlink.cpp:137:25: note: 'buf' declared here
                 uint8_t buf[MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL_LEN];
                         ^~~
```
This gets us to no warnings for the MAVLink stuff.
