### PR TITLE
Disable backpack in wifi and BLE modes

### DIFF
--- a/src/lib/Backpack/devBackpack.cpp
+++ b/src/lib/Backpack/devBackpack.cpp
@@ -363,7 +363,7 @@ static int event()
     if (OPT_USE_TX_BACKPACK && GPIO_PIN_BACKPACK_EN != UNDEF_PIN)
     {
         // EN should be HIGH to be active
-        digitalWrite(GPIO_PIN_BACKPACK_EN, config.GetBackpackDisable() ? LOW : HIGH);
+        digitalWrite(GPIO_PIN_BACKPACK_EN, (config.GetBackpackDisable() || connectionState == bleJoystick || connectionState == wifiUpdate) ? LOW : HIGH);
     }
 #endif
 #if !defined(PLATFORM_STM32)


### PR DESCRIPTION
When entering WiFi or BLE mode on the TX module we can disable the backpack (on devices that support this) so it's wifi (ESPNow) will not interfere.