### PR TITLE
Prevent immediate leaving bind mode if initrate change pending

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1609,7 +1609,13 @@ static void updateBindingMode()
         DBGLN("Connected request to enter binding mode...");
         BindingModeRequest = false;
         if (connectionState == connected)
+        {
             LostConnection(false);
+            // if the InitRate config item was changed by LostConnection
+            // save the config before entering bind, as the modified config
+            // will immediately boot it out of bind mode
+            config.Commit();
+        }
         EnterBindingMode();
     }
 }
@@ -1886,7 +1892,7 @@ void setup()
 #endif
 
     devicesStart();
-    
+
     // setup() eats up some of this time, which can cause the first mode connection to fail.
     // Resetting the time here give the first mode a better chance of connection.
     RFmodeLastCycled = millis();


### PR DESCRIPTION
Symptom: Using "Enter Bind Mode" on a connected RX immediately exits bind mode.
Problem: If there is an InitRate config change pending on disconnect, entering bind mode has a modified config which is the signal that bind has completed so the receiver enters bind mode then immediately leaves it. This forces a config commit before entering bind mode if the receiver is connected allowing the normal config modified binding exit condition.

Mentioned in #2744 I think this should be backported as a bug fix because it is pretty baffling why "Enter Bind Mode" seems to just fail the first time you press it.