### PR TITLE
MAVLink: only use a single com buffer from MAVLink include

### DIFF
--- a/src/lib/MAVLink/MAVLink.h
+++ b/src/lib/MAVLink/MAVLink.h
@@ -1,5 +1,6 @@
 #include "CRSF.h"
 #if !defined(PLATFORM_STM32)
+#define MAVLINK_COMM_NUM_BUFFERS 1
 #include "common/mavlink.h"
 #endif
 #include <CRSFHandset.h>

--- a/src/src/rx-serial/SerialMavlink.cpp
+++ b/src/src/rx-serial/SerialMavlink.cpp
@@ -42,6 +42,7 @@ void SerialMavlink::sendQueuedData(uint32_t maxBytesToSend)
 
 #else // ESP-based targets
 
+#define MAVLINK_COMM_NUM_BUFFERS 1
 #include "common/mavlink.h"
 
 #define MAV_FTP_OPCODE_OPENFILERO 4


### PR DESCRIPTION
This define defaults to 4, so were only using one (`MAVLINK_COMM_0`) so were declaring three extra buffers. The buffers are arrays of `mavlink_message_t` with size 291 and `mavlink_status_t` with size 28. So this saves 3*(291+28) = 957 bytes.