### PR TITLE
Allow setting 2400 domain for LR1121

### DIFF
--- a/src/python/build_flags.py
+++ b/src/python/build_flags.py
@@ -141,12 +141,18 @@ build_flags.append("-DLATEST_VERSION=" + get_version())
 build_flags.append("-DTARGET_NAME=" + re.sub("_VIA_.*", "", target_name))
 condense_flags()
 
-if '-DRADIO_SX127X=1' in build_flags or '-DRADIO_LR1121=1' in build_flags:
-    # disallow setting 2400s for 900
+if '-DRADIO_SX127X=1' in build_flags:
+    # disallow setting 2400 modes for SX127x
     if fnmatch.filter(build_flags, '*-DRegulatory_Domain_ISM_2400') or \
-        fnmatch.filter(build_flags, '*-DRegulatory_Domain_EU_CE_2400'):
-        print_error('Regulatory_Domain 2400 not compatible with RADIO_SX127X/RADIO_LR1121')
+            fnmatch.filter(build_flags, '*-DRegulatory_Domain_EU_CE_2400'):
+        print_error('Regulatory_Domain_*_2400 not compatible with RADIO_SX127X')
 
+if '-DRADIO_LR1121=1' in build_flags:
+    # disallow setting EU_CE_2400 for LR1121
+    if fnmatch.filter(build_flags, '*-DRegulatory_Domain_EU_CE_2400'):
+        print_error('Regulatory_Domain_EU_CE_2400 not compatible with RADIO_LR1121')
+
+if '-DRADIO_SX127X=1' in build_flags or '-DRADIO_LR1121=1' in build_flags:
     # require a domain be set for 900
     if not fnmatch.filter(build_flags, '*-DRegulatory_Domain*'):
         print_error('Please define a Regulatory_Domain in user_defines.txt')


### PR DESCRIPTION
Even though it's redundant. This fixes an issue where configurator requires a 2.4 domain and a 900 domain for LR1121 targets. This would cause a build error when building from source.