### PR TITLE
bug: increase ESP8266 hwTimer::resume buffer

### DIFF
--- a/src/lib/HWTIMER/ESP32_hwTimer.cpp
+++ b/src/lib/HWTIMER/ESP32_hwTimer.cpp
@@ -60,7 +60,7 @@ void ICACHE_RAM_ATTR hwTimer::resume()
         // When using EDGE triggered timer, enabling the timer causes an edge so the interrupt
         // is fired immediately, so this emulates the STM32 behaviour
         // Unlike the 8266 timer, the ESP32 timer can be started without delay.
-        // It does not interrupt the currnelty running IsrCallback(), but triggers immediatly once it has completed.
+        // It does not interrupt the currently running IsrCallback(), but triggers immediately once it has completed.
         timerAlarmWrite(timer, 0 * HWTIMER_TICKS_PER_US, true);
 #endif
         running = true;

--- a/src/lib/HWTIMER/ESP32_hwTimer.cpp
+++ b/src/lib/HWTIMER/ESP32_hwTimer.cpp
@@ -49,8 +49,8 @@ void ICACHE_RAM_ATTR hwTimer::resume()
 {
     if (timer && !running)
     {
-        running = true;
-
+        // The timer must be restarted so that the new timerAlarmWrite() period is set.
+        timerRestart(timer);
 #if defined(TARGET_TX)
         timerAlarmWrite(timer, HWtimerInterval, true);
 #else
@@ -59,8 +59,11 @@ void ICACHE_RAM_ATTR hwTimer::resume()
         isTick = false;
         // When using EDGE triggered timer, enabling the timer causes an edge so the interrupt
         // is fired immediately, so this emulates the STM32 behaviour
-        timerAlarmWrite(timer, HWtimerInterval >> 1, true);
+        // Unlike the 8266 timer, the ESP32 timer can be started without delay.
+        // It does not interrupt the currnelty running IsrCallback(), but triggers immediatly once it has completed.
+        timerAlarmWrite(timer, 0 * HWTIMER_TICKS_PER_US, true);
 #endif
+        running = true;
         timerAlarmEnable(timer);
         DBGLN("hwTimer resume");
     }

--- a/src/lib/HWTIMER/ESP8266_hwTimer.cpp
+++ b/src/lib/HWTIMER/ESP8266_hwTimer.cpp
@@ -46,8 +46,10 @@ void ICACHE_RAM_ATTR hwTimer::resume()
 #if defined(TARGET_TX)
         NextTimeout = ESP.getCycleCount() + HWtimerInterval;
 #else
-        // Fire the timer in 2us to get it started close to now
-        NextTimeout = ESP.getCycleCount() + (2 * HWTIMER_TICKS_PER_US * HWTIMER_PRESCALER);
+        // Fire the timer in 20us to get it started close to the correct starting time and phase.
+        // The 20us delay is requied to allow the transceiver IRQ enough time to return and finish IsrCallback().
+        // If it does not there is a chance that the IRQ will not be cleared and the radio will hang. 
+        NextTimeout = ESP.getCycleCount() + (20 * HWTIMER_TICKS_PER_US * HWTIMER_PRESCALER);
 #endif
         timer0_write(NextTimeout);
         interrupts();

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -172,6 +172,7 @@ int32_t PfdPrevRawOffset;
 RXtimerState_e RXtimerState;
 uint32_t GotConnectionMillis = 0;
 const uint32_t ConsiderConnGoodMillis = 1000; // minimum time before we can consider a connection to be 'good'
+bool doStartTimer = false;
 
 ///////////////////////////////////////////////
 
@@ -1056,7 +1057,7 @@ bool ICACHE_RAM_ATTR ProcessRFPacket(SX12xxDriverCommon::rx_status const status)
 
     PFDloop.extEvent(beginProcessing + PACKET_TO_TOCK_SLACK);
 
-    bool doStartTimer = false;
+    doStartTimer = false;
     unsigned long now = millis();
 
     LastValidPacket = now;
@@ -1106,8 +1107,6 @@ bool ICACHE_RAM_ATTR ProcessRFPacket(SX12xxDriverCommon::rx_status const status)
 #if defined(DEBUG_RX_SCOREBOARD)
     if (otaPktPtr->std.type != PACKET_TYPE_SYNC) DBGW(connectionHasModelMatch ? 'R' : 'r');
 #endif
-    if (doStartTimer)
-        hwTimer::resume(); // will throw an interrupt immediately
 
     return true;
 }
@@ -1122,6 +1121,13 @@ bool ICACHE_RAM_ATTR RXdoneISR(SX12xxDriverCommon::rx_status const status)
     if (ProcessRFPacket(status))
     {
         didFHSS = HandleFHSS();
+        
+        if (doStartTimer)
+        {
+            doStartTimer = false;
+            hwTimer::resume(); // will throw an interrupt immediately
+        }
+
         return true;
     }
     return false;


### PR DESCRIPTION
Currently after receiving a valid sync packet on a new connection, or after a mode change, calling hwTimer::resume() triggers the hwTimer immediately.  The below trace shows Tock immediately triggering **within** IsrCallback(), and because the next interval is a TLM send it writes a packet to the radio bufefr and sets tx mode.  IsrCallback() then completes and clears the IRQ (DIO goes low).

![image](https://github.com/ExpressLRS/ExpressLRS/assets/14170229/edfe4543-ac62-4fc0-9391-ac5b8c5c04d9)

It was seen that sometimes IsrCallback() would not complete after the hwTimer triggers, and the IRQ is not cleared.  This leaves the radio in a hung state.

![image](https://github.com/ExpressLRS/ExpressLRS/assets/14170229/9a7c322c-ad86-4346-9ab5-5b554de51f46)

This PR changes the 8266 hwTimer to trigger after a 20us period.  This is enough time for IsrCallback() to finish and clear the IRQ.

![image](https://github.com/ExpressLRS/ExpressLRS/assets/14170229/95cc1b32-3be5-42a9-87ea-88c7254deeb7)

The esp32 hwTimer was previously set to a new period of half the packet interval... which is just wrong.  But triggered correctly immediately after IsrCallback().  The esp32 doesnt not interrupt IsrCallback()! And the trigger appeared to be due to a stale timer (thanks PK).  Changes in the esp32 hwTimer are for clarity and so we know exactly what is happening.  These change have been tested on the esp32 Pico, S3, and C3.  They all trigger immediately after IsrCallback().

C3 trace below.
![image](https://github.com/ExpressLRS/ExpressLRS/assets/14170229/9b573c12-bec3-4c65-98d0-86c39e8add10)

Thanks to Mustard for picking up the issue

