### PR TITLE
VTXAdmin PitMode On using YAW channel to trigger

### DIFF
--- a/src/lib/VTX/devVTX.cpp
+++ b/src/lib/VTX/devVTX.cpp
@@ -38,18 +38,19 @@ void VtxTriggerSend()
 
 void VtxPitmodeSwitchUpdate()
 {
-    if (config.GetVtxPitmode() == PITMODE_OFF)
+    if (config.GetVtxPitmode() <= PITMODE_ON)
     {
+        pitmodeAuxState = config.GetVtxPitmode();
         return;
     }
 
     uint8_t auxInverted = config.GetVtxPitmode() % 2;
     uint8_t auxNumber = (config.GetVtxPitmode() / 2) + 3;
-    uint8_t currentPitmodeAuxState = CRSF_to_BIT(ChannelData[auxNumber]) ^ auxInverted;
+    uint8_t newPitmodeAuxState = CRSF_to_BIT(ChannelData[auxNumber]) ^ auxInverted;
 
-    if (pitmodeAuxState != currentPitmodeAuxState)
+    if (pitmodeAuxState != newPitmodeAuxState)
     {
-        pitmodeAuxState = currentPitmodeAuxState;
+        pitmodeAuxState = newPitmodeAuxState;
         sendEepromWrite = false;
         VtxTriggerSend();
     }
@@ -73,19 +74,12 @@ static void VtxConfigToMSPOut()
     packet.reset();
     packet.makeCommand();
     packet.function = MSP_SET_VTX_CONFIG;
-    packet.addByte(vtxIdx);
-    packet.addByte(0);
-    if (config.GetVtxPower()) {
+    packet.addByte(vtxIdx);     // band/channel or frequency low byte
+    packet.addByte(0);          // frequency high byte, if frequency mode
+    if (config.GetVtxPower())
+    {
         packet.addByte(config.GetVtxPower());
-
-        if (config.GetVtxPitmode() == PITMODE_OFF || config.GetVtxPitmode() == PITMODE_ON)
-        {
-            packet.addByte(config.GetVtxPitmode());
-        }
-        else
-        {
-            packet.addByte(pitmodeAuxState);
-        }
+        packet.addByte(pitmodeAuxState);
     }
 
     CRSF::AddMspMessage(&packet, CRSF_ADDRESS_FLIGHT_CONTROLLER);


### PR DESCRIPTION
If VTX Admim has PitMode set to ON, the YAW channel is being used to trigger it on and off. The issue is just this code, where only `PITMODE_OFF` is considered to not be "Pit mode on a switch", so `PITMODE_ON` is interpreted as "pit mode on channel 4"
```patch
-    if (config.GetVtxPitmode() == PITMODE_OFF)
+    if (config.GetVtxPitmode() <= PITMODE_ON)
```

I also added comments for what the bytes being added are, and combined the code for checking PITMODE_OFF/PITMODE_ON into one place instead of having two if statements in different places.

### Testing
* To reproduce bug (on any ELRS version since VTX Admin was added): Enable VTX Admin e.g. Band=R Channel=1 Power=1 (**must be set**!) PitMode=ON. Send VTX. Hold Yaw stick (or ch4, whatever you have on that) left, hold Yaw stick right Pit mode will be turning on and off