### PR TITLE
WORD_PADDED was returning number of words not bytes

### DIFF
--- a/src/include/targets.h
+++ b/src/include/targets.h
@@ -11,7 +11,7 @@
 /////////////////////////
 
 #define WORD_ALIGNED_ATTR __attribute__((aligned(4)))
-#define WORD_PADDED(size) (((size)+3)/4)
+#define WORD_PADDED(size) (((size)+3) & ~3)
 
 #ifdef PLATFORM_STM32
 /* ICACHE_RAM_ATTR1 is always linked into RAM */


### PR DESCRIPTION
This is what crashes STM32 transmitters when the receiver connects, from #2339 (SPI Optimizations). Could be crashing other platforms too because **all** the uses of this macro are writing out of bounds on all platforms.

The WORD_PADDED() macro was returning the number of **words** the allocation should be, and all the uses expect it to return the number of bytes with padding.