### PR TITLE
Add configurable mixer support(by hardware.html)

### DIFF
--- a/src/html/hardware.html
+++ b/src/html/hardware.html
@@ -293,6 +293,8 @@ td img.icon-pwm {
 					<tr><td colspan='2'><b>I2C</td></tr>
 					<tr><td></td><td>SCL pin<img class="icon-output"/></td><td><input size='3' id='i2c_scl' name='i2c_scl' type='text'/></td><td>I2C clock pin used to communicate with I2C devices</td></tr>
 					<tr><td></td><td>SDA pin<img class="icon-input"/><img class="icon-output"/></td><td><input size='3' id='i2c_sda' name='i2c_sda' type='text'/></td><td>I2C data pin used to communicate with I2C devices</td></tr>
+					<tr><td></td><td>Mixer Enable</td><td><input size='3' id='mixer_enable' name='mixer_enable' type='checkbox'/></td><td>Enable mixer on elrs</td></tr>
+					<tr><td></td><td>Mixer Config<img class="icon-pwm"/></td><td><textarea  id='mixer_cfg' name='mixer_cfg' class="json"></textarea></td><td>Mixer configuration</td></tr>
 @@end
 				</table>
 				<br>

--- a/src/html/hardware.js
+++ b/src/html/hardware.js
@@ -43,6 +43,9 @@ function submitHardwareSettings() {
   const formData = new FormData(_('upload_hardware'));
   xhr.send(JSON.stringify(Object.fromEntries(formData), function(k, v) {
     if (v === '') return undefined;
+    if(_(k) && _(k).classList.contains('json')) {
+      return JSON.parse(v);
+    }
     if (_(k) && _(k).type === 'checkbox') {
       return v === 'on';
     }
@@ -81,6 +84,8 @@ function updateHardwareSettings(data) {
     if (_(key)) {
       if (_(key).type === 'checkbox') {
         _(key).checked = value;
+      } else if(_(key).classList.contains("json")){
+        _(key).value = JSON.stringify(value);
       } else {
         if (Array.isArray(value)) _(key).value = value.toString();
         else _(key).value = value;

--- a/src/include/hardware.h
+++ b/src/include/hardware.h
@@ -140,9 +140,27 @@ typedef enum {
     HARDWARE_vtx_amp_vpd_100mW,
     HARDWARE_vtx_amp_pwm_25mW,
     HARDWARE_vtx_amp_pwm_100mW,
+    
+    // Mixer CFG
+    HARDWARE_mixer_enable,
+    HARDWARE_mixer_config,
 
     HARDWARE_LAST
 } nameType;
+
+typedef struct {
+    uint8_t channel_idx;
+    float k;
+    int16_t offset;
+}scaler_t;
+
+typedef struct {
+    uint8_t channel_idx;
+    scaler_t *scalers;
+    uint8_t scaler_cnt;
+    int16_t min;
+    int16_t max;
+}mixer_channel_t;
 
 bool hardware_init();
 const int hardware_pin(nameType name);


### PR DESCRIPTION
Hi, this pr implement a configurable  mixer, we can configure this mixer by some json in hardware.html:
![image](https://github.com/ExpressLRS/ExpressLRS/assets/9284611/4a3241dd-36c8-4b88-bfbd-d844468843b3)

motivation:
As I have only one Radio Controller, which has no screen and has no mixing function,
so each time when I make a micro plane which need mixing, I have to write hardcode in elrs to mix it, just like:

```c
                    if(ch==3){  // right
                        us = (pitch_us-roll_us)/2  + config.GetPwmChannel(ch)->val.failsafe + 988U; //1500+;
                    }else if(ch==0){ // left
                        us = (-pitch_us-roll_us)/2 + config.GetPwmChannel(ch)->val.failsafe + 988U;
```
which is a bit ugly. 
so this time, I implement this mixer, with which, we can also extend the output range of pwm(may be some servos need it)

sample mixer description:
```json
[
  {
    "channel_idx": 3,
    "min":700,
    "max":2500,
    "scalers": [
      {
        "input_chn": 1,
        "k": -0.4,
        "offset": -500
      },
      {
        "input_chn": 2,
        "k": 0.4,
        "offset": -500
      },
      {
        "input_chn": 3,
        "k": 1
      }
    ]
  },
  {
    "channel_idx": 5,
    "scalers": [
      {
        "input_chn": 1,
        "k": 0.4,
        "offset": -500
      },
      {
        "input_chn": 2,
        "k": -0.4,
        "offset": -500
      },
      {
        "input_chn": 3,
        "k": 1
      }
    ]
  }
]
```
of course, this description shoud be compress into:
```json
[{"channel_idx":3,"min":700,"max":2500,"scalers":[{"input_chn":1,"k":-0.4,"offset":-500},{"input_chn":2,"k":0.4,"offset":-500},{"input_chn":3,"k":1}]},{"channel_idx":5,"scalers":[{"input_chn":1,"k":0.4,"offset":-500},{"input_chn":2,"k":-0.4,"offset":-500},{"input_chn":3,"k":1}]}]
```
to decrease the size of hardware.json

```
the mixer output = SUM  (input val + offset) * k
```
