### PR TITLE
Fire TXdone when TLM forced off too

### DIFF
--- a/src/lib/LBT/LBT.cpp
+++ b/src/lib/LBT/LBT.cpp
@@ -112,6 +112,9 @@ void ICACHE_RAM_ATTR SetClearChannelAssessmentTime(void)
 
 SX12XX_Radio_Number_t ICACHE_RAM_ATTR ChannelIsClear(SX12XX_Radio_Number_t radioNumber)
 {
+  if (radioNumber == SX12XX_Radio_NONE)
+    return SX12XX_Radio_NONE;
+
   LBTSuccessCalc.inc(); // Increment count for every channel check
 
   if (!LBTEnabled)
@@ -161,7 +164,7 @@ SX12XX_Radio_Number_t ICACHE_RAM_ATTR ChannelIsClear(SX12XX_Radio_Number_t radio
       clearChannelsMask |= SX12XX_Radio_2;
     }
   }
-  
+
   // Useful to debug if and how long the rssi wait is, and rssi threshold rssiCutOff
   // DBGLN("wait: %d, cutoff: %d, rssi: %d %d, %s", validRSSIdelayUs - elapsed, rssiCutOff, rssiInst1, rssiInst2, clearChannelsMask ? "clear" : "in use");
 

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -590,9 +590,7 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
   {
     // No packet will be sent due to LBT.
     // Defer TXdoneCallback() to prepare for TLM when the IRQ is normally triggered.
-    deferExecutionMicros(ExpressLRS_currAirRate_RFperfParams->TOA, []() {
-        Radio.TXdoneCallback();
-    });
+    deferExecutionMicros(ExpressLRS_currAirRate_RFperfParams->TOA, Radio.TXdoneCallback);
   }
   else
 #endif


### PR DESCRIPTION
This extends #2768 to also take into account "Force telemetry off" being on. The TXdone ISR behavior should be consistent across all reasons telemetry will not be sent.

This also modified the LBT Clear Channel Assessment to not run if the requested radio is NONE. In the case of "Force Telemetry Off", the CCA would run and modify the `LBTSuccessCalc`, however no transmission is going to occur. On the TX side, this is used to alter the RX's reported LQ to account for LBT not transmitting, but on the RX this is not used currently so it is largely academic. At some point the RX might try to use this value for a calculation so we should make sure this number stays accurate.

I was tracking this problem for several days from a completely different angle and had no idea that Jye had already seen the issue breaking in a different way. I saw #2768, saw "LBT" and immediately discounted it because I do not have LBT enabled 😅.