### PR TITLE
Refactor to resolve web flashing failure after optimization

### DIFF
--- a/src/lib/Handset/CRSFHandset.cpp
+++ b/src/lib/Handset/CRSFHandset.cpp
@@ -72,7 +72,9 @@ void CRSFHandset::Begin()
     UARTinverted = halfDuplex; // on a full UART we will start uninverted checking first
     CRSFHandset::Port.begin(UARTrequestedBaud, SERIAL_8N1,
                      GPIO_PIN_RCSIGNAL_RX, GPIO_PIN_RCSIGNAL_TX,
-                     false, 500);
+                     false, 0);
+    // Arduino defaults every esp32 stream to a 1000ms timeout which is just baffling
+    CRSFHandset::Port.setTimeout(0);
     if (halfDuplex)
     {
         duplex_set_RX();
@@ -398,6 +400,25 @@ bool CRSFHandset::ProcessPacket()
     return packetReceived;
 }
 
+void CRSFHandset::alignBufferToSync(uint8_t startIdx)
+{
+    uint8_t *SerialInBuffer = inBuffer.asUint8_t;
+
+    for (unsigned int i=startIdx ; i<SerialInPacketPtr ; i++)
+    {
+        // If we find a header byte then move that and trailing bytes to the head of the buffer and let's go!
+        if (SerialInBuffer[i] == CRSF_ADDRESS_CRSF_TRANSMITTER || SerialInBuffer[i] == CRSF_SYNC_BYTE)
+        {
+            SerialInPacketPtr -= i;
+            memmove(SerialInBuffer, &SerialInBuffer[i], SerialInPacketPtr);
+            return;
+        }
+    }
+
+    // If no header found then discard this entire buffer
+    SerialInPacketPtr = 0;
+}
+
 void CRSFHandset::handleInput()
 {
     uint8_t *SerialInBuffer = inBuffer.asUint8_t;
@@ -434,76 +455,49 @@ void CRSFHandset::handleInput()
         flush_port_input();
     }
 
+    // Add new data, and then discard bytes until we start with header byte
     auto toRead = std::min(CRSFHandset::Port.available(), CRSF_MAX_PACKET_LEN - SerialInPacketPtr);
-    SerialInPacketPtr += (int)CRSFHandset::Port.readBytes(&SerialInBuffer[SerialInPacketPtr], toRead);
+    SerialInPacketPtr += CRSFHandset::Port.readBytes(&SerialInBuffer[SerialInPacketPtr], toRead);
+    alignBufferToSync(0);
 
-    // discard bytes until we start with header byte
-    if (!CRSFframeActive)
+    // Make sure we have at least a packet header and a length byte
+    if (SerialInPacketPtr < 3)
+        return;
+
+    // Sanity check: A total packet must be at least [sync][len][type][crc] (if no payload) and at most CRSF_MAX_PACKET_LEN
+    const uint32_t totalLen = SerialInBuffer[1] + 2;
+    if (totalLen < 4 || totalLen > CRSF_MAX_PACKET_LEN)
     {
-        for (int i=0 ; i<SerialInPacketPtr ; i++)
-        {
-            // If we find a header byte then move that and trailing bytes to the head of the buffer and let's go!
-            if (SerialInBuffer[i] == CRSF_ADDRESS_CRSF_TRANSMITTER || SerialInBuffer[i] == CRSF_SYNC_BYTE)
-            {
-                SerialInPacketPtr -= i;
-                memmove(SerialInBuffer, SerialInBuffer + i, SerialInPacketPtr);
-                CRSFframeActive = true;
-                break;
-            }
-        }
-        // If no header found then discard this entire buffer
-        if (!CRSFframeActive)
-        {
-            SerialInPacketPtr = 0;
-        }
+        // Start looking for another packet after this start byte
+        alignBufferToSync(1);
+        return;
     }
 
