### PR TITLE
GH-2645 Disabled advertisement of default gateway to DHCP clients

### DIFF
--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -75,6 +75,7 @@ static const byte DNS_PORT = 53;
 static IPAddress netMsk(255, 255, 255, 0);
 static DNSServer dnsServer;
 static IPAddress ipAddress;
+static IPAddress gatewayIpAddress(0, 0, 0, 0);
 
 #if defined(USE_MSP_WIFI) && defined(TARGET_RX)  //MSP2WIFI in enabled only for RX only at the moment
 #include "crsf2msp.h"
@@ -1116,7 +1117,7 @@ static void HandleWebUpdate()
         #elif defined(PLATFORM_ESP32)
         WiFi.setTxPower(WIFI_POWER_19_5dBm);
         #endif
-        WiFi.softAPConfig(ipAddress, ipAddress, netMsk);
+        WiFi.softAPConfig(ipAddress, gatewayIpAddress, netMsk);
         WiFi.softAP(wifi_ap_ssid, wifi_ap_password);
         startServices();
         break;


### PR DESCRIPTION
As per https://github.com/espressif/arduino-esp32/issues/1372#issuecomment-931507392 when the gateway is 0.0.0.0 there is no advertisement of gateway to the DHCP clients.

Resolves #2645

