### PR TITLE
Extend HoTT TLM sensor search discovery period

### DIFF
--- a/src/src/rx-serial/SerialHoTT_TLM.cpp
+++ b/src/src/rx-serial/SerialHoTT_TLM.cpp
@@ -3,6 +3,7 @@
 #include "SerialHoTT_TLM.h"
 #include "FIFO.h"
 #include "telemetry.h"
+#include "common.h"
 
 #define NOT_FOUND 0xff          // no device found indicator
 
@@ -12,7 +13,7 @@
 #define HOTT_CMD_DELAY 1        // 1 ms delay between CMD byte 1 and 2
 #define HOTT_WAIT_TX_COMPLETE 2 // 2 ms wait for CMD bytes transmission complete
 
-#define DISCOVERY_TIMEOUT 40000 // 40s device discovery time
+#define DISCOVERY_TIMEOUT 30000 // 30s device discovery time
 
 #define VARIO_MIN_CRSFRATE 1000 // CRSF telemetry packets will be sent if
 #define GPS_MIN_CRSFRATE 5000   // min rate timers in [ms] have expired
@@ -82,6 +83,12 @@ void SerialHoTT_TLM::processBytes(uint8_t *bytes, u_int16_t size)
 void SerialHoTT_TLM::sendQueuedData(uint32_t maxBytesToSend)
 {
     uint32_t now = millis();
+
+    if(connectionState != connected)
+    {
+        // suspend device discovery timer until receiver is connected
+        discoveryTimerStart = now;      
+    }
 
     // device discovery timer
     if (discoveryMode && (now - discoveryTimerStart >= DISCOVERY_TIMEOUT))

--- a/src/src/rx-serial/SerialHoTT_TLM.cpp
+++ b/src/src/rx-serial/SerialHoTT_TLM.cpp
@@ -12,7 +12,7 @@
 #define HOTT_CMD_DELAY 1        // 1 ms delay between CMD byte 1 and 2
 #define HOTT_WAIT_TX_COMPLETE 2 // 2 ms wait for CMD bytes transmission complete
 
-#define DISCOVERY_TIMEOUT 30000 // 30s device discovery time
+#define DISCOVERY_TIMEOUT 40000 // 40s device discovery time
 
 #define VARIO_MIN_CRSFRATE 1000 // CRSF telemetry packets will be sent if
 #define GPS_MIN_CRSFRATE 5000   // min rate timers in [ms] have expired


### PR DESCRIPTION
Problem:

More users, more devices used. A user reported a popular 3rd party HoTT telemetry device (ESC) not being detected under certain circumstances. Measurement revealed this device starts responding to bus master queries only after it receives a valid throttle signal (receiver connected, PWM outputs active). Furthermore this device only starts responding to busmaster requests 5s after it received the valid throttle signal most likely due to internal setup and and check routines. This combined with a worst case receiver connection time of 27 seconds (init rate not set to packet rate) pushed this device outside the 30s detection window.

Solution:

Start the device discovery timeout timer after the receiver is connected. This will ensure all devices including devices requiring valid PWM inputs will be have a minimum 30s detection window. 

Detailed analysis:

The trace shows the sequence of events at receiver power on. After receiver application start (marker 1) the device discovery starts (channel 0). 2.7s later (marker 2) the radio and receiver connect, PWM outputs start (trace 2). This is where the ESC starts receiving valid throttle signals. 5s later (marker 2) the ESC starts responding to the bus master requests.

![image](https://github.com/ExpressLRS/ExpressLRS/assets/5615068/f34eb05d-1dd9-4627-b6ef-d3690c23f1a8)

The worst case scenario will be the maximum possible receiver connection time due to a mismatch between receiver init rate and selected packet rate, e.g. set the packet rate to 100Hz, force init rate to be 100Hz too by turning of the radio while connected and the select 333Hz packet rate without adjusting init rate. The receiver connection time will now be 27s leaving only 3s of device discovery time for the ESC which -  adding the 5s delay until the device will listen to busmaster requests - will lead to the device no being registered.

![image](https://github.com/ExpressLRS/ExpressLRS/assets/5615068/cc7077b2-f0b3-4905-8d92-59a34283b4eb)

The solution starting the device discovery timeout timer at the instance of the receiver and radio connection ensures a minimum of 30s discovery time for all devices including ones relying on valid PWM inputs regardless of receiver connection timing.

![image](https://github.com/ExpressLRS/ExpressLRS/assets/5615068/8bcc3143-1660-452b-a84b-778caaa34738)

![image](https://github.com/ExpressLRS/ExpressLRS/assets/5615068/817f17f8-109c-4e99-b6f8-73e03b0af781)