### PR TITLE
R9M TX module airport support

### DIFF
--- a/src/include/target/Frsky_TX_R9M.h
+++ b/src/include/target/Frsky_TX_R9M.h
@@ -3,6 +3,7 @@
     #define DEVICE_NAME "FrSky R9M"
 #endif
 
+#define TARGET_R9M_TX
 #define TARGET_USE_EEPROM               1
 #define TARGET_EEPROM_ADDR              0x51
 #define TARGET_EEPROM_400K


### PR DESCRIPTION
R9M TX lacked support for airport. I added the support by hijacking the TxBackpack for TxUSB used by airport. This PR also includes "mode" selection using dip switch 1 on the module: TX module will operate in normal mode when dip1 in "ON" position and airport mode is enabled when dip switch is in off or down position.