### PR TITLE
Disables the handset when doing wifi update

### DIFF
--- a/src/lib/Handset/CRSFHandset.cpp
+++ b/src/lib/Handset/CRSFHandset.cpp
@@ -121,6 +121,7 @@ void CRSFHandset::Begin()
     CRSFHandset::Port.flush();
     flush_port_input();
 #endif
+    running = true;
 }
 
 void CRSFHandset::End()
@@ -135,6 +136,7 @@ void CRSFHandset::End()
         }
     }
     //CRSFHandset::Port.end(); // don't call serial.end(), it causes some sort of issue with the 900mhz hardware using gpio2 for serial
+    running = false;
     DBGLN("CRSF UART END");
 }
 
@@ -402,7 +404,7 @@ void CRSFHandset::handleInput()
 {
     uint8_t *SerialInBuffer = inBuffer.asUint8_t;
 
-    if (UARTwdt())
+    if (!running || UARTwdt())
     {
         return;
     }

--- a/src/lib/Handset/CRSFHandset.h
+++ b/src/lib/Handset/CRSFHandset.h
@@ -51,6 +51,7 @@ public:
     int getMinPacketInterval() const override;
 
 private:
+    bool running = false;
     inBuffer_U inBuffer = {};
 
     /// OpenTX mixer sync ///

--- a/src/lib/Handset/PPMHandset.cpp
+++ b/src/lib/Handset/PPMHandset.cpp
@@ -34,6 +34,7 @@ void PPMHandset::Begin()
 void PPMHandset::End()
 {
     rmt_driver_uninstall(PPM_RMT_CHANNEL);
+    rb = nullptr;
 }
 
 bool PPMHandset::IsArmed()
@@ -46,6 +47,11 @@ void PPMHandset::handleInput()
 {
     const auto now = millis();
     size_t length = 0;
+
+    if (rb == nullptr)
+    {
+        return;
+    }
 
     auto *items = static_cast<rmt_item32_t *>(xRingbufferReceive(rb, &length, 0));
     if (items)

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -48,7 +48,7 @@
 #include "config.h"
 
 #if defined(TARGET_TX)
-
+#include "handset.h"
 #include "wifiJoystick.h"
 
 extern TxConfig config;
@@ -731,6 +731,9 @@ static void WebUploadDataHandler(AsyncWebServerRequest *request, const String& f
   if (index == 0) {
     #ifdef HAS_WIFI_JOYSTICK
       WifiJoystick::StopJoystickService();
+    #endif
+    #if defined(TARGET_TX)
+      handset->End();
     #endif
 
     size_t filesize = request->header("X-FileSize").toInt();


### PR DESCRIPTION
# Problem
When updating an external module via WIFI while in the handset it will get to a certain point then reboot, cancelling the update!

# Solution
When starting the upload; disable the handset processing so as to avoid the crash of the module due to the CRSF watchdog.

# TODO
Not sure why it crashes yet, but investigation will continue so we can understand the root cause.