### PR TITLE
Remove generic targets from artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,7 +147,9 @@ jobs:
           merge-multiple: true
 
       - name: Copy hardware files to firmware folder
-        run: cp -r src/hardware dist/firmware
+        run: |
+          cp -r src/hardware dist/firmware
+          jq 'del(.generic)' src/hardware/targets.json > dist/firmware/hardware/targets.json
 
       - name: Copy Lua to to firmware folder
         run: |


### PR DESCRIPTION
Filter the `targets.json` during artifact generation so the generic targets do not show up in configurator as all targets should have an official entry in the file.