### PR TITLE
Fix betaflight passthrough erase flash

### DIFF
--- a/src/python/binary_flash.py
+++ b/src/python/binary_flash.py
@@ -91,7 +91,7 @@ def upload_esp8266_bf(args, options):
     if retval != ElrsUploadResult.Success:
         return retval
     try:
-        cmd = ['--passthrough', '--chip', 'esp8266', '--port', args.port, '--baud', str(args.baud), '--before', 'no_reset', '--after', 'soft_reset', '--no-stub', 'write_flash']
+        cmd = ['--passthrough', '--chip', 'esp8266', '--port', args.port, '--baud', str(args.baud), '--before', 'no_reset', '--after', 'soft_reset', 'write_flash']
         if args.erase: cmd.append('--erase-all')
         cmd.extend(['0x0000', args.file.name])
         esptool.main(cmd)


### PR DESCRIPTION
The option to erase before flashing was not working correctly with betaflight passthrough.
It would not even send the command to erase the flash! This is because the stub flasher needs to be installed for this work correctly and the stub flasher was not used to avoid an issue in earlier versions of the esptool that was bundled in the flasher.