### PR TITLE
Maintain link connection on config.commit() for team900

### DIFF
--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -630,7 +630,6 @@ void SX127xDriver::Config(uint8_t bw, uint8_t sf, uint8_t cr, uint32_t freq, uin
 void SX127xDriver::Config(uint8_t bw, uint8_t sf, uint8_t cr, uint32_t freq, uint8_t preambleLen, uint8_t syncWord, bool InvertIQ, uint8_t _PayloadLength, uint32_t interval)
 {
   PayloadLength = _PayloadLength;
-  IQinverted = InvertIQ;
   ConfigLoraDefaults();
   SetPreambleLength(preambleLen);
   SetSpreadingFactor((SX127x_SpreadingFactor)sf);

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -630,6 +630,7 @@ void SX127xDriver::Config(uint8_t bw, uint8_t sf, uint8_t cr, uint32_t freq, uin
 void SX127xDriver::Config(uint8_t bw, uint8_t sf, uint8_t cr, uint32_t freq, uint8_t preambleLen, uint8_t syncWord, bool InvertIQ, uint8_t _PayloadLength, uint32_t interval)
 {
   PayloadLength = _PayloadLength;
+  IQinverted = InvertIQ;
   ConfigLoraDefaults();
   SetPreambleLength(preambleLen);
   SetSpreadingFactor((SX127x_SpreadingFactor)sf);

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -356,7 +356,6 @@ void SetRFLinkRate(uint8_t index) // Set speed of RF link
 
   if ((ModParams == ExpressLRS_currAirRate_Modparams)
     && (RFperf == ExpressLRS_currAirRate_RFperfParams)
-    && (invertIQ == Radio.IQinverted)
     && (OtaSwitchModeCurrent == newSwitchMode))
     return;
 


### PR DESCRIPTION
After a Tx config.Commit() a call is made to SetRFLinkRate() to check if a new RF mode was set.  When only something like the TLM ratio is changed SetRFLinkRate should bomb out and not set all of the OTA parameters again.

BUT! IQinverted is not used for Team900 and could return a different result to the inverted setting defined by the UID.  It now appears as though the RF mode has changed and required reconfigurating.  The link then get out of step with the rx and drops, or get stuck in a low LQ state.

This PR removed the IQinverted check as Modparams is more than enough for this check.

Fixes https://github.com/ExpressLRS/ExpressLRS/issues/2984