### PR TITLE
RX LUA: make (SBUS) Failsafe Mode line visible

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -265,7 +265,7 @@
 						<div id="serial1-config">
 							<div class="mui-select">
 								<select id='serial1-protocol' name='serial1-protocol'>
-									<option value='0'>NONE</option>
+									<option value='0'>Off</option>
 									<option value='1'>CRSF</option>
 									<option value='2'>Inverted CRSF</option>
 									<option value='3'>SBUS</option>

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -227,7 +227,7 @@ enum eSerialProtocol : uint8_t
 #if defined(PLATFORM_ESP32)
 enum eSerial1Protocol : uint8_t
 {
-    PROTOCOL_SERIAL1_NONE,
+    PROTOCOL_SERIAL1_OFF,
     PROTOCOL_SERIAL1_CRSF,
     PROTOCOL_SERIAL1_INVERTED_CRSF,
     PROTOCOL_SERIAL1_SBUS,

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -199,8 +199,10 @@ enum eServoOutputMode : uint8_t
     somSCL,         // 10: I2C clock signal
     somSDA,         // 11: I2C data line
     somPwm,         // 12: true PWM mode (NOT SUPPORTED)
+#if defined(PLATFORM_ESP32)
     somSerial1RX,   // 13: secondary Serial RX
     somSerial1TX,   // 14: secondary Serial TX
+#endif
 };
 
 enum eServoOutputFailsafeMode : uint8_t
@@ -222,6 +224,7 @@ enum eSerialProtocol : uint8_t
     PROTOCOL_MAVLINK
 };
 
+#if defined(PLATFORM_ESP32)
 enum eSerial1Protocol : uint8_t
 {
     PROTOCOL_SERIAL1_NONE,
@@ -233,6 +236,7 @@ enum eSerial1Protocol : uint8_t
     PROTOCOL_SERIAL1_DJI_RS_PRO,
     PROTOCOL_SERIAL1_HOTT_TLM
 };
+#endif
 
 enum eFailsafeMode : uint8_t
 {

--- a/src/lib/CONFIG/config.cpp
+++ b/src/lib/CONFIG/config.cpp
@@ -1187,6 +1187,7 @@ void RxConfig::SetSerialProtocol(eSerialProtocol serialProtocol)
     }
 }
 
+#if defined(PLATFORM_ESP32)
 void RxConfig::SetSerial1Protocol(eSerial1Protocol serialProtocol)
 {
     if (m_config.serial1Protocol != serialProtocol)
@@ -1195,6 +1196,7 @@ void RxConfig::SetSerial1Protocol(eSerial1Protocol serialProtocol)
         m_modified = true;
     }
 }
+#endif
 
 void RxConfig::SetTeamraceChannel(uint8_t teamraceChannel)
 {

--- a/src/lib/CONFIG/config.h
+++ b/src/lib/CONFIG/config.h
@@ -257,7 +257,9 @@ public:
     bool GetForceTlmOff() const { return m_config.forceTlmOff; }
     uint8_t GetRateInitialIdx() const { return m_config.rateInitialIdx; }
     eSerialProtocol GetSerialProtocol() const { return (eSerialProtocol)m_config.serialProtocol; }
+#if defined(PLATFORM_ESP32)
     eSerial1Protocol GetSerial1Protocol() const { return (eSerial1Protocol)m_config.serial1Protocol; }
+#endif
     uint8_t GetTeamraceChannel() const { return m_config.teamraceChannel; }
     uint8_t GetTeamracePosition() const { return m_config.teamracePosition; }
     eFailsafeMode GetFailsafeMode() const { return (eFailsafeMode)m_config.failsafeMode; }
@@ -279,7 +281,9 @@ public:
     void SetForceTlmOff(bool forceTlmOff);
     void SetRateInitialIdx(uint8_t rateInitialIdx);
     void SetSerialProtocol(eSerialProtocol serialProtocol);
+#if defined(PLATFORM_ESP32)
     void SetSerial1Protocol(eSerial1Protocol serial1Protocol);
+#endif
     void SetTeamraceChannel(uint8_t teamraceChannel);
     void SetTeamracePosition(uint8_t teamracePosition);
     void SetFailsafeMode(eFailsafeMode failsafeMode);

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -513,11 +513,11 @@ static bool hasSerialdefined(int hardwarePin, eServoOutputMode mode)
       {
         return true;
       }
+    }
   }
 #endif
 
   return false;
