### PR TITLE
fix DEBUG_TX_FREERUN

### DIFF
--- a/src/lib/Handset/devHandset.cpp
+++ b/src/lib/Handset/devHandset.cpp
@@ -29,10 +29,7 @@ static int start()
 {
     handset->Begin();
 #if defined(DEBUG_TX_FREERUN)
-    if (!handset->connect())
-    {
-        ERRLN("CRSF::connected has not been initialised");
-    }
+    handset->forceConnection();
 #endif
     return DURATION_IMMEDIATELY;
 }

--- a/src/lib/Handset/handset.h
+++ b/src/lib/Handset/handset.h
@@ -95,6 +95,13 @@ public:
      */
     uint32_t GetRCdataLastRecv() const { return RCdataLastRecv; }
 
+#if defined(DEBUG_TX_FREERUN)
+    /**
+     * @brief Can be used to force a connected callback for debugging
+     */
+    void forceConnection() { if (connected) connected(); }
+#endif
+
 protected:
     virtual ~Handset() = default;
 


### PR DESCRIPTION
appears the DEBUG_TX_FREERUN define went bust a couple of months ago. PR restores functionality.  