### PR TITLE
I2C Baro: detect SPL06 also on alternate I2C address

### DIFF
--- a/src/lib/Baro/baro_spl06.cpp
+++ b/src/lib/Baro/baro_spl06.cpp
@@ -153,7 +153,15 @@ bool SPL06::detect()
     // Assumes Wire.begin() has already been called
     uint8_t chipid = 0;
 
+    // SPL06 can have two addresses based on the SDO pin.
+    // check primary address
     m_address = SPL06_I2C_ADDR;
+    readRegister(SPL06_CHIP_ID_REG, &chipid, sizeof(chipid));
+    if (chipid == SPL06_DEFAULT_CHIP_ID)
+        return true;
+
+    // check alternate address
+    m_address = SPL06_I2C_ADDR_ALT;
     readRegister(SPL06_CHIP_ID_REG, &chipid, sizeof(chipid));
     return chipid == SPL06_DEFAULT_CHIP_ID;
 }

--- a/src/lib/Baro/baro_spl06_regs.h
+++ b/src/lib/Baro/baro_spl06_regs.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #define SPL06_I2C_ADDR                          0x76
+#define SPL06_I2C_ADDR_ALT                      0x77
 #define SPL06_DEFAULT_CHIP_ID                   0x10
 
 #define SPL06_PRESSURE_START_REG                0x00


### PR DESCRIPTION
fixes #2688

changes:
- added check for presence of SPL06 at alternate address 0x77 if check fails at primary address 0x76 