-  }
 }
 
 static bool hasSerial0()

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -498,7 +498,7 @@ static bool isProtocolTypeSBUS()
         );
 }
 
-static bool hasSerialdefined(int hardwarePin, eServoOutputMode mode)
+static bool hasSerialDefined(int hardwarePin, eServoOutputMode mode)
 {
   if (hardwarePin != UNDEF_PIN)
   {
@@ -522,13 +522,13 @@ static bool hasSerialdefined(int hardwarePin, eServoOutputMode mode)
 
 static bool hasSerial0()
 {
-  return hasSerialdefined(GPIO_PIN_RCSIGNAL_TX, somSerial);
+  return hasSerialDefined(GPIO_PIN_RCSIGNAL_TX, somSerial);
 }
 
 #if defined(PLATFORM_ESP32)
 static bool hasSerial1()
 {
-  return hasSerialdefined(GPIO_PIN_SERIAL1_TX, somSerial1TX);
+  return hasSerialDefined(GPIO_PIN_SERIAL1_TX, somSerial1TX);
 }
 #endif
 

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -528,7 +528,7 @@ static bool hasSerial0()
 #if defined(PLATFORM_ESP32)
 static bool hasSerial1()
 {
-  return hasSerialdefined(GPIO_PIN_SERIAL1_TX, somSerial1RX);
+  return hasSerialdefined(GPIO_PIN_SERIAL1_TX, somSerial1TX);
 }
 #endif
 

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -27,7 +27,7 @@ static struct luaItem_selection luaSerialProtocol = {
 static struct luaItem_selection luaSerial1Protocol = {
     {"Protocol2", CRSF_TEXT_SELECTION},
     0, // value
-    "NONE;CRSF;Inverted CRSF;SBUS;Inverted SBUS;SUMD;DJI RS Pro;HoTT Telemetry",
+    "Off;CRSF;Inverted CRSF;SBUS;Inverted SBUS;SUMD;DJI RS Pro;HoTT Telemetry",
     STR_EMPTYSPACE
 };
 #endif

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -219,8 +219,8 @@ static void luaparamMappingChannelOut(struct luaPropertiesCommon *item, uint8_t 
 
       if (mode == somSerial1TX)
         serial1txAssigned = true;
-    }
 #endif
+    }
 
     setLuaUint8Value(&luaMappingChannelOut, arg);
 

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -483,6 +483,39 @@ static bool isProtocolTypeSBUS()
           prot1 == PROTOCOL_SERIAL1_SBUS || prot1 == PROTOCOL_SERIAL1_INVERTED_SBUS || prot1 == PROTOCOL_SERIAL1_DJI_RS_PRO);
 }
 
