### PR TITLE
Reset LQ to 100% on packet rate cycling

### DIFF
--- a/src/lib/LQCALC/LQCALC.h
+++ b/src/lib/LQCALC/LQCALC.h
@@ -6,6 +6,11 @@ template <uint8_t N>
 class LQCALC
 {
 public:
+    LQCALC(void)
+    {
+        reset100();
+    }
+
     /* Set the bit for the current period to true and update the running LQ */
     void add()
     {

--- a/src/lib/LQCALC/LQCALC.h
+++ b/src/lib/LQCALC/LQCALC.h
@@ -6,14 +6,6 @@ template <uint8_t N>
 class LQCALC
 {
 public:
-    LQCALC(void)
-    {
-        reset();
-        // count is reset here only once on construction to start LQ counting
-        // at 100% on first connect, but 0 out of N after a failsafe
-        count = 1;
-    }
-
     /* Set the bit for the current period to true and update the running LQ */
     void add()
     {
@@ -80,12 +72,19 @@ public:
     void reset()
     {
         // count is intentonally not zeroed here to start LQ counting up from 0
-        // after a failsafe, instead of down from 100
+        // after a failsafe, instead of down from 100. Use reset100() to start from 100
         LQ = 0;
         index = 0;
         LQmask = (1 << 0);
         for (uint8_t i = 0; i < (sizeof(LQArray)/sizeof(LQArray[0])); i++)
             LQArray[i] = 0;
+    }
+
+    /* Reset and start at 100% */
+    void reset100()
+    {
+        reset();
+        count = 1;
     }
 
     /*  Return true if the current period was add()ed */

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -353,9 +353,6 @@ void SetRFLinkRate(uint8_t index, bool bindMode) // Set speed of RF link
     OtaUpdateSerializers(smWideOr8ch, ModParams->PayloadLength);
     MspReceiver.setMaxPackageIndex(ELRS_MSP_MAX_PACKAGES);
     TelemetrySender.setMaxPackageIndex(OtaIsFullRes ? ELRS8_TELEMETRY_MAX_PACKAGES : ELRS4_TELEMETRY_MAX_PACKAGES);
-    // Always start a new packet rate at 100% LQ
-    LQCalc.reset100();
-    LQCalcDVDA.reset100();
 
     // Wait for (11/10) 110% of time it takes to cycle through all freqs in FHSS table (in ms)
     cycleInterval = ((uint32_t)11U * FHSSgetChannelCount() * ModParams->FHSShopInterval * interval) / (10U * 1000U);
@@ -1507,8 +1504,8 @@ static void cycleRfMode(unsigned long now)
         LastSyncPacket = now;           // reset this variable
         SendLinkStatstoFCForcedSends = 2;
         SetRFLinkRate(scanIndex % RATE_MAX, false); // switch between rates
-        LQCalc.reset();
-        LQCalcDVDA.reset();
+        LQCalc.reset100();
+        LQCalcDVDA.reset100();
         // Display the current air rate to the user as an indicator something is happening
         scanIndex++;
         Radio.RXnb();

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -323,7 +323,7 @@ void SetRFLinkRate(uint8_t index, bool bindMode) // Set speed of RF link
 #endif
 
     hwTimer::updateInterval(interval);
-    
+
     FHSSusePrimaryFreqBand = !(ModParams->radio_type == RADIO_TYPE_LR1121_LORA_2G4);
     FHSSuseDualBand = ModParams->radio_type == RADIO_TYPE_LR1121_LORA_DUAL;
 
@@ -353,6 +353,9 @@ void SetRFLinkRate(uint8_t index, bool bindMode) // Set speed of RF link
     OtaUpdateSerializers(smWideOr8ch, ModParams->PayloadLength);
     MspReceiver.setMaxPackageIndex(ELRS_MSP_MAX_PACKAGES);
     TelemetrySender.setMaxPackageIndex(OtaIsFullRes ? ELRS8_TELEMETRY_MAX_PACKAGES : ELRS4_TELEMETRY_MAX_PACKAGES);
+    // Always start a new packet rate at 100% LQ
+    LQCalc.reset100();
+    LQCalcDVDA.reset100();
 
     // Wait for (11/10) 110% of time it takes to cycle through all freqs in FHSS table (in ms)
     cycleInterval = ((uint32_t)11U * FHSSgetChannelCount() * ModParams->FHSShopInterval * interval) / (10U * 1000U);
@@ -376,7 +379,7 @@ bool ICACHE_RAM_ATTR HandleFHSS()
 
     if (geminiMode)
     {
-        if ((((OtaNonce + 1)/ExpressLRS_currAirRate_Modparams->FHSShopInterval) % 2 == 0) || FHSSuseDualBand) // When in DualBand do not switch between radios.  The OTA modulation paramters and HighFreq/LowFreq Tx amps are set during Config. 
+        if ((((OtaNonce + 1)/ExpressLRS_currAirRate_Modparams->FHSShopInterval) % 2 == 0) || FHSSuseDualBand) // When in DualBand do not switch between radios.  The OTA modulation paramters and HighFreq/LowFreq Tx amps are set during Config.
         {
             Radio.SetFrequencyReg(FHSSgetNextFreq(), SX12XX_Radio_1);
             Radio.SetFrequencyReg(FHSSgetGeminiFreq(), SX12XX_Radio_2);

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -394,8 +394,6 @@ void SetRFLinkRate(uint8_t index) // Set speed of RF link
   OtaUpdateSerializers(newSwitchMode, ModParams->PayloadLength);
   MspSender.setMaxPackageIndex(ELRS_MSP_MAX_PACKAGES);
   TelemetryReceiver.setMaxPackageIndex(OtaIsFullRes ? ELRS8_TELEMETRY_MAX_PACKAGES : ELRS4_TELEMETRY_MAX_PACKAGES);
-  // Always start a new packet rate at 100% LQ
-  LQCalc.reset100();
 
   ExpressLRS_currAirRate_Modparams = ModParams;
   ExpressLRS_currAirRate_RFperfParams = RFperf;

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -247,7 +247,7 @@ bool ICACHE_RAM_ATTR ProcessTLMpacket(SX12xxDriverCommon::rx_status const status
         break;
     }
   }
-  
+
 #if defined(Regulatory_Domain_EU_CE_2400)
   SetClearChannelAssessmentTime();
 #endif
@@ -394,6 +394,8 @@ void SetRFLinkRate(uint8_t index) // Set speed of RF link
   OtaUpdateSerializers(newSwitchMode, ModParams->PayloadLength);
   MspSender.setMaxPackageIndex(ELRS_MSP_MAX_PACKAGES);
   TelemetryReceiver.setMaxPackageIndex(OtaIsFullRes ? ELRS8_TELEMETRY_MAX_PACKAGES : ELRS4_TELEMETRY_MAX_PACKAGES);
+  // Always start a new packet rate at 100% LQ
+  LQCalc.reset100();
 
   ExpressLRS_currAirRate_Modparams = ModParams;
   ExpressLRS_currAirRate_RFperfParams = RFperf;
@@ -625,7 +627,7 @@ void ICACHE_RAM_ATTR timerCallback()
     nonceAdvance();
     return;
   }
-  
+
   Radio.isFirstRxIrq = true;
 
   // Sync OpenTX to this point
@@ -1392,7 +1394,7 @@ void setup()
 void loop()
 {
   uint32_t now = millis();
-  
+
   Radio.ignoreSecondIRQ = false;
 
   HandleUARTout(); // Only used for non-CRSF output


### PR DESCRIPTION
Resets the LQ to 100% on any packet rate cycling on the RX. This is mainly to lower the chance of getting a "RF Signal Critical" callout in EdgeTX when unbind + binding.

Brought up in [EdgeTX #4907](https://github.com/EdgeTX/edgetx/pull/4907#issuecomment-2078823088), after a bind completes, we really should start LQ at 100% rather than starting off at the 0% caused by disconnecting. It's a brand new session at that point, right?! Because the receiver goes into rate cycling mode after bind, this can not be done in `ExitBindingMode()`.

Caveat: Because the LQ calculator starts with 0 samples, it is more sensitive to presenting low LQ if there's a problem syncing, but if there's a problem syncing, then that's a legitimate representation.