### PR TITLE
Fix LBT TLM

### DIFF
--- a/src/include/deferred.h
+++ b/src/include/deferred.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <functional>
+
+void deferExecutionMicros(unsigned long us, std::function<void()> f);
+void executeDeferredFunction(unsigned long now);
+
+static inline void deferExecutionMillis(unsigned long ms, std::function<void()> f)
+{
+    deferExecutionMicros(ms * 1000, f);
+}

--- a/src/include/rxtx_common.h
+++ b/src/include/rxtx_common.h
@@ -14,5 +14,5 @@
 #include "POWERMGNT.h"
 
 void setupTargetCommon();
-void deferExecution(uint32_t ms, std::function<void()> f);
+void deferExecution(unsigned long us, std::function<void()> f);
 void executeDeferredFunction(unsigned long now);

--- a/src/include/rxtx_common.h
+++ b/src/include/rxtx_common.h
@@ -12,7 +12,6 @@
 #include "LQCALC.h"
 #include "OTA.h"
 #include "POWERMGNT.h"
+#include "deferred.h"
 
 void setupTargetCommon();
-void deferExecution(unsigned long us, std::function<void()> f);
-void executeDeferredFunction(unsigned long now);

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -3,8 +3,8 @@
 #include "rxtx_devLua.h"
 #include "helpers.h"
 #include "devServoOutput.h"
+#include "deferred.h"
 
-extern void deferExecution(unsigned long us, std::function<void()> f);
 extern void reconfigureSerial();
 extern bool BindingModeRequest;
 
