### PR TITLE
fixes HoTT Telemetry requiring an external diode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,7 +147,9 @@ jobs:
           merge-multiple: true
 
       - name: Copy hardware files to firmware folder
-        run: cp -r src/hardware dist/firmware
+        run: |
+          cp -r src/hardware dist/firmware
+          jq 'del(.generic)' src/hardware/targets.json > dist/firmware/hardware/targets.json
 
       - name: Copy Lua to to firmware folder
         run: |

--- a/src/include/targets.h
+++ b/src/include/targets.h
@@ -289,5 +289,11 @@ extern bool pwmSerialDefined;
 #endif
 
 #if defined(TARGET_UNIFIED_TX) || defined(TARGET_UNIFIED_RX)
+#if !defined(U0RXD_GPIO_NUM)
+#define U0RXD_GPIO_NUM (3)
+#endif
+#if !defined(U0TXD_GPIO_NUM)
+#define U0TXD_GPIO_NUM (1)
+#endif
 #include "hardware.h"
 #endif

--- a/src/src/rx-serial/SerialHoTT_TLM.cpp
+++ b/src/src/rx-serial/SerialHoTT_TLM.cpp
@@ -44,7 +44,7 @@ void SerialHoTT_TLM::setTXMode()
     // assumes half duplex line is connected to Serial RX GPIO
     pinMatrixInDetach(rxPin, false, false);                 // attach UART0 RX to static high level
     pinMode(rxPin, OUTPUT);                                 // set GPIO to OUTPUT
-    digitalWrite(rxPin, 1);                                 // and set it to high level
+    digitalWrite(rxPin, HIGH);                              // and set it to high level
     pinMatrixOutAttach(rxPin, U0TXD_OUT_IDX, false, false); // attach GPIO to UART0 TX
 #endif
 }

--- a/src/src/rx-serial/SerialHoTT_TLM.cpp
+++ b/src/src/rx-serial/SerialHoTT_TLM.cpp
@@ -41,21 +41,17 @@ int SerialHoTT_TLM::getMaxSerialReadSize()
 void SerialHoTT_TLM::setTXMode()
 {
 #if defined(PLATFORM_ESP32)
-    // assumes half duplex line is connected to Serial RX GPIO
-    pinMatrixInDetach(rxPin, false, false);                 // attach UART0 RX to static high level
-    pinMode(rxPin, OUTPUT);                                 // set GPIO to OUTPUT
-    digitalWrite(rxPin, HIGH);                              // and set it to high level
-    pinMatrixOutAttach(rxPin, U0TXD_OUT_IDX, false, false); // attach GPIO to UART0 TX
+    pinMode(halfDuplexPin, OUTPUT);                                 // set half duplex GPIO to OUTPUT
+    digitalWrite(halfDuplexPin, HIGH);                              // set half duplex GPIO to high level
+    pinMatrixOutAttach(halfDuplexPin, U0TXD_OUT_IDX, false, false); // attach GPIO as output of UART0 TX
 #endif
 }
 
 void SerialHoTT_TLM::setRXMode()
 {
 #if defined(PLATFORM_ESP32)
-    // assumes half duplex line is connected to Serial RX GPIO
-    pinMatrixOutDetach(rxPin, false, false);                // disconnect GPIO
-    pinMode(rxPin, INPUT_PULLUP);                           // set GPIO to input mode
-    pinMatrixInAttach(rxPin, U0RXD_IN_IDX, false);          // attach GPIO as input to UART0 RX
+    pinMode(halfDuplexPin, INPUT_PULLUP);                           // set half duplex GPIO to INPUT
+    pinMatrixInAttach(halfDuplexPin, U0RXD_IN_IDX, false);          // attach half duplex GPIO as input to UART0 RX
 #endif
 }
 

--- a/src/src/rx-serial/SerialHoTT_TLM.h
+++ b/src/src/rx-serial/SerialHoTT_TLM.h
@@ -265,7 +265,7 @@ public:
         : SerialIO(&out, &in)
     {
         // use UART0 default rx pin for half duplex if not defined otherwise
-        rxPin = GPIO_PIN_RCSIGNAL_RX == UNDEF_PIN ? 3 : GPIO_PIN_RCSIGNAL_RX;
+        rxPin = GPIO_PIN_RCSIGNAL_RX == UNDEF_PIN ? U0RXD_GPIO_NUM : GPIO_PIN_RCSIGNAL_RX;
 
         uint32_t now = millis();
 

--- a/src/src/rx-serial/SerialHoTT_TLM.h
+++ b/src/src/rx-serial/SerialHoTT_TLM.h
@@ -1,3 +1,5 @@
+#if defined(TARGET_RX) && (defined(PLATFORM_ESP8266) || defined(PLATFORM_ESP32))
+
 #pragma once
 
 #include "SerialIO.h"
@@ -357,3 +359,5 @@ private:
     const int32_t MinScale = 1000000L;
     const int32_t DegScale = 10000000L;
 };