-    // We have a packet header and at least a length byte as well, so we see if we have a pull packet for processing
-    if (CRSFframeActive && SerialInPacketPtr>2)
-    {
-        // Sanity check: If the length byte is pushing over the max packet size skip this header byte and start scanning again
-        if ((SerialInBuffer[1] + 2) > CRSF_MAX_PACKET_LEN)
-        {
-            for (int i=0 ; i<SerialInPacketPtr ; i++)
-            {
-                if (SerialInBuffer[i] == CRSF_ADDRESS_CRSF_TRANSMITTER || SerialInBuffer[i] == CRSF_SYNC_BYTE)
-                {
-                    SerialInPacketPtr -= i;
-                    memmove(SerialInBuffer, SerialInBuffer + i, SerialInPacketPtr);
-                    CRSFframeActive = true;
-                    return;
-                }
-            }
-            SerialInPacketPtr = 0;
-            CRSFframeActive = false;
-        }
-        // If we have at least the number of bytes for a full packet then validate and process it
-        else if (SerialInPacketPtr >= (SerialInBuffer[1] + 2))
-        {
-            uint8_t CalculatedCRC = crsf_crc.calc(SerialInBuffer + 2, SerialInBuffer[1] - 1);
+    // Only proceed one there are enough bytes in the buffer for the entire packet
+    if (SerialInPacketPtr < totalLen)
+        return;
 
-            if (CalculatedCRC == SerialInBuffer[SerialInBuffer[1] + 2 - 1])
+    uint8_t CalculatedCRC = crsf_crc.calc(&SerialInBuffer[2], totalLen - 3);
+    if (CalculatedCRC == SerialInBuffer[totalLen - 1])
+    {
+        GoodPktsCount++;
+        if (ProcessPacket())
+        {
+            handleOutput(totalLen);
+            if (RCdataCallback)
             {
-                GoodPktsCount++;
-                if (ProcessPacket())
-                {
-                    handleOutput(SerialInBuffer[1] + 2);
-                    if (RCdataCallback)
-                    {
-                        RCdataCallback();
-                    }
-                }
+                RCdataCallback();
             }
-            else
-            {
-                DBGLN("UART CRC failure");
-                BadPktsCount++;
-            }
-            SerialInPacketPtr -= (SerialInBuffer[1] + 2);
-            memmove(SerialInBuffer, SerialInBuffer + (SerialInBuffer[1] + 2), SerialInPacketPtr);
-            CRSFframeActive = false;
         }
     }
+    else
+    {
+        DBGLN("UART CRC failure");
+        BadPktsCount++;
+    }
+
+    SerialInPacketPtr -= totalLen;
+    memmove(SerialInBuffer, &SerialInBuffer[totalLen], SerialInPacketPtr);
 }
 
 void CRSFHandset::handleOutput(int receivedBytes)
@@ -765,9 +759,12 @@ bool CRSFHandset::UARTwdt()
     bool retval = false;
 #if !defined(DEBUG_TX_FREERUN)
     uint32_t now = millis();
-    if (now >= (UARTwdtLastChecked + UARTwdtInterval))
+    if (now - UARTwdtLastChecked > UARTwdtInterval)
     {
-        if (BadPktsCount >= GoodPktsCount || !controllerConnected)
+        // If no packets or more bad than good packets, rate cycle/autobaud the UART but
+        // do not adjust the parameters while in wifi mode. If a firmware is being
+        // uploaded, it will cause tons of serial errors during the flash writes
+        if ((connectionState != wifiUpdate) && (BadPktsCount >= GoodPktsCount || !controllerConnected))
         {
             DBGLN("Too many bad UART RX packets!");
 

--- a/src/lib/Handset/CRSFHandset.h
+++ b/src/lib/Handset/CRSFHandset.h
@@ -62,7 +62,6 @@ private:
 
     /// UART Handling ///
     uint8_t SerialInPacketPtr = 0; // index where we are reading/writing
-    bool CRSFframeActive = false;  // since we get a copy of the serial data use this flag to know when to ignore it
     static bool halfDuplex;
     bool transmitting = false;
     uint32_t GoodPktsCount = 0;
@@ -84,6 +83,7 @@ private:
     void duplex_set_TX() const;
     void RcPacketToChannelsData();
     bool processInternalCrsfPackage(uint8_t *package);
+    void alignBufferToSync(uint8_t startIdx);
     bool ProcessPacket();
     bool UARTwdt();
     uint32_t autobaud();


### PR DESCRIPTION
Replaces #2840

Resolve the issue in current master where attempting to update firmware over wifi hangs before completion, but only happens on external modules. This is happening due to flash writes during the update process causing errors in the handset stream, which CRSFHandset can not recover from, which then causes the module to go into `noCrossfire` state, the wifi stops working, and the UART is blocked because the buffer is full.

The bug is just that [this one line](https://github.com/ExpressLRS/ExpressLRS/blob/2d4b16718297baf7349b408b3356421a2642bf38/src/lib/Handset/CRSFHandset.cpp#L467) needs to start looking at the packet from index **1** not index 0, because this causes it to check the same corrupted packet over and over and over again instead of moving on.

Not content with just adding 1 to code, I also refactored the refactor to remove the duplicated code block that does the search/move. Once that code was removed it became obvious that it could be greatly simplified and the code de-nested into something simpler that also does not need the `CRSFframeActive` flag either-- any time there is 1 byte left in the buffer after "aligning" it, it is guaranteed to be CRSFframeActive = true.

Overall compiles to 12 bytes less code too, baby! To review, you probably just want to look at the [short new code](https://github.com/CapnBry/ExpressLRS/blob/dd72427270646e9cc765918f834f9660f2eb1d32/src/lib/Handset/CRSFHandset.cpp#L459) rather than the diff.

### Other changes

* Modified `UARTWdt()` to not cycle baud rates while in wifiUpdate mode to prevent locking ourselves out of flashing the firmware if we paint ourselves into a corner again. If this is a bad idea I can remove it.
* Fixed the UARTWdt interval check to be overflow-safe.
* Packets < 4 total bytes long are now also rejected as invalid. This would be a CRSF packet with no payload, which I do not believe exist so this could be < 5, but just in case I went with the safer value.
* The ESP32 HardwareSerial::begin()` call passed a "timeout" of 500ms, but the vague timeout passed here is the Arduino autobaud timeout, which is not used. This parameter could be removed entirely, but I instead set it to 0? Either way is fine but we should not be passing 500, right?
* Added a call to set the HardwareSerial _stream's_ timeout to 0. This defaults to 1000ms, which will cause any `readBytes()` call with a requested size of 0 to hang for 1s but also somehow lose data. Our code would have to be broken for this to happen, but I've included this for future us to not be scratching our heads if it happens. I wouldn't mind removing this if there are objections. Fun fact, there's also a **third** timeout option, the `rxTimeout` member. I often wonder wtf those Arduino people are doing over there.

### Tested

* RadioMaster Ranger Micro external module
* RadioMaster TX16S internal module
* DUPLETX_ESP (EP2) RX as TX