### PR TITLE
Avoid potential divide by zero in LBT dynamic power

### DIFF
--- a/src/src/dynpower.cpp
+++ b/src/src/dynpower.cpp
@@ -127,8 +127,9 @@ void DynamicPower_Update(uint32_t now)
   // It should be useful for bando or sudden lost of LoS cases.
   uint32_t lq_current = CRSF::LinkStatistics.uplink_Link_quality;
 #if defined(Regulatory_Domain_EU_CE_2400)
-  // make adjustment for packets not sent because the channel was not clear
-  lq_current = lq_current * 100 / LBTSuccessCalc.getLQ();
+  // Scale up receiver LQ for packets not sent because the channel was not clear
+  // the calculation could exceed 100% during a rate change or initial connect when the LQs are not synced
+  lq_current = std::min(lq_current * 100 / std::max((uint32_t)LBTSuccessCalc.getLQ(), (uint32_t)1U), (uint32_t)100U);
 #endif
   uint32_t lq_avg = dynpower_mavg_lq;
   int32_t lq_diff = lq_avg - lq_current;


### PR DESCRIPTION
There is a rare chance that LBT could cause a divide-by-zero in dynamic power if all 100 of the last transmits were not performed due to congestion. The calculated receiver LQ will now be 100%, as that's what the value would be approaching as `LBTSuccessCalc` approached 0.

There's almost no chance of this ever happening to anyone so this is largely a non-issue.
