### PR TITLE
New option to disable the triple power cycle bind method

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -103,6 +103,10 @@
 							<label for="lock-on-first-connection">Lock on first connection</label>
 						</div>
 						<div class="mui-checkbox">
+							<input id='disable-power-cycle-bind' name='disable-power-cycle-bind' type='checkbox'/>
+							<label for="disable-power-cycle-bind">Disable Power-Cycle Bind</label>
+						</div>
+						<div class="mui-checkbox">
 							<input id='is-airport' name='is-airport' type='checkbox'/>
 							<label for="is-airport">Use as AirPort Serial device</label>
 						</div>

--- a/src/lib/CONFIG/config.cpp
+++ b/src/lib/CONFIG/config.cpp
@@ -1009,6 +1009,10 @@ RxConfig::SetUID(uint8_t* uid)
 void
 RxConfig::SetPowerOnCounter(uint8_t powerOnCounter)
 {
+    if (firmwareOptions.disable_power_cycle_bind) {
+        return;
+    }
+
 #if defined(PLATFORM_ESP8266)
     realPowerOnCounter = powerOnCounter;
     if (powerOnCounter == 0)

--- a/src/lib/OPTIONS/options.cpp
+++ b/src/lib/OPTIONS/options.cpp
@@ -116,6 +116,11 @@ __attribute__ ((used)) static firmware_options_t flashedOptions = {
 #else
     .lock_on_first_connection = false,
 #endif
+#if defined(DISABLE_POWER_CYCLE_BIND)
+    .disable_power_cycle_bind = true,
+#else
+    .disable_power_cycle_bind = false,
+#endif
     ._unused2 = false,
 #if defined(USE_AIRPORT_AT_BAUD)
     .is_airport = true,
@@ -228,6 +233,7 @@ void saveOptions(Stream &stream, bool customised)
     #else
     doc["rcvr-uart-baud"] = firmwareOptions.uart_baud;
     doc["lock-on-first-connection"] = firmwareOptions.lock_on_first_connection;
+    doc["disable-power-cycle-bind"] = firmwareOptions.disable_power_cycle_bind;
     #endif
     doc["is-airport"] = firmwareOptions.is_airport;
     doc["domain"] = firmwareOptions.domain;
@@ -341,6 +347,7 @@ static void options_LoadFromFlashOrFile(EspFlashStream &strmFlash)
     firmwareOptions.is_airport = doc["is-airport"] | false;
     #endif
     firmwareOptions.lock_on_first_connection = doc["lock-on-first-connection"] | true;
+    firmwareOptions.disable_power_cycle_bind = doc["disable-power-cycle-bind"] | false;
     #endif
     firmwareOptions.domain = doc["domain"] | 0;
     firmwareOptions.flash_discriminator = doc["flash-discriminator"] | 0U;

--- a/src/lib/OPTIONS/options.cpp
+++ b/src/lib/OPTIONS/options.cpp
@@ -116,16 +116,16 @@ __attribute__ ((used)) static firmware_options_t flashedOptions = {
 #else
     .lock_on_first_connection = false,
 #endif
-#if defined(DISABLE_POWER_CYCLE_BIND)
-    .disable_power_cycle_bind = true,
-#else
-    .disable_power_cycle_bind = false,
-#endif
     ._unused2 = false,
 #if defined(USE_AIRPORT_AT_BAUD)
     .is_airport = true,
 #else
     .is_airport = false,
+#endif
+#if defined(DISABLE_POWER_CYCLE_BIND)
+    .disable_power_cycle_bind = true,
+#else
+    .disable_power_cycle_bind = false,
 #endif
 #endif
 #if defined(TARGET_TX)

--- a/src/lib/OPTIONS/options.h
+++ b/src/lib/OPTIONS/options.h
@@ -38,6 +38,7 @@ typedef struct _options {
     bool        lock_on_first_connection:1;
     bool        _unused2:1; // r9mm_mini_sbus
     bool        is_airport:1;
+    bool        disable_power_cycle_bind:1;
 #endif
 #if defined(TARGET_TX) || defined(UNIT_TEST)
     uint32_t    tlm_report_interval;

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -988,6 +988,10 @@ static void startMDNS()
   {
     options += " -DLOCK_ON_FIRST_CONNECTION";
   }
+  if (firmwareOptions.disable_power_cycle_bind)
+  {
+    options += " -DDISABLE_POWER_CYCLE_BIND";
+  }
   options += " -DRCVR_UART_BAUD=" + String(firmwareOptions.uart_baud);
   #endif
 

--- a/src/python/binary_configurator.py
+++ b/src/python/binary_configurator.py
@@ -114,6 +114,9 @@ def patch_rx_params(mm, pos, args):
     if args.airport_baud != None:
         val |= ~8
         val |= 0 if args.airport_baud == 0 else 8
+    if args.disable_power_cycle_bind != None:
+        val &= ~16
+        val |= (args.disable_power_cycle_bind << 4)
     mm[pos] = val
     return pos + 1
 
@@ -343,6 +346,9 @@ def main():
     parser.add_argument('--lock-on-first-connection', dest='lock_on_first_connection', action='store_true', help='Lock RF mode on first connection')
     parser.add_argument('--no-lock-on-first-connection', dest='lock_on_first_connection', action='store_false', help='Do not lock RF mode on first connection')
     parser.set_defaults(lock_on_first_connection=None)
+    parser.add_argument('--disable-power-cycle-bind', dest='disable_power_cycle_bind', action='store_true', help='Disable the triple power cycling binding function')
+    parser.add_argument('--no-disable-power-cycle-bind', dest='disable_power_cycle_bind', action='store_false', help='Allow the triple power cycling binding function')
+    parser.set_defaults(disable_power_cycle_bind=None)
     # TX Params
     parser.add_argument('--tlm-report', type=int, const=240, nargs='?', action='store', help='The interval (in milliseconds) between telemetry packets')
     parser.add_argument('--fan-min-runtime', type=int, const=30, nargs='?', action='store', help='The minimum amount of time the fan should run for (in seconds) if it turns on')

--- a/src/python/build_flags.py
+++ b/src/python/build_flags.py
@@ -67,6 +67,8 @@ def process_json_flag(define):
         json_flags['unlock-higher-power'] = True
     if define == "-DLOCK_ON_FIRST_CONNECTION" and isRX:
         json_flags['lock-on-first-connection'] = True
+    if define == "-DDISABLE_POWER_CYCLE_BIND" and isRX:
+        json_flags['disable-power-cycle-bind'] = True
 
 def process_build_flag(define):
     if define.startswith("-D") or define.startswith("!-D"):

--- a/src/python/serve_html.py
+++ b/src/python/serve_html.py
@@ -33,6 +33,7 @@ config = {
             "rcvr-uart-baud": 400000,
             "rcvr-invert-tx": False,
             "lock-on-first-connection": True,
+            "disable-power-cycle-bind": False,
             "domain": 1,
             # "wifi-on-interval": 60,
             "wifi-password": "w1f1-pAssw0rd",

--- a/src/user_defines.txt
+++ b/src/user_defines.txt
@@ -35,6 +35,8 @@
 
 -DLOCK_ON_FIRST_CONNECTION
 
+#-DDISABLE_POWER_CYCLE_BIND
+
 # For TX devices with fans, FAN_MIN_RUNTIME keeps the fan running even after the power level has
 # dropped below the configured Fan Threshold. This prevents the fan from turning on and off every
 # few seconds if the power level is constantly changing.


### PR DESCRIPTION
The triple power cycle bind method of binding can cause serious problems when the ELRS is used in an environment when/where power is not stable. If the power is somehow cut and re-established 3 times in very short pulses, the ELRS receiver can be put into a binding state and not recover the original intended connection to the transmitter.

This pull request adds a user-configurable option to disable this binding method. There is a checkbox added to the Wi-Fi configuration screen (underneath lock-on-first-connection). It's been added to the user_defines.txt and also all of the build related python scripts.