### PR TITLE
Allow Backpack in MAVLink mode to come back to Normal mode automatically

### DIFF
--- a/src/lib/Backpack/devBackpack.cpp
+++ b/src/lib/Backpack/devBackpack.cpp
@@ -371,14 +371,9 @@ static int event()
     uint8_t newMode = config.GetLinkMode();
     if (lastLinkMode != newMode)
     {
-        if (lastLinkMode == TX_NORMAL_MODE) {
-            // Backpack will autodetect MAVLink for now - no reason to send an MSP message
-        } else if (lastLinkMode == TX_MAVLINK_MODE) {
-            // Send a mavlink message to the TX backpack to change the mode
-            uint8_t mavlinkOutputBuffer[MAVLINK_MAX_PACKET_LEN];
-            uint16_t len = buildMAVLinkELRSModeChange(newMode, mavlinkOutputBuffer);
-            TxBackpack->write(mavlinkOutputBuffer, len);
-        }
+        uint8_t mavlinkOutputBuffer[MAVLINK_MAX_PACKET_LEN];
+        uint16_t len = buildMAVLinkELRSModeChange(newMode, mavlinkOutputBuffer);
+        TxBackpack->write(mavlinkOutputBuffer, len);
     }
     lastLinkMode = config.GetLinkMode();
 #endif

--- a/src/lib/Backpack/devBackpack.cpp
+++ b/src/lib/Backpack/devBackpack.cpp
@@ -366,7 +366,8 @@ static int event()
         digitalWrite(GPIO_PIN_BACKPACK_EN, config.GetBackpackDisable() ? LOW : HIGH);
     }
 #endif
-    // Update the backpack operating mode when the link mode changes
+#if !defined(PLATFORM_STM32)
+  // Update the backpack operating mode when the link mode changes
     uint8_t newMode = config.GetLinkMode();
     if (lastLinkMode != newMode)
     {
@@ -380,6 +381,7 @@ static int event()
         }
     }
     lastLinkMode = config.GetLinkMode();
+#endif
     return DURATION_IGNORE;
 }
 

--- a/src/lib/Backpack/devBackpack.cpp
+++ b/src/lib/Backpack/devBackpack.cpp
@@ -7,6 +7,7 @@
 #include "CRSFHandset.h"
 #include "config.h"
 #include "logging.h"
+#include "MAVLink.h"
 
 #define BACKPACK_TIMEOUT 20    // How often to check for backpack commands
 
@@ -30,7 +31,6 @@ uint8_t lastLinkMode; // will get set in start() and used in event()
 
 #include "CRSF.h"
 #include "hwTimer.h"
