### PR TITLE
Allow secret _user_defines.txt to replace user_defines.txt

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -7,6 +7,7 @@
 python/__pycache__/
 *.pyc
 super_defines.txt
+_user_defines.txt
 include/WebContent.h
 include/flashdiscrim.h
 .DS_Store

--- a/src/python/build_flags.py
+++ b/src/python/build_flags.py
@@ -138,8 +138,12 @@ def get_version():
 json_flags['flash-discriminator'] = randint(1,2**32-1)
 json_flags['wifi-on-interval'] = -1
 
-process_flags("user_defines.txt")
-process_flags("super_defines.txt") # allow secret super_defines to override user_defines
+if os.path.isfile("_user_defines.txt"):
+    process_flags("_user_defines.txt") #allow secret _user_defines to superseed user_defines
+else:
+    process_flags("user_defines.txt")
+    process_flags("super_defines.txt") # allow secret super_defines to override user_defines
+
 version_to_env()
 build_flags.append("-DLATEST_COMMIT=" + get_git_sha())
 build_flags.append("-DLATEST_VERSION=" + get_version())


### PR DESCRIPTION
To avoid accidentally committing and pushing `user_defines.txt` a local `_user_defines.txt` can be used that if present will replace `user_defines.txt`. `_user_defines.txt` will be git ignored.