### PR TITLE
Fix Airport communication

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -495,11 +495,7 @@ bool ICACHE_RAM_ATTR HandleSendTelemetryResponse()
     alreadyTLMresp = true;
     otaPkt.std.type = PACKET_TYPE_TLM;
 
-    if (firmwareOptions.is_airport)
-    {
-        OtaPackAirportData(&otaPkt, &apInputBuffer);
-    }
-    else if (NextTelemetryType == ELRS_TELEMETRY_TYPE_LINK)
+    if (NextTelemetryType == ELRS_TELEMETRY_TYPE_LINK)
     {
         OTA_LinkStats_s * ls;
         if (OtaIsFullRes)
@@ -535,7 +531,11 @@ bool ICACHE_RAM_ATTR HandleSendTelemetryResponse()
             NextTelemetryType = ELRS_TELEMETRY_TYPE_LINK;
         }
 
-        if (TelemetrySender.IsActive())
+        if (firmwareOptions.is_airport)
+        {
+            OtaPackAirportData(&otaPkt, &apInputBuffer);
+        }
+        else if (TelemetrySender.IsActive())
         {
             if (OtaIsFullRes)
             {

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1328,7 +1328,7 @@ static void setupSerial()
         serialIO = new SerialNOOP();
         return;
     }
-    if (config.GetSerialProtocol() == PROTOCOL_CRSF || config.GetSerialProtocol() == PROTOCOL_INVERTED_CRSF)
+    if (config.GetSerialProtocol() == PROTOCOL_CRSF || config.GetSerialProtocol() == PROTOCOL_INVERTED_CRSF || firmwareOptions.is_airport)
     {
         serialBaud = firmwareOptions.uart_baud;
     }

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -495,10 +495,11 @@ bool ICACHE_RAM_ATTR HandleSendTelemetryResponse()
     alreadyTLMresp = true;
     otaPkt.std.type = PACKET_TYPE_TLM;
 
-    bool noAirportDataQueued = firmwareOptions.is_airport && apOutputBuffer.size() == 0;
-    bool noTlmQueued = !TelemetrySender.IsActive() && noAirportDataQueued;
-
-    if (NextTelemetryType == ELRS_TELEMETRY_TYPE_LINK || noTlmQueued)
+    if (firmwareOptions.is_airport)
+    {
+        OtaPackAirportData(&otaPkt, &apInputBuffer);
+    }
+    else if (NextTelemetryType == ELRS_TELEMETRY_TYPE_LINK)
     {
         OTA_LinkStats_s * ls;
         if (OtaIsFullRes)
@@ -549,10 +550,6 @@ bool ICACHE_RAM_ATTR HandleSendTelemetryResponse()
                     otaPkt.std.tlm_dl.payload,
                     sizeof(otaPkt.std.tlm_dl.payload));
             }
-        }
-        else if (firmwareOptions.is_airport)
-        {
-            OtaPackAirportData(&otaPkt, &apInputBuffer);
         }
     }
 

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -495,7 +495,17 @@ bool ICACHE_RAM_ATTR HandleSendTelemetryResponse()
     alreadyTLMresp = true;
     otaPkt.std.type = PACKET_TYPE_TLM;
 
-    if (NextTelemetryType == ELRS_TELEMETRY_TYPE_LINK)
+    bool tlmQueued = false;
+    if (firmwareOptions.is_airport)
+    {
+        tlmQueued = apInputBuffer.size() > 0;
+    }
+    else
+    {
+        tlmQueued = TelemetrySender.IsActive();
+    }
+
+    if (NextTelemetryType == ELRS_TELEMETRY_TYPE_LINK || !tlmQueued)
     {
         OTA_LinkStats_s * ls;
         if (OtaIsFullRes)

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -548,7 +548,11 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
   }
   else
   {
-    if ((NextPacketIsMspData && MspSender.IsActive()) || dontSendChannelData)
+    if (firmwareOptions.is_airport)
+    {
+      OtaPackAirportData(&otaPkt, &apInputBuffer);
+    }
+    else if ((NextPacketIsMspData && MspSender.IsActive()) || dontSendChannelData)
     {
       otaPkt.std.type = PACKET_TYPE_MSPDATA;
       if (OtaIsFullRes)


### PR DESCRIPTION
3 fixes in this PR;

- Add back the deleted OtaPackAirportData() to tx_main.
- Correct the IF statement in rx_main by removing it and relocating OtaPackAirportData().
- Fix the Airport baud if the rx has another protocol select besides CRSF.