### PR TITLE
Fix boot-loop when no hardware definition uploaded

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1798,6 +1798,10 @@ void setup()
     hardwareConfigured = options_init();
     if (!hardwareConfigured)
     {
+        // In the failure case we set the logging to the null logger so nothing crashes
+        // if it decides to log something
+        SerialLogger = new NullStream();
+
         // Register the WiFi with the framework
         static device_affinity_t wifi_device[] = {
             {&WIFI_device, 1}

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1369,7 +1369,9 @@ void setup()
   }
   else
   {
-      TxBackpack = new NullStream();
+    // In the failure case we set the logging to the null logger so nothing crashes
+    // if it decides to log something
+    TxBackpack = new NullStream();
   }
 
 #if defined(HAS_BUTTON)

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1367,6 +1367,10 @@ void setup()
       connectionState = noCrossfire;
     }
   }
+  else
+  {
+      TxBackpack = new NullStream();
+  }
 
 #if defined(HAS_BUTTON)
   registerButtonFunction(ACTION_BIND, EnterBindingMode);


### PR DESCRIPTION
# Problem
For DIY users that upload the firmware but don't include the JSON, because they want to edit/upload it via the web UI, the TX was rebooting because the logging class was undefined and caused a null pointer panic.

# Testing
Build and upload a TX firmware, but press enter instead of selecting the JSON to upload
Before the fix, the TX reboots continuously.
After the fix, the TX boots to wifi mode and the default page is the hardware.html page.