### PR TITLE
Only allow one push to a hash in artifactory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,21 +193,27 @@ jobs:
             exit 0
           fi
 
-          echo "Uploading firmware to artifactory"
-          aws s3 cp --endpoint-url $AWS_ENDPOINT_URL firmware.zip s3://expresslrs/ExpressLRS/$GITHUB_SHA/firmware.zip
+          aws s3api head-object --endpoint-url $AWS_ENDPOINT_URL --bucket expresslrs --key ExpressLRS/$GITHUB_SHA/firmware.zip > /dev/null || NOT_EXIST=true
+          if [ $NOT_EXIST ]; then
+            echo "Uploading firmware to artifactory"
+            aws s3 cp --endpoint-url $AWS_ENDPOINT_URL firmware.zip s3://expresslrs/ExpressLRS/$GITHUB_SHA/firmware.zip
 
-          echo "Generating artifact index"
-          aws s3 ls --endpoint-url $AWS_ENDPOINT_URL s3://expresslrs/ExpressLRS/ | awk '{print $2}' | sed s/\\/// > /tmp/hashes
-          echo '{' > index.json
-          echo '"branches": {' >> index.json
-          git branch --list --remotes --format '"%(refname:short)": "%(objectname)",' | grep origin/ | sed s/origin.// | grep -f /tmp/hashes | head -c-2 >> index.json
-          echo '' >> index.json
-          echo '},' >> index.json
-          echo '"tags": {' >> index.json
-          git tag --list --format '"%(refname:short)": "%(objectname)",' | grep -f /tmp/hashes | head -c-2 >> index.json
-          echo '' >> index.json
-          echo '}' >> index.json
-          echo '}' >> index.json
+            echo "Generating artifact index"
+            aws s3 ls --endpoint-url $AWS_ENDPOINT_URL s3://expresslrs/ExpressLRS/ | awk '{print $2}' | sed s/\\/// > /tmp/hashes
+            echo '{' > index.json
+            echo '"branches": {' >> index.json
+            git branch --list --remotes --format '"%(refname:short)": "%(objectname)",' | grep origin/ | sed s/origin.// | grep -f /tmp/hashes | head -c-2 >> index.json
+            echo '' >> index.json
+            echo '},' >> index.json
+            echo '"tags": {' >> index.json
+            git tag --list --format '"%(refname:short)": "%(objectname)",' | grep -f /tmp/hashes | head -c-2 >> index.json
+            echo '' >> index.json
+            echo '}' >> index.json
+            echo '}' >> index.json
 
-          echo "Uploading artifact index"
-          aws s3 cp --endpoint-url $AWS_ENDPOINT_URL index.json s3://expresslrs/ExpressLRS/index.json
+            echo "Uploading artifact index"
+            aws s3 cp --endpoint-url $AWS_ENDPOINT_URL index.json s3://expresslrs/ExpressLRS/index.json
+          else
+            echo "Not overwriting already existing artifact at $GITHUB_SHA"
+            exit 1
+          fi


### PR DESCRIPTION
This will only allow one push to our artifact for any given hash.
This should stop any inadvertent clobbering of artifacts after they have been released.

The reason for the build failure is that I reran the build so it would fail as expected.

![Screenshot 2024-05-21 at 2 24 40 PM](https://github.com/ExpressLRS/ExpressLRS/assets/512740/fe8c69ed-28ad-4684-b65f-b09fbf11e608)
