### PR TITLE
Fix for ESP8285 RX as TX

### DIFF
--- a/src/lib/HWTIMER/ESP8266_hwTimer.cpp
+++ b/src/lib/HWTIMER/ESP8266_hwTimer.cpp
@@ -44,7 +44,7 @@ void ICACHE_RAM_ATTR hwTimer::resume()
         // tock() should always be the first event to maintain consistency
         isTick = false;
 #if defined(TARGET_TX)
-        NextTimeout = HWtimerInterval;
+        NextTimeout = ESP.getCycleCount() + HWtimerInterval;
 #else
         // Fire the timer in 2us to get it started close to now
         NextTimeout = ESP.getCycleCount() + (2 * HWTIMER_TICKS_PER_US * HWTIMER_PRESCALER);


### PR DESCRIPTION
As part of the cleanup of the timer code to make things consistent, I forgot to add `ESP.getCycleCount()` which sets the timer to trigger in the future! Without this the trigger time was in the past and the timer would have to loop and overflow back to 0.

Tested using DIY ESP8285 RX as TX connected to a jumper T20 internally, started the handset, started the RX then rebooted the handset and when the LED on the "RX as TX" came on and flashed a couple of times then connected to the RX. So maybe 2-3 seconds after powering on the handset.

fixes #2686 

Thanks for finding this @CapnBry 