### PR TITLE
Parse MSP messages from the backpack while TX is in mavlink mode

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1176,7 +1176,6 @@ static void HandleUARTin()
     {
       uint8_t buf[size];
       TxBackpack->readBytes(buf, size);
-      TxUSB->write(buf, size);
 
       // If the TX is in Mavlink mode, push the bytes into the fifo buffer
       if (config.GetLinkMode() == TX_MAVLINK_MODE)


### PR DESCRIPTION
The backpack version string no longer displays in the LUA `Backpack` folder if the TX link mode is set to `MAVLink`.
This is because the serial data from the `TxBackpack` stream gets treated as mavlink, and buffered into the FIFO, without inspecting it for any MSP responses from the Backpack, so even though the Backpack is sending a valid version string, it gets ignored.

** NOTE: **
The recent additions to the Backpack codebase for mavlink UDP forwarding have broken the sending of the version string on boot (instead, the backpack jumps straight to wifi mode if the TX is configured for mavlink). This also needs to be fixed for this to fully work again.

Also added a check to make sure we are getting valid mavlink packets before starting the timer (for when the TX is used independently of a handset).