### PR TITLE
Debounce BOOT0 readout in the hot loop

### DIFF
--- a/src/lib/Backpack/devBackpack.cpp
+++ b/src/lib/Backpack/devBackpack.cpp
@@ -25,6 +25,8 @@ bool lastRecordingState = false;
 #define PASSTHROUGH_BAUD BACKPACK_LOGGING_BAUD
 #endif
 
+#define GPIO_PIN_BOOT0 0
+
 #include "CRSF.h"
 #include "hwTimer.h"
 
@@ -113,12 +115,43 @@ bool lastRecordingState = false;
 }
 #endif
 
+#if defined(GPIO_PIN_BACKPACK_EN)
+
+static int debouncedRead(int pin) {
+    static const uint8_t min_matches = 100;
+
+    static int last_state = -1;
+    static uint8_t matches = 0;
+
+    int current_state;
+
+    current_state = digitalRead(pin);
+    if (current_state == last_state) {
+        matches = min(min_matches, (uint8_t)(matches + 1));
+    } else {
+        // We are bouncing. Reset the match counter.
+        matches = 0;
+        DBGLN("Bouncing!, current state: %d, last_state: %d, matches: %d", current_state, last_state, matches);
+    }
+
+    if (matches == min_matches) {
+        // We have a stable state and report it.
+        return current_state;
+    }
+
+    last_state = current_state;
+
+    // We don't have a definitive state we could report.
+    return -1;
+}
+#endif
+
 void checkBackpackUpdate()
 {
 #if defined(GPIO_PIN_BACKPACK_EN)
     if (GPIO_PIN_BACKPACK_EN != UNDEF_PIN)
     {
-        if (!digitalRead(0))
+        if (debouncedRead(GPIO_PIN_BOOT0) == 0)
         {
             startPassthrough();
         }
@@ -256,7 +289,7 @@ static void initialize()
 #if defined(GPIO_PIN_BACKPACK_EN)
     if (GPIO_PIN_BACKPACK_EN != UNDEF_PIN)
     {
-        pinMode(0, INPUT); // setup so we can detect pinchange for passthrough mode
+        pinMode(GPIO_PIN_BOOT0, INPUT); // setup so we can detect pinchange for passthrough mode
         pinMode(GPIO_PIN_BACKPACK_BOOT, OUTPUT);
         pinMode(GPIO_PIN_BACKPACK_EN, OUTPUT);
         // Shut down the backpack via EN pin and hold it there until the first event()


### PR DESCRIPTION
Connecting a USB cable sometimes introduces noise on the pins of the USB to UART converter leading to a low BOOT0 pin. In the main loop of TX this is checked for indication of a backpack update. Depending on timing this leads to the whole TX hanging since the serial connection is closed and the device enters passthrough mode.

Introduce a simple software debouncing to ensure the state of the pin has settled in case the first readout indicates BOOT0 is 0. This does not introduce additional latency on the default loop but prevents noise from breaking the main use case.