### PR TITLE
Upgrade JSON library

### DIFF
--- a/src/lib/OPTIONS/hardware.cpp
+++ b/src/lib/OPTIONS/hardware.cpp
@@ -221,7 +221,7 @@ bool hardware_init(EspFlashStream &strmFlash)
     builtinHardwareConfig.clear();
 
     Stream *strmSrc;
-    DynamicJsonDocument doc(2048);
+    JsonDocument doc;
     File file = SPIFFS.open("/hardware.json", "r");
     if (!file || file.isDirectory()) {
         constexpr size_t hardwareConfigOffset = ELRSOPTS_PRODUCTNAME_SIZE + ELRSOPTS_DEVICENAME_SIZE + ELRSOPTS_OPTIONS_SIZE;

--- a/src/lib/OPTIONS/options.cpp
+++ b/src/lib/OPTIONS/options.cpp
@@ -207,7 +207,7 @@ String& getOptions()
 
 void saveOptions(Stream &stream, bool customised)
 {
-    DynamicJsonDocument doc(1024);
+    JsonDocument doc;
 
     if (firmwareOptions.wifi_auto_on_interval != -1)
     {
@@ -264,8 +264,8 @@ bool options_HasStringInFlash(EspFlashStream &strmFlash)
  */
 static void options_LoadFromFlashOrFile(EspFlashStream &strmFlash)
 {
-    DynamicJsonDocument flashDoc(1024);
-    DynamicJsonDocument spiffsDoc(1024);
+    JsonDocument flashDoc;
+    JsonDocument spiffsDoc;
     bool hasFlash = false;
     bool hasSpiffs = false;
 
@@ -293,7 +293,7 @@ static void options_LoadFromFlashOrFile(EspFlashStream &strmFlash)
         }
     }
 
-    DynamicJsonDocument &doc = flashDoc;
+    JsonDocument &doc = flashDoc;
     if (hasFlash && hasSpiffs)
     {
         if (flashDoc["flash-discriminator"] == spiffsDoc["flash-discriminator"])
@@ -352,7 +352,7 @@ static void options_LoadFromFlashOrFile(EspFlashStream &strmFlash)
 */
 void options_SetTrueDefaults()
 {
-    DynamicJsonDocument doc(128);
+    JsonDocument doc;
     // The Regulatory Domain is retained, as there is no sensible default
     doc["domain"] = firmwareOptions.domain;
     doc["flash-discriminator"] = firmwareOptions.flash_discriminator;

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -263,7 +263,7 @@ static void UpdateSettings(AsyncWebServerRequest *request, JsonVariant &json)
   request->send(200);
 }
 
-static const char *GetConfigUidType(const JsonObject &json)
+static const char *GetConfigUidType(const JsonObject json)
 {
 #if defined(TARGET_RX)
   if (config.GetVolatileBind())
@@ -287,7 +287,7 @@ static void GetConfiguration(AsyncWebServerRequest *request)
 {
   bool exportMode = request->hasArg("export");
   AsyncJsonResponse *response = new AsyncJsonResponse();
-  const JsonObject& json = response->getRoot();
+  JsonObject json = response->getRoot();
 
   if (!exportMode)
   {
@@ -337,7 +337,7 @@ static void GetConfiguration(AsyncWebServerRequest *request)
     {
       const model_config_t &modelConfig = config.GetModelConfig(model);
       String strModel(model);
-      const JsonObject &modelJson = json["config"]["model"][strModel].to<JsonObject>();
+      JsonObject modelJson = json["config"]["model"][strModel].to<JsonObject>();
       modelJson["packet-rate"] = modelConfig.rate;
       modelJson["telemetry-ratio"] = modelConfig.tlm;
       modelJson["switch-mode"] = modelConfig.switchMode;
@@ -442,8 +442,8 @@ static void ImportConfiguration(AsyncWebServerRequest *request, JsonVariant &jso
   {
     for(JsonPair kv : json["model"].as<JsonObject>())
     {
-      uint8_t model = String(kv.key().c_str()).toInt();
-      const JsonObject &modelJson = kv.value();
+      uint8_t model = atoi(kv.key().c_str());
+      JsonObject modelJson = kv.value();
 
       config.SetModelId(model);
       if (modelJson.containsKey("packet-rate")) config.SetRate(modelJson["packet-rate"]);

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -59,7 +59,7 @@ lib_deps =
 	esphome/AsyncTCP-esphome @ 2.0.1 # use specific version - an update to this library breaks the build
 	lemmingdev/ESP32-BLE-Gamepad @ 0.5.2
 	h2zero/NimBLE-Arduino @ 1.4.1
-	bblanchon/ArduinoJson @ 6.19.4
+	bblanchon/ArduinoJson @ 7.0.4
 oled_lib_deps =
 	${env_common_esp32.lib_deps}
 	olikraus/U8g2 @ 2.34.4
@@ -98,7 +98,7 @@ build_src_filter = ${common_env_data.build_src_filter} -<ESP8266*.*> -<STM32*.*>
 lib_deps =
 	ottowinter/ESPAsyncWebServer-esphome @ 3.0.0
 	esphome/AsyncTCP-esphome @ 2.0.1 # use specific version - an update to this library breaks the build
-	bblanchon/ArduinoJson @ 6.19.4
+	bblanchon/ArduinoJson @ 7.0.4
 
 [env_common_esp32s3rx]
 platform = espressif32@6.4.0
@@ -139,7 +139,7 @@ extra_scripts =
 lib_deps =
 	makuna/NeoPixelBus @ 2.7.0
 	ottowinter/ESPAsyncWebServer-esphome @ 3.0.0
-	bblanchon/ArduinoJson @ 6.19.4
+	bblanchon/ArduinoJson @ 7.0.4
 upload_speed = 460800
 monitor_speed = 420000
 monitor_filters = esp8266_exception_decoder


### PR DESCRIPTION
Upgrading the JSON library and changing the way we use the JSON library for the large config export fixes the problem seen and worked around in #2727.

I doo NOT think we should backport this as it requires an upgrade to the library to fix the issue. I tried the fix in the `GetConfiguration` function without the upgrade, but the JSON document was cut short.