@@ -318,7 +318,7 @@ static void configureSerialPin(uint8_t sibling, uint8_t oldMode, uint8_t newMode
 
   if (oldMode != newMode)
   {
-    deferExecution(100000, [](){
+    deferExecutionMillis(100, [](){
       reconfigureSerial();
     });
   }
@@ -415,7 +415,7 @@ static void registerLuaParameters()
   registerLUAParameter(&luaSerialProtocol, [](struct luaPropertiesCommon* item, uint8_t arg){
     config.SetSerialProtocol((eSerialProtocol)arg);
     if (config.IsModified()) {
-      deferExecution(100000, [](){
+      deferExecutionMillis(100, [](){
         reconfigureSerial();
       });
     }
@@ -476,7 +476,7 @@ static void registerLuaParameters()
   registerLUAParameter(&luaBindMode, [](struct luaPropertiesCommon* item, uint8_t arg){
     // Complete when TX polls for status i.e. going back to idle, because we're going to lose connection
     if (arg == lcsQuery) {
-      deferExecution(200000, [](){ BindingModeRequest = true; });
+      deferExecutionMillis(200, [](){ BindingModeRequest = true; });
     }
     sendLuaCommandResponse(&luaBindMode, arg < 5 ? lcsExecuting : lcsIdle, arg < 5 ? "Entering..." : "");
   });

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -4,7 +4,7 @@
 #include "helpers.h"
 #include "devServoOutput.h"
 
-extern void deferExecution(uint32_t ms, std::function<void()> f);
+extern void deferExecution(unsigned long us, std::function<void()> f);
 extern void reconfigureSerial();
 extern bool BindingModeRequest;
 
@@ -318,7 +318,7 @@ static void configureSerialPin(uint8_t sibling, uint8_t oldMode, uint8_t newMode
 
   if (oldMode != newMode)
   {
-    deferExecution(100, [](){
+    deferExecution(100000, [](){
       reconfigureSerial();
     });
   }
@@ -415,7 +415,7 @@ static void registerLuaParameters()
   registerLUAParameter(&luaSerialProtocol, [](struct luaPropertiesCommon* item, uint8_t arg){
     config.SetSerialProtocol((eSerialProtocol)arg);
     if (config.IsModified()) {
-      deferExecution(100, [](){
+      deferExecution(100000, [](){
         reconfigureSerial();
       });
     }
@@ -476,7 +476,7 @@ static void registerLuaParameters()
   registerLUAParameter(&luaBindMode, [](struct luaPropertiesCommon* item, uint8_t arg){
     // Complete when TX polls for status i.e. going back to idle, because we're going to lose connection
     if (arg == lcsQuery) {
-      deferExecution(200, [](){ BindingModeRequest = true; });
+      deferExecution(200000, [](){ BindingModeRequest = true; });
     }
     sendLuaCommandResponse(&luaBindMode, arg < 5 ? lcsExecuting : lcsIdle, arg < 5 ? "Entering..." : "");
   });

--- a/src/lib/SCREEN/menu.cpp
+++ b/src/lib/SCREEN/menu.cpp
@@ -26,7 +26,7 @@ extern void setWifiUpdateMode();
 extern void SetSyncSpam();
 extern uint8_t adjustPacketRateForBaud(uint8_t rate);
 extern uint8_t adjustSwitchModeForAirRate(OtaSwitchMode_e eSwitchMode, uint8_t packetSize);
-extern void deferExecution(uint32_t ms, std::function<void()> f);
+extern void deferExecution(unsigned long us, std::function<void()> f);
 
 extern Display *display;
 
@@ -228,7 +228,7 @@ static void saveValueIndex(bool init)
             // If the switch mode is going to change, block the change while connected
             if (newSwitchMode == OtaSwitchModeCurrent || connectionState == disconnected)
             {
-                deferExecution(100, [actualRate, newSwitchMode](){
+                deferExecution(100000, [actualRate, newSwitchMode](){
                     config.SetRate(actualRate);
                     config.SetSwitchMode(newSwitchMode);
                     OtaUpdateSerializers((OtaSwitchMode_e)newSwitchMode, ExpressLRS_currAirRate_Modparams->PayloadLength);
@@ -242,7 +242,7 @@ static void saveValueIndex(bool init)
             // the pack and unpack functions are matched
             if (connectionState == disconnected)
             {
-                deferExecution(100, [val](){
+                deferExecution(100000, [val](){
                     config.SetSwitchMode(val);
                     OtaUpdateSerializers((OtaSwitchMode_e)val, ExpressLRS_currAirRate_Modparams->PayloadLength);
                     SetSyncSpam();
@@ -254,7 +254,7 @@ static void saveValueIndex(bool init)
             config.SetAntennaMode(values_index);
             break;
         case STATE_TELEMETRY:
-            deferExecution(100, [val](){
+            deferExecution(100000, [val](){
                 config.SetTlm(val);
                 SetSyncSpam();
             });

--- a/src/lib/SCREEN/menu.cpp
+++ b/src/lib/SCREEN/menu.cpp
@@ -8,6 +8,7 @@
 #include "POWERMGNT.h"
 #include "handset.h"
 #include "OTA.h"
+#include "deferred.h"
 
 #ifdef HAS_THERMAL
 #include "thermal.h"
@@ -26,7 +27,6 @@ extern void setWifiUpdateMode();
 extern void SetSyncSpam();
 extern uint8_t adjustPacketRateForBaud(uint8_t rate);
 extern uint8_t adjustSwitchModeForAirRate(OtaSwitchMode_e eSwitchMode, uint8_t packetSize);
-extern void deferExecution(unsigned long us, std::function<void()> f);
 
 extern Display *display;
 
@@ -228,7 +228,7 @@ static void saveValueIndex(bool init)
             // If the switch mode is going to change, block the change while connected
             if (newSwitchMode == OtaSwitchModeCurrent || connectionState == disconnected)
             {
-                deferExecution(100000, [actualRate, newSwitchMode](){
+                deferExecutionMillis(100, [actualRate, newSwitchMode](){
                     config.SetRate(actualRate);
                     config.SetSwitchMode(newSwitchMode);
                     OtaUpdateSerializers((OtaSwitchMode_e)newSwitchMode, ExpressLRS_currAirRate_Modparams->PayloadLength);
@@ -242,7 +242,7 @@ static void saveValueIndex(bool init)
             // the pack and unpack functions are matched
             if (connectionState == disconnected)
             {
-                deferExecution(100000, [val](){
+                deferExecutionMillis(100, [val](){
                     config.SetSwitchMode(val);
                     OtaUpdateSerializers((OtaSwitchMode_e)val, ExpressLRS_currAirRate_Modparams->PayloadLength);
                     SetSyncSpam();
@@ -254,7 +254,7 @@ static void saveValueIndex(bool init)
             config.SetAntennaMode(values_index);
             break;
         case STATE_TELEMETRY:
-            deferExecution(100000, [val](){
+            deferExecutionMillis(100, [val](){
                 config.SetTlm(val);
                 SetSyncSpam();
             });

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -57,7 +57,6 @@ extern void setButtonColors(uint8_t b1, uint8_t b2);
 extern RxConfig config;
 #endif
 
-extern void deferExecution(unsigned long us, std::function<void()> f);
 extern unsigned long rebootTime;
 
 static char station_ssid[33];

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -57,7 +57,7 @@ extern void setButtonColors(uint8_t b1, uint8_t b2);
 extern RxConfig config;
 #endif
 
-extern void deferExecution(uint32_t ms, std::function<void()> f);
+extern void deferExecution(unsigned long us, std::function<void()> f);
 extern unsigned long rebootTime;
 
 static char station_ssid[33];

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1156,7 +1156,7 @@ void MspReceiveComplete()
 #if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
         // The MSP packet needs to be ACKed so the TX doesn't
         // keep sending it, so defer the switch to wifi
-        deferExecution(500, []() {
+        deferExecution(500000, []() {
             setWifiUpdateMode();
         });
 #endif
@@ -1397,7 +1397,7 @@ static void setupConfigAndPocCheck()
     }
 
     // Set a deferred function to clear the power on counter if the RX has been running for more than 2s
-    deferExecution(2000, []() {
+    deferExecution(2000000, []() {
         if (connectionState != connected && config.GetPowerOnCounter() != 0)
         {
             config.SetPowerOnCounter(0);
@@ -1900,7 +1900,7 @@ void loop()
     #endif
 
     CheckConfigChangePending();
-    executeDeferredFunction(now);
+    executeDeferredFunction(micros());
 
     // Clear the power-on-count
     if ((connectionState == connected || connectionState == tentative) && config.GetPowerOnCounter() != 0)

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1156,7 +1156,7 @@ void MspReceiveComplete()
 #if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
         // The MSP packet needs to be ACKed so the TX doesn't
         // keep sending it, so defer the switch to wifi
-        deferExecution(500000, []() {
+        deferExecutionMillis(500, []() {
             setWifiUpdateMode();
         });
 #endif
@@ -1397,7 +1397,7 @@ static void setupConfigAndPocCheck()
     }
 
     // Set a deferred function to clear the power on counter if the RX has been running for more than 2s
-    deferExecution(2000000, []() {
+    deferExecutionMillis(2000, []() {
         if (connectionState != connected && config.GetPowerOnCounter() != 0)
         {
             config.SetPowerOnCounter(0);

--- a/src/src/rxtx_common.cpp
+++ b/src/src/rxtx_common.cpp
@@ -88,9 +88,12 @@ void deferExecutionMicros(unsigned long us, std::function<void()> f)
             deferred[i].started = micros();
             deferred[i].timeout = us;
             deferred[i].function = f;
-            break;
+            return;
         }
     }
+
+    // Bail out, there are no slots available!
+    DBGLN("No more deferred function slots available!");
 }
 
 void executeDeferredFunction(unsigned long now)

--- a/src/src/rxtx_common.cpp
+++ b/src/src/rxtx_common.cpp
@@ -9,9 +9,19 @@
 #include <Wire.h>
 #endif
 
-static unsigned long startDeferredTime = 0;
-static unsigned long deferredTimeout = 0;
-static std::function<void()> deferredFunction = nullptr;
+static const int maxDeferredFunctions = 3;
+
+struct deferred_t {
+    unsigned long started;
+    unsigned long timeout;
+    std::function<void()> function;
+};
+
+static deferred_t deferred[maxDeferredFunctions] = {
+    {0, 0, nullptr},
+    {0, 0, nullptr},
+    {0, 0, nullptr},
+};
 
 boolean i2c_enabled = false;
 
@@ -69,19 +79,29 @@ void setupTargetCommon()
     setupWire();
 }
 
-void deferExecution(unsigned long us, std::function<void()> f)
+void deferExecutionMicros(unsigned long us, std::function<void()> f)
 {
-    startDeferredTime = micros();
-    deferredTimeout = us;
-    deferredFunction = f;
+    for (int i=0 ; i<maxDeferredFunctions ; i++)
+    {
+        if (deferred[i].function == nullptr)
+        {
+            deferred[i].started = micros();
+            deferred[i].timeout = us;
+            deferred[i].function = f;
+            break;
+        }
+    }
 }
 
 void executeDeferredFunction(unsigned long now)
 {
     // execute deferred function if its time has elapsed
-    if (deferredFunction != nullptr && (now - startDeferredTime) > deferredTimeout)
+    for (int i=0 ; i<maxDeferredFunctions ; i++)
     {
-        deferredFunction();
-        deferredFunction = nullptr;
+        if (deferred[i].function != nullptr && (now - deferred[i].started) > deferred[i].timeout)
+        {
+            deferred[i].function();
+            deferred[i].function = nullptr;
+        }
     }
 }

--- a/src/src/rxtx_common.cpp
+++ b/src/src/rxtx_common.cpp
@@ -9,8 +9,8 @@
 #include <Wire.h>
 #endif
 
-static uint32_t startDeferredTime = 0;
-static uint32_t deferredTimeout = 0;
+static unsigned long startDeferredTime = 0;
+static unsigned long deferredTimeout = 0;
 static std::function<void()> deferredFunction = nullptr;
 
 boolean i2c_enabled = false;
@@ -69,10 +69,10 @@ void setupTargetCommon()
     setupWire();
 }
 
-void deferExecution(uint32_t ms, std::function<void()> f)
+void deferExecution(unsigned long us, std::function<void()> f)
 {
-    startDeferredTime = millis();
-    deferredTimeout = ms;
+    startDeferredTime = micros();
+    deferredTimeout = us;
     deferredFunction = f;
 }
 

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1381,9 +1381,6 @@ void setup()
     config.SetMotionMode(0); // Ensure motion detection is off
     UARTconnected();
   }
-
-  pinMode(19, OUTPUT);
-  digitalWrite(19, LOW);
 }
 
 void loop()

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -594,7 +594,7 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
   {
     // No packet will be sent due to LBT.
     // Defer TXdoneCallback() to prepare for TLM when the IRQ is normally triggered.
-    deferExecution(ExpressLRS_currAirRate_RFperfParams->TOA, []() {
+    deferExecutionMicros(ExpressLRS_currAirRate_RFperfParams->TOA, []() {
         Radio.TXdoneCallback();
     });
   }


### PR DESCRIPTION
Currently if CCA fails then txdone is immediately called.  This starts rx mode early and with a timeout, which can result in tlm packets being missed, plus link instability.

This PR delays the call to txdone and makes everything happy.

Please hold off merging this for a couple of days while I ask our 3 LBT users to test.