### PR TITLE
Fix lua lockup on launch due to previously-used function name

### DIFF
--- a/src/lua/elrsV3.lua
+++ b/src/lua/elrsV3.lua
@@ -897,7 +897,7 @@ local function checkCrsfModule()
     local mod = model.getModule(modIdx)
     if mod and mod.Type == 5 then
       -- CRSF found
-      checkModuleEnabled = nil
+      checkCrsfModule = nil
       return 0
     end
   end


### PR DESCRIPTION
Fixes a bug introduced in #2833 that causes a lockup when the lua is launched.

This was working, but when I added the longer error message about the internal module I brought over the older function name as part of the late changes. That's what I get for not doing all the testing over again and just using the simulator! 😞