### PR TITLE
Serial protocol channel mapper

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -192,7 +192,7 @@
 							<li><b>Features:</b> If an output is capable of supporting another function, that is indicated here</li>
 							<li><b>Mode:</b> Output frequency, 10KHz 0-100% duty cycle, binary On/Off, DShot, Serial, or I2C (some options are pin dependant)</li>
 							<ul>
-								<li>When enabling serial pins, be sure to select the <b>Serial Protocol</b> below and <b>UART baud</b> on the <b>Options</b> tab</li>
+								<li>When enabling serial pins, be sure to select the <b>Serial Protocol</b>, <b>Serial Channel Mapping</b> below and <b>UART baud</b> on the <b>Options</b> tab</li>
 							</ul>
 							<li><b>Input:</b> Input channel from the handset</li>
 							<li><b>Invert:</b> Invert input channel position</li>
@@ -257,6 +257,10 @@
 								</select>
 								<label for='serial-protocol'>Serial Protocol</label>
 							</div>
+							<h2>Serial Channel Mapping</h2>
+							Map order of channels in selected serial protocol.
+							<div class="mui-panel" id="sermap">
+							</div>								
 						</div>
 						<div id="serial1-config">
 							<div class="mui-select">

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -397,7 +397,24 @@ function updateConfig(data, options) {
       _('sbus-config').style.display = 'none';
     }
   }
