### PR TITLE
clear all form data before updating hardware setting

### DIFF
--- a/src/html/hardware.js
+++ b/src/html/hardware.js
@@ -99,6 +99,7 @@ function fileDragHover(e) {
 function fileSelectHandler(e) {
   fileDragHover(e);
   const files = e.target.files || e.dataTransfer.files;
+  _('upload_hardware').reset();
   for (const f of files) {
     parseFile(f);
   }


### PR DESCRIPTION
For now, if we upload a new pin.json file, it will not clear the old form data in html.

which would cause pin config leaving over conflict to new pin setting.