### PR TITLE
Prevent vtx msp on tx boot

### DIFF
--- a/src/lib/VTX/devVTX.cpp
+++ b/src/lib/VTX/devVTX.cpp
@@ -32,7 +32,8 @@ static enum VtxSendState_e
 
 void VtxTriggerSend()
 {
-    VtxSendState = VTXSS_MODIFIED;
+    VtxSendState = VTXSS_UNKNOWN;
+    sendEepromWrite = true;
     devicesTriggerEvent();
 }
 

--- a/src/lib/VTX/devVTX.cpp
+++ b/src/lib/VTX/devVTX.cpp
@@ -10,8 +10,9 @@
 #include "devButton.h"
 #include "handset.h"
 
-#define PITMODE_OFF     0
-#define PITMODE_ON      1
+#define PITMODE_NOT_INITIALISED    -1
+#define PITMODE_OFF                 0
+#define PITMODE_ON                  1
 
 // Delay after disconnect to preserve the VTXSS_CONFIRMED status
 // Needs to be long enough to reconnect, but short enough to
@@ -19,7 +20,7 @@
 #define VTX_DISCONNECT_DEBOUNCE_MS (10 * 1000)
 
 extern Stream *TxBackpack;
-static uint8_t pitmodeAuxState = 0;
+static int pitmodeAuxState = PITMODE_NOT_INITIALISED;
 static bool sendEepromWrite = true;
 
 static enum VtxSendState_e
@@ -49,7 +50,11 @@ void VtxPitmodeSwitchUpdate()
     uint8_t auxNumber = (config.GetVtxPitmode() / 2) + 3;
     uint8_t newPitmodeAuxState = CRSF_to_BIT(ChannelData[auxNumber]) ^ auxInverted;
 
-    if (pitmodeAuxState != newPitmodeAuxState)
+    if (pitmodeAuxState == PITMODE_NOT_INITIALISED)
+    {
+        pitmodeAuxState = newPitmodeAuxState;
+    }
+    else if (pitmodeAuxState != newPitmodeAuxState)
     {
         pitmodeAuxState = newPitmodeAuxState;
         sendEepromWrite = false;

--- a/src/lib/VTX/devVTX.cpp
+++ b/src/lib/VTX/devVTX.cpp
@@ -33,7 +33,7 @@ static enum VtxSendState_e
 
 void VtxTriggerSend()
 {
-    VtxSendState = VTXSS_UNKNOWN;
+    VtxSendState = VTXSS_MODIFIED;
     sendEepromWrite = true;
     devicesTriggerEvent();
 }

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -905,6 +905,8 @@ static void UpdateConnectDisconnectStatus()
       apInputBuffer.flush();
       apOutputBuffer.flush();
       uartInputBuffer.flush();
+
+      VtxTriggerSend();
     }
   }
   // If past RX_LOSS_CNT, or in awaitingModelId state for longer than DisconnectTimeoutMs, go to disconnected


### PR DESCRIPTION
This PR does 3 fixes;
- Prevent the VTx Admin from racking up MSP packets on Tx boot and without a connected Rx. This is due to pitmodeAuxState not being initialised correctly.
- Reinstates VTx MSP sends on TLM connection.  I dont know when this was removed.
- Fix eeprom writes by making sure they are sent on the first VTx MSP sends after Tx module boot.