### PR TITLE
Fix allowed rf modes in tx lua

### DIFF
--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -589,9 +589,6 @@ static void recalculatePacketRateOptions(int minInterval)
     for (int i=0 ; i < RATE_MAX ; i++)
     {
         uint8_t rate = i;
-#if defined(RADIO_LR1121) // Janky fix to order menu correctly
-        rate = (rate + 4) % RATE_MAX;
-#endif
         rate = RATE_MAX - 1 - rate;
         bool rateAllowed = get_elrs_airRateConfig(rate)->interval >= minInterval;
         const char *semi = strchrnul(pos, ';');

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -590,7 +590,7 @@ static void recalculatePacketRateOptions(int minInterval)
     {
         uint8_t rate = i;
         rate = RATE_MAX - 1 - rate;
-        bool rateAllowed = get_elrs_airRateConfig(rate)->interval >= minInterval;
+        bool rateAllowed = (get_elrs_airRateConfig(rate)->interval * get_elrs_airRateConfig(rate)->numOfSends) >= minInterval;
         const char *semi = strchrnul(pos, ';');
         if (rateAllowed)
         {


### PR DESCRIPTION
2 things...

Remove some left over janky code that reordered modes for the LR1121.  This caused the wrong modes to be masked.

Correct for D modes.  Currently L500 is allowed but D500 is not, even though they both sync with ETX at 500Hz.