### PR TITLE
Translate MAVLink telemetry to CRSF on the handset (rebased)

### DIFF
--- a/src/lib/CrsfProtocol/crsf_protocol.h
+++ b/src/lib/CrsfProtocol/crsf_protocol.h
@@ -307,6 +307,25 @@ typedef struct crsf_sensor_baro_vario_s
     int16_t verticalspd;  // Vertical speed in cm/s, BigEndian
 } PACKED crsf_sensor_baro_vario_t;
 
+// CRSF_FRAMETYPE_GPS
+typedef struct crsf_sensor_gps_s
+{
+    int32_t latitude; // degree / 10`000`000
+    int32_t longitude; // degree / 10`000`000
+    uint16_t groundspeed; // km/h / 10
+    uint16_t gps_heading; // degree / 100
+    uint16_t altitude; // meter ­1000m offset
+    uint8_t satellites_in_use; // counter
+} PACKED crsf_sensor_gps_t;
+
+// CRSF_FRAMETYPE_ATTITUDE
+typedef struct crsf_sensor_attitude_s
+{
+    int16_t pitch; // radians * 10000
+    int16_t roll; // radians * 10000
+    int16_t yaw; // radians * 10000
+} PACKED crsf_sensor_attitude_t;
+
 /*
  * 0x14 Link statistics
  * Payload:

--- a/src/lib/CrsfProtocol/crsf_protocol.h
+++ b/src/lib/CrsfProtocol/crsf_protocol.h
@@ -307,6 +307,12 @@ typedef struct crsf_sensor_baro_vario_s
     int16_t verticalspd;  // Vertical speed in cm/s, BigEndian
 } PACKED crsf_sensor_baro_vario_t;
 
+// CRSF_FRAMETYPE_VARIO
+typedef struct crsf_sensor_vario_s
+{
+    int16_t verticalspd;  // Vertical speed in cm/s, BigEndian
+} PACKED crsf_sensor_vario_t;
+
 // CRSF_FRAMETYPE_GPS
 typedef struct crsf_sensor_gps_s
 {

--- a/src/lib/CrsfProtocol/crsf_protocol.h
+++ b/src/lib/CrsfProtocol/crsf_protocol.h
@@ -326,6 +326,12 @@ typedef struct crsf_sensor_attitude_s
     int16_t yaw; // radians * 10000
 } PACKED crsf_sensor_attitude_t;
 
+// CRSF_FRAMETYPE_FLIGHT_MODE
+typedef struct crsf_sensor_flight_mode_s
+{
+    char flight_mode[16];
+} PACKED crsf_flight_mode_t;
+
 /*
  * 0x14 Link statistics
  * Payload:

--- a/src/lib/MAVLink/MAVLink.cpp
+++ b/src/lib/MAVLink/MAVLink.cpp
@@ -39,7 +39,7 @@ void convert_mavlink_to_crsf_telem(uint8_t *CRSFinBuffer, uint8_t count, Handset
                 // mm -> meters + 1000
                 crsfgps.p.altitude = htobe16(gps_int.alt / 1000 + 1000);
                 // cm/s -> km/h / 10
-                crsfgps.p.groundspeed = htobe16(gps_int.vel * 0.0036f * 10);
+                crsfgps.p.groundspeed = htobe16(gps_int.vel * 0.036f * 10);
                 crsfgps.p.latitude = htobe32(gps_int.lat);
                 crsfgps.p.longitude = htobe32(gps_int.lon);
                 crsfgps.p.gps_heading = htobe16(gps_int.cog);

--- a/src/lib/MAVLink/MAVLink.cpp
+++ b/src/lib/MAVLink/MAVLink.cpp
@@ -49,14 +49,7 @@ void convert_mavlink_to_crsf_telem(uint8_t *CRSFinBuffer, uint8_t count, Handset
                 // mm -> meters + 1000
                 crsfgps.p.altitude = htobe16(gps_int.alt / 1000 + 1000);
 #else
-                // mm -> meters + 1000 (uint16_t)
-                // int16_t relative_alt_16le = relative_alt;
-                // relative_alt_16le = (relative_alt_16le / 1000) + 1000;
-                // crsfgps.p.altitude = htobe16(relative_alt_16le);
-
                 crsfgps.p.altitude = htobe16(((int16_t)relative_alt) / 1000 + 1000);
-
-
 #endif
                 // cm/s -> km/h / 10
                 crsfgps.p.groundspeed = htobe16(gps_int.vel * 36 / 100);

--- a/src/lib/MAVLink/MAVLink.cpp
+++ b/src/lib/MAVLink/MAVLink.cpp
@@ -84,6 +84,11 @@ void convert_mavlink_to_crsf_telem(uint8_t *CRSFinBuffer, uint8_t count, Handset
                 CRSF_MK_FRAME_T(crsf_flight_mode_t)
                 crsffm = {0};
                 ap_flight_mode_name4(crsffm.p.flight_mode, ap_vehicle_from_mavtype(heartbeat.type), heartbeat.custom_mode);
+                // if we have a good flight mode, and we're armed, suffix the flight mode with a * - see Ardupilot's AP_CRSF_Telem::calc_flight_mode()
+                if (strlen(crsffm.p.flight_mode) == 4 && (heartbeat.base_mode & MAV_MODE_FLAG_SAFETY_ARMED)) {
+                    crsffm.p.flight_mode[4] = '*';
+                    crsffm.p.flight_mode[5] = '\0';
+                }
                 CRSF::SetHeaderAndCrc((uint8_t *)&crsffm, CRSF_FRAMETYPE_FLIGHT_MODE, CRSF_FRAME_SIZE(sizeof(crsffm)), CRSF_ADDRESS_CRSF_TRANSMITTER);
                 handset->sendTelemetryToTX((uint8_t *)&crsffm);
                 break;

--- a/src/lib/MAVLink/MAVLink.cpp
+++ b/src/lib/MAVLink/MAVLink.cpp
@@ -6,6 +6,9 @@
 void convert_mavlink_to_crsf_telem(uint8_t *CRSFinBuffer, uint8_t count, Handset *handset)
 {
 #if !defined(PLATFORM_STM32)
+    // Store the relative altitude for GPS altitude
+    static int32_t relative_alt = 0;
+
     for (uint8_t i = 0; i < count; i++)
     {
         mavlink_message_t msg;
@@ -41,8 +44,20 @@ void convert_mavlink_to_crsf_telem(uint8_t *CRSFinBuffer, uint8_t count, Handset
                 mavlink_msg_gps_raw_int_decode(&msg, &gps_int);
                 CRSF_MK_FRAME_T(crsf_sensor_gps_t)
                 crsfgps = {0};
+// We use altitude relative to home for GPS altitude, by default, but we can also use GPS altitude if USE_MAVLINK_GPS_ALTITUDE is defined
+#if defined(USE_MAVLINK_GPS_ALTITUDE)
                 // mm -> meters + 1000
                 crsfgps.p.altitude = htobe16(gps_int.alt / 1000 + 1000);
+#else
+                // mm -> meters + 1000 (uint16_t)
+                // int16_t relative_alt_16le = relative_alt;
+                // relative_alt_16le = (relative_alt_16le / 1000) + 1000;
+                // crsfgps.p.altitude = htobe16(relative_alt_16le);
+
+                crsfgps.p.altitude = htobe16(((int16_t)relative_alt) / 1000 + 1000);
+
+
+#endif
                 // cm/s -> km/h / 10
                 crsfgps.p.groundspeed = htobe16(gps_int.vel * 36 / 100);
                 crsfgps.p.latitude = htobe32(gps_int.lat);
@@ -56,14 +71,13 @@ void convert_mavlink_to_crsf_telem(uint8_t *CRSFinBuffer, uint8_t count, Handset
             case MAVLINK_MSG_ID_GLOBAL_POSITION_INT: {
                 mavlink_global_position_int_t global_pos;
                 mavlink_msg_global_position_int_decode(&msg, &global_pos);
-                CRSF_MK_FRAME_T(crsf_sensor_baro_vario_t)
-                crsfbaro = {0};
-                crsfbaro.p.altitude = htobe16(global_pos.relative_alt / 100 + 10000);
-                // force the top bit of altitude low to represent that it's in decimeters
-                crsfbaro.p.altitude &= 0x7FFF;
-                crsfbaro.p.verticalspd = htobe16(global_pos.vz);
-                CRSF::SetHeaderAndCrc((uint8_t *)&crsfbaro, CRSF_FRAMETYPE_BARO_ALTITUDE, CRSF_FRAME_SIZE(sizeof(crsf_sensor_baro_vario_t)), CRSF_ADDRESS_CRSF_TRANSMITTER);
-                handset->sendTelemetryToTX((uint8_t *)&crsfbaro);
+                CRSF_MK_FRAME_T(crsf_sensor_vario_t)
+                crsfvario = {0};
+                // store relative altitude for GPS Alt so we don't have 2 Alt sensors
+                relative_alt = global_pos.relative_alt;
+                crsfvario.p.verticalspd = htobe16(global_pos.vz);
+                CRSF::SetHeaderAndCrc((uint8_t *)&crsfvario, CRSF_FRAMETYPE_VARIO, CRSF_FRAME_SIZE(sizeof(crsf_sensor_vario_t)), CRSF_ADDRESS_CRSF_TRANSMITTER);
+                handset->sendTelemetryToTX((uint8_t *)&crsfvario);
                 break;
             }
             case MAVLINK_MSG_ID_ATTITUDE: {

--- a/src/lib/MAVLink/MAVLink.cpp
+++ b/src/lib/MAVLink/MAVLink.cpp
@@ -39,7 +39,7 @@ void convert_mavlink_to_crsf_telem(uint8_t *CRSFinBuffer, uint8_t count, Handset
                 // mm -> meters + 1000
                 crsfgps.p.altitude = htobe16(gps_int.alt / 1000 + 1000);
                 // cm/s -> km/h / 10
-                crsfgps.p.groundspeed = htobe16(gps_int.vel * 0.036f * 10);
+                crsfgps.p.groundspeed = htobe16(gps_int.vel * 36 / 100);
                 crsfgps.p.latitude = htobe32(gps_int.lat);
                 crsfgps.p.longitude = htobe32(gps_int.lon);
                 crsfgps.p.gps_heading = htobe16(gps_int.cog);

--- a/src/lib/MAVLink/MAVLink.cpp
+++ b/src/lib/MAVLink/MAVLink.cpp
@@ -14,6 +14,11 @@ void convert_mavlink_to_crsf_telem(uint8_t *CRSFinBuffer, uint8_t count, Handset
         // convert mavlink messages to CRSF messages
         if (have_message)
         {
+            // Only parse heartbeats from the autopilot (not GCS)
+            if (msg.compid != MAV_COMP_ID_AUTOPILOT1)
+            {
+                continue;
+            }
             switch (msg.msgid)
             {
             case MAVLINK_MSG_ID_BATTERY_STATUS: {

--- a/src/lib/MAVLink/MAVLink.cpp
+++ b/src/lib/MAVLink/MAVLink.cpp
@@ -1,4 +1,5 @@
 #include "MAVLink.h"
+#include "ardupilot_protocol.h"
 
 void convert_mavlink_to_crsf_telem(uint8_t *CRSFinBuffer, uint8_t count, Handset *handset)
 {
@@ -68,6 +69,17 @@ void convert_mavlink_to_crsf_telem(uint8_t *CRSFinBuffer, uint8_t count, Handset
                 crsfatt.p.yaw = htobe16(attitude.yaw * 10000);
                 CRSF::SetHeaderAndCrc((uint8_t *)&crsfatt, CRSF_FRAMETYPE_ATTITUDE, CRSF_FRAME_SIZE(sizeof(crsf_sensor_attitude_t)), CRSF_ADDRESS_CRSF_TRANSMITTER);
                 handset->sendTelemetryToTX((uint8_t *)&crsfatt);
+                break;
+            }
+            case MAVLINK_MSG_ID_HEARTBEAT: {
+                mavlink_heartbeat_t heartbeat;
+                mavlink_msg_heartbeat_decode(&msg, &heartbeat);
+                CRSF_MK_FRAME_T(crsf_flight_mode_t)
+                crsffm = {0};
+                ap_flight_mode_name4(crsffm.p.flight_mode, ap_vehicle_from_mavtype(heartbeat.type), heartbeat.custom_mode);
+                CRSF::SetHeaderAndCrc((uint8_t *)&crsffm, CRSF_FRAMETYPE_FLIGHT_MODE, CRSF_FRAME_SIZE(sizeof(crsffm)), CRSF_ADDRESS_CRSF_TRANSMITTER);
+                handset->sendTelemetryToTX((uint8_t *)&crsffm);
+                break;
             }
             }
         }

--- a/src/lib/MAVLink/MAVLink.cpp
+++ b/src/lib/MAVLink/MAVLink.cpp
@@ -1,5 +1,7 @@
 #include "MAVLink.h"
-#include "ardupilot_protocol.h"
+#if !defined(PLATFORM_STM32)
+    #include "ardupilot_protocol.h"
+#endif
 
 void convert_mavlink_to_crsf_telem(uint8_t *CRSFinBuffer, uint8_t count, Handset *handset)
 {

--- a/src/lib/MAVLink/MAVLink.cpp
+++ b/src/lib/MAVLink/MAVLink.cpp
@@ -53,7 +53,7 @@ void convert_mavlink_to_crsf_telem(uint8_t *CRSFinBuffer, uint8_t count, Handset
                 mavlink_msg_global_position_int_decode(&msg, &global_pos);
                 CRSF_MK_FRAME_T(crsf_sensor_baro_vario_t)
                 crsfbaro = {0};
-                crsfbaro.p.altitude = htobe16(global_pos.alt / 100 + 10000);
+                crsfbaro.p.altitude = htobe16(global_pos.relative_alt / 100 + 10000);
                 // force the top bit of altitude low to represent that it's in decimeters
                 crsfbaro.p.altitude &= 0x7FFF;
                 crsfbaro.p.verticalspd = htobe16(global_pos.vz);

--- a/src/lib/MAVLink/MAVLink.cpp
+++ b/src/lib/MAVLink/MAVLink.cpp
@@ -1,0 +1,76 @@
+#include "MAVLink.h"
+
+void convert_mavlink_to_crsf_telem(uint8_t *CRSFinBuffer, uint8_t count, Handset *handset)
+{
+#if !defined(PLATFORM_STM32)
+    for (uint8_t i = 0; i < count; i++)
+    {
+        mavlink_message_t msg;
+        mavlink_status_t status;
+        bool have_message = mavlink_parse_char(MAVLINK_COMM_0, CRSFinBuffer[CRSF_FRAME_NOT_COUNTED_BYTES + i], &msg, &status);
+        // convert mavlink messages to CRSF messages
+        if (have_message)
+        {
+            switch (msg.msgid)
+            {
+            case MAVLINK_MSG_ID_BATTERY_STATUS: {
+                mavlink_battery_status_t battery_status;
+                mavlink_msg_battery_status_decode(&msg, &battery_status);
+                CRSF_MK_FRAME_T(crsf_sensor_battery_t)
+                crsfbatt = {0};
+                // mV -> mv*100
+                crsfbatt.p.voltage = htobe16(battery_status.voltages[0] / 100);
+                // cA -> mA*100
+                crsfbatt.p.current = htobe16(battery_status.current_battery / 10);
+                crsfbatt.p.capacity = htobe32(battery_status.current_consumed) & 0x0FFF;
+                crsfbatt.p.remaining = battery_status.battery_remaining;
+                CRSF::SetHeaderAndCrc((uint8_t *)&crsfbatt, CRSF_FRAMETYPE_BATTERY_SENSOR, CRSF_FRAME_SIZE(sizeof(crsf_sensor_battery_t)), CRSF_ADDRESS_CRSF_TRANSMITTER);
+                handset->sendTelemetryToTX((uint8_t *)&crsfbatt);
+                break;
+            }
+            case MAVLINK_MSG_ID_GPS_RAW_INT: {
+                mavlink_gps_raw_int_t gps_int;
+                mavlink_msg_gps_raw_int_decode(&msg, &gps_int);
+                CRSF_MK_FRAME_T(crsf_sensor_gps_t)
+                crsfgps = {0};
+                // mm -> meters + 1000
+                crsfgps.p.altitude = htobe16(gps_int.alt / 1000 + 1000);
+                // cm/s -> km/h / 10
+                crsfgps.p.groundspeed = htobe16(gps_int.vel * 0.0036f * 10);
+                crsfgps.p.latitude = htobe32(gps_int.lat);
+                crsfgps.p.longitude = htobe32(gps_int.lon);
+                crsfgps.p.gps_heading = htobe16(gps_int.cog);
+                crsfgps.p.satellites_in_use = gps_int.satellites_visible;
+                CRSF::SetHeaderAndCrc((uint8_t *)&crsfgps, CRSF_FRAMETYPE_GPS, CRSF_FRAME_SIZE(sizeof(crsf_sensor_gps_t)), CRSF_ADDRESS_CRSF_TRANSMITTER);
+                handset->sendTelemetryToTX((uint8_t *)&crsfgps);
+                break;
+            }
+            case MAVLINK_MSG_ID_GLOBAL_POSITION_INT: {
+                mavlink_global_position_int_t global_pos;
+                mavlink_msg_global_position_int_decode(&msg, &global_pos);
+                CRSF_MK_FRAME_T(crsf_sensor_baro_vario_t)
+                crsfbaro = {0};
+                crsfbaro.p.altitude = htobe16(global_pos.alt / 100 + 10000);
+                // force the top bit of altitude low to represent that it's in decimeters
+                crsfbaro.p.altitude &= 0x7FFF;
+                crsfbaro.p.verticalspd = htobe16(global_pos.vz);
+                CRSF::SetHeaderAndCrc((uint8_t *)&crsfbaro, CRSF_FRAMETYPE_BARO_ALTITUDE, CRSF_FRAME_SIZE(sizeof(crsf_sensor_baro_vario_t)), CRSF_ADDRESS_CRSF_TRANSMITTER);
+                handset->sendTelemetryToTX((uint8_t *)&crsfbaro);
+                break;
+            }
+            case MAVLINK_MSG_ID_ATTITUDE: {
+                mavlink_attitude_t attitude;
+                mavlink_msg_attitude_decode(&msg, &attitude);
+                CRSF_MK_FRAME_T(crsf_sensor_attitude_t)
+                crsfatt = {0};
+                crsfatt.p.pitch = htobe16(attitude.pitch * 10000);
+                crsfatt.p.roll = htobe16(attitude.roll * 10000);
+                crsfatt.p.yaw = htobe16(attitude.yaw * 10000);
+                CRSF::SetHeaderAndCrc((uint8_t *)&crsfatt, CRSF_FRAMETYPE_ATTITUDE, CRSF_FRAME_SIZE(sizeof(crsf_sensor_attitude_t)), CRSF_ADDRESS_CRSF_TRANSMITTER);
+                handset->sendTelemetryToTX((uint8_t *)&crsfatt);
+            }
+            }
+        }
+    }
+#endif
+}

--- a/src/lib/MAVLink/MAVLink.h
+++ b/src/lib/MAVLink/MAVLink.h
@@ -1,0 +1,8 @@
+#include "CRSF.h"
+#if !defined(PLATFORM_STM32)
+#include "common/mavlink.h"
+#endif
+#include <CRSFHandset.h>
+
+// Takes a MAVLink message wrapped in CRSF and possibly converts it to a CRSF telemetry message
+void convert_mavlink_to_crsf_telem(uint8_t *CRSFinBuffer, uint8_t count, Handset *handset);

--- a/src/lib/MAVLink/ardupilot_protocol.h
+++ b/src/lib/MAVLink/ardupilot_protocol.h
@@ -1,0 +1,292 @@
+//*******************************************************
+// Copyright (c) MLRS project
+// GPL3
+// https://www.gnu.org/licenses/gpl-3.0.de.html
+// OlliW @ www.olliw.eu
+//*******************************************************
+// ArduPilot Protocol Stuff
+//*******************************************************
+#pragma once
+#ifndef ARDUPILOT_PROTOCOL_H
+#define ARDUPILOT_PROTOCOL_H
+
+
+//-------------------------------------------------------
+// ArduPilot flight modes
+//-------------------------------------------------------
+
+// this we got from ArduCopter/mode.h
+typedef enum {
+    AP_COPTER_FLIGHTMODE_STABILIZE =     0,  // manual airframe angle with manual throttle
+    AP_COPTER_FLIGHTMODE_ACRO =          1,  // manual body-frame angular rate with manual throttle
+    AP_COPTER_FLIGHTMODE_ALT_HOLD =      2,  // manual airframe angle with automatic throttle
+    AP_COPTER_FLIGHTMODE_AUTO =          3,  // fully automatic waypoint control using mission commands
+    AP_COPTER_FLIGHTMODE_GUIDED =        4,  // fully automatic fly to coordinate or fly at velocity/direction using GCS immediate commands
+    AP_COPTER_FLIGHTMODE_LOITER =        5,  // automatic horizontal acceleration with automatic throttle
+    AP_COPTER_FLIGHTMODE_RTL =           6,  // automatic return to launching point
+    AP_COPTER_FLIGHTMODE_CIRCLE =        7,  // automatic circular flight with automatic throttle
+    AP_COPTER_FLIGHTMODE_LAND =          9,  // automatic landing with horizontal position control
+    AP_COPTER_FLIGHTMODE_DRIFT =        11,  // semi-autonomous position, yaw and throttle control
+    AP_COPTER_FLIGHTMODE_SPORT =        13,  // manual earth-frame angular rate control with manual throttle
+    AP_COPTER_FLIGHTMODE_FLIP =         14,  // automatically flip the vehicle on the roll axis
+    AP_COPTER_FLIGHTMODE_AUTOTUNE =     15,  // automatically tune the vehicle's roll and pitch gains
+    AP_COPTER_FLIGHTMODE_POSHOLD =      16,  // automatic position hold with manual override, with automatic throttle
+    AP_COPTER_FLIGHTMODE_BRAKE =        17,  // full-brake using inertial/GPS system, no pilot input
+    AP_COPTER_FLIGHTMODE_THROW =        18,  // throw to launch mode using inertial/GPS system, no pilot input
+    AP_COPTER_FLIGHTMODE_AVOID_ADSB =   19,  // automatic avoidance of obstacles in the macro scale - e.g. full-sized aircraft
+    AP_COPTER_FLIGHTMODE_GUIDED_NOGPS = 20,  // guided mode but only accepts attitude and altitude
+    AP_COPTER_FLIGHTMODE_SMART_RTL =    21,  // SMART_RTL returns to home by retracing its steps
+    AP_COPTER_FLIGHTMODE_FLOWHOLD  =    22,  // FLOWHOLD holds position with optical flow without rangefinder
+    AP_COPTER_FLIGHTMODE_FOLLOW    =    23,  // follow attempts to follow another vehicle or ground station
+    AP_COPTER_FLIGHTMODE_ZIGZAG    =    24,  // ZIGZAG mode is able to fly in a zigzag manner with predefined point A and point B
+    AP_COPTER_FLIGHTMODE_SYSTEMID  =    25,  // System ID mode produces automated system identification signals in the controllers
+    AP_COPTER_FLIGHTMODE_AUTOROTATE =   26,  // Autonomous autorotation
+    AP_COPTER_FLIGHTMODE_AUTO_RTL =     27,  // Auto RTL, this is not a true mode, AUTO will report as this mode if entered to perform a DO_LAND_START Landing sequence
+    AP_COPTER_FLIGHTMODE_TURTLE =       28,  // Flip over after crash
+} AP_COPTER_FLIGHTMODE_ENUM;
+
+
+// this we got from ArduPlane/mode.h
+typedef enum {
+    AP_PLANE_FLIGHTMODE_MANUAL        = 0,
+    AP_PLANE_FLIGHTMODE_CIRCLE        = 1,
+    AP_PLANE_FLIGHTMODE_STABILIZE     = 2,
+    AP_PLANE_FLIGHTMODE_TRAINING      = 3,
+    AP_PLANE_FLIGHTMODE_ACRO          = 4,
+    AP_PLANE_FLIGHTMODE_FLY_BY_WIRE_A = 5,
+    AP_PLANE_FLIGHTMODE_FLY_BY_WIRE_B = 6,
+    AP_PLANE_FLIGHTMODE_CRUISE        = 7,
+    AP_PLANE_FLIGHTMODE_AUTOTUNE      = 8,
+    AP_PLANE_FLIGHTMODE_AUTO          = 10,
+    AP_PLANE_FLIGHTMODE_RTL           = 11,
+    AP_PLANE_FLIGHTMODE_LOITER        = 12,
+    AP_PLANE_FLIGHTMODE_TAKEOFF       = 13,
+    AP_PLANE_FLIGHTMODE_AVOID_ADSB    = 14,
+    AP_PLANE_FLIGHTMODE_GUIDED        = 15,
+    AP_PLANE_FLIGHTMODE_INITIALISING  = 16,
+    AP_PLANE_FLIGHTMODE_QSTABILIZE    = 17,
+    AP_PLANE_FLIGHTMODE_QHOVER        = 18,
+    AP_PLANE_FLIGHTMODE_QLOITER       = 19,
+    AP_PLANE_FLIGHTMODE_QLAND         = 20,
+    AP_PLANE_FLIGHTMODE_QRTL          = 21,
+    AP_PLANE_FLIGHTMODE_QAUTOTUNE     = 22,
+    AP_PLANE_FLIGHTMODE_QACRO         = 23,
+    AP_PLANE_FLIGHTMODE_THERMAL       = 24,
+    AP_PLANE_FLIGHTMODE_LOITER_ALT_QLAND = 25,
+} AP_PLANE_FLIGHTMODE_ENUM;
+
+
+// this we got from Rover/mode.h
+typedef enum {
+    AP_ROVER_FLIGHTMODE_MANUAL       = 0,
+    AP_ROVER_FLIGHTMODE_ACRO         = 1,
+    AP_ROVER_FLIGHTMODE_STEERING     = 3,
+    AP_ROVER_FLIGHTMODE_HOLD         = 4,
+    AP_ROVER_FLIGHTMODE_LOITER       = 5,
+    AP_ROVER_FLIGHTMODE_FOLLOW       = 6,
+    AP_ROVER_FLIGHTMODE_SIMPLE       = 7,
+    AP_ROVER_FLIGHTMODE_DOCK         = 8,
+    AP_ROVER_FLIGHTMODE_AUTO         = 10,
+    AP_ROVER_FLIGHTMODE_RTL          = 11,
+    AP_ROVER_FLIGHTMODE_SMART_RTL    = 12,
+    AP_ROVER_FLIGHTMODE_GUIDED       = 15,
+    AP_ROVER_FLIGHTMODE_INITIALISING = 16,
+} AP_ROVER_FLIGHTMODE_ENUM;
+
+
+// this we got from ArduSub/defines.h
+typedef enum {
+    AP_SUB_FLIGHTMODE_STABILIZE =     0,  // manual angle with manual depth/throttle
+    AP_SUB_FLIGHTMODE_ACRO =          1,  // manual body-frame angular rate with manual depth/throttle
+    AP_SUB_FLIGHTMODE_ALT_HOLD =      2,  // manual angle with automatic depth/throttle
+    AP_SUB_FLIGHTMODE_AUTO =          3,  // fully automatic waypoint control using mission commands
+    AP_SUB_FLIGHTMODE_GUIDED =        4,  // fully automatic fly to coordinate or fly at velocity/direction using GCS immediate commands
+    AP_SUB_FLIGHTMODE_CIRCLE =        7,  // automatic circular flight with automatic throttle
+    AP_SUB_FLIGHTMODE_SURFACE =       9,  // automatically return to surface, pilot maintains horizontal control
+    AP_SUB_FLIGHTMODE_POSHOLD =      16,  // automatic position hold with manual override, with automatic throttle
+    AP_SUB_FLIGHTMODE_MANUAL =       19,  // Pass-through input with no stabilization
+    AP_SUB_FLIGHTMODE_MOTOR_DETECT = 20   // Automatically detect motors orientation
+} AP_SUB_FLIGHTMODE_ENUM;
+
+
+// these we find in ArduCopter/mode.h
+void ap_copter_flight_mode_name4(char* name4, uint8_t flight_mode)
+{
+    switch (flight_mode) {
+    case AP_COPTER_FLIGHTMODE_STABILIZE:    strcpy(name4, "STAB"); break;
+    case AP_COPTER_FLIGHTMODE_ACRO:         strcpy(name4, "ACRO"); break;
+    case AP_COPTER_FLIGHTMODE_ALT_HOLD:     strcpy(name4, "ALTH"); break;
+    case AP_COPTER_FLIGHTMODE_AUTO:         strcpy(name4, "AUTO"); break; // can be also "ARTL"
+    case AP_COPTER_FLIGHTMODE_GUIDED:       strcpy(name4, "GUID"); break;
+    case AP_COPTER_FLIGHTMODE_LOITER:       strcpy(name4, "LOIT"); break;
+    case AP_COPTER_FLIGHTMODE_RTL:          strcpy(name4, "RTL "); break;
+    case AP_COPTER_FLIGHTMODE_CIRCLE:       strcpy(name4, "CIRC"); break;
+    case AP_COPTER_FLIGHTMODE_LAND:         strcpy(name4, "LAND"); break;
+    case AP_COPTER_FLIGHTMODE_DRIFT:        strcpy(name4, "DRIF"); break;
+    case AP_COPTER_FLIGHTMODE_SPORT:        strcpy(name4, "SPRT"); break;
+    case AP_COPTER_FLIGHTMODE_FLIP:         strcpy(name4, "FLIP"); break;
+    case AP_COPTER_FLIGHTMODE_AUTOTUNE:     strcpy(name4, "ATUN"); break;
+    case AP_COPTER_FLIGHTMODE_POSHOLD:      strcpy(name4, "PHLD"); break;
+    case AP_COPTER_FLIGHTMODE_BRAKE:        strcpy(name4, "BRAK"); break;
+    case AP_COPTER_FLIGHTMODE_THROW:        strcpy(name4, "THRW"); break;
+    case AP_COPTER_FLIGHTMODE_AVOID_ADSB:   strcpy(name4, "AVOI"); break;
+    case AP_COPTER_FLIGHTMODE_GUIDED_NOGPS: strcpy(name4, "GNGP"); break;
+    case AP_COPTER_FLIGHTMODE_SMART_RTL:    strcpy(name4, "SRTL"); break;
+    case AP_COPTER_FLIGHTMODE_FLOWHOLD:     strcpy(name4, "FHLD"); break;
+    case AP_COPTER_FLIGHTMODE_FOLLOW:       strcpy(name4, "FOLL"); break;
+    case AP_COPTER_FLIGHTMODE_ZIGZAG:       strcpy(name4, "ZIGZ"); break;
+    case AP_COPTER_FLIGHTMODE_SYSTEMID:     strcpy(name4, "SYSI"); break;
+    case AP_COPTER_FLIGHTMODE_AUTOROTATE:   strcpy(name4, "AROT"); break;
+    case AP_COPTER_FLIGHTMODE_AUTO_RTL:     strcpy(name4, "ARTL"); break;
+    case AP_COPTER_FLIGHTMODE_TURTLE:       strcpy(name4, "TRTL"); break;
+    default:
+        strcpy(name4, "");
+    }
+}
+
+
+// these we find in ArduPlane/mode.h
+void ap_plane_flight_mode_name4(char* name4, uint8_t flight_mode)
+{
+    switch (flight_mode) {
+    case AP_PLANE_FLIGHTMODE_MANUAL:        strcpy(name4, "MANU"); break;
+    case AP_PLANE_FLIGHTMODE_CIRCLE:        strcpy(name4, "CIRC"); break;
+    case AP_PLANE_FLIGHTMODE_STABILIZE:     strcpy(name4, "STAB"); break;
+    case AP_PLANE_FLIGHTMODE_TRAINING:      strcpy(name4, "TRAN"); break;
+    case AP_PLANE_FLIGHTMODE_ACRO:          strcpy(name4, "ACRO"); break;
+    case AP_PLANE_FLIGHTMODE_FLY_BY_WIRE_A: strcpy(name4, "FBWA"); break;
+    case AP_PLANE_FLIGHTMODE_FLY_BY_WIRE_B: strcpy(name4, "FBWB"); break;
+    case AP_PLANE_FLIGHTMODE_CRUISE:        strcpy(name4, "CRUS"); break;
+    case AP_PLANE_FLIGHTMODE_AUTOTUNE:      strcpy(name4, "ATUN"); break;
+    case AP_PLANE_FLIGHTMODE_AUTO:          strcpy(name4, "AUTO"); break;
+    case AP_PLANE_FLIGHTMODE_RTL:           strcpy(name4, "RTL "); break;
+    case AP_PLANE_FLIGHTMODE_LOITER:        strcpy(name4, "LOIT"); break;
+    case AP_PLANE_FLIGHTMODE_TAKEOFF:       strcpy(name4, "TKOF"); break;
+    case AP_PLANE_FLIGHTMODE_AVOID_ADSB:    strcpy(name4, "AVOI"); break;
+    case AP_PLANE_FLIGHTMODE_GUIDED:        strcpy(name4, "GUID"); break;
+    case AP_PLANE_FLIGHTMODE_INITIALISING:  strcpy(name4, "INIT"); break;
+    case AP_PLANE_FLIGHTMODE_QSTABILIZE:    strcpy(name4, "QSTB"); break;
+    case AP_PLANE_FLIGHTMODE_QHOVER:        strcpy(name4, "QHOV"); break;
+    case AP_PLANE_FLIGHTMODE_QLOITER:       strcpy(name4, "QLOT"); break;
+    case AP_PLANE_FLIGHTMODE_QLAND:         strcpy(name4, "QLND"); break;
+    case AP_PLANE_FLIGHTMODE_QRTL:          strcpy(name4, "QRTL"); break;
+    case AP_PLANE_FLIGHTMODE_QAUTOTUNE:     strcpy(name4, "QATN"); break;
+    case AP_PLANE_FLIGHTMODE_QACRO:         strcpy(name4, "QACO"); break;
+    case AP_PLANE_FLIGHTMODE_THERMAL:       strcpy(name4, "THML"); break;
+    case AP_PLANE_FLIGHTMODE_LOITER_ALT_QLAND: strcpy(name4, "L2QL"); break;
+    default:
+        strcpy(name4, "");
+    }
+}
+
+
+// these we find in Rover/mode.h
+void ap_rover_flight_mode_name4(char* name4, uint8_t flight_mode)
+{
+    switch (flight_mode) {
+    case AP_ROVER_FLIGHTMODE_MANUAL:        strcpy(name4, "MANU"); break;
+    case AP_ROVER_FLIGHTMODE_ACRO:          strcpy(name4, "ACRO"); break;
+    case AP_ROVER_FLIGHTMODE_STEERING:      strcpy(name4, "STER"); break;
+    case AP_ROVER_FLIGHTMODE_HOLD:          strcpy(name4, "HOLD"); break;
+    case AP_ROVER_FLIGHTMODE_LOITER:        strcpy(name4, "LOIT"); break;
+    case AP_ROVER_FLIGHTMODE_FOLLOW:        strcpy(name4, "FOLL"); break;
+    case AP_ROVER_FLIGHTMODE_SIMPLE:        strcpy(name4, "SMPL"); break;
+    case AP_ROVER_FLIGHTMODE_DOCK:          strcpy(name4, "DOCK"); break;
+    case AP_ROVER_FLIGHTMODE_AUTO:          strcpy(name4, "AUTO"); break;
+    case AP_ROVER_FLIGHTMODE_RTL:           strcpy(name4, "RTL "); break;
+    case AP_ROVER_FLIGHTMODE_SMART_RTL:     strcpy(name4, "SRTL"); break;
+    case AP_ROVER_FLIGHTMODE_GUIDED:        strcpy(name4, "GUID"); break;
+    case AP_ROVER_FLIGHTMODE_INITIALISING:  strcpy(name4, "INIT"); break;
+    default:
+        strcpy(name4, "");
+    }
+}
+
+
+// there are these? made them up myself
+void ap_sub_flight_mode_name4(char* name4, uint8_t flight_mode)
+{
+    switch (flight_mode) {
+    case AP_SUB_FLIGHTMODE_STABILIZE:       strcpy(name4, "STAB"); break;
+    case AP_SUB_FLIGHTMODE_ACRO:            strcpy(name4, "ACRO"); break;
+    case AP_SUB_FLIGHTMODE_ALT_HOLD:        strcpy(name4, "AHLD"); break;
+    case AP_SUB_FLIGHTMODE_AUTO:            strcpy(name4, "AUTO"); break;
+    case AP_SUB_FLIGHTMODE_GUIDED:          strcpy(name4, "GUID"); break;
+    case AP_SUB_FLIGHTMODE_CIRCLE:          strcpy(name4, "CIRC"); break;
+    case AP_SUB_FLIGHTMODE_SURFACE:         strcpy(name4, "SURF"); break; // ?
+    case AP_SUB_FLIGHTMODE_POSHOLD:         strcpy(name4, "PHLD"); break;
+    case AP_SUB_FLIGHTMODE_MANUAL:          strcpy(name4, "MANU"); break;
+    case AP_SUB_FLIGHTMODE_MOTOR_DETECT:    strcpy(name4, "MDET"); break; // ?
+    default:
+        strcpy(name4, "");
+    }
+}
+
+
+//-------------------------------------------------------
+// ArduPilot vehicles
+//-------------------------------------------------------
+
+typedef enum {
+    AP_VEHICLE_GENERIC = 0,
+    AP_VEHICLE_COPTER,
+    AP_VEHICLE_PLANE,
+    AP_VEHICLE_ROVER,
+    AP_VEHICLE_SUB,
+} AP_VEHICLE_ENUM;
+
+
+// this we deduce by searching for MAV_TYPE in ArduPilot code
+uint8_t ap_vehicle_from_mavtype(uint8_t mav_type)
+{
+    switch (mav_type) {
+    case MAV_TYPE_COAXIAL:
+    case MAV_TYPE_HELICOPTER:
+    case MAV_TYPE_TRICOPTER:
+    case MAV_TYPE_QUADROTOR:
+    case MAV_TYPE_HEXAROTOR:
+    case MAV_TYPE_OCTOROTOR:
+    case MAV_TYPE_DECAROTOR:
+    case MAV_TYPE_DODECAROTOR:
+        return AP_VEHICLE_COPTER;
+
+    case MAV_TYPE_SURFACE_BOAT:
+    case MAV_TYPE_GROUND_ROVER:
+        return AP_VEHICLE_ROVER;
+
+    case MAV_TYPE_SUBMARINE:
+        return AP_VEHICLE_SUB;
+
+    case MAV_TYPE_GENERIC:
+        return AP_VEHICLE_GENERIC; // sadly we don't know nothing
+    }
+
+    return AP_VEHICLE_PLANE; // let's guess it's a plane
+}
+
+
+//-------------------------------------------------------
+// more
+//-------------------------------------------------------
+
+void ap_flight_mode_name4(char* name4, uint8_t vehicle, uint8_t flight_mode)
+{
+    switch (vehicle) {
+    case AP_VEHICLE_COPTER:
+        ap_copter_flight_mode_name4(name4, flight_mode);
+        return;
+    case AP_VEHICLE_PLANE:
+        ap_plane_flight_mode_name4(name4, flight_mode);
+        return;
+    case AP_VEHICLE_ROVER:
+        ap_rover_flight_mode_name4(name4, flight_mode);
+        return;
+    case AP_VEHICLE_SUB:
+        ap_sub_flight_mode_name4(name4, flight_mode);
+        return;
+    }
+
+    strcpy(name4, "");
+}
+
+#endif // ARDUPILOT_PROTOCOL_H

--- a/src/src/rx-serial/SerialHoTT_TLM.cpp
+++ b/src/src/rx-serial/SerialHoTT_TLM.cpp
@@ -22,15 +22,6 @@
                                 // to HoTT bus speed if only a HoTT Vario is connected and
                                 // values change every HoTT bus poll cycle.
 
-typedef struct crsf_sensor_gps_s
-{
-    int32_t latitude;     // degree / 10,000,000 big endian
-    int32_t longitude;    // degree / 10,000,000 big endian
-    uint16_t groundspeed; // km/h / 10 big endian
-    uint16_t heading;     // GPS heading, degree/100 big endian
-    uint16_t altitude;    // meters, +1000m big endian
-    uint8_t satellites;   // satellites
-} PACKED crsf_sensor_gps_t;
 
 extern Telemetry telemetry;
 
@@ -271,9 +262,9 @@ void SerialHoTT_TLM::sendCRSFgps(uint32_t now)
     crsfGPS.p.latitude = htobe32(getHoTTlatitude());
     crsfGPS.p.longitude = htobe32(getHoTTlongitude());
     crsfGPS.p.groundspeed = htobe16(getHoTTgroundspeed() * 10); // Hott 1 = 1 km/h, ELRS 1 = 0.1km/h
-    crsfGPS.p.heading = htobe16(getHoTTheading() * 100);
+    crsfGPS.p.gps_heading = htobe16(getHoTTheading() * 100);
     crsfGPS.p.altitude = htobe16(getHoTTMSLaltitude() + 1000); // HoTT 1 = 1m, CRSF: 0m = 1000
-    crsfGPS.p.satellites = getHoTTsatellites();
+    crsfGPS.p.satellites_in_use = getHoTTsatellites();
     CRSF::SetHeaderAndCrc((uint8_t *)&crsfGPS, CRSF_FRAMETYPE_GPS, CRSF_FRAME_SIZE(sizeof(crsf_sensor_gps_t)), CRSF_ADDRESS_CRSF_TRANSMITTER);
 
     // send packet only if min rate timer expired or values have changed

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -23,7 +23,7 @@
 #include "devPDET.h"
 #include "devBackpack.h"
 
-#include "common/mavlink.h"
+#include "MAVLink.h"
 
 #if defined(PLATFORM_ESP32_S3)
 #include "USB.h"
@@ -1490,74 +1490,8 @@ void loop()
         {
           // raw mavlink data - forward to USB rather than handset
           uint8_t count = CRSFinBuffer[1];
-          for (uint8_t i = 0; i < count; i++)
-          {
-            mavlink_message_t msg;
-            mavlink_status_t status;
-            bool have_message = mavlink_parse_char(MAVLINK_COMM_0, CRSFinBuffer[CRSF_FRAME_NOT_COUNTED_BYTES + i], &msg, &status);
-            // convert mavlink messages to CRSF messages
-            if (have_message) {
-              switch (msg.msgid)
-              {
-                case MAVLINK_MSG_ID_BATTERY_STATUS:
-                {
-                  mavlink_battery_status_t battery_status;
-                  mavlink_msg_battery_status_decode(&msg, &battery_status);
-                  CRSF_MK_FRAME_T(crsf_sensor_battery_t) crsfbatt = { 0 };
-                  // mV -> mv*100
-                  crsfbatt.p.voltage = htobe16(battery_status.voltages[0] / 100);
-                  // cA -> mA*100
-                  crsfbatt.p.current = htobe16(battery_status.current_battery / 10);
-                  crsfbatt.p.capacity = htobe32(battery_status.current_consumed) & 0x0FFF;
-                  crsfbatt.p.remaining = battery_status.battery_remaining;
-                  CRSF::SetHeaderAndCrc((uint8_t *)&crsfbatt, CRSF_FRAMETYPE_BATTERY_SENSOR, CRSF_FRAME_SIZE(sizeof(crsf_sensor_battery_t)), CRSF_ADDRESS_CRSF_TRANSMITTER);
-                  handset->sendTelemetryToTX((uint8_t *)&crsfbatt);
-                  break;
-                }
-                case MAVLINK_MSG_ID_GPS_RAW_INT:
-                {
-                  mavlink_gps_raw_int_t gps_int;
-                  mavlink_msg_gps_raw_int_decode(&msg, &gps_int);
-                  CRSF_MK_FRAME_T(crsf_sensor_gps_t) crsfgps = { 0 };
-                  // mm -> meters + 1000
-                  crsfgps.p.altitude = htobe16(gps_int.alt / 1000 + 1000);
-                  // cm/s -> km/h / 10
-                  crsfgps.p.groundspeed = htobe16(gps_int.vel * 36 / 100);
-                  crsfgps.p.latitude = htobe32(gps_int.lat);
-                  crsfgps.p.longitude = htobe32(gps_int.lon);
-                  crsfgps.p.gps_heading = htobe16(gps_int.cog);
-                  crsfgps.p.satellites_in_use = gps_int.satellites_visible;
-                  CRSF::SetHeaderAndCrc((uint8_t *)&crsfgps, CRSF_FRAMETYPE_GPS, CRSF_FRAME_SIZE(sizeof(crsf_sensor_gps_t)), CRSF_ADDRESS_CRSF_TRANSMITTER);
-                  handset->sendTelemetryToTX((uint8_t *)&crsfgps);
-                  break;
-                }
-                case MAVLINK_MSG_ID_GLOBAL_POSITION_INT:
-                {
-                  mavlink_global_position_int_t global_pos;
-                  mavlink_msg_global_position_int_decode(&msg, &global_pos);
-                  CRSF_MK_FRAME_T(crsf_sensor_baro_vario_t) crsfbaro = { 0 };
-                  crsfbaro.p.altitude = htobe16(global_pos.alt / 100 + 10000);
-                  // force the top bit of altitude low to represent that it's in decimeters
-                  crsfbaro.p.altitude &= 0x7FFF;
-                  crsfbaro.p.verticalspd = htobe16(global_pos.vz);
-                  CRSF::SetHeaderAndCrc((uint8_t *)&crsfbaro, CRSF_FRAMETYPE_BARO_ALTITUDE, CRSF_FRAME_SIZE(sizeof(crsf_sensor_baro_vario_t)), CRSF_ADDRESS_CRSF_TRANSMITTER);
-                  handset->sendTelemetryToTX((uint8_t *)&crsfbaro);
-                  break;
-                }
-                case MAVLINK_MSG_ID_ATTITUDE:
-                {
-                  mavlink_attitude_t attitude;
-                  mavlink_msg_attitude_decode(&msg, &attitude);
-                  CRSF_MK_FRAME_T(crsf_sensor_attitude_t) crsfatt = { 0 };
-                  crsfatt.p.pitch = htobe16(attitude.pitch * 10000);
-                  crsfatt.p.roll = htobe16(attitude.roll * 10000);
-                  crsfatt.p.yaw = htobe16(attitude.yaw * 10000);
-                  CRSF::SetHeaderAndCrc((uint8_t *)&crsfatt, CRSF_FRAMETYPE_ATTITUDE, CRSF_FRAME_SIZE(sizeof(crsf_sensor_attitude_t)), CRSF_ADDRESS_CRSF_TRANSMITTER);
-                  handset->sendTelemetryToTX((uint8_t *)&crsfatt);
-                }
-              }
-            }
-          }
+          // Convert to CRSF telemetry where we can
+          convert_mavlink_to_crsf_telem(CRSFinBuffer, count, handset);
           // If we have a backpack 
           TxUSB->write(CRSFinBuffer + CRSF_FRAME_NOT_COUNTED_BYTES, count);
           if (TxUSB != TxBackpack)

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -23,6 +23,8 @@
 #include "devPDET.h"
 #include "devBackpack.h"
 
+#include "common/mavlink.h"
+
 #if defined(PLATFORM_ESP32_S3)
 #include "USB.h"
 #define USBSerial Serial
@@ -1488,6 +1490,75 @@ void loop()
         {
           // raw mavlink data - forward to USB rather than handset
           uint8_t count = CRSFinBuffer[1];
+          for (uint8_t i = 0; i < count; i++)
+          {
+            mavlink_message_t msg;
+            mavlink_status_t status;
+            bool have_message = mavlink_parse_char(MAVLINK_COMM_0, CRSFinBuffer[CRSF_FRAME_NOT_COUNTED_BYTES + i], &msg, &status);
+            // convert mavlink messages to CRSF messages
+            if (have_message) {
+              switch (msg.msgid)
+              {
+                case MAVLINK_MSG_ID_BATTERY_STATUS:
+                {
+                  mavlink_battery_status_t battery_status;
+                  mavlink_msg_battery_status_decode(&msg, &battery_status);
+                  CRSF_MK_FRAME_T(crsf_sensor_battery_t) crsfbatt = { 0 };
+                  // mV -> mv*100
+                  crsfbatt.p.voltage = htobe16(battery_status.voltages[0] / 100);
+                  // cA -> mA*100
+                  crsfbatt.p.current = htobe16(battery_status.current_battery / 10);
+                  crsfbatt.p.capacity = htobe32(battery_status.current_consumed) & 0x0FFF;
+                  crsfbatt.p.remaining = battery_status.battery_remaining;
+                  CRSF::SetHeaderAndCrc((uint8_t *)&crsfbatt, CRSF_FRAMETYPE_BATTERY_SENSOR, CRSF_FRAME_SIZE(sizeof(crsf_sensor_battery_t)), CRSF_ADDRESS_CRSF_TRANSMITTER);
+                  handset->sendTelemetryToTX((uint8_t *)&crsfbatt);
+                  break;
+                }
+                case MAVLINK_MSG_ID_GPS_RAW_INT:
+                {
+                  mavlink_gps_raw_int_t gps_int;
+                  mavlink_msg_gps_raw_int_decode(&msg, &gps_int);
+                  CRSF_MK_FRAME_T(crsf_sensor_gps_t) crsfgps = { 0 };
+                  // mm -> meters + 1000
+                  crsfgps.p.altitude = htobe16(gps_int.alt / 1000 + 1000);
+                  // cm/s -> km/h / 10
+                  crsfgps.p.groundspeed = htobe16(gps_int.vel * 36 / 100);
+                  crsfgps.p.latitude = htobe32(gps_int.lat);
+                  crsfgps.p.longitude = htobe32(gps_int.lon);
+                  crsfgps.p.gps_heading = htobe16(gps_int.cog);
+                  crsfgps.p.satellites_in_use = gps_int.satellites_visible;
+                  CRSF::SetHeaderAndCrc((uint8_t *)&crsfgps, CRSF_FRAMETYPE_GPS, CRSF_FRAME_SIZE(sizeof(crsf_sensor_gps_t)), CRSF_ADDRESS_CRSF_TRANSMITTER);
+                  handset->sendTelemetryToTX((uint8_t *)&crsfgps);
+                  break;
+                }
+                case MAVLINK_MSG_ID_GLOBAL_POSITION_INT:
+                {
+                  mavlink_global_position_int_t global_pos;
+                  mavlink_msg_global_position_int_decode(&msg, &global_pos);
+                  CRSF_MK_FRAME_T(crsf_sensor_baro_vario_t) crsfbaro = { 0 };
+                  crsfbaro.p.altitude = htobe16(global_pos.alt / 100 + 10000);
+                  // force the top bit of altitude low to represent that it's in decimeters
+                  crsfbaro.p.altitude &= 0x7FFF;
+                  crsfbaro.p.verticalspd = htobe16(global_pos.vz);
+                  CRSF::SetHeaderAndCrc((uint8_t *)&crsfbaro, CRSF_FRAMETYPE_BARO_ALTITUDE, CRSF_FRAME_SIZE(sizeof(crsf_sensor_baro_vario_t)), CRSF_ADDRESS_CRSF_TRANSMITTER);
+                  handset->sendTelemetryToTX((uint8_t *)&crsfbaro);
+                  break;
+                }
+                case MAVLINK_MSG_ID_ATTITUDE:
+                {
+                  mavlink_attitude_t attitude;
+                  mavlink_msg_attitude_decode(&msg, &attitude);
+                  CRSF_MK_FRAME_T(crsf_sensor_attitude_t) crsfatt = { 0 };
+                  crsfatt.p.pitch = htobe16(attitude.pitch * 10000);
+                  crsfatt.p.roll = htobe16(attitude.roll * 10000);
+                  crsfatt.p.yaw = htobe16(attitude.yaw * 10000);
+                  CRSF::SetHeaderAndCrc((uint8_t *)&crsfatt, CRSF_FRAMETYPE_ATTITUDE, CRSF_FRAME_SIZE(sizeof(crsf_sensor_attitude_t)), CRSF_ADDRESS_CRSF_TRANSMITTER);
+                  handset->sendTelemetryToTX((uint8_t *)&crsfatt);
+                }
+              }
+            }
+          }
+          // If we have a backpack 
           TxUSB->write(CRSFinBuffer + CRSF_FRAME_NOT_COUNTED_BYTES, count);
           if (TxUSB != TxBackpack)
           {

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1492,8 +1492,8 @@ void loop()
           uint8_t count = CRSFinBuffer[1];
           // Convert to CRSF telemetry where we can
           convert_mavlink_to_crsf_telem(CRSFinBuffer, count, handset);
-          // If we have a backpack 
           TxUSB->write(CRSFinBuffer + CRSF_FRAME_NOT_COUNTED_BYTES, count);
+          // If we have a backpack
           if (TxUSB != TxBackpack)
           {
             TxBackpack->write(CRSFinBuffer + CRSF_FRAME_NOT_COUNTED_BYTES, count);

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -63,6 +63,7 @@ lib_deps =
 	lemmingdev/ESP32-BLE-Gamepad @ 0.5.2
 	h2zero/NimBLE-Arduino @ 1.4.1
 	bblanchon/ArduinoJson @ 7.0.4
+	${common_env_data.mavlink_lib_dep}
 oled_lib_deps =
 	${env_common_esp32.lib_deps}
 	olikraus/U8g2 @ 2.34.4


### PR DESCRIPTION
## Contributors
Re-submitting this one on behalf of @MUSTARDTIGERFPV who did all the actual work here. This is the rebase (proper) branch that PK fixed up after I failed dismally at Git.
Original PR here: https://github.com/ExpressLRS/ExpressLRS/pull/2792

## What this PR accomplishes

When using the new MAVLink link mode, we no longer have access to FC telemetry like GPS coordinates, flight mode, altitude, etc. That data *is* however available in the MAVLink stream; this PR adds functionality to the TX to interpret the MAVLink messages going through it to your GCS and convert relevant parameters into CRSF telemetry, putting values like altitude back in your handset and in your EdgeTX telemetry logs.

## What's needed to get it out of draft state

1. Testing is needed with ESP8285-based transmitters, which have less free memory to play around with.
2. It's likely that explicitly declaring buffers (and eschewing the default 4 channels' worth of buffers) would reduce memory usage by ~800k.
3. Real-world testing - my bench FC's GPS values are pretty boring - things might get funny in the real world.

## Preview

![mavlink-rc-crsf](https://github.com/ExpressLRS/ExpressLRS/assets/122312693/38755095-1cf1-4363-b12e-5dfab4cf3afd)