-#include <MAVLink.h>
 
 [[noreturn]] void startPassthrough()
 {

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -707,7 +707,6 @@ static void registerLuaParameters()
       if (isDisconnected)
       {
         config.SetLinkMode(arg);
-devicesTriggerEvent(); // trigger event to let the backpack know the link mode has changed (see devBackpack)
       }
       else
       {

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -707,6 +707,7 @@ static void registerLuaParameters()
       if (isDisconnected)
       {
         config.SetLinkMode(arg);
+devicesTriggerEvent(); // trigger event to let the backpack know the link mode has changed (see devBackpack)
       }
       else
       {

--- a/src/lib/MAVLink/MAVLink.cpp
+++ b/src/lib/MAVLink/MAVLink.cpp
@@ -126,3 +126,21 @@ bool isThisAMavPacket(uint8_t *buffer, uint16_t bufferSize)
 #endif
     return false;
 }
+
+uint16_t buildMAVLinkELRSModeChange(uint8_t mode, uint8_t *buffer)
+{
+    constexpr uint16_t MAVLINK_TUNNEL_MSG_TYPE_ELRS_MODE_CHANGE = 0x8;
+    mavlink_tunnel_t tunnelMsg;
+    tunnelMsg.target_system = 255;
+    tunnelMsg.target_component = MAV_COMP_ID_UDP_BRIDGE;
+    tunnelMsg.payload_type = 0;
+    tunnelMsg.payload_length = 3;
+    memset(tunnelMsg.payload, 0, sizeof(tunnelMsg.payload));
+    tunnelMsg.payload[0] = MAVLINK_TUNNEL_MSG_TYPE_ELRS_MODE_CHANGE >> 8;
+    tunnelMsg.payload[1] = MAVLINK_TUNNEL_MSG_TYPE_ELRS_MODE_CHANGE & 0xFF;
+    tunnelMsg.payload[2] = mode;
+    mavlink_message_t msg;
+    mavlink_msg_tunnel_encode(255, MAV_COMP_ID_TELEMETRY_RADIO, &msg, &tunnelMsg);
+    uint16_t len = mavlink_msg_to_send_buffer(buffer, &msg);
+    return len;
+}

--- a/src/lib/MAVLink/MAVLink.cpp
+++ b/src/lib/MAVLink/MAVLink.cpp
@@ -130,12 +130,12 @@ bool isThisAMavPacket(uint8_t *buffer, uint16_t bufferSize)
 uint16_t buildMAVLinkELRSModeChange(uint8_t mode, uint8_t *buffer)
 {
 #if !defined(PLATFORM_STM32)
-    constexpr uint16_t MAVLINK_TUNNEL_MSG_TYPE_ELRS_MODE_CHANGE = 0x8;
+    constexpr uint8_t ELRS_MODE_CHANGE = 0x8;
     mavlink_command_int_t commandMsg;
     commandMsg.target_system = 255;
     commandMsg.target_component = MAV_COMP_ID_UDP_BRIDGE;
     commandMsg.command = MAV_CMD_USER_1;
-    commandMsg.param1 = MAVLINK_TUNNEL_MSG_TYPE_ELRS_MODE_CHANGE;
+    commandMsg.param1 = ELRS_MODE_CHANGE;
     commandMsg.param2 = mode;
     mavlink_message_t msg;
     mavlink_msg_command_int_encode(255, MAV_COMP_ID_TELEMETRY_RADIO, &msg, &commandMsg);

--- a/src/lib/MAVLink/MAVLink.cpp
+++ b/src/lib/MAVLink/MAVLink.cpp
@@ -131,17 +131,14 @@ uint16_t buildMAVLinkELRSModeChange(uint8_t mode, uint8_t *buffer)
 {
 #if !defined(PLATFORM_STM32)
     constexpr uint16_t MAVLINK_TUNNEL_MSG_TYPE_ELRS_MODE_CHANGE = 0x8;
-    mavlink_tunnel_t tunnelMsg;
-    tunnelMsg.target_system = 255;
-    tunnelMsg.target_component = MAV_COMP_ID_UDP_BRIDGE;
-    tunnelMsg.payload_type = 0;
-    tunnelMsg.payload_length = 3;
-    memset(tunnelMsg.payload, 0, sizeof(tunnelMsg.payload));
-    tunnelMsg.payload[0] = MAVLINK_TUNNEL_MSG_TYPE_ELRS_MODE_CHANGE >> 8;
-    tunnelMsg.payload[1] = MAVLINK_TUNNEL_MSG_TYPE_ELRS_MODE_CHANGE & 0xFF;
-    tunnelMsg.payload[2] = mode;
+    mavlink_command_int_t commandMsg;
+    commandMsg.target_system = 255;
+    commandMsg.target_component = MAV_COMP_ID_UDP_BRIDGE;
+    commandMsg.command = MAV_CMD_USER_1;
+    commandMsg.param1 = MAVLINK_TUNNEL_MSG_TYPE_ELRS_MODE_CHANGE;
+    commandMsg.param2 = mode;
     mavlink_message_t msg;
-    mavlink_msg_tunnel_encode(255, MAV_COMP_ID_TELEMETRY_RADIO, &msg, &tunnelMsg);
+    mavlink_msg_command_int_encode(255, MAV_COMP_ID_TELEMETRY_RADIO, &msg, &commandMsg);
     uint16_t len = mavlink_msg_to_send_buffer(buffer, &msg);
     return len;
 #else

--- a/src/lib/MAVLink/MAVLink.cpp
+++ b/src/lib/MAVLink/MAVLink.cpp
@@ -129,6 +129,7 @@ bool isThisAMavPacket(uint8_t *buffer, uint16_t bufferSize)
 
 uint16_t buildMAVLinkELRSModeChange(uint8_t mode, uint8_t *buffer)
 {
+#if !defined(PLATFORM_STM32)
     constexpr uint16_t MAVLINK_TUNNEL_MSG_TYPE_ELRS_MODE_CHANGE = 0x8;
     mavlink_tunnel_t tunnelMsg;
     tunnelMsg.target_system = 255;
@@ -143,4 +144,7 @@ uint16_t buildMAVLinkELRSModeChange(uint8_t mode, uint8_t *buffer)
     mavlink_msg_tunnel_encode(255, MAV_COMP_ID_TELEMETRY_RADIO, &msg, &tunnelMsg);
     uint16_t len = mavlink_msg_to_send_buffer(buffer, &msg);
     return len;
+#else
+    return 0;
+#endif
 }

--- a/src/lib/MAVLink/MAVLink.h
+++ b/src/lib/MAVLink/MAVLink.h
@@ -9,3 +9,4 @@
 void convert_mavlink_to_crsf_telem(uint8_t *CRSFinBuffer, uint8_t count, Handset *handset);
 
 bool isThisAMavPacket(uint8_t *buffer, uint16_t bufferSize);
+uint16_t buildMAVLinkELRSModeChange(uint8_t mode, uint8_t *buffer);


### PR DESCRIPTION
Needs companion Backpack PR - this makes it so that going from MAVLink to Normal link mode moves the backpack too.