### PR TITLE
Enable two slot fifo for all crsf ext frames

### DIFF
--- a/src/lib/Telemetry/telemetry.cpp
+++ b/src/lib/Telemetry/telemetry.cpp
@@ -144,7 +144,7 @@ void Telemetry::ResetState()
     telemetry_state = TELEMETRY_IDLE;
     currentTelemetryByte = 0;
     currentPayloadIndex = 0;
-    currentQueueIndex = 0;
+    twoslotLastQueueIndex = 0;
     receivedPackages = 0;
 
     uint8_t offset = 0;
@@ -336,12 +336,12 @@ bool Telemetry::AppendTelemetryPackage(uint8_t *package)
                     // Sending the second slot, use the first
                     targetIndex = payloadTypesCount - 2;
                 }
-                else if (currentQueueIndex == payloadTypesCount - 2 && payloadTypes[currentQueueIndex].updated)
+                else if (twoslotLastQueueIndex == payloadTypesCount - 2 && payloadTypes[twoslotLastQueueIndex].updated)
                 {
                     // Previous frame saved to the first slot, use the second
                     targetIndex = payloadTypesCount - 1;
                 }
-                currentQueueIndex = targetIndex;
+                twoslotLastQueueIndex = targetIndex;
             }
         }
         else

--- a/src/lib/Telemetry/telemetry.h
+++ b/src/lib/Telemetry/telemetry.h
@@ -75,6 +75,7 @@ private:
     telemetry_state_s telemetry_state;
     uint8_t currentTelemetryByte;
     uint8_t currentPayloadIndex;
+    uint8_t currentQueueIndex;
     volatile crsf_telemetry_package_t *telemetryPackageHead;
     uint8_t receivedPackages;
     bool callBootloader;

--- a/src/lib/Telemetry/telemetry.h
+++ b/src/lib/Telemetry/telemetry.h
@@ -75,7 +75,7 @@ private:
     telemetry_state_s telemetry_state;
     uint8_t currentTelemetryByte;
     uint8_t currentPayloadIndex;
-    uint8_t currentQueueIndex;
+    uint8_t twoslotLastQueueIndex;
     volatile crsf_telemetry_package_t *telemetryPackageHead;
     uint8_t receivedPackages;
     bool callBootloader;


### PR DESCRIPTION
Change dropping behaviour: overwrite oldest message in fifo that is not sent yet

TBD: test with different FC projects if this change breaks anything

More generic PR based on https://github.com/pmattila/ExpressLRS/commit/46d1a88dc1028d8df2a4ef3cf23c2ea80c63aac0