### PR TITLE
Fix TX logging with I2C

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1232,8 +1232,8 @@ static void setupTarget()
     digitalWrite(GPIO_PIN_ANT_CTRL_COMPL, !diversityAntennaState);
   }
 
-  setupTargetCommon();
   setupSerial();
+  setupTargetCommon();
 }
 
 bool setupHardwareFromOptions()


### PR DESCRIPTION
# Problem
On a TX module that has some I2C devices e.g gyro, LM75a etc, if the firmware is built with `-DDEBUG_LOG` the module will enter a boot-loop on startup.
The issue is that `setupTargetCommon()` is called before `setupSerial()`. `setupSerial()` configures the debug logging UART or Null logger, and `setupTargetCommon()` has some debug code when the I2C bus is being initialised.

# Solution
Swap the order of the calls. This will ensure that all the serial and logging is initialised before any logging is attempted.

# Testing
Flash a TX (like the Ranger bling edition) with `-DDEBUG_LOG`
It will enter a boot-loop on startup.
Flash with this PR and it will boot as normal.