### PR TITLE
WebUI gzip reminder fix

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -142,7 +142,7 @@
 					If this happens you will need to recover via USB/Serial. You may also download the
 					<a href="firmware.bin" title="Click to download firmware">currently running firmware</a>.
 					<br/><br/>
-@@if (PLATFORM.find('8285')>0):
+@@if (PLATFORM.find('8285')>=0):
 					<div class="mui-panel" style="background-color: #fcecae;text-align:center;">Do NOT decompress/unzip/extract the firmware.bin.gz file, upload the file as it is.</div>
 					<br/>
 @@end

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -143,7 +143,7 @@
 					<a href="firmware.bin" title="Click to download firmware">currently running firmware</a>.
 					<br/><br/>
 @@if PLATFORM.find('8285'):
-					<div class="mui-panel" style="background-color: #fcecae;">Do NOT decompress/unzip/extract the firmware.bin.gz file, upload the file as it is.</div>
+					<div class="mui-panel" style="background-color: #fcecae;text-align:center;">Do NOT decompress/unzip/extract the firmware.bin.gz file, upload the file as it is.</div>
 					<br/>
 @@end
 					<button id="upload_btn" class="mui-btn mui-btn--primary upload" style="margin: 0 auto; display:block;">

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -142,7 +142,7 @@
 					If this happens you will need to recover via USB/Serial. You may also download the
 					<a href="firmware.bin" title="Click to download firmware">currently running firmware</a>.
 					<br/><br/>
-@@if PLATFORM.endswith('8285'):
+@@if PLATFORM.find('8285'):
 					<div class="mui-panel" style="background-color: #fcecae;">Do NOT decompress/unzip/extract the firmware.bin.gz file, upload the file as it is.</div>
 					<br/>
 @@end

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -142,7 +142,7 @@
 					If this happens you will need to recover via USB/Serial. You may also download the
 					<a href="firmware.bin" title="Click to download firmware">currently running firmware</a>.
 					<br/><br/>
-@@if PLATFORM.find('8285'):
+@@if (PLATFORM.find('8285')>0):
 					<div class="mui-panel" style="background-color: #fcecae;text-align:center;">Do NOT decompress/unzip/extract the firmware.bin.gz file, upload the file as it is.</div>
 					<br/>
 @@end

--- a/src/python/serve_html.py
+++ b/src/python/serve_html.py
@@ -112,6 +112,10 @@ config = {
 
 def apply_template(mainfile):
     global isTX, hasSubGHz
+    if(isTX):
+        platform = 'Unified_ESP32_2400_TX'
+    else:
+        platform = 'Unified_ESP8285_2400_RX'
     engine = Engine(
         loader=FileLoader(["html"]),
         extensions=[CoreExtension("@@")]
@@ -119,7 +123,7 @@ def apply_template(mainfile):
     template = engine.get_template(mainfile)
     data = template.render({
             'VERSION': 'testing (xxxxxx)',
-            'PLATFORM': 'Unified_ESP8285_2400_RX',
+            'PLATFORM': platform,
             'isTX': isTX,
             'hasSubGHz': hasSubGHz
         })

--- a/src/python/serve_html.py
+++ b/src/python/serve_html.py
@@ -119,7 +119,7 @@ def apply_template(mainfile):
     template = engine.get_template(mainfile)
     data = template.render({
             'VERSION': 'testing (xxxxxx)',
-            'PLATFORM': 'Unified_ESP8285',
+            'PLATFORM': 'Unified_ESP8285_2400_RX',
             'isTX': isTX,
             'hasSubGHz': hasSubGHz
         })


### PR DESCRIPTION
Maybe we have been too zealous with the previous PR for this we immediately approved it.

But endswith() will not work.

Our PLATFORM text is
Unified_ESP8285_2400_RX
so endswith('8285') will not ever work and the reminder will not ever show up (except on our mockup via serve_html.py)

Tested with an actual esp8285-based receiver, and an esp32-based receivers:
esp8285 receivers:
foxeer Lite Rx
flywoo
Happymodel EP1
RadioMaster RP3

esp32 Rx:
Happymodel ES900RX Dual
BetaFPV Super P
