### PR TITLE
Fixes 3 issues with the displays

### DIFF
--- a/src/lib/SCREEN/devScreen.cpp
+++ b/src/lib/SCREEN/devScreen.cpp
@@ -36,14 +36,6 @@ static bool jumpToChannelSelect = false;
 
 static int handle(void)
 {
-#if defined(JOY_ADC_VALUES) && defined(PLATFORM_ESP32)
-    // if we are using analog joystick then we can't cancel because WiFi is using the ADC2 (i.e. channel >= 8)!
-    if (connectionState == wifiUpdate && digitalPinToAnalogChannel(GPIO_PIN_JOYSTICK) >= 8)
-    {
-        return DURATION_NEVER;
-    }
-#endif
-
 #ifdef HAS_GSENSOR
     is_screen_flipped = gsensor.isFlipped();
 
@@ -81,7 +73,19 @@ static int handle(void)
     {
         int key;
         bool isLongPressed;
+#if defined(JOY_ADC_VALUES) && defined(PLATFORM_ESP32)
+        // if we are using analog joystick then we can't cancel because WiFi is using the ADC2 (i.e. channel >= 8)!
+        if (connectionState == wifiUpdate && digitalPinToAnalogChannel(GPIO_PIN_JOYSTICK) >= 8)
+        {
+            key = INPUT_KEY_NO_PRESS;
+        }
+        else
+        {
+            fivewaybutton.update(&key, &isLongPressed);
+        }
+#else
         fivewaybutton.update(&key, &isLongPressed);
+#endif
         fsm_event_t fsm_event;
         switch (key)
         {

--- a/src/lib/SCREEN/menu.cpp
+++ b/src/lib/SCREEN/menu.cpp
@@ -577,7 +577,7 @@ fsm_state_entry_t const wifi_update_menu_fsm[] = {
     {STATE_LAST}
 };
 fsm_state_event_t const wifi_menu_update_events[] = {MENU_EVENTS(wifi_update_menu_fsm)};
-fsm_state_event_t const wifi_ext_execute_events[] = {{EVENT_TIMEOUT, GOTO(STATE_WIFI_EXECUTE)}};
+fsm_state_event_t const wifi_ext_execute_events[] = {{EVENT_TIMEOUT, ACTION_POP}};
 fsm_state_entry_t const wifi_ext_menu_fsm[] = {
     {STATE_WIFI_EXECUTE, nullptr, executeWiFi, 1000, wifi_ext_execute_events, ARRAY_SIZE(wifi_ext_execute_events)},
     {STATE_LAST}

--- a/src/lib/SCREEN/menu.h
+++ b/src/lib/SCREEN/menu.h
@@ -16,7 +16,6 @@ enum fsm_state_s {
     STATE_BIND,
     STATE_WIFI,
     STATE_VTX,
-    STATE_LINKSTATS,
 
     STATE_POWER_MAX,
     STATE_POWER_DYNAMIC,
@@ -57,6 +56,8 @@ enum fsm_state_s {
     STATE_VALUE_INC,
     STATE_VALUE_DEC,
     STATE_VALUE_SAVE,
+
+    STATE_LINKSTATS
 };
 
 


### PR DESCRIPTION
As the title says, theres actually ~~2~~3 issues here.

The first is the display issue from #2915, which was introduced when the Linkstats page was added to the displays.

The second has been there for some time which is that the RX WiFi, Backpack Wifi and VRx Wifi screens should only display for second and pop back because they only send a command to the underlying device!

Thirdly, some OLED modules use an ADC pin which is part of the second group of ADCs which is shared by the wifi module, and when in wifi mode, the ADC is unavailable. The code used to early exit the OLED handler function so the OLED was not displaying the wifi screen.

Fixes #2915 