### PR TITLE
Decrease mav rx to ardu baud

### DIFF
--- a/src/src/rx-serial/SerialMavlink.cpp
+++ b/src/src/rx-serial/SerialMavlink.cpp
@@ -5,6 +5,8 @@
 #include "common.h"
 #include "CRSF.h"
 
+#define MIN_PACKET_INTERVAL 4 // Only send RC at a max rate of 250Hz so the TX line is not saturated with RC override packets.
+
 // Variables / constants for Mavlink //
 FIFO<MAV_INPUT_BUF_LEN> mavlinkInputBuffer;
 FIFO<MAV_OUTPUT_BUF_LEN> mavlinkOutputBuffer;
@@ -91,8 +93,8 @@ uint32_t SerialMavlink::sendRCFrame(bool frameAvailable, bool frameMissed, uint3
     mavlink_msg_rc_channels_override_encode(this_system_id, this_component_id, &msg, &rc_override);
     uint16_t len = mavlink_msg_to_send_buffer(buf, &msg);
     _outputPort->write(buf, len);
-    
-    return DURATION_IMMEDIATELY;
+
+    return MIN_PACKET_INTERVAL;
 }
 
 int SerialMavlink::getMaxSerialReadSize()

--- a/src/src/rx-serial/SerialMavlink.cpp
+++ b/src/src/rx-serial/SerialMavlink.cpp
@@ -5,8 +5,6 @@
 #include "common.h"
 #include "CRSF.h"
 
-#define MIN_PACKET_INTERVAL 4 // Only send RC at a max rate of 250Hz so the TX line is not saturated with RC override packets.
-
 // Variables / constants for Mavlink //
 FIFO<MAV_INPUT_BUF_LEN> mavlinkInputBuffer;
 FIFO<MAV_OUTPUT_BUF_LEN> mavlinkOutputBuffer;
@@ -67,6 +65,15 @@ uint32_t SerialMavlink::sendRCFrame(bool frameAvailable, bool frameMissed, uint3
         return DURATION_IMMEDIATELY;
     }
 
+    // Limit RC to a max rate of 250Hz so the TX line is not saturated with RC override packets.
+    const uint32_t now = micros();
+    if ((now - lastSentRCPacket) > RCPacketInterval)
+    {
+        return DURATION_IMMEDIATELY;
+    }
+    
+    lastSentRCPacket = now; 
+
     const mavlink_rc_channels_override_t rc_override {
         chan1_raw: CRSF_to_US(channelData[0]),
         chan2_raw: CRSF_to_US(channelData[1]),
@@ -94,7 +101,7 @@ uint32_t SerialMavlink::sendRCFrame(bool frameAvailable, bool frameMissed, uint3
     uint16_t len = mavlink_msg_to_send_buffer(buf, &msg);
     _outputPort->write(buf, len);
 
-    return MIN_PACKET_INTERVAL;
+    return DURATION_IMMEDIATELY;
 }
 
 int SerialMavlink::getMaxSerialReadSize()
@@ -112,10 +119,9 @@ void SerialMavlink::processBytes(uint8_t *bytes, u_int16_t size)
 
 void SerialMavlink::sendQueuedData(uint32_t maxBytesToSend)
 {
-
     // Send radio messages at 100Hz
     const uint32_t now = millis();
-    if ((now - lastSentFlowCtrl) > 10)
+    if ((now - lastSentFlowCtrl) > flowCtrlInterval)
     {
         lastSentFlowCtrl = now; 
 

--- a/src/src/rx-serial/SerialMavlink.h
+++ b/src/src/rx-serial/SerialMavlink.h
@@ -24,11 +24,15 @@ public:
 private:
     void processBytes(uint8_t *bytes, u_int16_t size) override;
 
+    const uint8_t RCPacketInterval = 4;
+    uint32_t lastSentRCPacket = 0;
+
     const uint8_t this_system_id;
     const uint8_t this_component_id;
 
     const uint8_t target_system_id;
     const uint8_t target_component_id;
 
+    const uint8_t flowCtrlInterval = 10;
     uint32_t lastSentFlowCtrl = 0;
 };

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1300,7 +1300,7 @@ static void setupSerial()
     else if (config.GetSerialProtocol() == PROTOCOL_MAVLINK)
     {
         mavlinkSerialOutput = true;
-        serialBaud = 460800;
+        serialBaud = 230400;
     }
 #if defined(PLATFORM_ESP8266) || defined(PLATFORM_ESP32)
     else if (config.GetSerialProtocol() == PROTOCOL_HOTT_TLM)


### PR DESCRIPTION
As suggested by MT, we appear to be dropping bytes on the wire from the FC.  As a result we drop about 1% of the packets because they never actually make it to the Rx.

Reducing the baud looks to eliminate (or greatly reduce) the issue.

![image](https://github.com/ExpressLRS/ExpressLRS/assets/14170229/4aa3ea65-e327-482d-b424-53043d13f263)
