### PR TITLE
Remove Dual Band option from hardware with only a single LR1121

### DIFF
--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -591,6 +591,13 @@ static void recalculatePacketRateOptions(int minInterval)
         uint8_t rate = i;
         rate = RATE_MAX - 1 - rate;
         bool rateAllowed = (get_elrs_airRateConfig(rate)->interval * get_elrs_airRateConfig(rate)->numOfSends) >= minInterval;
+
+        // Remove Dual Band menu option from hardware with only a single LR1121
+        if (GPIO_PIN_NSS_2 == UNDEF_PIN && get_elrs_airRateConfig(rate)->radio_type == RADIO_TYPE_LR1121_LORA_DUAL)
+        {
+            rateAllowed = false;
+        }
+
         const char *semi = strchrnul(pos, ';');
         if (rateAllowed)
         {

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1725,6 +1725,13 @@ static void cycleRfMode(unsigned long now)
         Radio.RXnb();
         DBGLN("%u", ExpressLRS_currAirRate_Modparams->interval);
 
+        // Skip Dual Band modes for hardware with only a single LR1121
+        while (GPIO_PIN_NSS_2 == UNDEF_PIN && get_elrs_airRateConfig(scanIndex % RATE_MAX)->radio_type == RADIO_TYPE_LR1121_LORA_DUAL)
+        {
+            DBGLN("Skip %u", get_elrs_airRateConfig(scanIndex % RATE_MAX)->interval);
+            scanIndex++;
+        }
+
         // Switch to FAST_SYNC if not already in it (won't be if was just connected)
         RFmodeCycleMultiplier = 1;
     } // if time to switch RF mode


### PR DESCRIPTION
This PR removes the GemX rates from hardware with only a single LR1121.  We cant have a users thinking hardware is operating in GemX modes, when in fact only the SubGHz band is used.

The Rx will cycle past these modes on boot.  BUT, if a users connects to a single LR1121 Rx with a GemX Tx they can change to a GemX mode and the Rx will follow.  I think it will be better to maintain a link than drop it, but I can be easily persuaded if others dont agree. 

Currently I dont know how to handle this with the display and thats a future problem when hardware becomes available.