### PR TITLE
Once more... fix for LBT

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -666,15 +666,6 @@ void ICACHE_RAM_ATTR timerCallback()
     DynamicPower_TelemetryUpdate(DYNPOWER_UPDATE_MISSED);
   }
 
-#if defined(Regulatory_Domain_EU_CE_2400)
-  // The last period was receiving tlm, but nothing was received.
-  // No need to enter rxmode again, lets just read the latest GetRssiInst().
-  if (!(TelemetryRcvPhase == ttrpExpectingTelem && !LQCalc.currentIsSet()))
-  {
-    SetClearChannelAssessmentTime(); // Get RSSI reading here, used also for next TX if in receiveMode.
-  }
-#endif
-
   TelemetryRcvPhase = ttrpTransmitting;
 
   // Do not send a stale channels packet to the RX if one has not been received from the handset

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -248,10 +248,6 @@ bool ICACHE_RAM_ATTR ProcessTLMpacket(SX12xxDriverCommon::rx_status const status
     }
   }
 
-#if defined(Regulatory_Domain_EU_CE_2400)
-  SetClearChannelAssessmentTime();
-#endif
-
   return true;
 }
 
@@ -839,6 +835,13 @@ bool ICACHE_RAM_ATTR RXdoneISR(SX12xxDriverCommon::rx_status const status)
   }
 
   bool packetSuccessful = ProcessTLMpacket(status);
+  if (packetSuccessful)
+  {
+    TelemetryRcvPhase = ttrpTransmitting;
+#if defined(Regulatory_Domain_EU_CE_2400)
+    SetClearChannelAssessmentTime();
+#endif
+  }
   busyTransmitting = false;
   return packetSuccessful;
 }

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -826,13 +826,12 @@ bool ICACHE_RAM_ATTR RXdoneISR(SX12xxDriverCommon::rx_status const status)
   }
 
   bool packetSuccessful = ProcessTLMpacket(status);
+#if defined(Regulatory_Domain_EU_CE_2400)
   if (packetSuccessful)
   {
-    TelemetryRcvPhase = ttrpTransmitting;
-#if defined(Regulatory_Domain_EU_CE_2400)
     SetClearChannelAssessmentTime();
-#endif
   }
+#endif
   busyTransmitting = false;
   return packetSuccessful;
 }


### PR DESCRIPTION
Whilst looking for an issue with LBT at 50Hz, another issue was spotted with LBT and airport.

The first is that after receiving a valid telemetry packet, the CCA was started but the TLM mode flag was not reset which meant that when the timer comes around to start the next window, it would call the CCA function again.

The second issue is that in airport mode, after processing the airport packet it would return from the `ProcessTLMpacket` function early and therefore not start the CCA call.

To fix these issues the CCA call is moved to the `RXdoneISR` function after `ProcessTLMpacket` is called and returns `true`, which means it processed a packet. Also if the packet has been accepted and processed then set the TLM mode flag back to transmitting mode.