### PR TITLE
Allow flashing an RX as a TX

### DIFF
--- a/src/python/UnifiedConfiguration.py
+++ b/src/python/UnifiedConfiguration.py
@@ -6,6 +6,8 @@ import struct
 import sys
 
 from external import jmespath
+from firmware import TXType
+
 
 def findFirmwareEnd(f):
     f.seek(0, 0)
@@ -32,7 +34,7 @@ def findFirmwareEnd(f):
         pos = pos + 32
     return pos
 
-def appendToFirmware(firmware_file, product_name, lua_name, defines, config, layout_file):
+def appendToFirmware(firmware_file, product_name, lua_name, defines, config, layout_file, rx_as_tx):
     product = (product_name.encode() + (b'\0' * 128))[0:128]
     device = (lua_name.encode() + (b'\0' * 16))[0:16]
     end = findFirmwareEnd(firmware_file)
@@ -47,6 +49,12 @@ def appendToFirmware(firmware_file, product_name, lua_name, defines, config, lay
                 hardware = json.load(h)
                 if 'overlay' in config:
                     hardware.update(config['overlay'])
+                if rx_as_tx is not None:
+                    if hardware['serial_rx'] is None or hardware['serial_tx'] is None:
+                        sys.stderr.write(f'Cannot select this target as RX-as-TX\n')
+                        exit(1)
+                    if rx_as_tx == TXType.external and hardware['serial_rx']:
+                        hardware['serial_rx'] = hardware['serial_tx']
                 layout = (json.JSONEncoder().encode(hardware).encode() + (b'\0' * 2048))[0:2048]
                 firmware_file.write(layout)
         except EnvironmentError:
@@ -63,7 +71,7 @@ def appendToFirmware(firmware_file, product_name, lua_name, defines, config, lay
         firmware_file.write(config['prior_target_name'].upper().encode())
         firmware_file.write(b'\0')
 
-def doConfiguration(file, defines, config, moduletype, frequency, platform, device_name):
+def doConfiguration(file, defines, config, moduletype, frequency, platform, device_name, rx_as_tx):
     product_name = "Unified"
     lua_name = "Unified"
     layout = None
@@ -99,7 +107,7 @@ def doConfiguration(file, defines, config, moduletype, frequency, platform, devi
         layout = f"hardware/{dir}/{config['layout_file']}"
 
     lua_name = lua_name if device_name is None else device_name
-    appendToFirmware(file, product_name, lua_name, defines, config, layout)
+    appendToFirmware(file, product_name, lua_name, defines, config, layout, rx_as_tx)
 
 def appendConfiguration(source, target, env):
     target_name = env.get('PIOENV', '').upper()
@@ -129,7 +137,7 @@ def appendConfiguration(source, target, env):
     defines = json.JSONEncoder().encode(env['OPTIONS_JSON'])
 
     with open(str(target[0]), "r+b") as firmware_file:
-        doConfiguration(firmware_file, defines, config, moduletype, frequency, platform, device_name)
+        doConfiguration(firmware_file, defines, config, moduletype, frequency, platform, device_name, None)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Configure Unified Firmware")
@@ -155,4 +163,4 @@ if __name__ == '__main__':
         dir = 'TX' if moduletype == 'tx' else 'RX'
         layout = f"hardware/{dir}/{config['layout_file']}"
 
-    appendToFirmware(args.file, product_name, lua_name, args.options, config, layout)
+    appendToFirmware(args.file, product_name, lua_name, args.options, config, layout, None)

--- a/src/python/UnifiedConfiguration.py
+++ b/src/python/UnifiedConfiguration.py
@@ -50,11 +50,14 @@ def appendToFirmware(firmware_file, product_name, lua_name, defines, config, lay
                 if 'overlay' in config:
                     hardware.update(config['overlay'])
                 if rx_as_tx is not None:
-                    if hardware['serial_rx'] is None or hardware['serial_tx'] is None:
+                    if 'serial_rx' not in hardware or 'serial_tx' not in hardware:
                         sys.stderr.write(f'Cannot select this target as RX-as-TX\n')
                         exit(1)
                     if rx_as_tx == TXType.external and hardware['serial_rx']:
                         hardware['serial_rx'] = hardware['serial_tx']
+                    if 'led_red' not in hardware and 'led' in hardware:
+                        hardware['led_red'] = hardware['led']
+                        del hardware['led']
                 layout = (json.JSONEncoder().encode(hardware).encode() + (b'\0' * 2048))[0:2048]
                 firmware_file.write(layout)
         except EnvironmentError:

--- a/src/python/firmware.py
+++ b/src/python/firmware.py
@@ -30,6 +30,15 @@ class FirmwareOptions(NamedTuple):
     offset: int
     firmware: str
 
+
+class TXType(Enum):
+    internal = 'internal'
+    external = 'external'
+
+    def __str__(self):
+        return self.value
+
+
 def find_patch_location(mm):
     return mm.find(b'\xBE\xEF\xBA\xBE\xCA\xFE\xF0\x0D')
 


### PR DESCRIPTION
Adds an option to the flasher which allows flashing an RX as a TX.
The option is as follows
```
  --rx-as-tx {internal,external}
                        Flash an RX module with TX firmware, either internal (full-duplex) or external (half-duplex)
```

- ESP32 based receivers allow you to select `internal` or `external` as the option.
- ESP8285 based receivers only allow `internal`.
- STM32 is not supported.

Need to open an issue with Configurator so an advanced/expert option can be added when selecting an RX to flash.