### PR TITLE
Fix PWM issue of esp8266 device when duty is 0

### DIFF
--- a/src/lib/PWM/PWM_ESP8266.cpp
+++ b/src/lib/PWM/PWM_ESP8266.cpp
@@ -46,7 +46,7 @@ void PWMController::setMicroseconds(pwm_channel_t channel, uint16_t microseconds
     if (microseconds == 0 || microseconds==refreshInterval[channel])
     {
         stopWaveform8266(pin);
-        digitalWrite(pin, microseconds == 0 ? HIGH : LOW);
+        digitalWrite(pin, microseconds == 0 ? LOW : HIGH);
         return;
     }
     startWaveform8266(pin, microseconds, refreshInterval[channel] - microseconds);


### PR DESCRIPTION
Here seems a opposite logic with implement intention, which caused the gpio set HIGH when the duty is 0.

Tested in DIY esp8266 device with Generic 2400.json with 2 pwm pins.
