### PR TITLE
Update rfmodelastcycled at the end of setup()

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1886,6 +1886,10 @@ void setup()
 #endif
 
     devicesStart();
+    
+    // setup() eats up some of this time, which can cause the first mode connection to fail.
+    // Resetting the time here give the first mode a better chance of connection.
+    RFmodeLastCycled = millis();
 }
 
 void loop()


### PR DESCRIPTION
This is a particular issue for the LR1121 due to the super long reset delay that is called during setup,