### PR TITLE
Fix ESP32 based PWM receivers in debug mode

### DIFF
--- a/src/include/targets.h
+++ b/src/include/targets.h
@@ -289,6 +289,9 @@ extern bool pwmSerialDefined;
 #endif
 
 #if defined(TARGET_UNIFIED_TX) || defined(TARGET_UNIFIED_RX)
+#if defined(PLATFORM_ESP32)
+#include <soc/uart_pins.h>
+#endif
 #if !defined(U0RXD_GPIO_NUM)
 #define U0RXD_GPIO_NUM (3)
 #endif


### PR DESCRIPTION
The include soc/uarts.h for pin definitions was not present in the targets.h file so it used the ESP8285 default pins, which is not correct for ESP32S3 and C3 targets!