### PR TITLE
Servo stretch feature for wider range servo PWM pulses

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -197,13 +197,19 @@
 							</ul>
 							<li><b>Input:</b> Input channel from the handset</li>
 							<li><b>Invert:</b> Invert input channel position</li>
-							<li><b>750us:</b> Use half pulse width (494-1006us) with center 750us instead of 988-2012us</li>
+							<li><b>Pulse Span:</b> (only affects servo pulses)
+								<ul>
+									<li>Normal: Pulse width 988us-2012us using normal CRSF limits</li>
+									<li>Half: Use half pulse width (494-1006us) with center 750us instead of 988-2012us</li>
+									<li>Stretched: Pulse width 476us-2524us using normal CRSF limits, for wide range servos</li>
+								</ul>
+							</li>
 							<li><b>Failsafe</b>
 								<ul>
 									<li>"Set Position" sets the servo to an absolute "Failsafe Pos"
 										<ul>
 											<li>Does not use "Invert" flag</li>
-											<li>Value will be halved if "750us" flag is set</li>
+											<li>Value will respect the "Pulse Span" attribute</li>
 											<li>Will be converted to binary for "On/Off" mode (>1500us = HIGH)</li>
 										</ul>
 									</li>

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -199,6 +199,13 @@ enum eServoOutputFailsafeMode : uint8_t
     PWMFAILSAFE_LAST_POSITION, // continue to pulse last used value
 };
 
+enum eServoOutputPulseSpan : uint8_t
+{
+    PWMPULSESPAN_NORMAL,       // normal range for pulse width
+    PWMPULSESPAN_HALF,         // half the width, 750us center, 494-1006us range
+    PWMPULSESPAN_STRETCHED,    // 500us to 2500us for wide ranged servos
+};
+
 enum eSerialProtocol : uint8_t
 {
     PROTOCOL_CRSF,

--- a/src/lib/CONFIG/config.cpp
+++ b/src/lib/CONFIG/config.cpp
@@ -1053,7 +1053,7 @@ RxConfig::SetStorageProvider(ELRS_EEPROM *eeprom)
 
 #if defined(GPIO_PIN_PWM_OUTPUTS)
 void
-RxConfig::SetPwmChannel(uint8_t ch, uint16_t failsafe, uint8_t inputCh, bool inverted, uint8_t mode, bool narrow)
+RxConfig::SetPwmChannel(uint8_t ch, uint16_t failsafe, uint8_t inputCh, bool inverted, uint8_t mode, uint8_t pulsespan)
 {
     if (ch > PWM_MAX_CHANNELS)
         return;
@@ -1064,7 +1064,7 @@ RxConfig::SetPwmChannel(uint8_t ch, uint16_t failsafe, uint8_t inputCh, bool inv
     newConfig.val.inputChannel = inputCh;
     newConfig.val.inverted = inverted;
     newConfig.val.mode = mode;
-    newConfig.val.narrow = narrow;
+    newConfig.val.pulsespan = pulsespan;
     if (pwm->raw == newConfig.raw)
         return;
 

--- a/src/lib/CONFIG/config.h
+++ b/src/lib/CONFIG/config.h
@@ -189,9 +189,10 @@ typedef union {
                  inputChannel:4, // 0-based input channel
                  inverted:1,     // invert channel output
                  mode:4,         // Output mode (eServoOutputMode)
-                 narrow:1,       // Narrow output mode (half pulse width)
+                 narrow:1,       // Narrow output mode (half pulse width). DEPRECATED, replaced with pulsespan
                  failsafeMode:2, // failsafe output mode (eServoOutputFailsafeMode)
-                 unused:10;      // FUTURE: When someone complains "everyone" uses inverted polarity PWM or something :/
+                 pulsespan:2,    // normal, narrow, or stretched (eServoOutputPulseSpan)
+                 unused:8;       // FUTURE: When someone complains "everyone" uses inverted polarity PWM or something :/
     } val;
     uint32_t raw;
 } rx_config_pwm_t;
@@ -261,7 +262,7 @@ public:
     void SetDefaults(bool commit);
     void SetStorageProvider(ELRS_EEPROM *eeprom);
     #if defined(GPIO_PIN_PWM_OUTPUTS)
-    void SetPwmChannel(uint8_t ch, uint16_t failsafe, uint8_t inputCh, bool inverted, uint8_t mode, bool narrow);
+    void SetPwmChannel(uint8_t ch, uint16_t failsafe, uint8_t inputCh, bool inverted, uint8_t mode, uint8_t pulsespan);
     void SetPwmChannelRaw(uint8_t ch, uint32_t raw);
     #endif
     void SetForceTlmOff(bool forceTlmOff);

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -76,7 +76,13 @@ static void servoWrite(uint8_t ch, uint16_t us)
         }
         else
         {
-            PWM.setMicroseconds(pwmChannels[ch], us / (chConfig->val.narrow + 1));
+            if (chConfig->val.pulsespan == PWMPULSESPAN_HALF || chConfig->val.narrow) {
+                us /= 2;
+            }
+            else if (chConfig->val.pulsespan == PWMPULSESPAN_STRETCHED) {
+                us = fmap(us, 1000, 2000, 500, 2500);
+            }
+            PWM.setMicroseconds(pwmChannels[ch], us);
         }
     }
 }


### PR DESCRIPTION
There are some servos that require PWM pulses about 500us to 2500us to get their full range of motion

There are some people who purchase "servo stretcher" devices to translate pulses from 1000-2000us to 500-2500us just to use these servos. However, this obviously costs money, space, and weight. So why not just add this feature to ELRS?!

Previously, there was a "narrow" flag for the pulses that made them half as long. My code addition converts this to both a "half" mode and a "stretched" mode. The checkbox in the web-ui has changed into a drop-down.

I have tested this and observed the signals on a logic analyzer to confirm the pulse widths. I have also checked that loading and saving from the web-ui works as expected.