### PR TITLE
set OtaCrcInitializer to OTA_VERSION_ID during binding

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1673,7 +1673,7 @@ static void EnterBindingMode()
         return;
     }
 
-    // Binding uses a CRCInit=0, 50Hz, and InvertIQ
+    // Binding uses 50Hz, and InvertIQ
     OtaCrcInitializer = OTA_VERSION_ID;
     InBindingMode = true;
     // Any method of entering bind resets a loan

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1674,7 +1674,7 @@ static void EnterBindingMode()
     }
 
     // Binding uses a CRCInit=0, 50Hz, and InvertIQ
-    OtaCrcInitializer = 0;
+    OtaCrcInitializer = OTA_VERSION_ID;
     InBindingMode = true;
     // Any method of entering bind resets a loan
     // Model can be reloaned immediately by binding now

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -973,7 +973,7 @@ static void EnterBindingMode()
   // Queue up sending the Master UID as MSP packets
   SendUIDOverMSP();
 
-  // Binding uses a CRCInit=0, 50Hz, and InvertIQ
+  // Binding uses 50Hz, and InvertIQ
   OtaCrcInitializer = OTA_VERSION_ID;
   OtaNonce = 0; // Lock the OtaNonce to prevent syncspam packets
   InBindingMode = true; // Set binding mode before SetRFLinkRate() for correct IQ

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -974,7 +974,7 @@ static void EnterBindingMode()
   SendUIDOverMSP();
 
   // Binding uses a CRCInit=0, 50Hz, and InvertIQ
-  OtaCrcInitializer = 0;
+  OtaCrcInitializer = OTA_VERSION_ID;
   OtaNonce = 0; // Lock the OtaNonce to prevent syncspam packets
   InBindingMode = true; // Set binding mode before SetRFLinkRate() for correct IQ
 


### PR DESCRIPTION
It is still possible for a 2.4G Rx on V3 to receive a bind packet from a Tx on V4.  The Rx will not connect correctly after receiving the bind packet, but this still should not happen.