### PR TITLE
Remove two sources of telemetry startup hangs

### DIFF
--- a/src/lib/StubbornReceiver/stubborn_receiver.cpp
+++ b/src/lib/StubbornReceiver/stubborn_receiver.cpp
@@ -58,22 +58,32 @@ void StubbornReceiver::ReceiveData(uint8_t const packageIndex, uint8_t const * c
     }
 
     bool acceptData = false;
+    // If this is the last package, accept as being complete
     if (packageIndex == 0 && currentPackage > 1)
     {
         // PackageIndex 0 (the final packet) can also contain data
         acceptData = true;
         finishedData = true;
     }
+    // If this package is the expected index, accept and advance index
     else if (packageIndex == currentPackage)
     {
         acceptData = true;
-        currentPackage++;
+    }
+    // If this is the first package from the sender, and we're mid-receive
+    // assume the sender has restarted without resync or is freshly booted
+    // skip the resync process entirely and just pretend this is a fresh boot too
+    else if (packageIndex == 1 && currentPackage > 1)
+    {
+        ResetState();
+        acceptData = true;
     }
 
     if (acceptData)
     {
         uint8_t len = std::min((uint8_t)(length - currentOffset), dataLen);
         memcpy(&data[currentOffset], receiveData, len);
+        currentPackage++;
         currentOffset += len;
         telemetryConfirm = !telemetryConfirm;
     }

--- a/src/lib/StubbornSender/stubborn_sender.h
+++ b/src/lib/StubbornSender/stubborn_sender.h
@@ -7,6 +7,7 @@
 
 typedef enum {
     SENDER_IDLE = 0,
+    SEND_PENDING,
     SENDING,
     WAIT_UNTIL_NEXT_CONFIRM,
     RESYNC,
@@ -31,7 +32,7 @@ private:
     uint8_t currentOffset;
     uint8_t bytesLastPayload;
     uint8_t currentPackage;
-    bool waitUntilTelemetryConfirm;
+    bool telemetryConfirmExpectedValue;
     uint16_t waitCount;
     uint16_t maxWaitCount;
     uint8_t maxPackageIndex;

--- a/src/test/test_stubborn/test_stubborn.cpp
+++ b/src/test/test_stubborn/test_stubborn.cpp
@@ -415,6 +415,92 @@ void test_stubborn_link_variable_size_per_call(void)
         doMultibyte = !doMultibyte;
     }
 }
+
+/***
+ * @brief: Make sure the packageIndex does not advance before the package is actually retreived with `GetCurrentPayload`
+*/
+void test_stubborn_link_premature_advance(void)
+{
+    uint8_t batterySequence[] = {0xEC,10,0x08,0,0,0,0,0,0,0,0,109};
+    sender.setMaxPackageIndex(ELRS4_TELEMETRY_MAX_PACKAGES);
+    sender.ResetState();
+    sender.SetDataToTransmit(batterySequence, sizeof(batterySequence));
+    uint8_t data[1];
+    uint8_t packageIndex;
+    bool confirmValue = true;
+
+    // Simulate ACKs coming in before the packet is sent
+    sender.ConfirmCurrentPayload(confirmValue);
+    sender.ConfirmCurrentPayload(confirmValue);
+    sender.ConfirmCurrentPayload(confirmValue);
+    sender.ConfirmCurrentPayload(confirmValue);
+
+    // Normal operation commences
+    packageIndex = sender.GetCurrentPayload(data, 1);
+    // packageIndex should still be the first package
+    TEST_ASSERT_EQUAL(1, packageIndex);
+
+    sender.ConfirmCurrentPayload(confirmValue);
+    packageIndex = sender.GetCurrentPayload(data, 1);
+    // packageIndex should now be the second package
+    TEST_ASSERT_EQUAL(2, packageIndex);
+}
+
+/***
+ * @brief: Make sure Receiver will fast-resync if it sees the sender has reset
+*/
+void test_stubborn_link_forlorn_receiver(void)
+{
+    uint8_t testSequence1[] = {1,2,3,4,5,6};
+    uint8_t testSequence2[] = {11,12,13,14,15,16,17,18,19,20};
+    sender.setMaxPackageIndex(ELRS4_TELEMETRY_MAX_PACKAGES);
+    sender.ResetState();
+    sender.SetDataToTransmit(testSequence1, sizeof(testSequence1));
+    uint8_t packageIndex;
+
+    uint8_t dataOta[1];
+    uint8_t dataReceiver[64];
+    receiver.setMaxPackageIndex(ELRS4_TELEMETRY_MAX_PACKAGES);
+    receiver.ResetState();
+    receiver.SetDataToReceive(dataReceiver, sizeof(dataReceiver));
+
+    // Start by sending part of the package, but use an odd number to make
+    // sure telemetry confirm is not going to match up
+    for(int i = 0; i < 3; i++)
+    {
+        packageIndex = sender.GetCurrentPayload(dataOta, sizeof(dataOta));
+        receiver.ReceiveData(packageIndex, dataOta, sizeof(dataOta));
+        sender.ConfirmCurrentPayload(receiver.GetCurrentConfirm());
+    }
+
+    // Simulate the Sender rebooting and starting a different send
+    // Note nothing is done to the receiver to help it figure it out
+    sender.setMaxPackageIndex(ELRS4_TELEMETRY_MAX_PACKAGES);
+    sender.ResetState();
+    sender.SetDataToTransmit(testSequence2, sizeof(testSequence2));
+
+    int position = 0;
+    int lastPackageIndex = -1;
+    while (!receiver.HasFinishedData() && position < 10000)
+    {
+        ++position;
+        packageIndex = sender.GetCurrentPayload(dataOta, sizeof(dataOta));
+        // If receiver is working properly, packageIndex should go 1, 2, 3, 4, 5, 6, 7, 8, 9, 0
+        // If it is not working properly it will likely go 1, 2, 2, 2, 2, ... ELRS4_TELEMETRY_MAX_PACKAGES, 0, 0, 0, 0
+        TEST_ASSERT_NOT_EQUAL_MESSAGE(lastPackageIndex, packageIndex, "Sender stalled");
+        lastPackageIndex = packageIndex;
+
+        receiver.ReceiveData(packageIndex, dataOta, sizeof(dataOta));
+        sender.ConfirmCurrentPayload(receiver.GetCurrentConfirm());
+
+    }
+    TEST_ASSERT_EQUAL(sizeof(testSequence2), position);
+    // The data that comes out the other side should be the second sequence, not the first
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(testSequence2, dataReceiver, sizeof(testSequence2));
+
+    receiver.Unlock();
+}
+
 // Unity setup/teardown
 void setUp() {}
 void tearDown() {}
