### PR TITLE
Fix config being corrupted on 8285 receivers

### DIFF
--- a/src/lib/CONFIG/config.h
+++ b/src/lib/CONFIG/config.h
@@ -233,7 +233,11 @@ public:
     // Getters
     bool     GetIsBound() const;
     const uint8_t* GetUID() const { return m_config.uid; }
+#if defined(PLATFORM_ESP8266)
+    uint8_t  GetPowerOnCounter() const;
+#else
     uint8_t  GetPowerOnCounter() const { return m_config.powerOnCounter; }
+#endif
     uint8_t  GetModelId() const { return m_config.modelId; }
     uint8_t GetPower() const { return m_config.power; }
     uint8_t GetAntennaMode() const { return m_config.antennaMode; }

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1587,7 +1587,7 @@ static void updateBindingMode()
     }
 
     // If the power on counter is >=3, enter binding, the counter will be reset after 2s
-    else if (config.GetPowerOnCounter() >= 3)
+    else if (!InBindingMode && config.GetPowerOnCounter() >= 3)
     {
 #if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
         // Never enter wifi if forced to binding mode


### PR DESCRIPTION
When plugging in a battery, the receiver will increment the power-on-counter, this will force an erase/write cycle on the config flash page. The can take approximately 70ms. If the power is removed or dips out during this phase the entire config will be lost!

During startup the only thing changed is the power-on-counter, so this PR moves the power-on-counter out of the config sector and creates a new sector before that specifically designed for the power-on-count, so the config should never be clobbered.

This new implementation uses the fact that an erased sector is all 0xFF and for each power cycle it writes 0x00 to the next free position in the sector, which can be done by just writing as setting bits to 0 only requires a write operation which is much faster than an erase/write cycle. The actual count is the number of 0x00 bytes in the sector.
Doing it this way means that the sector does not need to be erased each power cycle. It is only erased after the power-on-count timer expires, i.e. after 2 seconds of the receiver being powered on or the first connection, whichever is first.
