### PR TITLE
Remove mav_ul

### DIFF
--- a/src/lib/OTA/OTA.h
+++ b/src/lib/OTA/OTA.h
@@ -66,16 +66,10 @@ typedef struct {
         } PACKED dbg_linkstats;
         /** PACKET_TYPE_MSP **/
         struct {
-            uint8_t packageIndex;
+            uint8_t packageIndex:7,
+                    tlmFlag:1;
             uint8_t payload[ELRS4_MSP_BYTES_PER_CALL];
         } msp_ul;
-        /** PACKET_TYPE_MAV **/
-        struct {
-            uint8_t packageIndex:5,
-                    tlmFlag:1,
-                    spare:2;
-            uint8_t payload[ELRS4_MSP_BYTES_PER_CALL];
-        } mav_ul;
         /** PACKET_TYPE_SYNC **/
         OTA_Sync_s sync;
         /** PACKET_TYPE_TLM **/
@@ -123,16 +117,10 @@ typedef struct {
         /** PACKET_TYPE_MSP **/
         struct {
             uint8_t packetType: 2,
-                    packageIndex: 6;
-            uint8_t payload[ELRS8_MSP_BYTES_PER_CALL];
-        } msp_ul;
-        /** PACKET_TYPE_MAV **/
-        struct {
-            uint8_t packetType: 2,
                     packageIndex: 5,
                     tlmFlag: 1;
             uint8_t payload[ELRS8_MSP_BYTES_PER_CALL];
-        } mav_ul;
+        } msp_ul;
         /** PACKET_TYPE_SYNC **/
         struct {
             uint8_t packetType; // only low 2 bits

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -939,34 +939,30 @@ static void ICACHE_RAM_ATTR ProcessRfPacket_MSP(OTA_Packet_s const * const otaPk
     uint8_t dataLen;
     if (OtaIsFullRes)
     {
+        packageIndex = otaPktPtr->full.msp_ul.packageIndex;
+        payload = otaPktPtr->full.msp_ul.payload;
+        dataLen = sizeof(otaPktPtr->full.msp_ul.payload);
         if (config.GetSerialProtocol() == PROTOCOL_MAVLINK)
         {
-            packageIndex = otaPktPtr->full.msp_ul.packageIndex;
-            payload = otaPktPtr->full.msp_ul.payload;
-            dataLen = sizeof(otaPktPtr->full.msp_ul.payload);
             TelemetrySender.ConfirmCurrentPayload(otaPktPtr->full.msp_ul.tlmFlag);
         }
         else
         {
-            packageIndex = otaPktPtr->full.msp_ul.packageIndex & 0b00011111;
-            payload = otaPktPtr->full.msp_ul.payload;
-            dataLen = sizeof(otaPktPtr->full.msp_ul.payload);
+            packageIndex &= ELRS8_TELEMETRY_MAX_PACKAGES;
         }
     }
     else
     {
+        packageIndex = otaPktPtr->std.msp_ul.packageIndex;
+        payload = otaPktPtr->std.msp_ul.payload;
+        dataLen = sizeof(otaPktPtr->std.msp_ul.payload);
         if (config.GetSerialProtocol() == PROTOCOL_MAVLINK)
         {
-            packageIndex = otaPktPtr->std.msp_ul.packageIndex;
-            payload = otaPktPtr->std.msp_ul.payload;
-            dataLen = sizeof(otaPktPtr->std.msp_ul.payload);
             TelemetrySender.ConfirmCurrentPayload(otaPktPtr->std.msp_ul.tlmFlag);
         }
         else
         {
-            packageIndex = otaPktPtr->std.msp_ul.packageIndex & 0b00111111;
-            payload = otaPktPtr->std.msp_ul.payload;
-            dataLen = sizeof(otaPktPtr->std.msp_ul.payload);
+            packageIndex &= ELRS4_TELEMETRY_MAX_PACKAGES;
         }
     }
 

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -941,14 +941,14 @@ static void ICACHE_RAM_ATTR ProcessRfPacket_MSP(OTA_Packet_s const * const otaPk
     {
         if (config.GetSerialProtocol() == PROTOCOL_MAVLINK)
         {
-            packageIndex = otaPktPtr->full.mav_ul.packageIndex;
-            payload = otaPktPtr->full.mav_ul.payload;
-            dataLen = sizeof(otaPktPtr->full.mav_ul.payload);
-            TelemetrySender.ConfirmCurrentPayload(otaPktPtr->full.mav_ul.tlmFlag);
+            packageIndex = otaPktPtr->full.msp_ul.packageIndex;
+            payload = otaPktPtr->full.msp_ul.payload;
+            dataLen = sizeof(otaPktPtr->full.msp_ul.payload);
+            TelemetrySender.ConfirmCurrentPayload(otaPktPtr->full.msp_ul.tlmFlag);
         }
         else
         {
-            packageIndex = otaPktPtr->full.msp_ul.packageIndex;
+            packageIndex = otaPktPtr->full.msp_ul.packageIndex & 0b00011111;
             payload = otaPktPtr->full.msp_ul.payload;
             dataLen = sizeof(otaPktPtr->full.msp_ul.payload);
         }
@@ -957,14 +957,14 @@ static void ICACHE_RAM_ATTR ProcessRfPacket_MSP(OTA_Packet_s const * const otaPk
     {
         if (config.GetSerialProtocol() == PROTOCOL_MAVLINK)
         {
-            packageIndex = otaPktPtr->std.mav_ul.packageIndex;
-            payload = otaPktPtr->std.mav_ul.payload;
-            dataLen = sizeof(otaPktPtr->std.mav_ul.payload);
-            TelemetrySender.ConfirmCurrentPayload(otaPktPtr->std.mav_ul.tlmFlag);
+            packageIndex = otaPktPtr->std.msp_ul.packageIndex;
+            payload = otaPktPtr->std.msp_ul.payload;
+            dataLen = sizeof(otaPktPtr->std.msp_ul.payload);
+            TelemetrySender.ConfirmCurrentPayload(otaPktPtr->std.msp_ul.tlmFlag);
         }
         else
         {
-            packageIndex = otaPktPtr->std.msp_ul.packageIndex;
+            packageIndex = otaPktPtr->std.msp_ul.packageIndex & 0b00111111;
             payload = otaPktPtr->std.msp_ul.payload;
             dataLen = sizeof(otaPktPtr->std.msp_ul.payload);
         }

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -234,7 +234,7 @@ bool ICACHE_RAM_ATTR ProcessTLMpacket(SX12xxDriverCommon::rx_status const status
       dataLen = sizeof(ota8->tlm_dl.payload);
     }
     //DBGLN("pi=%u len=%u", ota8->tlm_dl.packageIndex, dataLen);
-    TelemetryReceiver.ReceiveData(ota8->tlm_dl.packageIndex, telemPtr, dataLen);
+    TelemetryReceiver.ReceiveData(ota8->tlm_dl.packageIndex & 0b00011111, telemPtr, dataLen);
   }
   // Std res mode
   else
@@ -251,7 +251,7 @@ bool ICACHE_RAM_ATTR ProcessTLMpacket(SX12xxDriverCommon::rx_status const status
           OtaUnpackAirportData(otaPktPtr, &apOutputBuffer);
           return true;
         }
-        TelemetryReceiver.ReceiveData(otaPktPtr->std.tlm_dl.packageIndex,
+        TelemetryReceiver.ReceiveData(otaPktPtr->std.tlm_dl.packageIndex & 0b00111111,
           otaPktPtr->std.tlm_dl.payload,
           sizeof(otaPktPtr->std.tlm_dl.payload));
         break;
@@ -531,10 +531,10 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
       {
         if (config.GetLinkMode() == TX_MAVLINK_MODE)
         {
-          otaPkt.full.mav_ul.packageIndex = MspSender.GetCurrentPayload(
-            otaPkt.full.mav_ul.payload,
-            sizeof(otaPkt.full.mav_ul.payload));
-          otaPkt.full.mav_ul.tlmFlag = TelemetryReceiver.GetCurrentConfirm();
+          otaPkt.full.msp_ul.packageIndex = MspSender.GetCurrentPayload(
+            otaPkt.full.msp_ul.payload,
+            sizeof(otaPkt.full.msp_ul.payload));
+          otaPkt.full.msp_ul.tlmFlag = TelemetryReceiver.GetCurrentConfirm();
         }
         else
         {
@@ -547,10 +547,10 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
       {
         if (config.GetLinkMode() == TX_MAVLINK_MODE)
         {
-          otaPkt.std.mav_ul.packageIndex = MspSender.GetCurrentPayload(
-            otaPkt.std.mav_ul.payload,
-            sizeof(otaPkt.std.mav_ul.payload));
-          otaPkt.std.mav_ul.tlmFlag = TelemetryReceiver.GetCurrentConfirm();
+          otaPkt.std.msp_ul.packageIndex = MspSender.GetCurrentPayload(
+            otaPkt.std.msp_ul.payload,
+            sizeof(otaPkt.std.msp_ul.payload));
+          otaPkt.std.msp_ul.tlmFlag = TelemetryReceiver.GetCurrentConfirm();
         }
         else
         {

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -234,7 +234,7 @@ bool ICACHE_RAM_ATTR ProcessTLMpacket(SX12xxDriverCommon::rx_status const status
       dataLen = sizeof(ota8->tlm_dl.payload);
     }
     //DBGLN("pi=%u len=%u", ota8->tlm_dl.packageIndex, dataLen);
-    TelemetryReceiver.ReceiveData(ota8->tlm_dl.packageIndex & 0b00011111, telemPtr, dataLen);
+    TelemetryReceiver.ReceiveData(ota8->tlm_dl.packageIndex & ELRS8_TELEMETRY_MAX_PACKAGES, telemPtr, dataLen);
   }
   // Std res mode
   else
@@ -251,7 +251,7 @@ bool ICACHE_RAM_ATTR ProcessTLMpacket(SX12xxDriverCommon::rx_status const status
           OtaUnpackAirportData(otaPktPtr, &apOutputBuffer);
           return true;
         }
-        TelemetryReceiver.ReceiveData(otaPktPtr->std.tlm_dl.packageIndex & 0b00111111,
+        TelemetryReceiver.ReceiveData(otaPktPtr->std.tlm_dl.packageIndex & ELRS4_TELEMETRY_MAX_PACKAGES,
           otaPktPtr->std.tlm_dl.payload,
           sizeof(otaPktPtr->std.tlm_dl.payload));
         break;
@@ -529,35 +529,19 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
       otaPkt.std.type = PACKET_TYPE_MSPDATA;
       if (OtaIsFullRes)
       {
+        otaPkt.full.msp_ul.packageIndex = MspSender.GetCurrentPayload(
+          otaPkt.full.msp_ul.payload,
+          sizeof(otaPkt.full.msp_ul.payload));
         if (config.GetLinkMode() == TX_MAVLINK_MODE)
-        {
-          otaPkt.full.msp_ul.packageIndex = MspSender.GetCurrentPayload(
-            otaPkt.full.msp_ul.payload,
-            sizeof(otaPkt.full.msp_ul.payload));
           otaPkt.full.msp_ul.tlmFlag = TelemetryReceiver.GetCurrentConfirm();
-        }
-        else
-        {
-          otaPkt.full.msp_ul.packageIndex = MspSender.GetCurrentPayload(
-            otaPkt.full.msp_ul.payload,
-            sizeof(otaPkt.full.msp_ul.payload));
-        }
       }
       else
       {
+        otaPkt.std.msp_ul.packageIndex = MspSender.GetCurrentPayload(
+          otaPkt.std.msp_ul.payload,
+          sizeof(otaPkt.std.msp_ul.payload));
         if (config.GetLinkMode() == TX_MAVLINK_MODE)
-        {
-          otaPkt.std.msp_ul.packageIndex = MspSender.GetCurrentPayload(
-            otaPkt.std.msp_ul.payload,
-            sizeof(otaPkt.std.msp_ul.payload));
           otaPkt.std.msp_ul.tlmFlag = TelemetryReceiver.GetCurrentConfirm();
-        }
-        else
-        {
-          otaPkt.std.msp_ul.packageIndex = MspSender.GetCurrentPayload(
-            otaPkt.std.msp_ul.payload,
-            sizeof(otaPkt.std.msp_ul.payload));
-        }
       }
 
       // send channel data next so the channel messages also get sent during msp transmissions


### PR DESCRIPTION
This PR removes the mav_ul OTA packet structure and unifies Mav with the MSP structure.

What does this mean?  MSP now works between tx/rx on different protocols e.g. the rx Lua will now load when the tx is set the Mav, but the rx is still on crsf.

- Master will now work with a mix of Mav/Normal to rx/tx.
- A 3.4.2 tx will connect to rx on Mav and open Lua.
- A Mav tx will NOT connect to a 3.4.2 rx.  So broken as normal, and while this isnt great... who is using a Mav tx with a 3.4.2 rx!