### PR TITLE
Remove automatic mavlink protocol detection (for now)

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1246,11 +1246,6 @@ void MspReceiveComplete()
 #endif
         break;
     case MSP_ELRS_MAVLINK_TLM: // 0xFD
-        if (config.GetSerialProtocol() != PROTOCOL_MAVLINK)
-        {
-            config.SetSerialProtocol(PROTOCOL_MAVLINK);
-            reconfigureSerial();
-        }
         // raw mavlink data
         mavlinkOutputBuffer.atomicPushBytes(&MspData[2], MspData[1]);
         break;


### PR DESCRIPTION
PR https://github.com/ExpressLRS/ExpressLRS/pull/2799 added functionality to automatically detect mavlink data (from the TX module) on the RX, and change the serial output protocol to `MAVLink` when it did. This was a quality of life addition to help users with initial setup.

The problem is, it's false triggering, and changing the serial protocol from `CRSF` (or whatever it was set to) to `MAVLink` if the TX receives any kind of garbage bytes from the USB or Backpack UARTs on-boot. This will obviously be very problematic for people, as the RX will randomly kick itself into a serial protocol setting which may not suit your craft.

Removing the auto detection for now until a fool proof way to detect valid MAV packets is developed.