### PR TITLE
prevent WaitOnBusy from waiting on non-existing radio

### DIFF
--- a/src/lib/LR1121Driver/LR1121_hal.cpp
+++ b/src/lib/LR1121Driver/LR1121_hal.cpp
@@ -157,9 +157,9 @@ bool ICACHE_RAM_ATTR LR1121Hal::WaitOnBusy(SX12XX_Radio_Number_t radioNumber)
         {
             if (digitalRead(GPIO_PIN_BUSY) == LOW) return true;
         }
-        else if (GPIO_PIN_BUSY_2 != UNDEF_PIN && radioNumber == SX12XX_Radio_2)
+        else if (radioNumber == SX12XX_Radio_2)
         {
-            if (digitalRead(GPIO_PIN_BUSY_2) == LOW) return true;
+            if (GPIO_PIN_BUSY_2 == UNDEF_PIN || digitalRead(GPIO_PIN_BUSY_2) == LOW) return true;
         }
         else if (radioNumber == SX12XX_Radio_All)
         {

--- a/src/lib/SX1280Driver/SX1280_hal.cpp
+++ b/src/lib/SX1280Driver/SX1280_hal.cpp
@@ -259,9 +259,9 @@ bool ICACHE_RAM_ATTR SX1280Hal::WaitOnBusy(SX12XX_Radio_Number_t radioNumber)
             {
                 if (digitalRead(GPIO_PIN_BUSY) == LOW) return true;
             }
-            else if (GPIO_PIN_BUSY_2 != UNDEF_PIN && radioNumber == SX12XX_Radio_2)
+            else if (radioNumber == SX12XX_Radio_2)
             {
-                if (digitalRead(GPIO_PIN_BUSY_2) == LOW) return true;
+                if (GPIO_PIN_BUSY_2 == UNDEF_PIN || digitalRead(GPIO_PIN_BUSY_2) == LOW) return true;
             }
             else if (radioNumber == SX12XX_Radio_All)
             {


### PR DESCRIPTION
In situations where `WaitOnBusy` is called with `SX12XX_Radio_2` although no second radio is present, the function currently always waits a full `wtimeoutUS`

This pr modifies the behaviour to return immediately instead.