### PR TITLE
Silence unused-variable warning

### DIFF
--- a/src/lib/LED/devLED.cpp
+++ b/src/lib/LED/devLED.cpp
@@ -51,7 +51,9 @@ static const uint8_t *_durations;
 static uint8_t _count;
 static uint8_t _counter = 0;
 static bool hasRGBLeds = false;
+#if defined(TARGET_TX)
 static bool hasGBLeds = false;
+#endif
 
 static uint16_t updateLED()
 {
@@ -141,6 +143,7 @@ static int timeout()
     return updateLED();
 }
 
+#if !defined(TARGET_RX)
 static void setPowerLEDs()
 {
     if (hasGBLeds)
@@ -166,6 +169,7 @@ static void setPowerLEDs()
         }
     }
 }
+#endif
 
 static int event()
 {


### PR DESCRIPTION
This silences a compile time warning:

```
lib/LED/devLED.cpp:144:13: warning: 'void setPowerLEDs()' defined but not used [-Wunused-function]
 static void setPowerLEDs()
             ^~~~~~~~~~~~
```