### PR TITLE
VTX fixes 3

### DIFF
--- a/src/lib/BLE/devBLE.cpp
+++ b/src/lib/BLE/devBLE.cpp
@@ -77,7 +77,7 @@ static int timeout()
     return DURATION_NEVER;
 }
 
-static int event()
+static int event(bool timeout_expired)
 {
     if (connectionState == bleJoystick) {
         hwTimer::stop();

--- a/src/lib/BUZZER/devBuzzer.cpp
+++ b/src/lib/BUZZER/devBuzzer.cpp
@@ -88,7 +88,7 @@ static int start()
     return DURATION_NEVER;
 }
 
-static int event()
+static int event(bool timeout_expired)
 {
     if (GPIO_PIN_BUZZER == UNDEF_PIN || firmwareOptions.buzzer_mode == buzzerQuiet)
     {

--- a/src/lib/Backpack/devBackpack.cpp
+++ b/src/lib/Backpack/devBackpack.cpp
@@ -321,7 +321,7 @@ static int timeout()
     return BACKPACK_TIMEOUT;
 }
 
-static int event()
+static int event(bool timeout_expired)
 {
 #if defined(GPIO_PIN_BACKPACK_EN)
     if (OPT_USE_TX_BACKPACK && GPIO_PIN_BACKPACK_EN != UNDEF_PIN)

--- a/src/lib/DEVICE/device.cpp
+++ b/src/lib/DEVICE/device.cpp
@@ -131,7 +131,8 @@ static int _devicesUpdate(unsigned long now)
         if (uiDevices[i].core == core || core == -1) {
             if (handleEvents && uiDevices[i].device->event)
             {
-                int delay = (uiDevices[i].device->event)();
+                bool timeout_expired = now >= deviceTimeout[i];
+                int delay = (uiDevices[i].device->event)(timeout_expired);
                 if (delay != DURATION_IGNORE)
                 {
                     deviceTimeout[i] = delay == DURATION_NEVER ? 0xFFFFFFFF : now + delay;

--- a/src/lib/DEVICE/device.h
+++ b/src/lib/DEVICE/device.h
@@ -25,7 +25,7 @@ typedef struct {
      * If DURATION_IGNORE is returned, then the current timeout value kept and timeout()
      * will be called when it expires.
      */
-    int (*event)();
+    int (*event)(bool timeout_expired);
 
     /**
      * @brief The current timeout duration has expired so take appropriate action and return

--- a/src/lib/Handset/devHandset.cpp
+++ b/src/lib/Handset/devHandset.cpp
@@ -43,7 +43,7 @@ static int timeout()
     return DURATION_IMMEDIATELY;
 }
 
-static int event()
+static int event(bool timeout_expired)
 {
     // An event should be generated every time the TX power changes
     CRSF::LinkStatistics.uplink_TX_Power = powerToCrsfPower(PowerLevelContainer::currPower());

--- a/src/lib/LED/devLED.cpp
+++ b/src/lib/LED/devLED.cpp
@@ -167,7 +167,12 @@ static void setPowerLEDs()
     }
 }
 
-static int event()
+static int start(void)
+{
+    return DURATION_IMMEDIATELY;
+}
+
+static int event(bool timeout_expired)
 {
     #if defined(TARGET_RX)
         if (InBindingMode && GPIO_PIN_LED != UNDEF_PIN)
@@ -308,7 +313,7 @@ static int event()
 
 device_t LED_device = {
     .initialize = initialize,
-    .start = event,
+    .start = start,
     .event = event,
     .timeout = timeout
 };

--- a/src/lib/LED/devRGB.cpp
+++ b/src/lib/LED/devRGB.cpp
@@ -436,6 +436,11 @@ static int start()
     return DURATION_IMMEDIATELY;
 }
 
+static int event(bool timeout_expired)
+{
+    return DURATION_IMMEDIATELY;
+}
+
 static int timeout()
 {
     if (GPIO_PIN_LED_WS2812 == UNDEF_PIN)
@@ -507,7 +512,7 @@ static int timeout()
 device_t RGB_device = {
     .initialize = initialize,
     .start = start,
-    .event = timeout,
+    .event = event,
     .timeout = timeout
 };
 

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -431,7 +431,7 @@ static void registerLuaParameters()
   registerLUAParameter(nullptr);
 }
 
-static int event()
+static int event(bool timeout_expired)
 {
   setLuaTextSelectionValue(&luaSerialProtocol, config.GetSerialProtocol());
   setLuaTextSelectionValue(&luaFailsafeMode, config.GetFailsafeMode());
@@ -492,7 +492,7 @@ static int timeout()
 static int start()
 {
   registerLuaParameters();
-  event();
+  event(false);
   return DURATION_IMMEDIATELY;
 }
 

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -270,7 +270,7 @@ static struct luaItem_string luaBackpackVersion = {
 //---------------------------- BACKPACK ------------------
 
 static char luaBadGoodString[10];
-static int event();
+static int event(bool timeout_expired);
 
 extern TxConfig config;
 extern void VtxTriggerSend();
@@ -775,7 +775,7 @@ static void registerLuaParameters()
   registerLUAParameter(NULL);
 }
 
-static int event()
+static int event(bool timeout_expired)
 {
   if (connectionState > FAILURE_STATES)
   {
@@ -849,7 +849,7 @@ static int start()
   setLuaStringValue(&luaInfo, luaBadGoodString);
   luaRegisterDevicePingCallback(&luadevUpdateBadGood);
 
-  event();
+  event(false);
   return DURATION_IMMEDIATELY;
 }
 

--- a/src/lib/MSPVTX/devMSPVTX.cpp
+++ b/src/lib/MSPVTX/devMSPVTX.cpp
@@ -361,7 +361,7 @@ static void initialize()
     }
 }
 
-static int event(void)
+static int event(bool timeout_expired)
 {
     if (GPIO_PIN_SPI_VTX_NSS == UNDEF_PIN)
     {

--- a/src/lib/POWER_DETECT/devPDET.cpp
+++ b/src/lib/POWER_DETECT/devPDET.cpp
@@ -46,7 +46,7 @@ static int start()
  *
  * @return int duration in ms to call the 'timeout' function
  */
-static int event()
+static int event(bool timeout_expired)
 {
     if (GPIO_PIN_PA_PDET == UNDEF_PIN || connectionState > connectionState_e::MODE_STATES)
     {

--- a/src/lib/SCREEN/devScreen.cpp
+++ b/src/lib/SCREEN/devScreen.cpp
@@ -171,7 +171,7 @@ static int start()
     return DURATION_NEVER;
 }
 
-static int event()
+static int event(bool timeout_expired)
 {
     if (OPT_USE_OLED_I2C || OPT_USE_OLED_SPI || OPT_USE_OLED_SPI_SMALL || OPT_HAS_TFT_SCREEN)
     {

--- a/src/lib/SerialUpdate/devSerialUpdate.cpp
+++ b/src/lib/SerialUpdate/devSerialUpdate.cpp
@@ -22,7 +22,7 @@ static void initialize()
     running = true;
 }
 
-static int event()
+static int event(bool timeout_expired)
 {
     if (connectionState == serialUpdate && running)
     {

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -231,7 +231,7 @@ static int start()
     return DURATION_NEVER;
 }
 
-static int event()
+static int event(bool timeout_expired)
 {
     if (!OPT_HAS_SERVO_OUTPUT || connectionState == disconnected)
     {

--- a/src/lib/THERMAL/devThermal.cpp
+++ b/src/lib/THERMAL/devThermal.cpp
@@ -244,7 +244,7 @@ static int start()
     return DURATION_IMMEDIATELY;
 }
 
-static int event()
+static int event(bool timeout_expired)
 {
 #if defined(HAS_THERMAL)
     if (OPT_HAS_THERMAL_LM75A && GPIO_PIN_SCL != UNDEF_PIN && GPIO_PIN_SDA != UNDEF_PIN)

--- a/src/lib/VTX/devVTX.cpp
+++ b/src/lib/VTX/devVTX.cpp
@@ -101,7 +101,7 @@ static void initialize()
     registerButtonFunction(ACTION_SEND_VTX, VtxTriggerSend);
 }
 
-static int event()
+static int event(bool timeout_expired)
 {
     if (VtxSendState == VTXSS_MODIFIED ||
         (VtxSendState == VTXSS_UNKNOWN && connectionState == connected))

--- a/src/lib/VTXSPI/devVTXSPI.cpp
+++ b/src/lib/VTXSPI/devVTXSPI.cpp
@@ -47,16 +47,24 @@ pwm_channel_t rfAmpPwmChannel = -1;
 
 uint16_t vtxSPIFrequency = 6000;
 static uint16_t vtxSPIFrequencyCurrent = 6000;
+
 uint8_t vtxSPIPowerIdx = 0;
 static uint8_t vtxSPIPowerIdxCurrent = 0;
+
 uint8_t vtxSPIPitmode = 1;
 static uint8_t vtxSPIPitmodeCurrent = 1;
+
 static uint8_t RfAmpVrefState = 0;
+
 static uint16_t vtxSPIPWM = MAX_PWM;
+static uint16_t vtxPreviousSPIPWM = 0;
+
 static uint16_t vtxMinPWM = MIN_PWM;
 static uint16_t vtxMaxPWM = MAX_PWM;
+
 static uint16_t VpdSetPoint = 0;
 static uint16_t Vpd = 0;
+
 
 static bool stopVtxMonitoring = false;
 
@@ -153,6 +161,10 @@ static void RfAmpVrefOff()
 
 static void setPWM()
 {
+    if (vtxSPIPWM == vtxPreviousSPIPWM) {
+        return;
+    }
+
 #if defined(PLATFORM_ESP32_S3)
     PWM.setDuty(rfAmpPwmChannel, vtxSPIPWM * 1000 / 4096);
 #elif defined(PLATFORM_ESP32)
@@ -167,6 +179,8 @@ static void setPWM()
 #else
     analogWrite(GPIO_PIN_RF_AMP_PWM, vtxSPIPWM);
 #endif
+
+    vtxPreviousSPIPWM = vtxSPIPWM;
 }
 
 void VTxOutputMinimum()

--- a/src/lib/VTXSPI/devVTXSPI.cpp
+++ b/src/lib/VTXSPI/devVTXSPI.cpp
@@ -239,12 +239,14 @@ static uint16_t LinearInterpVpdSetPointArray(const uint16_t VpdSetPointArray[])
         {
             if (vtxSPIFrequencyCurrent < VpdFreqArray[i + 1])
             {
-                newVpd = VpdSetPointArray[i] + ((VpdSetPointArray[i + 1]-VpdSetPointArray[i])/(VpdFreqArray[i + 1]-VpdFreqArray[i])) * (vtxSPIFrequencyCurrent - VpdFreqArray[i]);
+                newVpd = VpdSetPointArray[i] +
+                    ((VpdSetPointArray[i + 1]-VpdSetPointArray[i]) / (VpdFreqArray[i + 1] - VpdFreqArray[i])) *
+                    (vtxSPIFrequencyCurrent - VpdFreqArray[i]);
             }
         }
     }
 
-    DBGLN("VTX: linearVpd, value: %d", newVpd);
+    DBGLN("VTX: linearlinearInterpVpdSetPointArray, value: %d", newVpd);
 
     return newVpd;
 }
@@ -267,10 +269,14 @@ static uint16_t LinearInterpSetPwm(const uint16_t PwmArray[])
         {
             if (vtxSPIFrequencyCurrent < VpdFreqArray[i + 1])
             {
-                newPwm = PwmArray[i] + ((PwmArray[i + 1]-PwmArray[i])/(VpdFreqArray[i + 1]-VpdFreqArray[i])) * (vtxSPIFrequencyCurrent - VpdFreqArray[i]);
+                newPwm = PwmArray[i] +
+                    ((PwmArray[i + 1] - PwmArray[i]) / (VpdFreqArray[i + 1] - VpdFreqArray[i])) *
+                    (vtxSPIFrequencyCurrent - VpdFreqArray[i]);
             }
         }
     }
+
+    DBGLN("VTX: linearInterpSetPwm, value: %d", newPwm);
 
     return newPwm;
 }
@@ -372,12 +378,12 @@ void disableVTxSpi()
 
 static void initialize()
 {
-    #if defined(TARGET_UNIFIED_RX)
+#if defined(TARGET_UNIFIED_RX)
     VpdSetPointArray25mW = VPD_VALUES_25MW;
     VpdSetPointArray100mW = VPD_VALUES_100MW;
     PwmArray25mW = PWM_VALUES_25MW;
     PwmArray100mW = PWM_VALUES_100MW;
-    #endif
+#endif
 
     if (GPIO_PIN_SPI_VTX_NSS != UNDEF_PIN)
     {

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -1202,7 +1202,7 @@ static int start()
   return firmwareOptions.wifi_auto_on_interval;
 }
 
-static int event()
+static int event(bool timeout_expired)
 {
   if (connectionState == wifiUpdate || connectionState > FAILURE_STATES)
   {

--- a/src/python/build_flags.py
+++ b/src/python/build_flags.py
@@ -36,7 +36,7 @@ def dequote(str):
     return str
 
 def process_json_flag(define):
-    parts = re.search("-D(.*)\s*=\s*(.*)$", define)
+    parts = re.search(r"-D(.*)\s*=\s*(.*)$", define)
     if parts and define.startswith("-D"):
         if parts.group(1) == "MY_BINDING_PHRASE":
             json_flags['uid'] = [x for x in hashlib.md5(define.encode()).digest()[0:6]]
@@ -45,19 +45,19 @@ def process_json_flag(define):
         if parts.group(1) == "HOME_WIFI_PASSWORD":
             json_flags['wifi-password'] = dequote(parts.group(2))
         if parts.group(1) == "AUTO_WIFI_ON_INTERVAL":
-            parts = re.search("-D(.*)\s*=\s*\"?([0-9]+).*\"?$", define)
+            parts = re.search(r"-D(.*)\s*=\s*\"?([0-9]+).*\"?$", define)
             json_flags['wifi-on-interval'] = int(dequote(parts.group(2)))
         if parts.group(1) == "TLM_REPORT_INTERVAL_MS"  and not isRX:
-            parts = re.search("-D(.*)\s*=\s*\"?([0-9]+).*\"?$", define)
+            parts = re.search(r"-D(.*)\s*=\s*\"?([0-9]+).*\"?$", define)
             json_flags['tlm-interval'] = int(dequote(parts.group(2)))
         if parts.group(1) == "FAN_MIN_RUNTIME"  and not isRX:
-            parts = re.search("-D(.*)\s*=\s*\"?([0-9]+).*\"?$", define)
+            parts = re.search(r"-D(.*)\s*=\s*\"?([0-9]+).*\"?$", define)
             json_flags['fan-runtime'] = int(dequote(parts.group(2)))
         if parts.group(1) == "RCVR_UART_BAUD" and isRX:
-            parts = re.search("-D(.*)\s*=\s*\"?([0-9]+).*\"?$", define)
+            parts = re.search(r"-D(.*)\s*=\s*\"?([0-9]+).*\"?$", define)
             json_flags['rcvr-uart-baud'] = int(dequote(parts.group(2)))
         if parts.group(1) == "USE_AIRPORT_AT_BAUD":
-            parts = re.search("-D(.*)\s*=\s*\"?([0-9]+).*\"?$", define)
+            parts = re.search(r"-D(.*)\s*=\s*\"?([0-9]+).*\"?$", define)
             json_flags['is-airport'] = True
             if isRX:
                 json_flags['rcvr-uart-baud'] = int(dequote(parts.group(2)))
@@ -81,15 +81,15 @@ def process_build_flag(define):
             parsedMelody = melodyparser.parse(define.split('"')[1::2][0])
             define = "-DMY_STARTUP_MELODY_ARR=\"" + parsedMelody + "\""
         if "HOME_WIFI_SSID=" in define:
-            parts = re.search("(.*)=\w*\"(.*)\"$", define)
+            parts = re.search(r"(.*)=\w*\"(.*)\"$", define)
             if parts and parts.group(2):
                 define = "-DHOME_WIFI_SSID=" + string_to_ascii(parts.group(2))
         if "HOME_WIFI_PASSWORD=" in define:
-            parts = re.search("(.*)=\w*\"(.*)\"$", define)
+            parts = re.search(r"(.*)=\w*\"(.*)\"$", define)
             if parts and parts.group(2):
                 define = "-DHOME_WIFI_PASSWORD=" + string_to_ascii(parts.group(2))
         if "DEVICE_NAME=" in define:
-            parts = re.search("(.*)=\w*'?\"(.*)\"'?$", define)
+            parts = re.search(r"(.*)=\w*'?\"(.*)\"'?$", define)
             if parts and parts.group(2):
                 env['DEVICE_NAME'] = parts.group(2)
         if not define in build_flags:
@@ -118,7 +118,7 @@ def condense_flags():
     global build_flags
     for line in build_flags:
         # Some lines have multiple flags so this will split them and remove them all
-        for flag in re.findall("!-D\s*[^\s]+", line):
+        for flag in re.findall(r"!-D\s*[^\s]+", line):
             build_flags = [x.replace(flag,"") for x in build_flags] # remove the removal flag
             build_flags = [x.replace(flag[1:],"") for x in build_flags] # remove the flag if it matches the removal flag
     build_flags = [x for x in build_flags if (x.strip() != "")] # remove any blank items

--- a/src/src/rx-serial/devSerialIO.cpp
+++ b/src/src/rx-serial/devSerialIO.cpp
@@ -34,7 +34,7 @@ static int start()
     return DURATION_IMMEDIATELY;
 }
 
-static int event()
+static int event(bool timeout_expired)
 {
     static connectionState_e lastConnectionState = disconnected;
     serialIO->setFailsafe(connectionState == disconnected && lastConnectionState == connected);


### PR DESCRIPTION
See individual commits.

Of note is the commit that moves the 350ms (!) VTX boot delay handling into the event timeout system which unblocks the rest of the ELRS startup code and provides a more timely power on sequence.

The event system had to be updated a little so that code could respond to an event which occurs during an existing timeout, prior to this events usually override any existing timeout value, which in the case of the VTX is NOT what you want while you're waiting for the boot delay timeout to elapse.