+  
+  const htmlFields = [`<table class="serialmappnl mui-table"><tbody><tr><th class="fixed-column">Output</th><th>Input</th></tr>`];
+  data['serial-channel-map'].forEach((item, index) => {
 
+    const serMapInputSelect = enumSelectGenerate(`sermap_${index}_ch`, Number(item),
+      ['ch1', 'ch2', 'ch3', 'ch4',
+        'ch5 (AUX1)', 'ch6 (AUX2)', 'ch7 (AUX3)', 'ch8 (AUX4)',
+        'ch9 (AUX5)', 'ch10 (AUX6)', 'ch11 (AUX7)', 'ch12 (AUX8)',
+        'ch13 (AUX9)', 'ch14 (AUX10)', 'ch15 (AUX11)', 'ch16 (AUX12)']);  
+    htmlFields.push(`<tr><td class="mui--text-center mui--text-title">${index + 1}</td><td>${serMapInputSelect}</td></tr>`);
+  });
+  htmlFields.push('</tbody></table>');
+  const grp = document.createElement('DIV');
+  grp.setAttribute('class', 'group');
+  grp.innerHTML = htmlFields.join('');
+
+  _('sermap').appendChild(grp);
+    
   _('serial1-protocol').onchange = () => {
     if (_('is-airport').checked) {
       _('rcvr-uart-baud').disabled = false;
@@ -751,10 +768,15 @@ _('connect').addEventListener('click', callback('Connect to Home Network', 'An e
 if (_('config')) {
   _('config').addEventListener('submit', callback('Set Configuration', 'An error occurred updating the configuration', '/config',
       (xmlhttp) => {
+        serChanMap = []
+        for(let i = 0; i < 16; i++) {
+          serChanMap.push(+_(`sermap_${i}_ch`).value);
+        }
         xmlhttp.setRequestHeader('Content-Type', 'application/json');
         return JSON.stringify({
           "pwm": getPwmFormData(),
           "serial-protocol": +_('serial-protocol').value,
+          "serial-channel-map": serChanMap,
           "serial1-protocol": +_('serial1-protocol').value,
           "sbus-failsafe": +_('sbus-failsafe').value,
           "modelid": +_('modelid').value,

--- a/src/lib/CONFIG/config.h
+++ b/src/lib/CONFIG/config.h
@@ -16,7 +16,7 @@
 #define RX_CONFIG_MAGIC     (0b10U << 30)
 
 #define TX_CONFIG_VERSION   7U
-#define RX_CONFIG_VERSION   9U
+#define RX_CONFIG_VERSION   10U
 
 #if defined(TARGET_TX)
 
@@ -224,6 +224,7 @@ typedef struct __attribute__((packed)) {
                 teamracePitMode:1;  // FUTURE: Enable pit mode when disabling model
     uint8_t     serial1Protocol:4,  // secondary serial protocol
                 serial1Protocol_unused:4;
+    uint8_t     serialChannelMap[16]; // Map of serial channels output 
 } rx_config_t;
 
 class RxConfig
@@ -248,6 +249,7 @@ public:
     bool GetForceTlmOff() const { return m_config.forceTlmOff; }
     uint8_t GetRateInitialIdx() const { return m_config.rateInitialIdx; }
     eSerialProtocol GetSerialProtocol() const { return (eSerialProtocol)m_config.serialProtocol; }
+    uint8_t  GetSerialChannelMap(uint8_t ch) { return m_config.serialChannelMap[ch]; }
     eSerial1Protocol GetSerial1Protocol() const { return (eSerial1Protocol)m_config.serial1Protocol; }
     uint8_t GetTeamraceChannel() const { return m_config.teamraceChannel; }
     uint8_t GetTeamracePosition() const { return m_config.teamracePosition; }
@@ -269,6 +271,7 @@ public:
     void SetForceTlmOff(bool forceTlmOff);
     void SetRateInitialIdx(uint8_t rateInitialIdx);
     void SetSerialProtocol(eSerialProtocol serialProtocol);
+    void SetSerialChannelMap(uint8_t ch, uint8_t map);
     void SetSerial1Protocol(eSerial1Protocol serial1Protocol);
     void SetTeamraceChannel(uint8_t teamraceChannel);
     void SetTeamracePosition(uint8_t teamracePosition);
@@ -282,7 +285,8 @@ private:
     void UpgradeEepromV5();
     void UpgradeEepromV6();
     void UpgradeEepromV7V8();
-
+    void UpgradeEepromV9();
+    
     rx_config_t m_config;
     ELRS_EEPROM *m_eeprom;
     bool        m_modified;

--- a/src/lib/CONFIG/config_legacy.h
+++ b/src/lib/CONFIG/config_legacy.h
@@ -157,3 +157,31 @@ typedef struct {
 } v7_rx_config_t;
 
 // V8 is just V7 except PWM config inserted 10khz PWM in the middle
+
+typedef struct __attribute__((packed)) {
+    uint32_t    version;
+    uint8_t     uid[UID_LEN];
+    uint8_t     unused_padding[2];
+    uint32_t    flash_discriminator;
+    struct __attribute__((packed)) {
+        uint16_t    scale;          // FUTURE: Override compiled vbat scale
+        int16_t     offset;         // FUTURE: Override comiled vbat offset
+    } vbat;
+    uint8_t     volatileBind:1,     // 0=Persistent 1=Volatile
+                unused_onLoan:1,
+                power:4,
+                antennaMode:2;      // 0=0, 1=1, 2=Diversity
+    uint8_t     powerOnCounter:3,
+                forceTlmOff:1,
+                rateInitialIdx:4;   // Rate to start rateCycling at on boot
+    uint8_t     modelId;
+    uint8_t     serialProtocol:4,
+                failsafeMode:2,
+                unused:2;
+    v6_rx_config_pwm_t pwmChannels[PWM_MAX_CHANNELS] __attribute__((aligned(4)));
+    uint8_t     teamraceChannel:4,
+                teamracePosition:3,
+                teamracePitMode:1;  // FUTURE: Enable pit mode when disabling model
+    uint8_t     serial1Protocol:4,  // secondary serial protocol
+                serial1Protocol_unused:4;
+}v9_rx_config_t;

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -355,6 +355,10 @@ static void GetConfiguration(AsyncWebServerRequest *request)
     json["config"]["mode"] = wifiMode == WIFI_STA ? "STA" : "AP";
     #if defined(TARGET_RX)
     json["config"]["serial-protocol"] = config.GetSerialProtocol();
+    for(u_int8_t i = 0; i < 16; i++)
+    {
+      json["config"]["serial-channel-map"][i] = config.GetSerialChannelMap(i);
+    }
     json["config"]["serial1-protocol"] = config.GetSerial1Protocol();
     json["config"]["sbus-failsafe"] = config.GetFailsafeMode();
     json["config"]["modelid"] = config.GetModelId();
@@ -529,6 +533,14 @@ static void UpdateConfiguration(AsyncWebServerRequest *request, JsonVariant &jso
     config.SetPwmChannelRaw(channel, val);
   }
   #endif
+
+  JsonArray serialChannelMap = json["serial-channel-map"].as<JsonArray>();
+  for(uint32_t channel = 0 ; channel < serialChannelMap.size() ; channel++)
+  {
+    uint32_t val = serialChannelMap[channel];
+    //DBGLN("PWMch(%u)=%u", channel, val);
+    config.SetSerialChannelMap(channel, val);
+  }
 
   config.Commit();
   request->send(200, "text/plain", "Configuration updated");


### PR DESCRIPTION
Possibility to map serial channels to allow exclusion of CH5 for fixed wings gyros.

Previous pull was rejected, so tried to implement based on the recommendation.