### PR TITLE
Fix SX1280 and LE1121 power setting

### DIFF
--- a/src/lib/LR1121Driver/LR1121.h
+++ b/src/lib/LR1121Driver/LR1121.h
@@ -51,7 +51,7 @@ public:
 private:
     // constant used for no power change pending
     // must not be a valid power register value
-    static const uint8_t PWRPENDING_NONE = 0xff;
+    static const uint8_t PWRPENDING_NONE = 0x7f;
 
     // LR1121_RadioOperatingModes_t currOpmode;
     bool modeSupportsFei;

--- a/src/lib/SX1280Driver/SX1280.h
+++ b/src/lib/SX1280Driver/SX1280.h
@@ -55,7 +55,7 @@ public:
 private:
     // constant used for no power change pending
     // must not be a valid power register value
-    static const uint8_t PWRPENDING_NONE = 0xff;
+    static const uint8_t PWRPENDING_NONE = 0x7f;
 
     SX1280_RadioOperatingModes_t currOpmode;
     uint8_t packet_mode;


### PR DESCRIPTION
Whilst testing my LR1121 based TX module I noticed that 500mW output power (value -1 in the table) was not adjusting the actual power from the previous output power. This was because the pending guard was using -1 (0xFF) as the guard value!