### PR TITLE
Backport #2931 "Split RC data sending from polling and queued data sending"

### DIFF
--- a/src/src/rx-serial/SerialIO.h
+++ b/src/src/rx-serial/SerialIO.h
@@ -70,6 +70,8 @@ public:
     /**
      * @brief send any previously queued data to the serial port stream `_outputPort`
      * member variable.
+     *
+     * This method is called each time around the main loop.
      */
     virtual void sendQueuedData(uint32_t maxBytesToSend);
 
@@ -81,6 +83,8 @@ public:
      *
      * This method *should* not be overridden by custom implementations, it is
      * only overridden by the `SerialNOOP` implementation.
+     *
+     * This method is called each time around the main loop.
      */
     virtual void processSerialInput();
 

--- a/src/src/rx-serial/SerialMavlink.cpp
+++ b/src/src/rx-serial/SerialMavlink.cpp
@@ -6,6 +6,8 @@
 #include "CRSF.h"
 #include "config.h"
 
+#define MAVLINK_RC_PACKET_INTERVAL 10
+
 // Variables / constants for Mavlink //
 FIFO<MAV_INPUT_BUF_LEN> mavlinkInputBuffer;
 FIFO<MAV_OUTPUT_BUF_LEN> mavlinkOutputBuffer;
@@ -96,7 +98,7 @@ uint32_t SerialMavlink::sendRCFrame(bool frameAvailable, bool frameMissed, uint3
     uint16_t len = mavlink_msg_to_send_buffer(buf, &msg);
     _outputPort->write(buf, len);
     
-    return DURATION_IMMEDIATELY;
+    return MAVLINK_RC_PACKET_INTERVAL;
 }
 
 int SerialMavlink::getMaxSerialReadSize()

--- a/src/src/rx-serial/devSerialIO.cpp
+++ b/src/src/rx-serial/devSerialIO.cpp
@@ -226,13 +226,23 @@ static int timeout(devserial_ctx_t *ctx)
     // Verify there is new ChannelData and they should be sent on
     bool sendChannels = confirmFrameAvailable(ctx);
 
-    uint32_t duration = (*(ctx->io))->sendRCFrame(sendChannels, missed, ChannelData);
+    return (*(ctx->io))->sendRCFrame(sendChannels, missed, ChannelData);
+}
 
-    // still get telemetry and send link stats if theres no model match
-    (*(ctx->io))->processSerialInput();
-    (*(ctx->io))->sendQueuedData((*(ctx->io))->getMaxSerialWriteSize());
-    
-    return duration;
+void handleSerialIO() {
+    // still get telemetry and send link stats if there's no model match
+    if (*(serial0.io) != nullptr)
+    {
+        (*(serial0.io))->processSerialInput();
+        (*(serial0.io))->sendQueuedData((*(serial0.io))->getMaxSerialWriteSize());
+    }
+#if defined(PLATFORM_ESP32)
+    if (*(serial1.io) != nullptr)
+    {
+        (*(serial1.io))->processSerialInput();
+        (*(serial1.io))->sendQueuedData((*(serial1.io))->getMaxSerialWriteSize());
+    }
+#endif
 }
 
 static int timeout0()

--- a/src/src/rx-serial/devSerialIO.h
+++ b/src/src/rx-serial/devSerialIO.h
@@ -6,5 +6,6 @@ extern device_t Serial0_device;
 #if defined(PLATFORM_ESP32)
 extern device_t Serial1_device;
 #endif
+extern void handleSerialIO();
 extern void crsfRCFrameAvailable();
 extern void crsfRCFrameMissed();

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -2159,6 +2159,9 @@ void loop()
 
     devicesUpdate(now);
 
+    // read and process any data from serial ports, send any queued non-RC data
+    handleSerialIO();
+
 #if defined(PLATFORM_ESP8266) || defined(PLATFORM_ESP32)
     // If the reboot time is set and the current time is past the reboot time then reboot.
     if (rebootTime != 0 && now > rebootTime) {


### PR DESCRIPTION
By splitting the RC data send and the polling/queued data sending this allows us to limit the packet rate independently of all the other packet data that needs to be sent in a timely manner.
This is particularly useful for the MavLINK serial receiver code where we want to limit the number of RC packets to 250Hz but keep the OTA packet rate at say 1000Hz. This PR does NOT do this, it just enables it by the separation of the code paths.

To limit the RC rate we just need to return an interval from the `sendRCFrame` function in the serial handler rather than the current `DURATION_IMMEDIATELY`.

This PR also includes rate limiter on the RC data packets for MavLINK to 100Hz so as not to swamp the link.