### PR TITLE
Added information about the target

### DIFF
--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -542,17 +542,21 @@ static void WebUpdateGetTarget(AsyncWebServerRequest *request)
   json["reg_domain"] = FHSSgetRegulatoryDomain();
   json["git-commit"] = commit;
 #if defined(TARGET_TX)
-  json["radio-type"] = "TX";
+  json["module-type"] = "TX";
 #endif
 #if defined(TARGET_RX)
-  json["radio-type"] = "RX";
+  json["module-type"] = "RX";
+#endif
+#if defined(RADIO_SX128X)
+  json["radio-type"] = "SX128X";
+  json["has-sub-ghz"] = false;
 #endif
 #if defined(RADIO_SX127X)
-  json["is-sx127x"] = true;
+  json["radio-type"] = "SX127X";
   json["has-sub-ghz"] = true;
 #endif
 #if defined(RADIO_LR1121)
-  json["is-lr1121"] = true;
+  json["radio-type"] = "LR1121";
   json["has-sub-ghz"] = true;
 #endif
 

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -540,6 +540,22 @@ static void WebUpdateGetTarget(AsyncWebServerRequest *request)
   json["product_name"] = product_name;
   json["lua_name"] = device_name;
   json["reg_domain"] = FHSSgetRegulatoryDomain();
+  json["git-commit"] = commit;
+#if defined(TARGET_TX)
+  json["is-tx"] = true;
+#endif
+#if defined(TARGET_RX)
+  json["is-rx"] = true;
+#endif
+#if defined(RADIO_SX127X)
+  json["is-sx127x"] = true;
+  json["has-sub-ghz"] = true;
+#endif
+#if defined(RADIO_LR1121)
+  json["is-lr1121"] = true;
+  json["has-sub-ghz"] = true;
+#endif
+
   AsyncResponseStream *response = request->beginResponseStream("application/json");
   serializeJson(json, *response);
   request->send(response);

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -542,10 +542,10 @@ static void WebUpdateGetTarget(AsyncWebServerRequest *request)
   json["reg_domain"] = FHSSgetRegulatoryDomain();
   json["git-commit"] = commit;
 #if defined(TARGET_TX)
-  json["is-tx"] = true;
+  json["radio-type"] = "TX";
 #endif
 #if defined(TARGET_RX)
-  json["is-rx"] = true;
+  json["radio-type"] = "RX";
 #endif
 #if defined(RADIO_SX127X)
   json["is-sx127x"] = true;


### PR DESCRIPTION
While working on a new frontend for the configuration of modules and receivers, I found myself lacking runtime information from the target, such as if it is a TX or RX, if the radio is SX127x or LR1121.

This PR adds them to the `/target` endpoint so that we can interrogate the device for the required information.