### PR TITLE
LBT - change tx modules to use rxmode with timeout

### DIFF
--- a/src/lib/LBT/LBT.h
+++ b/src/lib/LBT/LBT.h
@@ -9,6 +9,5 @@ extern LQCALC<100> LBTSuccessCalc;
 extern bool LBTEnabled;
 
 void ICACHE_RAM_ATTR SetClearChannelAssessmentTime(void);
-void ICACHE_RAM_ATTR BeginClearChannelAssessment(void);
 SX12XX_Radio_Number_t ICACHE_RAM_ATTR ChannelIsClear(SX12XX_Radio_Number_t radioNumber);
 #endif

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -227,7 +227,7 @@ void ICACHE_RAM_ATTR SX1280Driver::CommitOutputPower()
     hal.WriteCommand(SX1280_RADIO_SET_TXPARAMS, buf, sizeof(buf), SX12XX_Radio_All);
 }
 
-void SX1280Driver::SetMode(SX1280_RadioOperatingModes_t OPmode, SX12XX_Radio_Number_t radioNumber)
+void SX1280Driver::SetMode(SX1280_RadioOperatingModes_t OPmode, SX12XX_Radio_Number_t radioNumber, uint32_t incomingTimeout)
 {
     /*
     Comment out since it is difficult to keep track of dual radios.
@@ -239,6 +239,8 @@ void SX1280Driver::SetMode(SX1280_RadioOperatingModes_t OPmode, SX12XX_Radio_Num
     // }
 
     WORD_ALIGNED_ATTR uint8_t buf[3];
+    uint16_t tempTimeout;
+
     switch (OPmode)
     {
 
@@ -263,9 +265,10 @@ void SX1280Driver::SetMode(SX1280_RadioOperatingModes_t OPmode, SX12XX_Radio_Num
         break;
 
     case SX1280_MODE_RX:
+        tempTimeout = incomingTimeout ? (incomingTimeout * 1000 / RX_TIMEOUT_PERIOD_BASE_NANOS) : timeout;
         buf[0] = RX_TIMEOUT_PERIOD_BASE;
-        buf[1] = timeout >> 8;
-        buf[2] = timeout & 0xFF;
+        buf[1] = tempTimeout >> 8;
+        buf[2] = tempTimeout & 0xFF;
         hal.WriteCommand(SX1280_RADIO_SET_RX, buf, sizeof(buf), radioNumber, 100);
         break;
 
@@ -557,10 +560,10 @@ bool ICACHE_RAM_ATTR SX1280Driver::RXnbISR(uint16_t irqStatus, SX12XX_Radio_Numb
     return RXdoneCallback(fail);
 }
 
-void ICACHE_RAM_ATTR SX1280Driver::RXnb(SX1280_RadioOperatingModes_t rxMode)
+void ICACHE_RAM_ATTR SX1280Driver::RXnb(SX1280_RadioOperatingModes_t rxMode, uint32_t incomingTimeout)
 {
     RFAMP.RXenable();
-    SetMode(rxMode, SX12XX_Radio_All);
+    SetMode(rxMode, SX12XX_Radio_All, incomingTimeout);
 }
 
 uint8_t ICACHE_RAM_ATTR SX1280Driver::GetRxBufferAddr(SX12XX_Radio_Number_t radioNumber)

--- a/src/lib/SX1280Driver/SX1280.h
+++ b/src/lib/SX1280Driver/SX1280.h
@@ -41,7 +41,7 @@ public:
     bool FrequencyErrorAvailable() const { return modeSupportsFei && (LastPacketSNRRaw > 0); }
 
     void TXnb(uint8_t * data, uint8_t size, SX12XX_Radio_Number_t radioNumber);
-    void RXnb(SX1280_RadioOperatingModes_t rxMode = SX1280_MODE_RX);
+    void RXnb(SX1280_RadioOperatingModes_t rxMode = SX1280_MODE_RX, uint32_t incomingTimeout = 0);
 
     uint16_t GetIrqStatus(SX12XX_Radio_Number_t radioNumber);
     void ClearIrqStatus(uint16_t irqMask, SX12XX_Radio_Number_t radioNumber);
@@ -64,7 +64,7 @@ private:
     uint8_t pwrPending;
     SX1280_RadioOperatingModes_t fallBackMode;
 
-    void SetMode(SX1280_RadioOperatingModes_t OPmode, SX12XX_Radio_Number_t radioNumber);
+    void SetMode(SX1280_RadioOperatingModes_t OPmode, SX12XX_Radio_Number_t radioNumber, uint32_t incomingTimeout = 0);
     void SetFIFOaddr(uint8_t txBaseAddr, uint8_t rxBaseAddr);
 
     // LoRa functions

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -433,10 +433,6 @@ bool ICACHE_RAM_ATTR HandleSendTelemetryResponse()
         return false; // don't bother sending tlm if disconnected or TLM is off
     }
 
-#if defined(Regulatory_Domain_EU_CE_2400)
-    BeginClearChannelAssessment();
-#endif
-
     // ESP requires word aligned buffer
     WORD_ALIGNED_ATTR OTA_Packet_s otaPkt = {0};
     alreadyTLMresp = true;
@@ -1120,10 +1116,9 @@ bool ICACHE_RAM_ATTR RXdoneISR(SX12xxDriverCommon::rx_status const status)
 
 void ICACHE_RAM_ATTR TXdoneISR()
 {
-#if defined(Regulatory_Domain_EU_CE_2400)
-    BeginClearChannelAssessment();
-#else
     Radio.RXnb();
+#if defined(Regulatory_Domain_EU_CE_2400)
+    SetClearChannelAssessmentTime();
 #endif
 #if defined(DEBUG_RX_SCOREBOARD)
     DBGW('T');

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -248,7 +248,9 @@ bool ICACHE_RAM_ATTR ProcessTLMpacket(SX12xxDriverCommon::rx_status const status
     }
   }
   
+#if defined(Regulatory_Domain_EU_CE_2400)
   SetClearChannelAssessmentTime();
+#endif
 
   return true;
 }

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -247,6 +247,9 @@ bool ICACHE_RAM_ATTR ProcessTLMpacket(SX12xxDriverCommon::rx_status const status
         break;
     }
   }
+  
+  SetClearChannelAssessmentTime();
+
   return true;
 }
 
@@ -583,9 +586,11 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
     // set the transceiver the correct fallback mode
     Radio.TXdoneCallback();
   }
+  else
 #endif
-
-  Radio.TXnb((uint8_t*)&otaPkt, ExpressLRS_currAirRate_Modparams->PayloadLength, transmittingRadio);
+  {
+    Radio.TXnb((uint8_t*)&otaPkt, ExpressLRS_currAirRate_Modparams->PayloadLength, transmittingRadio);
+  }
 }
 
 void ICACHE_RAM_ATTR nonceAdvance()
@@ -607,12 +612,6 @@ void ICACHE_RAM_ATTR timerCallback()
   {
     nonceAdvance();
     return;
-  }
-
-  // No packet has been sent due to LBT.  Call TXdoneCallback to prepare for TLM.
-  if (Radio.GetLastTransmitRadio() == SX12XX_Radio_NONE)
-  {
-		Radio.TXdoneCallback();
   }
 
   // Sync OpenTX to this point
@@ -656,11 +655,17 @@ void ICACHE_RAM_ATTR timerCallback()
     // Indicate no telemetry packet received to the DP system
     DynamicPower_TelemetryUpdate(DYNPOWER_UPDATE_MISSED);
   }
-  TelemetryRcvPhase = ttrpTransmitting;
 
 #if defined(Regulatory_Domain_EU_CE_2400)
-    BeginClearChannelAssessment(); // Get RSSI reading here, used also for next TX if in receiveMode.
+  // The last period was receiving tlm, but nothing was received.
+  // No need to enter rxmode again, lets just read the latest GetRssiInst().
+  if (!(TelemetryRcvPhase == ttrpExpectingTelem && !LQCalc.currentIsSet()))
+  {
+    SetClearChannelAssessmentTime(); // Get RSSI reading here, used also for next TX if in receiveMode.
+  }
 #endif
+
+  TelemetryRcvPhase = ttrpTransmitting;
 
   // Do not send a stale channels packet to the RX if one has not been received from the handset
   // *Do* send data if a packet has never been received from handset and the timer is running
@@ -842,7 +847,7 @@ void ICACHE_RAM_ATTR TXdoneISR()
       // from RX enable to valid instant RSSI values are returned.
       // If rx was already started by TLM prepare above, this call will let RX
       // continue as normal.
-      BeginClearChannelAssessment();
+      SetClearChannelAssessmentTime();
     }
 #endif // non-CE
   }
@@ -1342,7 +1347,7 @@ void setup()
       ChangeRadioParams();
 
   #if defined(Regulatory_Domain_EU_CE_2400)
-      BeginClearChannelAssessment();
+      SetClearChannelAssessmentTime();
   #endif
       hwTimer::init(nullptr, timerCallback);
       connectionState = noCrossfire;


### PR DESCRIPTION
Currently F500 mode can have disconnection issues when used with LBT.  This because the tx module uses rxmode continuous when sampling rssi instantaneous as part of Clear Channel Assessment (CCA).  F500 has a packet interval of 2000us, but an OTA packet time of ~400us.  So the gap between packets is long enough for noise to be read as a packet and trigger an IRQ.

The fix for this is to change the rxmode from continuous to a timeout.  The timeout only needs to be long enough for GetRssiInst to be updated, which is every symbol.

Since this change I have not had any tlm lost, or disconnects over about 6 hrs.  Testing included a Gemini TX yelling 50Hz packets and the SPI trace looks awful with dropped packets.

The other changes are optimising how CCA is started and minimising calls to set rxmode.