### PR TITLE
Fix disabling of wifi-auto-on-internal

### DIFF
--- a/src/lib/OPTIONS/options.cpp
+++ b/src/lib/OPTIONS/options.cpp
@@ -322,7 +322,7 @@ static void options_LoadFromFlashOrFile(EspFlashStream &strmFlash)
     {
         firmwareOptions.hasUID = false;
     }
-    int32_t wifiInterval = doc["wifi-on-interval"] | 60;
+    int32_t wifiInterval = doc["wifi-on-interval"] | -1;
     firmwareOptions.wifi_auto_on_interval = wifiInterval == -1 ? -1 : wifiInterval * 1000;
     strlcpy(firmwareOptions.home_wifi_ssid, doc["wifi-ssid"] | "", sizeof(firmwareOptions.home_wifi_ssid));
     strlcpy(firmwareOptions.home_wifi_password, doc["wifi-password"] | "", sizeof(firmwareOptions.home_wifi_password));

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -972,7 +972,7 @@ static void startMDNS()
     return;
   }
 
-  String options = "-DAUTO_WIFI_ON_INTERVAL=" + String(firmwareOptions.wifi_auto_on_interval / 1000);
+  String options = "-DAUTO_WIFI_ON_INTERVAL=" + (firmwareOptions.wifi_auto_on_interval == -1 ? "-1" : String(firmwareOptions.wifi_auto_on_interval / 1000));
 
   #ifdef TARGET_TX
   if (firmwareOptions.unlock_higher_power)


### PR DESCRIPTION
When the wifi-auto-on checkbox is disabled in Configurator, no value is given to the options JSON file, this is correct.
As part of the updated binding PR #2542 it changed the default (missing) value to 60 seconds rather than -1 (disabled).
The binding PR also broke the web UI when an empty field for the wifi-auto-on sent no value, so the 60 seconds kicked in rather than the -1!

This PR just reinstates the -1 behaviour as the default value for the missing value case.

Fixes #2892 
