### PR TITLE
adds previousMean() to MeanAccumulator

### DIFF
--- a/src/lib/MeanAccumulator/MeanAccumulator.h
+++ b/src/lib/MeanAccumulator/MeanAccumulator.h
@@ -14,13 +14,18 @@ public:
     {
         if (_count)
         {
-            IncrementType retVal = _accumulator / _count;
+            _previousMean = _accumulator / _count;
             reset();
 
-            return retVal;
+            return _previousMean;
         }
         return NoValueReturn;
     }
+
+    IncrementType previousMean()
+    {
+        return _previousMean;
+    }    
 
     void reset()
     {
@@ -36,4 +41,5 @@ public:
 private:
     StorageType _accumulator;
     StorageType _count;
+    IncrementType _previousMean;
 };

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -422,7 +422,14 @@ void ICACHE_RAM_ATTR LinkStatsToOta(OTA_LinkStats_s * const ls)
 #if defined(DEBUG_FREQ_CORRECTION)
     ls->SNR = FreqCorrection * 127 / FreqCorrectionMax;
 #else
-    ls->SNR = SnrMean.mean();
+    if (SnrMean.getCount())
+    {
+        ls->SNR = SnrMean.mean();
+    }
+    else
+    {
+        ls->SNR = SnrMean.previousMean();
+    }
 #endif
 }
 


### PR DESCRIPTION
The default behavior for the MeanAccumulator is to return a fixed value when no mean is available.  For SnrMean (aka RSNR) this was set to -16, or -4 when converted and displayed in Lua or logs.  This resulted in -4 being displayed often if the link was poor e.g. low LQ.

This PR adds the previous mean value for RSNR when a mean is not available, and is a little more inline with how RSSI is reported.