### PR TITLE
Channel limits, generic mixer and channel remapper

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -184,7 +184,7 @@
 @@if not isTX:
 			<div class="mui-tabs__pane" id="pane-justified-3">
 				<div class="mui-panel">
-					<div id="model_tab">
+					<div id="mixing_tab">
 						<h2>Channel Mixing</h2>
 						Setup mixes on the incoming CRSF data. This also effects for serial protocol output.
 						<ul>

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -185,6 +185,20 @@
 			<div class="mui-tabs__pane" id="pane-justified-3">
 				<div class="mui-panel">
 					<div id="model_tab">
+						<h2>Channel Mixing</h2>
+						Setup mixes on the incoming CRSF data. This also effects for serial protocol output.
+						<ul>
+							<li><b>Active:</b> If the mix is applied.</li>
+							<li><b>Source:</b> Source channel used by the mix.</li>
+							<li><b>Destination:</b> Destination to apply the result of the mix.</li>
+							<li><b>Negative weight:</b>Percentage of the result mix to apply on the negative side.</li>
+							<li><b>Positive weight:</b>Percentage of the result mix to apply on the positive side.</li>
+							<li><b>Offset / Sub-trim:</b></li>
+						</ul>
+						<form action="/mixes" id="mixes" method="post"></form>
+					</div>
+
+					<div id="model_tab">
 						<h2>PWM Output</h2>
 						Set PWM output mode and failsafe positions.
 						<ul>

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -29,13 +29,12 @@ function getPwmFormData() {
     const failsafeField = _(`pwm_${ch}_fs`);
     const failsafeModeField = _(`pwm_${ch}_fsmode`);
     let failsafe = failsafeField.value;
-    if (failsafe > 2011) failsafe = 2011;
-    if (failsafe < 988) failsafe = 988;
+    if (failsafe > 2135) failsafe = 2135;
+    if (failsafe < 885) failsafe = 885;
     failsafeField.value = failsafe;
     let failsafeMode = failsafeModeField.value;
 
-    const raw = (narrow << 19) | (mode << 15) | (invert << 14) | (inChannel << 10) | (failsafeMode << 20) | (failsafe - 988);
-    // console.log(`PWM ${ch} mode=${mode} input=${inChannel} fs=${failsafe} fsmode=${failsafeMode} inv=${invert} nar=${narrow} raw=${raw}`);
+    const raw = (narrow << 20) | (mode << 16) | (invert << 15) | (inChannel << 11) | (failsafeMode << 21) | failsafe;
     outData.push(raw);
     ++ch;
   }
