### PR TITLE
HoTT Telemetry: robustness measure

### DIFF
--- a/src/src/rx-serial/SerialHoTT_TLM.cpp
+++ b/src/src/rx-serial/SerialHoTT_TLM.cpp
@@ -110,6 +110,7 @@ void SerialHoTT_TLM::pollDevice(uint8_t id)
 {
     // send data request to device
     _outputPort->write(START_OF_CMD_B);
+    delay(1);
     _outputPort->write(id);
 }
 

--- a/src/src/rx-serial/SerialHoTT_TLM.cpp
+++ b/src/src/rx-serial/SerialHoTT_TLM.cpp
@@ -4,9 +4,12 @@
 #include "FIFO.h"
 #include "telemetry.h"
 
+#define NOT_FOUND 0xff          // no device found indicator
 
 #define HOTT_POLL_RATE 150      // default HoTT bus poll rate [ms]
 #define HOTT_LEAD_OUT 10        // minimum gap between end of payload to next poll
+
+#define HOTT_CMD_DELAY 1        // 1 ms delay between CMD byte 1 and 2
 
 #define DISCOVERY_TIMEOUT 30000 // 30s device discovery time
 
@@ -69,49 +72,67 @@ void SerialHoTT_TLM::sendQueuedData(uint32_t maxBytesToSend)
     }
 
     // device polling scheduler
-    if (now - lastPoll >= HOTT_POLL_RATE)
-    {
-        lastPoll = now;
-
-        // start up in device discovery mode, after timeout regular operation
-        pollNextDevice();
-    }
+    scheduleDevicePolling(now);
 
     // CRSF packet scheduler
     scheduleCRSFtelemetry(now);
 }
 
-void SerialHoTT_TLM::pollNextDevice()
+void SerialHoTT_TLM::scheduleDevicePolling(uint32_t now)
 {
-    // clear serial in buffer
-    hottInputBuffer.flush();
-
-    // work out next device to be polled all in discovery
-    // mode, only detected ones in non-discovery mode)
-    for (uint i = 0; i < LAST_DEVICE; i++)
+    // send CMD byte 1
+    if (now - lastPoll >= HOTT_POLL_RATE)
     {
-        if (nextDevice == LAST_DEVICE)
+        lastPoll = now;
+
+        // work out next device to be polled. All devices in discovery
+        // mode, only detected devices in non-discovery mode)  
+        nextDeviceID = NOT_FOUND;
+
+        for (uint i = FIRST_DEVICE; i < LAST_DEVICE; i++)
         {
-            nextDevice = FIRST_DEVICE;
+            if (nextDevice == LAST_DEVICE)
+            {
+                nextDevice = FIRST_DEVICE;
+            }
+
+            if (device[nextDevice].present || discoveryMode)
+            {
+                nextDeviceID = device[nextDevice].deviceID;
+
+                nextDevice++;
+                
+                break;
+            }
+
+            nextDevice++;
         }
 
-        if (device[nextDevice].present || discoveryMode)
+        // no device found, nothing to do
+        if (nextDeviceID == NOT_FOUND)
         {
-            pollDevice(device[nextDevice++].deviceID);
-
-            break;
+            return;
         }
 
-        nextDevice++;
+        // clear serial in buffer
+        hottInputBuffer.flush();
+
+        // write CMD byte 1
+        _outputPort->write(START_OF_CMD_B);
+
+        // ready to send CMD byte 2
+        sendCmdByte2 = true;
     }
-}
 
-void SerialHoTT_TLM::pollDevice(uint8_t id)
-{
-    // send data request to device
-    _outputPort->write(START_OF_CMD_B);
-    delay(1);
-    _outputPort->write(id);
+    // delay sending CMD byte 2 to accomodate for slow devices
+    if ((now - lastPoll >= HOTT_CMD_DELAY) && sendCmdByte2)
+    {
+        // write CMD byte 2
+        _outputPort->write(nextDeviceID);
+
+        // both CMD bytes written, prepare next cycle
+        sendCmdByte2 = false;
+    }
 }
 
 void SerialHoTT_TLM::processFrame()
@@ -175,7 +196,7 @@ void SerialHoTT_TLM::scheduleCRSFtelemetry(uint32_t now)
             sendCRSFvario(now);
         }
 
-    // HoTT GAM, EAM, ESC -> send batter packet
+    // HoTT GAM, EAM, ESC -> send battery packet
     if (device[GAM].present || device[EAM].present || device[ESC].present)
     {
         sendCRSFbattery(now);

--- a/src/src/rx-serial/SerialHoTT_TLM.h
+++ b/src/src/rx-serial/SerialHoTT_TLM.h
@@ -262,6 +262,7 @@ public:
         uint32_t now = millis();
 
         lastPoll = now;
+        sendCmdByte2 = false;
         discoveryTimerStart = now;
     }
 
@@ -276,11 +277,10 @@ public:
 
 private:
     void processBytes(uint8_t *bytes, u_int16_t size) override;
-
-    void pollNextDevice();
-    void pollDevice(uint8_t id);
     void processFrame();
     uint8_t calcFrameCRC(uint8_t *buf);
+
+    void scheduleDevicePolling(uint32_t now);
 
     void scheduleCRSFtelemetry(uint32_t now);
     void sendCRSFvario(uint32_t now);
@@ -324,8 +324,10 @@ private:
 
     bool discoveryMode = true;
     uint8_t nextDevice = FIRST_DEVICE;
+    uint8_t nextDeviceID;
 
     uint32_t lastPoll;
+    bool sendCmdByte2;
     uint32_t discoveryTimerStart;
 
     uint32_t lastVarioSent = 0;


### PR DESCRIPTION
Got user feedback about 33601 Vario and S8361 80V voltage module not working. Both modules use very slow Microchip PIC processors without hardware UART meaning even slower software serial implementation. They just aren't fast enough to read serial data sent back to back. A small delay of net 500us between polling byte 1 and 2 makes polling more robust.

Tested on ER6 with 33601 and also a variety of other sensors for regression testing.

![image](https://github.com/ExpressLRS/ExpressLRS/assets/5615068/e9c30be4-5130-4536-927d-25316a68f703)
