### PR TITLE
Don't keep the binding phrase as a compile parameter

### DIFF
--- a/src/python/build_flags.py
+++ b/src/python/build_flags.py
@@ -71,7 +71,6 @@ def process_json_flag(define):
 def process_build_flag(define):
     if define.startswith("-D") or define.startswith("!-D"):
         if "MY_BINDING_PHRASE" in define:
-            build_flags.append(define)
             bindingPhraseHash = hashlib.md5(define.encode()).digest()
             UIDbytes = ",".join(list(map(str, bindingPhraseHash))[0:6])
             define = "-DMY_UID=" + UIDbytes


### PR DESCRIPTION
Building from PR's, git commits, or local checkouts fails if the user has "special" characters in their bind-phrase, line `&` or `;` or others that the shell interprets.

Rather then trying to escape the myriad of characters I opted to just remove the define from the compile as the value is not  used because it is just translated into the UID by the `build_flags.py` script anyway.