@@ -77,15 +76,15 @@ function updatePwmSettings(arPwm) {
   var pinRxIndex = undefined;
   var pinTxIndex = undefined;
   var pinModes = []
-  // arPwm is an array of raw integers [49664,50688,51200]. 10 bits of failsafe position, 4 bits of input channel, 1 bit invert, 4 bits mode, 1 bit for narrow/750us
+  // arPwm is an array of raw integers [49664,50688,51200]. 11 bits of failsafe position, 4 bits of input channel, 1 bit invert, 4 bits mode, 1 bit for narrow/750us
   const htmlFields = ['<div class="mui-panel pwmpnl"><table class="pwmtbl mui-table"><tr><th class="fixed-column">Output</th><th class="mui--text-center fixed-column">Features</th><th>Mode</th><th>Input</th><th class="mui--text-center fixed-column">Invert?</th><th class="mui--text-center fixed-column">750us?</th><th class="mui--text-center fixed-column pwmitm">Failsafe Mode</th><th class="mui--text-center fixed-column pwmitm">Failsafe Pos</th></tr>'];
   arPwm.forEach((item, index) => {
-    const failsafe = (item.config & 1023) + 988; // 10 bits
-    const failsafeMode = (item.config >> 20) & 3; // 2 bits
-    const ch = (item.config >> 10) & 15; // 4 bits
-    const inv = (item.config >> 14) & 1;
-    const mode = (item.config >> 15) & 15; // 4 bits
-    const narrow = (item.config >> 19) & 1;
+    const failsafe = (item.config & 2047); // 11 bits
+    const failsafeMode = (item.config >> 21) & 3; // 2 bits
+    const ch = (item.config >> 11) & 15; // 4 bits
+    const inv = (item.config >> 15) & 1;
+    const mode = (item.config >> 16) & 15; // 4 bits
+    const narrow = (item.config >> 20) & 1;
     const features = item.features;
     const modes = ['50Hz', '60Hz', '100Hz', '160Hz', '333Hz', '400Hz', '10KHzDuty', 'On/Off'];
     if (features & 16) {

--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -28,6 +28,8 @@ function getPwmFormData() {
     const narrow = _(`pwm_${ch}_nar`).checked ? 1 : 0;
     const failsafeField = _(`pwm_${ch}_fs`);
     const failsafeModeField = _(`pwm_${ch}_fsmode`);
+    const limitMinField = _(`pwm_${ch}_limit_min`);
+    const limitMaxField = _(`pwm_${ch}_limit_max`);
     let failsafe = failsafeField.value;
     if (failsafe > 2135) failsafe = 2135;
     if (failsafe < 885) failsafe = 885;
@@ -36,6 +38,7 @@ function getPwmFormData() {
 
     const raw = (narrow << 20) | (mode << 16) | (invert << 15) | (inChannel << 11) | (failsafeMode << 21) | failsafe;
     outData.push(raw);
+    outData.push(limitMinField.value << 16 | limitMaxField.value);
     ++ch;
   }
   return outData;
@@ -77,7 +80,7 @@ function updatePwmSettings(arPwm) {
   var pinTxIndex = undefined;
   var pinModes = []
   // arPwm is an array of raw integers [49664,50688,51200]. 11 bits of failsafe position, 4 bits of input channel, 1 bit invert, 4 bits mode, 1 bit for narrow/750us
-  const htmlFields = ['<div class="mui-panel pwmpnl"><table class="pwmtbl mui-table"><tr><th class="fixed-column">Output</th><th class="mui--text-center fixed-column">Features</th><th>Mode</th><th>Input</th><th class="mui--text-center fixed-column">Invert?</th><th class="mui--text-center fixed-column">750us?</th><th class="mui--text-center fixed-column pwmitm">Failsafe Mode</th><th class="mui--text-center fixed-column pwmitm">Failsafe Pos</th></tr>'];
+  const htmlFields = ['<div class="mui-panel pwmpnl"><table class="pwmtbl mui-table"><tr><th class="fixed-column">Output</th><th class="mui--text-center fixed-column">Features</th><th>Mode</th><th>Input</th><th class="mui--text-center fixed-column">Invert?</th><th class="mui--text-center fixed-column">750us?</th><th class="mui--text-center fixed-column pwmitm">Failsafe Mode</th><th class="mui--text-center fixed-column pwmitm">Failsafe Pos</th><th class="mui--text-center fixed-column">Negative Limit</th><th class="mui--text-center fixed-column">Positive Limit</th></tr>'];
   arPwm.forEach((item, index) => {
     const failsafe = (item.config & 2047); // 11 bits
     const failsafeMode = (item.config >> 21) & 3; // 2 bits
@@ -145,7 +148,10 @@ function updatePwmSettings(arPwm) {
             <td><div class="mui-checkbox mui--text-center"><input type="checkbox" id="pwm_${index}_inv"${(inv) ? ' checked' : ''}></div></td>
             <td><div class="mui-checkbox mui--text-center"><input type="checkbox" id="pwm_${index}_nar"${(narrow) ? ' checked' : ''}></div></td>
             <td>${failsafeModeSelect}</td>
-            <td><div class="mui-textfield compact"><input id="pwm_${index}_fs" value="${failsafe}" size="6" class="pwmitm" /></div></td></tr>`);
+            <td><div class="mui-textfield compact"><input id="pwm_${index}_fs" value="${failsafe}" size="6" class="pwmitm" /></div></td>
+            <td><div class="mui-textfield compact"><input id="pwm_${index}_limit_min" value="${item.limits.min}" size="6"/></div></td>
+            <td><div class="mui-textfield compact"><input id="pwm_${index}_limit_max" value="${item.limits.max}" size="6"/></div></td>
+            </tr>`);
     pinModes[index] = mode;
   });
   htmlFields.push('</table></div>');
@@ -162,6 +168,8 @@ function updatePwmSettings(arPwm) {
     _(`pwm_${index}_nar`).disabled = onoff;
     _(`pwm_${index}_fs`).disabled = onoff;
     _(`pwm_${index}_fsmode`).disabled = onoff;
+    _(`pwm_${index}_limit_min`).disabled = onoff;
+    _(`pwm_${index}_limit_max`).disabled = onoff;
   }
   arPwm.forEach((item,index)=>{
     const pinMode = _(`pwm_${index}_mode`)

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -309,6 +309,12 @@ extern connectionState_e connectionState;
 extern expresslrs_mod_settings_s *ExpressLRS_currAirRate_Modparams;
 extern expresslrs_rf_pref_params_s *ExpressLRS_currAirRate_RFperfParams;
 extern uint32_t ChannelData[CRSF_NUM_CHANNELS]; // Current state of channels, CRSF format
+#if defined(MIXER)
+// The first 16 mixes are used for remapping outputs. This includes serial
+// outputs and PWM outputs.
+constexpr uint8_t MAX_MIXES = 30; // json library seems to crash with more that 30 list elements
+extern uint32_t ChannelMixedData[CRSF_NUM_CHANNELS]; // Current state of channels after mixing, CRSF format
+#endif
 
 uint32_t uidMacSeedGet();
 bool isDualRadio();

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -313,7 +313,9 @@ extern uint32_t ChannelData[CRSF_NUM_CHANNELS]; // Current state of channels, CR
 // The first 16 mixes are used for remapping outputs. This includes serial
 // outputs and PWM outputs.
 constexpr uint8_t MAX_MIXES = 30; // json library seems to crash with more that 30 list elements
+constexpr uint8_t MAX_LOGICAL_SWITCHES = 16;
 extern uint32_t ChannelMixedData[CRSF_NUM_CHANNELS]; // Current state of channels after mixing, CRSF format
+extern bool LogicalSwitchData[MAX_LOGICAL_SWITCHES]; // Current state of logical switches
 #endif
 
 uint32_t uidMacSeedGet();

--- a/src/include/target/Unified_ESP_RX.h
+++ b/src/include/target/Unified_ESP_RX.h
@@ -151,3 +151,5 @@
 #endif
 
 #define GPIO_PIN_FAN_EN hardware_pin(HARDWARE_misc_fan_en)
+
+#define MIXER

--- a/src/lib/CONFIG/config.cpp
+++ b/src/lib/CONFIG/config.cpp
@@ -751,6 +751,18 @@ void RxConfig::Load()
                 (uint16_t) mix->val.offset
             );
         }
+        DBGLN("Logical switches:");
+        for (uint8_t switch_number = 0 ; switch_number < MAX_LOGICAL_SWITCHES; switch_number++)
+        {
+            const rx_config_logical_switch_t *lswitch = config.GetLogicalSwitch(switch_number);
+            DBGLN("Logical switch %d: type %d source %d and %d params %d",
+                switch_number,
+                (uint8_t) lswitch->val.type,
+                (uint8_t) lswitch->val.source,
+                (uint8_t) lswitch->val.and_switch,
+                (uint32_t) lswitch->val.params
+            );
+        }
         #endif // MIXER && DEBUG_LOG
         return;
     }

--- a/src/lib/CONFIG/config.h
+++ b/src/lib/CONFIG/config.h
@@ -183,6 +183,48 @@ extern TxConfig config;
 ///////////////////////////////////////////////////
 
 #if defined(TARGET_RX)
+
+#if defined(MIXER)
+typedef enum {
+    MIX_SOURCE_CH1,
+    MIX_SOURCE_CH2,
+    MIX_SOURCE_CH3,
+    MIX_SOURCE_CH4,
+    MIX_SOURCE_CH5,
+    MIX_SOURCE_CH6,
+    MIX_SOURCE_CH7,
+    MIX_SOURCE_CH8,
+    MIX_SOURCE_CH9,
+    MIX_SOURCE_CH10,
+    MIX_SOURCE_CH11,
+    MIX_SOURCE_CH12,
+    MIX_SOURCE_CH13,
+    MIX_SOURCE_CH14,
+    MIX_SOURCE_CH15,
+    MIX_SOURCE_CH16,
+    MIX_SOURCE_FAILSAFE,
+} mix_source_t;
+
+typedef enum {
+    MIX_DESTINATION_CH1,
+    MIX_DESTINATION_CH2,
+    MIX_DESTINATION_CH3,
+    MIX_DESTINATION_CH4,
+    MIX_DESTINATION_CH5,
+    MIX_DESTINATION_CH6,
+    MIX_DESTINATION_CH7,
+    MIX_DESTINATION_CH8,
+    MIX_DESTINATION_CH9,
+    MIX_DESTINATION_CH10,
+    MIX_DESTINATION_CH11,
+    MIX_DESTINATION_CH12,
+    MIX_DESTINATION_CH13,
+    MIX_DESTINATION_CH14,
+    MIX_DESTINATION_CH15,
+    MIX_DESTINATION_CH16,
+} mix_destination_t;
+#endif // MIXER
+
 constexpr uint8_t PWM_MAX_CHANNELS = 16;
 
 typedef enum : uint8_t {
@@ -213,6 +255,19 @@ typedef union {
     uint32_t raw;
 } rx_config_pwm_t;
 
+typedef union {
+    struct {
+        uint64_t active:1,          // enable/disable the mix
+                 source:6,          // mix_source_t
+                 destination:6,     // mix_destination_t
+                 weight_negative:8, // -100% - +100% (signed int)
+                 weight_positive:8, // -100% - +100% (signed int)
+                 offset:11,         // CRSF value to be added/subtracted (signed int)
+                 unused:24;         // TBD
+    } val;
+    uint64_t raw;
+} rx_config_mix_t;
+
 typedef struct __attribute__((packed)) {
     uint32_t    version;
     uint8_t     uid[UID_LEN];
@@ -239,6 +294,9 @@ typedef struct __attribute__((packed)) {
                 teamracePosition:3,
                 teamracePitMode:1;  // FUTURE: Enable pit mode when disabling model
     rx_config_pwm_limits_t pwmLimits[PWM_MAX_CHANNELS];
+    #if defined(MIXER)
+    rx_config_mix_t mixes[MAX_MIXES];
+    #endif
 } rx_config_t;
 
 class RxConfig
@@ -265,6 +323,9 @@ public:
     const rx_config_pwm_t *GetPwmChannel(uint8_t ch) const { return &m_config.pwmChannels[ch]; }
     const rx_config_pwm_limits_t *GetPwmChannelLimits(uint8_t ch) const { return &m_config.pwmLimits[ch]; }
     #endif
+    #if defined(MIXER)
+    const rx_config_mix_t *GetMix(uint8_t mixNumber) const { return &m_config.mixes[mixNumber]; }
+    #endif
     bool GetForceTlmOff() const { return m_config.forceTlmOff; }
     uint8_t GetRateInitialIdx() const { return m_config.rateInitialIdx; }
     eSerialProtocol GetSerialProtocol() const { return (eSerialProtocol)m_config.serialProtocol; }
@@ -290,6 +351,14 @@ public:
     void SetPwmChannelRaw(uint8_t ch, uint32_t raw);
     void SetPwmChannelLimits(uint8_t ch, uint16_t min, uint16_t max);
     void SetPwmChannelLimitsRaw(uint8_t ch, uint32_t raw);
+    #endif
+    #if defined(MIXER)
+    void SetMixer(
+        uint8_t mixNumber, mix_source_t source, mix_destination_t destination,
+        int8_t weight_negative, int8_t weight_positive, uint16_t offset,
+        bool active
+    );
+    void SetMixerRaw(uint8_t mixNumber, uint64_t raw);
     #endif
     void SetForceTlmOff(bool forceTlmOff);
     void SetRateInitialIdx(uint8_t rateInitialIdx);

--- a/src/lib/CONFIG/config.h
+++ b/src/lib/CONFIG/config.h
@@ -193,13 +193,13 @@ typedef enum : uint8_t {
 
 typedef union {
     struct {
-        uint32_t failsafe:10,    // us output during failsafe +988 (e.g. 512 here would be 1500us)
+        uint32_t failsafe:11,    // us output during failsafe
                  inputChannel:4, // 0-based input channel
                  inverted:1,     // invert channel output
                  mode:4,         // Output mode (eServoOutputMode)
                  narrow:1,       // Narrow output mode (half pulse width)
                  failsafeMode:2, // failsafe output mode (eServoOutputFailsafeMode)
-                 unused:10;      // FUTURE: When someone complains "everyone" uses inverted polarity PWM or something :/
+                 unused:9;       // FUTURE: When someone complains "everyone" uses inverted polarity PWM or something :/
     } val;
     uint32_t raw;
 } rx_config_pwm_t;
@@ -297,6 +297,7 @@ private:
     void UpgradeEepromV5();
     void UpgradeEepromV6();
     void UpgradeEepromV7V8();
+    void UpgradeEepromV9();
 
     rx_config_t m_config;
     ELRS_EEPROM *m_eeprom;

--- a/src/lib/CONFIG/config.h
+++ b/src/lib/CONFIG/config.h
@@ -193,6 +193,15 @@ typedef enum : uint8_t {
 
 typedef union {
     struct {
+        uint32_t max:12,
+                 min:12,
+                 unused: 8;
+    } val;
+    uint32_t raw;
+} rx_config_pwm_limits_t;
+
+typedef union {
+    struct {
         uint32_t failsafe:11,    // us output during failsafe
                  inputChannel:4, // 0-based input channel
                  inverted:1,     // invert channel output
@@ -229,6 +238,7 @@ typedef struct __attribute__((packed)) {
     uint8_t     teamraceChannel:4,
                 teamracePosition:3,
                 teamracePitMode:1;  // FUTURE: Enable pit mode when disabling model
+    rx_config_pwm_limits_t pwmLimits[PWM_MAX_CHANNELS];
 } rx_config_t;
 
 class RxConfig
@@ -253,6 +263,7 @@ public:
     bool     IsModified() const { return m_modified; }
     #if defined(GPIO_PIN_PWM_OUTPUTS)
     const rx_config_pwm_t *GetPwmChannel(uint8_t ch) const { return &m_config.pwmChannels[ch]; }
+    const rx_config_pwm_limits_t *GetPwmChannelLimits(uint8_t ch) const { return &m_config.pwmLimits[ch]; }
     #endif
     bool GetForceTlmOff() const { return m_config.forceTlmOff; }
     uint8_t GetRateInitialIdx() const { return m_config.rateInitialIdx; }
@@ -277,6 +288,8 @@ public:
     #if defined(GPIO_PIN_PWM_OUTPUTS)
     void SetPwmChannel(uint8_t ch, uint16_t failsafe, uint8_t inputCh, bool inverted, uint8_t mode, bool narrow);
     void SetPwmChannelRaw(uint8_t ch, uint32_t raw);
+    void SetPwmChannelLimits(uint8_t ch, uint16_t min, uint16_t max);
+    void SetPwmChannelLimitsRaw(uint8_t ch, uint32_t raw);
     #endif
     void SetForceTlmOff(bool forceTlmOff);
     void SetRateInitialIdx(uint8_t rateInitialIdx);

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -449,10 +449,9 @@ static void luaparamSetFailsafe(struct luaPropertiesCommon *item, uint8_t arg)
     for (int ch=0; ch<GPIO_PIN_PWM_OUTPUTS_COUNT; ++ch)
     {
       rx_config_pwm_t newPwmCh;
-      // The value must fit into the 10 bit range of the failsafe
       newPwmCh.raw = config.GetPwmChannel(ch)->raw;
-      newPwmCh.val.failsafe = CRSF_to_UINT10(constrain(ChannelData[config.GetPwmChannel(ch)->val.inputChannel], CRSF_CHANNEL_VALUE_MIN, CRSF_CHANNEL_VALUE_MAX));
-      //DBGLN("FSCH(%u) crsf=%u us=%u", ch, ChannelData[ch], newPwmCh.val.failsafe+988U);
+      newPwmCh.val.failsafe = CRSF_to_US(constrain(ChannelData[config.GetPwmChannel(ch)->val.inputChannel], CRSF_CHANNEL_VALUE_MIN, CRSF_CHANNEL_VALUE_MAX));
+      //DBGLN("FSCH(%u) crsf=%u us=%u", ch, ChannelData[ch], newPwmCh.val.failsafe);
       config.SetPwmChannelRaw(ch, newPwmCh.raw);
     }
   }

--- a/src/lib/OPTIONS/hardware.cpp
+++ b/src/lib/OPTIONS/hardware.cpp
@@ -8,6 +8,7 @@
 #else
 #include <SPIFFS.h>
 #endif
+#define ARDUINOJSON_USE_LONG_LONG 1
 #include <ArduinoJson.h>
 
 typedef enum {

--- a/src/lib/OPTIONS/options.cpp
+++ b/src/lib/OPTIONS/options.cpp
@@ -180,6 +180,7 @@ bool options_init()
 
 #else // TARGET_UNIFIED_TX || TARGET_UNIFIED_RX
 
+#define ARDUINOJSON_USE_LONG_LONG 1
 #include <ArduinoJson.h>
 #include <StreamString.h>
 #if defined(PLATFORM_ESP8266)

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -128,6 +128,11 @@ static void servosUpdate(unsigned long now)
             {
                 us = 3000U - us;
             }
+
+            // Limit output values to configured limits
+            const rx_config_pwm_limits_t *limits = config.GetPwmChannelLimits(ch);
+            us = constrain(us, limits->val.min, limits->val.max);
+
             servoWrite(ch, us);
         } /* for each servo */
     }     /* if newChannelsAvailable */

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -113,7 +113,11 @@ static void servosUpdate(unsigned long now)
         for (int ch = 0 ; ch < GPIO_PIN_PWM_OUTPUTS_COUNT ; ++ch)
         {
             const rx_config_pwm_t *chConfig = config.GetPwmChannel(ch);
+            #if defined(MIXER)
+            const unsigned crsfVal = ChannelMixedData[chConfig->val.inputChannel];
+            #else
             const unsigned crsfVal = ChannelData[chConfig->val.inputChannel];
+            #endif
             // crsfVal might 0 if this is a switch channel, and it has not been
             // received yet. Delay initializing the servo until the channel is valid
             if (crsfVal == 0)

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -377,6 +377,8 @@ static void GetConfiguration(AsyncWebServerRequest *request)
     {
       json["config"]["pwm"][ch]["config"] = config.GetPwmChannel(ch)->raw;
       json["config"]["pwm"][ch]["pin"] = GPIO_PIN_PWM_OUTPUTS[ch];
+      json["config"]["pwm"][ch]["limits"]["min"] = config.GetPwmChannelLimits(ch)->val.min;
+      json["config"]["pwm"][ch]["limits"]["max"] = config.GetPwmChannelLimits(ch)->val.max;
       uint8_t features = 0;
       auto pin = GPIO_PIN_PWM_OUTPUTS[ch];
       if (pin == U0TXD_GPIO_NUM) features |= 1;  // SerialTX supported
@@ -536,11 +538,18 @@ static void UpdateConfiguration(AsyncWebServerRequest *request, JsonVariant &jso
 
   #if defined(GPIO_PIN_PWM_OUTPUTS)
   JsonArray pwm = json["pwm"].as<JsonArray>();
-  for(uint32_t channel = 0 ; channel < pwm.size() ; channel++)
+  for(uint32_t channel = 0 ; channel < pwm.size() / 2; channel++)
   {
-    uint32_t val = pwm[channel];
+    // uint32_t val = pwm[channel];
     //DBGLN("PWMch(%u)=%u", channel, val);
+    // First uint32
+    uint32_t val = pwm[2 * channel];
+    DBGLN("PWMch(%u)=%u", channel, val);
     config.SetPwmChannelRaw(channel, val);
+    // Second uint32
+    val = pwm[(2 * channel) + 1];
+    DBGLN("PWMlm(%u)=%u", channel, val);
+    config.SetPwmChannelLimits(channel, val >> 16, val & 0xffff);
   }
   #endif
 

--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -156,8 +156,10 @@ connectionState_e connectionState = disconnected;
 expresslrs_mod_settings_s *ExpressLRS_currAirRate_Modparams = nullptr;
 expresslrs_rf_pref_params_s *ExpressLRS_currAirRate_RFperfParams = nullptr;
 
-// Current state of channels, CRSF format
-uint32_t ChannelData[CRSF_NUM_CHANNELS];
+uint32_t ChannelData[CRSF_NUM_CHANNELS];      // Current state of channels, CRSF format
+#if defined(MIXER)
+uint32_t ChannelMixedData[CRSF_NUM_CHANNELS]; // Current state of channels after mixing, CRSF format
+#endif
 
 uint8_t ICACHE_RAM_ATTR TLMratioEnumToValue(expresslrs_tlm_ratio_e const enumval)
 {

--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -159,6 +159,7 @@ expresslrs_rf_pref_params_s *ExpressLRS_currAirRate_RFperfParams = nullptr;
 uint32_t ChannelData[CRSF_NUM_CHANNELS];      // Current state of channels, CRSF format
 #if defined(MIXER)
 uint32_t ChannelMixedData[CRSF_NUM_CHANNELS]; // Current state of channels after mixing, CRSF format
+bool LogicalSwitchData[MAX_LOGICAL_SWITCHES]; // Current state of logical switches
 #endif
 
 uint8_t ICACHE_RAM_ATTR TLMratioEnumToValue(expresslrs_tlm_ratio_e const enumval)

--- a/src/src/rx-serial/devSerialIO.cpp
+++ b/src/src/rx-serial/devSerialIO.cpp
@@ -226,7 +226,11 @@ static int timeout(devserial_ctx_t *ctx)
     // Verify there is new ChannelData and they should be sent on
     bool sendChannels = confirmFrameAvailable(ctx);
 
+    #if defined(MIXER)
+    uint32_t duration = (*(ctx->io))->sendRCFrame(sendChannels, missed, ChannelMixedData);
+    #else
     uint32_t duration = (*(ctx->io))->sendRCFrame(sendChannels, missed, ChannelData);
+    #endif
 
     // still get telemetry and send link stats if theres no model match
     (*(ctx->io))->processSerialInput();

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -259,6 +259,75 @@ bool BindingModeRequest = false;
 extern void setWifiUpdateMode();
 void reconfigureSerial();
 
+#if defined(MIXER)
+void applyMixes()
+{
+    int64_t newChannelData[CRSF_NUM_CHANNELS];
+    for (uint8_t i = 0; i < CRSF_NUM_CHANNELS; i++)
+        newChannelData[i] = CRSF_CHANNEL_VALUE_MID;
+
+    for (unsigned mix_number = 0; mix_number < MAX_MIXES; mix_number++)
+    {
+        const rx_config_mix_t *mix = config.GetMix(mix_number);
+
+        if (!mix->val.active)
+            continue;
+
+        newChannelData[mix->val.destination] += mix->val.offset;
+
+        // The fist 16 enums are CRSF input channels
+        if (mix->val.source < 16)
+        {
+            const unsigned crsfVal = ChannelData[mix->val.source];
+            if (crsfVal < CRSF_CHANNEL_VALUE_MID)
+            {
+                uint16_t command = CRSF_CHANNEL_VALUE_MID - crsfVal;
+                int8_t scale = mix->val.weight_negative;
+                int32_t scaled = command * scale / 100;
+                newChannelData[mix->val.destination] -= scaled;
+            }
+            else
+            {
+                uint16_t value = crsfVal - CRSF_CHANNEL_VALUE_MID;
+                int8_t scale = mix->val.weight_positive;
+                int32_t result = value * scale / 100;
+                newChannelData[mix->val.destination] += result;
+            }
+        }
+        else
+        {
+            switch (mix->val.source)
+            {
+            case MIX_SOURCE_FAILSAFE:
+            {
+                // This is a full max throw input when we are in failsafe which
+                // can be mixed to other channels.
+                int8_t scale = (int8_t) mix->val.weight_positive;
+                uint32_t result = (CRSF_CHANNEL_VALUE_MAX - CRSF_CHANNEL_VALUE_MID) * scale / 100;
+                newChannelData[mix->val.destination] += result;
+                break;
+            }
+
+            // Later we will add other source mixes here (gyro, failsafe, etc)
+
+            default:
+                break;
+            }
+        }
+    }
+
+    for (unsigned ch = 0; ch < CRSF_NUM_CHANNELS; ch++)
+    {
+        if (newChannelData[ch] < CRSF_CHANNEL_VALUE_MIN)
+            ChannelMixedData[ch] = CRSF_CHANNEL_VALUE_MIN;
+        else if (newChannelData[ch] > CRSF_CHANNEL_VALUE_MAX)
+            ChannelMixedData[ch] = CRSF_CHANNEL_VALUE_MAX;
+        else
+            ChannelMixedData[ch] = newChannelData[ch];
+    }
+}
+#endif // MIXER
+
 uint8_t getLq()
 {
     return LQCalc.getLQ();
@@ -817,6 +886,9 @@ void ICACHE_RAM_ATTR HWtimerCallbackTock()
         {
             crsfRCFrameMissed();
         }
+        #if defined(MIXER)
+        applyMixes();
+        #endif
     }
 
     if (!didFHSS)
@@ -932,6 +1004,9 @@ static void ICACHE_RAM_ATTR ProcessRfPacket_RC(OTA_Packet_s const * const otaPkt
     {
         if (ExpressLRS_currAirRate_Modparams->numOfSends == 1)
         {
+            #if defined(MIXER)
+            applyMixes();
+            #endif
             crsfRCFrameAvailable();
             // teamrace is only checked for servos because the teamrace model select logic only runs
             // when new frames are available, and will decide later if the frame will be forwarded

--- a/src/test/test_crsf/test_crsf.cpp
+++ b/src/test/test_crsf/test_crsf.cpp
@@ -8,7 +8,11 @@
 
 using namespace std;
 
+#if defined(MIXER)
+uint32_t ChannelData[CRSF_NUM_CHANNELS + GYRO_SOURCES];      // Current state of channels, CRSF format
+#else
 uint32_t ChannelData[CRSF_NUM_CHANNELS];      // Current state of channels, CRSF format
+#endif
 
 GENERIC_CRC8 test_crc(CRSF_CRC_POLY);
 

--- a/src/test/test_msp/msp_tests.cpp
+++ b/src/test/test_msp/msp_tests.cpp
@@ -6,7 +6,11 @@
 #include "mock_serial.h"
 
 MSP MSPProtocol;
+#if defined(MIXER)
+uint32_t ChannelData[CRSF_NUM_CHANNELS + GYRO_SOURCES];      // Current state of channels, CRSF format
+#else
 uint32_t ChannelData[CRSF_NUM_CHANNELS];      // Current state of channels, CRSF format
+#endif
 
 void test_msp_receive(void)
 {

--- a/src/test/test_msp_vtx/msp_vtx_tests.cpp
+++ b/src/test/test_msp_vtx/msp_vtx_tests.cpp
@@ -8,7 +8,11 @@
 
 using namespace std;
 
+#if defined(MIXER)
+uint32_t ChannelData[CRSF_NUM_CHANNELS + GYRO_SOURCES];      // Current state of channels, CRSF format
+#else
 uint32_t ChannelData[CRSF_NUM_CHANNELS];      // Current state of channels, CRSF format
+#endif
 
 GENERIC_CRC8 test_crc(CRSF_CRC_POLY);
 

--- a/src/test/test_ota/test_switches.cpp
+++ b/src/test/test_ota/test_switches.cpp
@@ -20,7 +20,11 @@
 #include "crsf_sysmocks.h"
 
 CRSF crsf;  // need an instance to provide the fields used by the code under test
+#if defined(MIXER)
+uint32_t ChannelData[CRSF_NUM_CHANNELS + GYRO_SOURCES];      // Current state of channels, CRSF format
+#else
 uint32_t ChannelData[CRSF_NUM_CHANNELS];      // Current state of channels, CRSF format
+#endif
 uint8_t UID[6] = {1,2,3,4,5,6};
 
 void test_crsf_endpoints()

--- a/src/test/test_telemetry/test_telemetry.cpp
+++ b/src/test/test_telemetry/test_telemetry.cpp
@@ -5,7 +5,11 @@
 #include "common.h"
 
 Telemetry telemetry;
+#if defined(MIXER)
+uint32_t ChannelData[CRSF_NUM_CHANNELS + GYRO_SOURCES];      // Current state of channels, CRSF format
+#else
 uint32_t ChannelData[CRSF_NUM_CHANNELS];      // Current state of channels, CRSF format
+#endif
 
 int sendData(uint8_t *data, int length)
 {


### PR DESCRIPTION
# RFC - Adding a generic mixer

This PR adds prerequisites for receiver gyro support, primarily to be used for stabilization of airplanes and cars.

Having a generic receiver mixer is however very useful in many cases.

The gyro devlopment happens here: https://github.com/awigen/ExpressLRS

## Full resolution failsafe

Full resolution channels can go from 885us to 2135us and the current failsafe configuration storage isn't large enough to hold it.

The current failsafe configuration is stored in the EEPROM as a 10-bit value and a magic constant of 988us is used to convert it to the appropriate units.

To allow a failsafe to any valid channel range, this PR converts the failsafe configuration to an 11-bit value and removes the magic constant.

## Channel limits

When controlling servo outputs it's important to limit the range of motion of the servo to avoid binding and possible damage. When gyro support is added it is no longer possible to limit the servo range solely from the transmitter as the gyro will add to the channel commanded position.

This PR adds a channel limits to channels.

TODO: Change the way the limits are applied so that we map the input range 0-100% to the new limited output range. This would mean the servo limit only needs to be set once on the receiver, the transmitter should just use default 100% limits.

The downside to this approach is that the limits can not be adjusted on the transmitter without using forward programming with lua.

## Generic mixer

To support gyro functionality, a mixer is needed to add the gyro output to the channel output. A generic mixer is also useful for other scenarios, some examples are:

* Sbus channel ordering. By mixing input CRSF channels to different output channels, the order of the SBUS channels can be changed.
* Rudder -> Nose wheel mixing. Logical conditions for a mixer rule can be used to set the mix active only when the landing gear is down.
* V-tail mixing and other tail configurations
* Reducing the number of TX channels. One TX aileron channel, one TX flapp channel while controlling multiple servos with individual limits. This can open up different ELRS modes to be used by not transmitting redundant/extrapolatable data.

TODO: Add logical conditions to the mixer.

## Receiver gyro support

With the addition of the prerequisites, gyro support can be added to the receiver. See my https://github.com/awigen/ExpressLRS/tree/gyro-with-mixer branch for the current state of this work.

![image](https://github.com/user-attachments/assets/1fe3c927-0d05-4c71-b55d-a3d042ef2e29)
