### PR TITLE
Hide button color editors in web UI

### DIFF
--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -842,7 +842,9 @@ function updateButtons(data) {
     for (const [p, v] of Object.entries(_v['action'])) {
       appendRow(parseInt(b), parseInt(p), v);
     }
-    _(`button${parseInt(b)+1}-color-div`).style.display = 'block';
+    if (_v['color'] !== undefined) {
+      _(`button${parseInt(b)+1}-color-div`).style.display = 'block';
+    }
     _(`button${parseInt(b)+1}-color`).value = toRGB(_v['color']);
   }
   _('button1-color').oninput = changeCurrentColors;

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -312,7 +312,9 @@ static void GetConfiguration(AsyncWebServerRequest *request)
   for (int button=0 ; button<button_count ; button++)
   {
     const tx_button_color_t *buttonColor = config.GetButtonActions(button);
-    json["config"]["button-actions"][button]["color"] = buttonColor->val.color;
+    if (hardware_int(button == 0 ? HARDWARE_button_led_index : HARDWARE_button2_led_index) != -1) {
+      json["config"]["button-actions"][button]["color"] = buttonColor->val.color;
+    }
     for (int pos=0 ; pos<button_GetActionCnt() ; pos++)
     {
       json["config"]["button-actions"][button]["action"][pos]["is-long-press"] = buttonColor->val.actions[pos].pressType ? true : false;

--- a/src/python/serve_html.py
+++ b/src/python/serve_html.py
@@ -92,7 +92,7 @@ config = {
                     ]
                 },
                 {
-                    "color" : 224,
+                    #"color" : 224, # No color for you button 2
                     "action": [
                         {
                             "is-long-press": False,


### PR DESCRIPTION
If a TX does not have a button color index defined then hide the editor elements in the web UI.

The `serve_html.py` script was also changed so you can see that it works for individual buttons as well.