### PR TITLE
Replace syncSpamAResidualTimeMS with a counter

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -406,6 +406,10 @@ void SetRFLinkRate(uint8_t index) // Set speed of RF link
     Radio.SetFrequencyReg(FHSSgetInitialGeminiFreq(), SX12XX_Radio_2);
   }
 
+  // InitialFreq has been set, so lets also reset the FHSS Idx and Nonce.
+  FHSSsetCurrIndex(0);
+  OtaNonce = 0;
+
   OtaUpdateSerializers(newSwitchMode, ModParams->PayloadLength);
   MspSender.setMaxPackageIndex(ELRS_MSP_MAX_PACKAGES);
   TelemetryReceiver.setMaxPackageIndex(OtaIsFullRes ? ELRS8_TELEMETRY_MAX_PACKAGES : ELRS4_TELEMETRY_MAX_PACKAGES);

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -515,8 +515,8 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
 
   uint8_t NonceFHSSresult = OtaNonce % ExpressLRS_currAirRate_Modparams->FHSShopInterval;
 
-  // Sync spam
-  if (syncSpamCounter || (syncSpamCounterAfterRateChange && FHSSonSyncChannel()))
+  // Sync spam only happens on slot 1 and 2 and can't be disabled
+  if ((syncSpamCounter || (syncSpamCounterAfterRateChange && FHSSonSyncChannel())) && (NonceFHSSresult == 1 || NonceFHSSresult == 2))
   {
     otaPkt.std.type = PACKET_TYPE_SYNC;
     GenerateSyncPacketData(OtaIsFullRes ? &otaPkt.full.sync.sync : &otaPkt.std.sync);


### PR DESCRIPTION
With the current syncSpamAResidualTimeMS of 500ms, there is a good chance on the slower rates(...Im looking at you 50Hz) that the rx will not receive a sync packet.  This is due to frequency hopping and that the rx is only listening on the initial frequency.  The tx may take a number of seconds to come back around to that frequency.

This PR adds a counter to spam sync packets after the change, and they are only sent on the initial frequency that the rx is listening on.  Then if the tx receives a tlm connection it cancels the remaining counter.  This results in a faster connection at the slower rates in particular.