### PR TITLE
Change rx to PROTOCOL_MAVLINK if mav packets are received

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1214,7 +1214,7 @@ void MspReceiveComplete()
         if (config.GetSerialProtocol() != PROTOCOL_MAVLINK)
         {
             config.SetSerialProtocol(PROTOCOL_MAVLINK);
-            deferExecutionMicros(100, reconfigureSerial);
+            reconfigureSerial();
         }
         // raw mavlink data
         mavlinkOutputBuffer.atomicPushBytes(&MspData[2], MspData[1]);

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -237,6 +237,7 @@ static uint8_t debugRcvrLinkstatsFhssIdx;
 bool BindingModeRequest = false;
 
 extern void setWifiUpdateMode();
+void reconfigureSerial();
 
 uint8_t getLq()
 {
@@ -1210,6 +1211,11 @@ void MspReceiveComplete()
 #endif
         break;
     case MSP_ELRS_MAVLINK_TLM: // 0xFD
+        if (config.GetSerialProtocol() != PROTOCOL_MAVLINK)
+        {
+            config.SetSerialProtocol(PROTOCOL_MAVLINK);
+            deferExecutionMicros(100, reconfigureSerial);
+        }
         // raw mavlink data
         mavlinkOutputBuffer.atomicPushBytes(&MspData[2], MspData[1]);
         break;


### PR DESCRIPTION
If the rx receives a Mav packet from a GCS it will automatically change into PROTOCOL_MAVLINK.  This change is not based on the tx Lua menu and the user can not accidentally switch the rx into mav from this menu.

Further dev may come later to auto configure the rx protocol based on the tx Lua menu selection.