### PR TITLE
Fix LR1121 binding compatibility

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -256,7 +256,7 @@ static uint8_t debugRcvrLinkstatsFhssIdx;
 
 bool BindingModeRequest = false;
 static uint32_t BindingRateChangeTime;
-#define BindingRateChangeCyclePeriod 250
+#define BindingRateChangeCyclePeriod 125
 
 extern void setWifiUpdateMode();
 void reconfigureSerial();

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -255,6 +255,8 @@ static uint8_t debugRcvrLinkstatsFhssIdx;
 #endif
 
 bool BindingModeRequest = false;
+static uint32_t BindingRateChangeTime;
+#define BindingRateChangeCyclePeriod 250
 
 extern void setWifiUpdateMode();
 void reconfigureSerial();
@@ -1752,11 +1754,7 @@ static void EnterBindingMode()
     // Start attempting to bind
     // Lock the RF rate and freq while binding
     SetRFLinkRate(enumRatetoIndex(RATE_BINDING), true);
-    Radio.SetFrequencyReg(FHSSgetInitialFreq());
-    if (geminiMode)
-    {
-        Radio.SetFrequencyReg(FHSSgetInitialGeminiFreq(), SX12XX_Radio_2);
-    }
+
     // If the Radio Params (including InvertIQ) parameter changed, need to restart RX to take effect
     Radio.RXnb();
 
@@ -1799,13 +1797,31 @@ static void ExitBindingMode()
     devicesTriggerEvent();
 }
 
-static void updateBindingMode()
+static void updateBindingMode(unsigned long now)
 {
     // Exit binding mode if the config has been modified, indicating UID has been set
     if (InBindingMode && config.IsModified())
     {
         ExitBindingMode();
     }
+
+#if defined(RADIO_LR1121)
+    // Change frequency domains every 500ms.  This will allow single LR1121 receivers to receive bind packets from SX12XX Tx modules.
+    else if (InBindingMode && (now - BindingRateChangeTime) > BindingRateChangeCyclePeriod)
+    {
+        BindingRateChangeTime = now;
+        if (ExpressLRS_currAirRate_Modparams->index == RATE_DUALBAND_BINDING)
+        {
+            SetRFLinkRate(enumRatetoIndex(RATE_BINDING), true);
+        }
+        else
+        {
+            SetRFLinkRate(RATE_DUALBAND_BINDING, true);
+        }
+
+        Radio.RXnb();
+    }
+#endif
 
     // If the power on counter is >=3, enter binding, the counter will be reset after 2s
     else if (!InBindingMode && config.GetPowerOnCounter() >= 3)
@@ -2229,7 +2245,7 @@ void loop()
     }
 
     updateTelemetryBurst();
-    updateBindingMode();
+    updateBindingMode(now);
     updateSwitchMode();
     checkGeminiMode();
     DynamicPower_UpdateRx(false);


### PR DESCRIPTION
This PR mainly targets LR1121 hardware, but there is a global change increasing the number of Bind packets sent from 6 to 25.  At the binding mode of 50Hz, packet are sent for 250ms on each freq domain.

LR1121 based Tx hardware now switches frequency halfway through spamming.  This allows binding with both LR1121 and SX12XX based hardware.

LR1121 based Rx hardware now cycles between the 2 freq domains every 125ms (~6 packets).

This has been tested across all combinations of LR1121 and SX12XX hardware, Gemini and non gemini.