### PR TITLE
Unremove firmwareOptions uid when customizing

### DIFF
--- a/src/lib/OPTIONS/options.cpp
+++ b/src/lib/OPTIONS/options.cpp
@@ -211,6 +211,11 @@ void saveOptions(Stream &stream, bool customised)
 {
     JsonDocument doc;
 
+    if (firmwareOptions.hasUID)
+    {
+        JsonArray uid = doc.createNestedArray("uid");
+        copyArray(firmwareOptions.uid, sizeof(firmwareOptions.uid), uid);
+    }
     if (firmwareOptions.wifi_auto_on_interval != -1)
     {
         doc["wifi-on-interval"] = firmwareOptions.wifi_auto_on_interval / 1000;


### PR DESCRIPTION
Returns some code removed during #2542 which I thought was unneeded. When saving a customized json firmwareOptions to SPIFFS, the binding UID was not copied. This led to TX modules forgetting their bindphrase if any firmwareOptions is customized.

It was unneeded on the receiver since the config storage copies the value out immediately, so the json is only needed to transfer the UID from the flashing process to config storage. However, I forgot the TX does not store the UID in config storage so the JSON must always contain the UID.

The RX's Binding Storage: Returnable also relies on having the UID in json as well, so that wouldn't work properly if the user set storage to returnable, loaned the model, then the loanee changed the wifi credentials and tried to return the model. Therefore the json UID is needed on both receiver and transmitter.

Fixes #2864, thanks to @sokil for the awesome bug report!