+
+#endif

--- a/src/src/rx-serial/SerialHoTT_TLM.h
+++ b/src/src/rx-serial/SerialHoTT_TLM.h
@@ -266,8 +266,8 @@ public:
     explicit SerialHoTT_TLM(Stream &out, Stream &in)
         : SerialIO(&out, &in)
     {
-        // use UART0 default rx pin for half duplex if not defined otherwise
-        rxPin = GPIO_PIN_RCSIGNAL_RX == UNDEF_PIN ? U0RXD_GPIO_NUM : GPIO_PIN_RCSIGNAL_RX;
+        // use UART0 default TX pin for half duplex if not defined otherwise
+        halfDuplexPin = GPIO_PIN_RCSIGNAL_TX == UNDEF_PIN ? U0TXD_GPIO_NUM : GPIO_PIN_RCSIGNAL_TX;
 
         uint32_t now = millis();
 
@@ -336,7 +336,7 @@ private:
 
     FIFO<HOTT_MAX_BUF_LEN> hottInputBuffer;
 
-    uint8_t rxPin;
+    uint8_t halfDuplexPin;
 
     bool discoveryMode = true;
     uint8_t nextDevice = FIRST_DEVICE;

--- a/src/src/rx-serial/SerialHoTT_TLM.h
+++ b/src/src/rx-serial/SerialHoTT_TLM.h
@@ -252,6 +252,11 @@ typedef struct
     bool present;
 } hottDevice_t;
 
+enum {
+    HOTT_RECEIVING,
+    HOTT_CMD1SENT,
+    HOTT_CMD2SENT
+};
 
 class SerialHoTT_TLM : public SerialIO
 {
@@ -259,11 +264,15 @@ public:
     explicit SerialHoTT_TLM(Stream &out, Stream &in)
         : SerialIO(&out, &in)
     {
+        // use UART0 default rx pin for half duplex if not defined otherwise
+        rxPin = GPIO_PIN_RCSIGNAL_RX == UNDEF_PIN ? 3 : GPIO_PIN_RCSIGNAL_RX;
+
         uint32_t now = millis();
 
         lastPoll = now;
-        sendCmdByte2 = false;
         discoveryTimerStart = now;
+
+        cmdSendState = HOTT_RECEIVING;
     }
 
     virtual ~SerialHoTT_TLM() {}
@@ -276,6 +285,9 @@ public:
     void sendQueuedData(uint32_t maxBytesToSend) override;
 
 private:
+    void setTXMode();
+    void setRXMode();
+
     void processBytes(uint8_t *bytes, u_int16_t size) override;
     void processFrame();
     uint8_t calcFrameCRC(uint8_t *buf);
@@ -322,12 +334,14 @@ private:
 
     FIFO<HOTT_MAX_BUF_LEN> hottInputBuffer;
 
+    uint8_t rxPin;
+
     bool discoveryMode = true;
     uint8_t nextDevice = FIRST_DEVICE;
     uint8_t nextDeviceID;
 
     uint32_t lastPoll;
-    bool sendCmdByte2;
+    uint8_t cmdSendState;
     uint32_t discoveryTimerStart;
 
     uint32_t lastVarioSent = 0;


### PR DESCRIPTION
This allows connecting HoTT Telemetry sensors without the need to DIY an adapter cable with diode. The changes are entirely local to protocol HoTT Telemetry (SerialHoTT_TLM.h/.cpp) and makes using HoTT sensors plug&play on ESP32 receivers, being especially user friendly for ESP32 based PWM receivers like the popular ER6x, ER8x and SuperP 14ch.

I kindly ask to consider this for RC2 as it would spare first time adopters to DIY adapter cables with diodes  (which is not every users thing). And I apologize for being late with this but mostly blame the really crappy ESP/IDF documentation on HAL matrix.