### PR TITLE
Fake progress time increase to 10s for ESP8285

### DIFF
--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -511,7 +511,11 @@ function completeHandler(event) {
     // This is basically a delayed display of the success dialog with a fake progress
     let percent = 0;
     const interval = setInterval(()=>{
+@@if (PLATFORM.find('8285')>=0):
+      percent = percent + 1;
+@@else:
       percent = percent + 2;
+@@end 
       _('progressBar').value = percent;
       _('status').innerHTML = percent + '% flashed... please wait';
       if (percent === 100) {

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -1,4 +1,4 @@
-@@require(isTX)
+@@require(PLATFORM, isTX)
 
 /* eslint-disable comma-dangle */
 /* eslint-disable max-len */


### PR DESCRIPTION
For the ESP8285 WebUI firmware update, for the gzipped firmware file, the current 5s fake progress time (after WiFi upload, waiting for the unit to reboot) is not enough.

This PR extends the fake progress time from 5s to 10s.

I tested that an 8285 unit reboot is complete in about 9s point.