### PR TITLE
Fix PWM section layout in web UI

### DIFF
--- a/src/html/elrs.css
+++ b/src/html/elrs.css
@@ -349,7 +349,6 @@ body, input, select, textarea {
 
     /* Custom code for ExpressLRS PWM Output table */
   .pwmpnl {
-	overflow-x: auto;
 	min-width: fit-content;
   }
   .pwmtbl table {
@@ -365,6 +364,7 @@ body, input, select, textarea {
   .pwmitm {
 	min-width: 6em;
 	white-space: nowrap;
+	width: fit-content;
   }
 
   /*==========================*/


### PR DESCRIPTION
The dropdowns for channel and mode where truncated for smaller number of outputs.
Also the cells are set to `fit-content` to make it look little nicer.

Heres a screenshot after the fixes.
![Screenshot 2024-04-05 at 9 09 29 AM](https://github.com/ExpressLRS/ExpressLRS/assets/512740/52710726-6060-48e7-902d-d36dda2453cd)

Fixes #2636 
