### PR TITLE
SBUS: failsafe mode Last Position stops SBUS output

### DIFF
--- a/src/src/rx-serial/SerialSBUS.cpp
+++ b/src/src/rx-serial/SerialSBUS.cpp
@@ -21,7 +21,7 @@ uint32_t SerialSBUS::sendRCFrame(bool frameAvailable, bool frameMissed, uint32_t
     }
     sendPackets = true;
 
-    if ((!frameAvailable && !frameMissed) || _outputPort->availableForWrite() < 25)
+    if ((!frameAvailable && !frameMissed && !effectivelyFailsafed) || _outputPort->availableForWrite() < 25)
     {
         return DURATION_IMMEDIATELY;
     }


### PR DESCRIPTION
Problem: 

In a failsafe situation (i.e. disconnected state) the status of frameMissed and frameAvailable is false. This leads to skipping the output of SBUS frames in a failsafe situation with failsafe mode Last Position selected. 

Solution:

Extend the logic for skipping an SBUS frame to take the failsafe state in account. Now SBUS frames will be output with frozen data (last position), the failsafe bit set and at 9ms interval.