### PR TITLE
LUA: prevent multiple I2C SCL/SDA selections

### DIFF
--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -163,6 +163,36 @@ static struct luaItem_command luaBindMode = {
 #if defined(GPIO_PIN_PWM_OUTPUTS)
 static void luaparamMappingChannelOut(struct luaPropertiesCommon *item, uint8_t arg)
 {
+    bool sclAssigned = false;
+    bool sdaAssigned = false;
+
+    const char *no1Option    = ";";
+    const char *no2Options   = ";;";
+    const char *dshot        = ";DShot";
+    const char *serial_RX    = ";Serial RX";
+    const char *serial_TX    = ";Serial TX";
+    const char *i2c_SCL      = ";I2C SCL;";
+    const char *i2c_SDA      = ";;I2C SDA";
+    const char *i2c_BOTH     = ";I2C SCL;I2C SDA";
+
+    const char *pModeString;
+
+
+    // find out if use once only modes have already been assigned
+    for (uint8_t ch = 0; ch < GPIO_PIN_PWM_OUTPUTS_COUNT; ch++)
+    {
+      if (ch == (arg -1))
+        continue;
+
+      eServoOutputMode mode = (eServoOutputMode)config.GetPwmChannel(ch)->val.mode;
+      
+      if (mode == somSCL)
+        sclAssigned = true;
+
+      if (mode == somSDA)
+        sdaAssigned = true;
+    }
+
     setLuaUint8Value(&luaMappingChannelOut, arg);
 
     // When the selected output channel changes, update the available PWM modes for that pin
@@ -173,47 +203,72 @@ static void luaparamMappingChannelOut(struct luaPropertiesCommon *item, uint8_t 
     // DShot output (1 option)
     // ;DShot
     // ESP8266 enum skips this, so it is never present
-    if (GPIO_PIN_PWM_OUTPUTS[arg-1] != 0)
+    if (GPIO_PIN_PWM_OUTPUTS[arg-1] != 0)   // DShot doesn't work with GPIO0, exclude it
     {
-        strcat(pwmModes, ";DShot");
+        pModeString = dshot;
     }
     else
 #endif
     {
-        strcat(pwmModes, ";");
+        pModeString = no1Option;
     }
+    strcat(pwmModes, pModeString);
 
     // SerialIO outputs (1 option)
     // ;[Serial RX] | [Serial TX]
     if (GPIO_PIN_PWM_OUTPUTS[arg-1] == 3)
     {
-        strcat(pwmModes, ";Serial RX");
+        pModeString = serial_RX;
     }
     else if (GPIO_PIN_PWM_OUTPUTS[arg-1] == 1)
     {
-        strcat(pwmModes, ";Serial TX");
+        pModeString = serial_TX;
     }
     else
     {
-        strcat(pwmModes, ";");
+        pModeString = no1Option;
     }
+    strcat(pwmModes, pModeString);
 
     // I2C pins (2 options)
     // ;[I2C SCL] ;[I2C SDA]
-    // If the target defines SCL/SDA then those pins MUST be used,
-    // otherwise allow any pin to be either SCL or SDA
-    if (GPIO_PIN_PWM_OUTPUTS[arg-1] == GPIO_PIN_SCL)
+    if (GPIO_PIN_SCL != UNDEF_PIN || GPIO_PIN_SDA != UNDEF_PIN)
     {
-        strcat(pwmModes, ";I2C SCL;");
+        // If the target defines SCL/SDA then those pins MUST be used
+        if (GPIO_PIN_PWM_OUTPUTS[arg-1] == GPIO_PIN_SCL)
+        {
+            pModeString = i2c_SCL;
+        }
+        else if (GPIO_PIN_PWM_OUTPUTS[arg-1] == GPIO_PIN_SDA)
+        {
+            pModeString = i2c_SDA;
+        }
+        else
+        {
+            pModeString = no2Options;
+        }
+    } 
+    else
+    {  
+        // otherwise allow any pin to be either SCL or SDA but only once
+        if (sclAssigned && !sdaAssigned)
+        {
+            pModeString = i2c_SDA;
+        }
+        else if (sdaAssigned && !sclAssigned)
+        {
+            pModeString = i2c_SCL;
+        }
+        else if (!sclAssigned && !sdaAssigned)
+        {
+            pModeString = i2c_BOTH;
+        }
+        else
+        {
+            pModeString = no2Options;
+        }
     }
-    else if (GPIO_PIN_PWM_OUTPUTS[arg-1] == GPIO_PIN_SDA)
-    {
-        strcat(pwmModes, ";;I2C SDA");
-    }
-    else if (GPIO_PIN_SCL == UNDEF_PIN || GPIO_PIN_SDA == UNDEF_PIN)
-    {
-        strcat(pwmModes, ";I2C SCL;I2C SDA");
-    }
+    strcat(pwmModes, pModeString);
 
     // trim off trailing semicolons (assumes pwmModes has at least 1 non-semicolon)
     for (auto lastPos = strlen(pwmModes)-1; pwmModes[lastPos] == ';'; lastPos--)


### PR DESCRIPTION
fixes #2623 also for the LUA UI