### PR TITLE
Fix the power-on-counter reset so it does not cause a connection loss at startup

### DIFF
--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -226,8 +226,6 @@ static int start()
         }
 #endif
     }
-    // set servo outputs to failsafe position on start in case they want to play silly buggers!
-    servosFailsafe();
     return DURATION_NEVER;
 }
 


### PR DESCRIPTION
# Problem
Resetting the power-on-counter to zero and saving to flash 2 seconds after boot, which causes a loss of connection.

# Solution
1. reset the counter to zero and save if we get a tentative connection within the first 2 seconds.
2. reset the counter to zero and save if we reach the 2 second timeout, the counter has not already been reset and we do not have a connection.

# Other Issues
During the testing of this I found that the new behaviour with 3x power cycle binding would only work on exactly 3 power cycles! This was because the RX would enter bind mode and clear the power on count so if the user was doing a 4th power cycle it would effectively be back at counter 1.

This has been fixed to work for 3 or more power cycles by not resetting the counter when entering bind mode, but deferring to section 2 in the Solution above.