### PR TITLE
Lower webui config heap allocation on ESP32

### DIFF
--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -286,7 +286,7 @@ static const char *GetConfigUidType(JsonDocument &json)
 static void GetConfiguration(AsyncWebServerRequest *request)
 {
 #if defined(PLATFORM_ESP32)
-  DynamicJsonDocument json(32768);
+  DynamicJsonDocument json(16384);
 #else
   DynamicJsonDocument json(2048);
 #endif


### PR DESCRIPTION
Reduces the JSON document size allocation used for generating both the config json and model export json from 32KB to 16KB. Resolves crashes (for me) when doing the "Save Model Configuration File" from the webui: [Discord User](https://discord.com/channels/596350022191415318/797109686285107241/1242865028839768074) and confirmed by Deadbyte and myself.

### Details 
Y'all done run the TX modules out of RAM now too? Generating the model configuration file runs out of RAM during serialization:
```cpp
  AsyncResponseStream *response = request->beginResponseStream("application/json");  // 1
  serializeJson(json, *response);  // 2 <-- crashes here
  request->send(response);  // 3
```

From my experimentation, it seems to be right on the edge.
```
1- Heap Free=38684 Contiguous=29684 Json=10576
2- 36444 27636
(crash)
```

You'd think it would fit, there's 36KB free and AsyncResponseStream only has a 1460 byte buffer, but the size that `serializeJson()` needs does seem to depend on the size of the **allocated** JsonDocument, not the used size. If I free up other RAM but keep a 32KB JsonDocument:
```
1-Heap Free=38660 Contiguous=29684 Json=10576
// RAM is freed here
2- 58600 49140 
3- 50544 23540  <-- Note that serialize took 8KB, but dropped the contiguous by 26500!
```

With a 16KB JsonDocument there's more heap free always and the serialize only takes 18432 off the largest contiguous block vs 26500 for writing the exact same data except starting with less extra space in the JsonDocument.
```
1-Heap Free=55108 Contiguous=45044 Json=10576
2-Free 52848 45044
3-Free 44792 26612
```