### PR TITLE
Suppress a "fatal" error when building from a commit hash

### DIFF
--- a/src/python/elrs_helpers.py
+++ b/src/python/elrs_helpers.py
@@ -3,7 +3,7 @@ import re
 import subprocess
 
 def git_cmd(*args):
-    return subprocess.check_output(["git"] + list(args)).decode("utf-8").rstrip('\r\n')
+    return subprocess.check_output(["git"] + list(args), stderr=subprocess.DEVNULL).decode("utf-8").rstrip('\r\n')
 
 
 def get_git_version():


### PR DESCRIPTION
This is just silencing a "fatal" error from git, which is _not_ fatal the ExpressLRS build.