### PR TITLE
GemX Lua RF Mode Labels

### DIFF
--- a/src/lib/LUA/rxtx_devLua.cpp
+++ b/src/lib/LUA/rxtx_devLua.cpp
@@ -7,8 +7,8 @@ const char STR_LUA_PACKETRATES[] =
 #if defined(RADIO_SX127X)
     "D50Hz(-112dBm);25Hz(-123dBm);50Hz(-120dBm);100Hz(-117dBm);100Hz Full(-112dBm);200Hz(-112dBm)";
 #elif defined(RADIO_LR1121)
-    "50Hz(-115dBm);100Hz Full(-112dBm);150Hz(-112dBm);250Hz(-108dBm);333Hz Full(-105dBm);500Hz(-105dBm);" // 2.4G
-    "50Hz(-120dBm);100Hz(-117dBm);100Hz Full(-112dBm);200Hz(-112dBm);200Hz Full(-111dBm);250Hz(-111dBm);" // 900M
+    "50Hz 2.4G;100Hz Full 2.4G;150Hz 2.4G;250Hz 2.4G;333Hz Full 2.4G;500Hz 2.4G;" // 2.4G
+    "50Hz Low Band;100Hz Low Band;100Hz Full Low Band;200Hz Low Band;200Hz Full Low Band;250Hz Low Band;" // 900M
     "X100Hz Full(-112dBm);X150Hz(-112dBm)"; // Dual
 #elif defined(RADIO_SX128X)
     "50Hz(-115dBm);100Hz Full(-112dBm);150Hz(-112dBm);250Hz(-108dBm);333Hz Full(-105dBm);500Hz(-105dBm);"


### PR DESCRIPTION
Currently there is no obvious way to identify the Sub GHz band from the 2.4GHz RF modes in Lua.  This PR replaces the sensitivity values with an identifier.  It not great to remove this info, but it is also easily found at https://www.expresslrs.org/info/signal-health/?h=sensitivity#rf-mode-indexes-rfmd

The GemX modes are identifiable with the 'X' prefix and the sensitivity values have been left.  Being new modes users will be interested to see the sensitivity values.

Im not set on these labels and open to discussion on alternatives.  Just keep in mind we need to keep them shortish,