### PR TITLE
Fix TypeError in upload_wifi by removing extra argument

### DIFF
--- a/src/python/binary_flash.py
+++ b/src/python/binary_flash.py
@@ -33,7 +33,7 @@ class UploadMethod(Enum):
     def __str__(self):
         return self.value
 
-def upload_wifi(args, options, upload_addr, isstm: bool):
+def upload_wifi(args, options, upload_addr):
     wifi_mode = 'upload'
     if args.force == True:
         wifi_mode = 'uploadforce'
@@ -42,9 +42,9 @@ def upload_wifi(args, options, upload_addr, isstm: bool):
     if args.port:
         upload_addr = [args.port]
     if options.mcuType == MCUType.ESP8266:
-        return upload_via_esp8266_backpack.do_upload('firmware.bin.gz', wifi_mode, upload_addr, isstm, {})
+        return upload_via_esp8266_backpack.do_upload('firmware.bin.gz', wifi_mode, upload_addr,{})
     else:
-        return upload_via_esp8266_backpack.do_upload(args.file.name, wifi_mode, upload_addr, isstm, {})
+        return upload_via_esp8266_backpack.do_upload(args.file.name, wifi_mode, upload_addr, {})
 
 def upload_stm32_uart(args, options):
     if args.port == None:


### PR DESCRIPTION
fix: remove unused `isstm` argument from do_upload

The `isstm` argument was not needed in the do_upload function call, leading to a TypeError. This change removes the unused argument for better alignment with the function definition.