+static bool hasSerialdefined(int hardwarePin, eServoOutputMode mode)
+{
+  if (hardwarePin != UNDEF_PIN)
+  {
+    return true;
+  }
+
+#if defined(GPIO_PIN_PWM_OUTPUTS)
+  {
+    for (uint8_t ch = 0; ch < GPIO_PIN_PWM_OUTPUTS_COUNT; ch++)
+    {
+      if (config.GetPwmChannel(ch)->val.mode == mode)
+      {
+        return true;
+      }
+  }
+#endif
+
+  return false;
+  }
+}
+
+static bool hasSerial0()
+{
+  return hasSerialdefined(GPIO_PIN_RCSIGNAL_TX, somSerial);
+}
+
+static bool hasSerial1()
+{
+  return hasSerialdefined(GPIO_PIN_SERIAL1_TX, somSerial1RX);
+}
+
+
 static void registerLuaParameters()
 {
   registerLUAParameter(&luaSerialProtocol, [](struct luaPropertiesCommon* item, uint8_t arg){
@@ -578,8 +611,25 @@ static void updateBindModeLabel()
 
 static int event()
 {
-  setLuaTextSelectionValue(&luaSerialProtocol, config.GetSerialProtocol());
-  setLuaTextSelectionValue(&luaSerial1Protocol, config.GetSerial1Protocol());
+  if (hasSerial0())
+  {
+    setLuaTextSelectionValue(&luaSerialProtocol, config.GetSerialProtocol());
+    LUA_FIELD_SHOW(luaSerialProtocol);
+  }
+  else
+  {
+    LUA_FIELD_HIDE(luaSerialProtocol);
+  }
+
+  if (hasSerial1())
+  {
+    setLuaTextSelectionValue(&luaSerial1Protocol, config.GetSerial1Protocol());
+    LUA_FIELD_SHOW(luaSerial1Protocol);
+  }
+  else
+  {
+    LUA_FIELD_HIDE(luaSerial1Protocol);
+  }
   
   if (isProtocolTypeSBUS())
   {

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -508,7 +508,7 @@ static void UpdateConfiguration(AsyncWebServerRequest *request, JsonVariant &jso
   uint8_t protocol = json["serial-protocol"] | 0;
   config.SetSerialProtocol((eSerialProtocol)protocol);
 
-#if defined(PLATFORM_ESP8266)
+#if defined(PLATFORM_ESP32)
   uint8_t protocol1 = json["serial1-protocol"] | 0;
   config.SetSerial1Protocol((eSerial1Protocol)protocol1);
 #endif

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -508,8 +508,10 @@ static void UpdateConfiguration(AsyncWebServerRequest *request, JsonVariant &jso
   uint8_t protocol = json["serial-protocol"] | 0;
   config.SetSerialProtocol((eSerialProtocol)protocol);
 
+#if defined(PLATFORM_ESP8266)
   uint8_t protocol1 = json["serial1-protocol"] | 0;
   config.SetSerial1Protocol((eSerial1Protocol)protocol1);
+#endif
 
   uint8_t failsafe = json["sbus-failsafe"] | 0;
   config.SetFailsafeMode((eFailsafeMode)failsafe);

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -357,7 +357,9 @@ static void GetConfiguration(AsyncWebServerRequest *request)
     json["config"]["mode"] = wifiMode == WIFI_STA ? "STA" : "AP";
     #if defined(TARGET_RX)
     json["config"]["serial-protocol"] = config.GetSerialProtocol();
+#if defined(PLATFORM_ESP32)
     json["config"]["serial1-protocol"] = config.GetSerial1Protocol();
+#endif
     json["config"]["sbus-failsafe"] = config.GetFailsafeMode();
     json["config"]["modelid"] = config.GetModelId();
     json["config"]["force-tlm"] = config.GetForceTlmOff();

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1519,7 +1519,7 @@ static void setupSerial1()
 
     switch(config.GetSerial1Protocol())
     {
-        case PROTOCOL_SERIAL1_NONE:
+        case PROTOCOL_SERIAL1_OFF:
             break;
         case PROTOCOL_SERIAL1_CRSF:
             Serial1.begin(firmwareOptions.uart_baud, SERIAL_8N1, serial1RXpin, serial1TXpin, false);


### PR DESCRIPTION
Problem: using the LUA script to change from non-SBUS type serial protocols like CRSF to SBUS type protocols (SBUS,  Inv. SBUS, DJI) only showed the (SBUS) failsafe mode settings line after power cycling the receiver.

Solution: instantly hide or make failsafe mode settings visible depending on newly selected serial protocol.

Additional change: fix typo

Edit after discussion:
- rx LUA will show Protocol2 unconditional if rx is on ESP32 platform
- Failsafe Mode renamed to SBUS failsafe to avoid confusion with PWM failsafe.
- SBUS failsafe setting will also be visible unconditionally
- changed Protocol2 setting NONE to Off