@@ -433,6 +519,8 @@ int main(int argc, char **argv)
     RUN_TEST(test_stubborn_link_multiple_packages);
     RUN_TEST(test_stubborn_link_resync_then_send);
     RUN_TEST(test_stubborn_link_variable_size_per_call);
+    RUN_TEST(test_stubborn_link_premature_advance);
+    RUN_TEST(test_stubborn_link_forlorn_receiver);
     UNITY_END();
 
     return 0;


### PR DESCRIPTION
This PR addresses two conditions in which the telemetry / MSP connection will not work for a long time (5-15s) when a receiver is first started, despite the connection being fully established.
  * Bug: The StubbornSender can actually process an ACK before it ever sends the packet, where it should not.
  * New Feature: The StubbornReceiver should automatically abort any in-progress transfer if it detects the other end has restarted.

Symptoms: Handset telemetry items other than LinkStats taking 5-15s to start updating after model boot if handset stayed on. Betaflight Lua script hangs at "Requesting API version..." for a really long time, when it should be unreadably instant, the Betaflight CMS Lua just staying blank. These problems have plagued us since pre 1.0 but it fixes itself so who would bother spending time to fix it? 😁

## Stubborn Sender Premature Advance (🐛)

The stubborn sender can have a packet acked before it is even sent if the telemetry confirm bit happens to match (50/50 chance). How the code expects to work:
  1. SENDER - Starting from IDLE, the system queues a telemetry packet
  2. SENDER - currentPackage is reset to 1
  3. SENDER - A telemetry slot arrives and package 1 is sent OTA
  4. RCVR - The other side receives the package and the expected current package matches 1, so the telemetryConfirm bit is flipped
  5. RCVR - The `telemetryConfirm` is sent from the stubborn receiver OTA
  6. SENDER - The change in the `telemetryConfirm` indicates the package was received, package counter is incremented, and this repeats as long as needed

However, `telemetryConfirm` is always present in packets going RCVR to SENDER. Between steps 2 and 3 above, if the OTA's `telemetryConfirm` happens to match the expected value, the SENDER jumps from step 2 to 6 without ever transmitting the package. Shannon Modulation at work!

To resolve this, we simply don't advance the package counter on SENDER before the packet has been sent. This is handled using the new `SEND_PENDING` StubbornSender state.

## Forlorn Subborn Receiver (🎁)

If the Stubborn Receiver was in the middle of a multi-package transfer and the Sender is unplugged, the StubbornReceiver will keep waiting forever for the the transfer to resume, even in the face of a new package arriving. This scenario
  1. SENDER - Starts trasferring a larger telemetry item, such as GPS, or any item really, as all telemetry items take a minimum of two packages to transfer
  2. RCVR - Receives the expected package 1, updates to expect package 2 next
  3. SENDER - User unplugs the model, cancelling the transfer mid-stream
  4. SENDER - Boots on a new battery, starts uploading telemetry item starting with package 1
  5. RCVR - Is expecting package 2, so ignores the new package 1. Over and over. And over. And over. And over.
  6. SENDER - After at least 20 telemetry periods have passed, SENDER goes into RESYNC and sends package MAX
  7. RCVR - Sees package MAX and acknowledges the resync, resetting the expected package counter to 1
  8. Communication actually begins
  
To solve this one, RCVR automatically resets its state any time it receives package 1 when it is expecting a higher numbered package. This should only occur if SENDER is restarted but RCVR is not. This allows telemetry to be received immediately without waiting for the SENDER to go to RESYNC.

## Mitigating Factors

If VTX Admin is on, the connection is kicked up to 1:2 telemetry on connect to perform the operation. This accelerates the RESYNC behavior in StubbornSender due to the high packet rate, and can make the issue difficult to even detect.

## Still Broken?

The opposite condition. If the RCVR (Handset TX module) restarts while the SENDER (ELRS receiver) is mid-transmission, the RCVR can not fast restart. It does not know what the expected telemetry bit needs to be so if must wait for the SENDER to restart. This can not be improved without making some assumptions about the link on the SENDER side, which becomes unsafe. I have a branch where the SENDER will do only 2 resends instead of 20 if the LQ is >97%, but it is a lot of code that could be problematic if it keeps making the decision to throw out an in-process transmission too soon.

## Semi-related

You know me and good variable names, I love em. `waitUntilTelemetryConfirm` was not yummy since it sounds like a action that may or may not take place, when actually this variable is just holding the expected telemConfirm bit. Renamed to `telemetryConfirmExpectedValue` which is a mouthful but I think it is very clear now.