### PR TITLE
Phase 5: STM32 Obliteration: RX device cleanup

### DIFF
--- a/src/include/target/Unified_ESP32_TX.h
+++ b/src/include/target/Unified_ESP32_TX.h
@@ -128,3 +128,4 @@
 #define OPT_HAS_THERMAL_LM75A hardware_flag(HARDWARE_thermal_lm75a)
 #define OPT_HAS_THERMAL OPT_HAS_THERMAL_LM75A // If any of the sensors are present
 
+#define OPT_HAS_VTX_SPI false

--- a/src/include/target/Unified_ESP8285_TX.h
+++ b/src/include/target/Unified_ESP8285_TX.h
@@ -70,3 +70,5 @@
 #define OPT_HAS_GSENSOR false
 #define OPT_HAS_GSENSOR_STK8xxx false
 #define GPIO_PIN_GSENSOR_INT UNDEF_PIN
+
+#define OPT_HAS_VTX_SPI false

--- a/src/include/target/Unified_ESP_RX.h
+++ b/src/include/target/Unified_ESP_RX.h
@@ -83,7 +83,6 @@
 #define GPIO_PIN_PWM_OUTPUTS_COUNT hardware_int(HARDWARE_pwm_outputs_count)
 
 // VBat
-#define USE_ANALOG_VBAT
 #define GPIO_ANALOG_VBAT hardware_pin(HARDWARE_vbat)
 #define ANALOG_VBAT_OFFSET hardware_int(HARDWARE_vbat_offset)
 #define ANALOG_VBAT_SCALE hardware_int(HARDWARE_vbat_scale)

--- a/src/include/target/Unified_ESP_RX.h
+++ b/src/include/target/Unified_ESP_RX.h
@@ -1,5 +1,3 @@
-#define HAS_BARO
-
 // Serial
 #define GPIO_PIN_RCSIGNAL_RX hardware_pin(HARDWARE_serial_rx)
 #define GPIO_PIN_RCSIGNAL_TX hardware_pin(HARDWARE_serial_tx)

--- a/src/include/target/Unified_ESP_RX.h
+++ b/src/include/target/Unified_ESP_RX.h
@@ -88,8 +88,6 @@
 
 #if defined(PLATFORM_ESP32)
 // VTX
-#define HAS_VTX_SPI
-#define HAS_MSP_VTX
 #define OPT_HAS_VTX_SPI (hardware_pin(HARDWARE_vtx_nss) != UNDEF_PIN)
 #define GPIO_PIN_RF_AMP_PWM hardware_pin(HARDWARE_vtx_amp_pwm)
 #define GPIO_PIN_RF_AMP_VPD hardware_pin(HARDWARE_vtx_amp_vpd)

--- a/src/include/target/Unified_ESP_RX.h
+++ b/src/include/target/Unified_ESP_RX.h
@@ -81,6 +81,7 @@
 // PWM
 #define GPIO_PIN_PWM_OUTPUTS hardware_i16_array(HARDWARE_pwm_outputs)
 #define GPIO_PIN_PWM_OUTPUTS_COUNT hardware_int(HARDWARE_pwm_outputs_count)
+#define OPT_HAS_SERVO_OUTPUT (GPIO_PIN_PWM_OUTPUTS_COUNT > 0)
 
 // VBat
 #define GPIO_ANALOG_VBAT hardware_pin(HARDWARE_vbat)

--- a/src/include/targets.h
+++ b/src/include/targets.h
@@ -29,23 +29,6 @@
  * Features
  * define features based on pins before defining pins as UNDEF_PIN
  */
-#if defined(GPIO_PIN_SPI_VTX_NSS)
-#if !defined(HAS_VTX_SPI)
-#define HAS_VTX_SPI
-#define HAS_MSP_VTX
-#define OPT_HAS_VTX_SPI true
-#endif
-#else
-#define OPT_HAS_VTX_SPI false
-#endif
-
-#if defined(GPIO_PIN_SDA) && defined(GPIO_PIN_SCL)
-#define USE_I2C
-#else
-#define GPIO_PIN_SDA UNDEF_PIN
-#define GPIO_PIN_SCL UNDEF_PIN
-#endif
-
 #ifndef GPIO_PIN_BUFFER_OE
 #define GPIO_PIN_BUFFER_OE UNDEF_PIN
 #endif

--- a/src/include/targets.h
+++ b/src/include/targets.h
@@ -192,13 +192,6 @@ extern bool pwmSerialDefined;
 #define OPT_CRSF_RCVR_NO_SERIAL false
 #endif
 
-#if defined(USE_ANALOG_VBAT) && !defined(GPIO_ANALOG_VBAT)
-#define GPIO_ANALOG_VBAT        A0
-#if !defined(ANALOG_VBAT_SCALE)
-#define ANALOG_VBAT_SCALE       1
-#endif
-#endif
-
 #if defined(RADIO_SX128X)
 #define Regulatory_Domain_ISM_2400 1
 // ISM 2400 band is in use => undefine other requlatory domain defines

--- a/src/lib/AnalogVbat/devAnalogVbat.cpp
+++ b/src/lib/AnalogVbat/devAnalogVbat.cpp
@@ -1,6 +1,5 @@
 #include "devAnalogVbat.h"
 
-#if defined(USE_ANALOG_VBAT)
 #include <Arduino.h>
 #include "CRSF.h"
 #include "telemetry.h"
@@ -119,5 +118,3 @@ device_t AnalogVbat_device = {
     .event = nullptr,
     .timeout = timeout,
 };
-
-#endif /* if USE_ANALOG_VCC */

--- a/src/lib/AnalogVbat/devAnalogVbat.h
+++ b/src/lib/AnalogVbat/devAnalogVbat.h
@@ -3,8 +3,6 @@
 #include "common.h"
 #include "device.h"
 
-#if defined(USE_ANALOG_VBAT)
 void Vbat_enableSlowUpdate(bool enable);
 
 extern device_t AnalogVbat_device;
-#endif

--- a/src/lib/Baro/devBaro.cpp
+++ b/src/lib/Baro/devBaro.cpp
@@ -1,7 +1,7 @@
 
 #include "devBaro.h"
 
-#if defined(HAS_BARO)
+#if defined(PLATFORM_ESP32) && defined(TARGET_RX)
 
 #include "CRSF.h"
 #include "logging.h"

--- a/src/lib/Baro/devBaro.cpp
+++ b/src/lib/Baro/devBaro.cpp
@@ -1,7 +1,7 @@
 
 #include "devBaro.h"
 
-#if defined(PLATFORM_ESP32) && defined(TARGET_RX)
+#if defined(TARGET_RX)
 
 #include "CRSF.h"
 #include "logging.h"

--- a/src/lib/Baro/devBaro.h
+++ b/src/lib/Baro/devBaro.h
@@ -2,9 +2,7 @@
 
 #include "common.h"
 #include "device.h"
-#if defined(USE_ANALOG_VBAT)
 #include "devAnalogVbat.h"
-#endif
 
 #if defined(HAS_BARO)
 

--- a/src/lib/Baro/devBaro.h
+++ b/src/lib/Baro/devBaro.h
@@ -4,8 +4,6 @@
 #include "device.h"
 #include "devAnalogVbat.h"
 
-#if defined(HAS_BARO)
-
 enum eBaroReadState : uint8_t
 {
     brsNoBaro,
@@ -17,4 +15,3 @@ enum eBaroReadState : uint8_t
 };
 
 extern device_t Baro_device;
-#endif

--- a/src/lib/CONFIG/config.cpp
+++ b/src/lib/CONFIG/config.cpp
@@ -842,13 +842,11 @@ void RxConfig::UpgradeEepromV4()
     {
         UpgradeUid(nullptr, v4Config.isBound ? v4Config.uid : nullptr);
         m_config.modelId = v4Config.modelId;
-        #if defined(GPIO_PIN_PWM_OUTPUTS)
         // OG PWMP had only 8 channels
         for (unsigned ch=0; ch<8; ++ch)
         {
             PwmConfigV4(&v4Config.pwmChannels[ch], &m_config.pwmChannels[ch]);
         }
-        #endif
     }
 }
 
@@ -883,12 +881,10 @@ void RxConfig::UpgradeEepromV5()
         m_config.rateInitialIdx = v5Config.rateInitialIdx;
         m_config.modelId = v5Config.modelId;
 
-        #if defined(GPIO_PIN_PWM_OUTPUTS)
         for (unsigned ch=0; ch<16; ++ch)
         {
             PwmConfigV5(&v5Config.pwmChannels[ch], &m_config.pwmChannels[ch]);
         }
-        #endif
     }
 }
 
@@ -919,12 +915,10 @@ void RxConfig::UpgradeEepromV6()
         m_config.rateInitialIdx = v6Config.rateInitialIdx;
         m_config.modelId = v6Config.modelId;
 
-        #if defined(GPIO_PIN_PWM_OUTPUTS)
         for (unsigned ch=0; ch<16; ++ch)
         {
             PwmConfigV6(&v6Config.pwmChannels[ch], &m_config.pwmChannels[ch]);
         }
-        #endif
     }
 }
 
@@ -950,14 +944,12 @@ void RxConfig::UpgradeEepromV7V8()
         m_config.serialProtocol = v7Config.serialProtocol;
         m_config.failsafeMode = v7Config.failsafeMode;
 
-#if defined(GPIO_PIN_PWM_OUTPUTS)
         for (unsigned ch=0; ch<16; ++ch)
         {
             m_config.pwmChannels[ch].raw = v7Config.pwmChannels[ch].raw;
             if (!isV8 && m_config.pwmChannels[ch].val.mode > somOnOff)
                 m_config.pwmChannels[ch].val.mode += 1;
         }
-#endif
     }
 }
 
@@ -1146,7 +1138,6 @@ RxConfig::SetDefaults(bool commit)
     if (GPIO_PIN_NSS_2 != UNDEF_PIN)
         m_config.antennaMode = 0; // 0 is diversity for dual radio
 
-#if defined(GPIO_PIN_PWM_OUTPUTS)
     for (int ch=0; ch<PWM_MAX_CHANNELS; ++ch)
     {
         uint8_t mode = som50Hz;
@@ -1165,7 +1156,6 @@ RxConfig::SetDefaults(bool commit)
         SetPwmChannel(ch, 512, ch, false, mode, false);
     }
     SetPwmChannel(2, 0, 2, false, 0, false); // ch2 is throttle, failsafe it to 988
-#endif
 
     m_config.teamraceChannel = AUX7; // CH11
 
@@ -1191,7 +1181,6 @@ RxConfig::SetStorageProvider(ELRS_EEPROM *eeprom)
     }
 }
 
-#if defined(GPIO_PIN_PWM_OUTPUTS)
 void
 RxConfig::SetPwmChannel(uint8_t ch, uint16_t failsafe, uint8_t inputCh, bool inverted, uint8_t mode, bool narrow)
 {
@@ -1225,7 +1214,6 @@ RxConfig::SetPwmChannelRaw(uint8_t ch, uint32_t raw)
     pwm->raw = raw;
     m_modified = true;
 }
-#endif
 
 void
 RxConfig::SetForceTlmOff(bool forceTlmOff)

--- a/src/lib/CONFIG/config.h
+++ b/src/lib/CONFIG/config.h
@@ -260,9 +260,7 @@ public:
     uint8_t GetPower() const { return m_config.power; }
     uint8_t GetAntennaMode() const { return m_config.antennaMode; }
     bool     IsModified() const { return m_modified; }
-    #if defined(GPIO_PIN_PWM_OUTPUTS)
     const rx_config_pwm_t *GetPwmChannel(uint8_t ch) const { return &m_config.pwmChannels[ch]; }
-    #endif
     bool GetForceTlmOff() const { return m_config.forceTlmOff; }
     uint8_t GetRateInitialIdx() const { return m_config.rateInitialIdx; }
     eSerialProtocol GetSerialProtocol() const { return (eSerialProtocol)m_config.serialProtocol; }
@@ -285,10 +283,8 @@ public:
     void SetAntennaMode(uint8_t antennaMode);
     void SetDefaults(bool commit);
     void SetStorageProvider(ELRS_EEPROM *eeprom);
-    #if defined(GPIO_PIN_PWM_OUTPUTS)
     void SetPwmChannel(uint8_t ch, uint16_t failsafe, uint8_t inputCh, bool inverted, uint8_t mode, bool narrow);
     void SetPwmChannelRaw(uint8_t ch, uint32_t raw);
-    #endif
     void SetForceTlmOff(bool forceTlmOff);
     void SetRateInitialIdx(uint8_t rateInitialIdx);
     void SetSerialProtocol(eSerialProtocol serialProtocol);

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -14,9 +14,7 @@ extern void reconfigureSerial1();
 extern bool BindingModeRequest;
 
 static char modelString[] = "000";
-#if defined(GPIO_PIN_PWM_OUTPUTS)
 static char pwmModes[] = "50Hz;60Hz;100Hz;160Hz;333Hz;400Hz;10kHzDuty;On/Off;DShot;Serial RX;Serial TX;I2C SCL;I2C SDA;Serial2 RX;Serial2 TX";
-#endif
 
 static struct luaItem_selection luaSerialProtocol = {
     {"Protocol", CRSF_TEXT_SELECTION},
@@ -121,7 +119,6 @@ static struct luaItem_string luaELRSversion = {
 
 //---------------------------- Output Mapping -----------------------------
 
-#if defined(GPIO_PIN_PWM_OUTPUTS)
 static struct luaItem_folder luaMappingFolder = {
     {"Output Mapping", CRSF_FOLDER},
 };
@@ -170,8 +167,6 @@ static struct luaItem_command luaSetFailsafe = {
     STR_EMPTYSPACE
 };
 
-#endif // GPIO_PIN_PWM_OUTPUTS
-
 //---------------------------- Output Mapping -----------------------------
 
 static struct luaItem_selection luaBindStorage = {
@@ -187,7 +182,6 @@ static struct luaItem_command luaBindMode = {
     STR_EMPTYSPACE
 };
 
-#if defined(GPIO_PIN_PWM_OUTPUTS)
 static void luaparamMappingChannelOut(struct luaPropertiesCommon *item, uint8_t arg)
 {
     bool sclAssigned = false;
@@ -480,8 +474,6 @@ static void luaparamSetFailsafe(struct luaPropertiesCommon *item, uint8_t arg)
   sendLuaCommandResponse((struct luaItem_command *)item, newStep, msg);
 }
 
-#endif // GPIO_PIN_PWM_OUTPUTS
-
 #if defined(POWER_OUTPUT_VALUES)
 
 static void luaparamSetPower(struct luaPropertiesCommon* item, uint8_t arg)
@@ -556,7 +548,6 @@ static void registerLuaParameters()
     config.SetTeamracePosition(arg);
   }, luaTeamraceFolder.common.id);
 
-#if defined(GPIO_PIN_PWM_OUTPUTS)
   if (OPT_HAS_SERVO_OUTPUT)
   {
     luaparamMappingChannelOut(&luaMappingOutputMode.common, luaMappingChannelOut.properties.u.value);
@@ -567,7 +558,6 @@ static void registerLuaParameters()
     registerLUAParameter(&luaMappingInverted, &luaparamMappingInverted, luaMappingFolder.common.id);
     registerLUAParameter(&luaSetFailsafe, &luaparamSetFailsafe);
   }
-#endif
 
   registerLUAParameter(&luaBindStorage, [](struct luaPropertiesCommon* item, uint8_t arg) {
     config.SetBindStorage((rx_config_bindstorage_t)arg);
@@ -620,7 +610,6 @@ static int event()
   setLuaTextSelectionValue(&luaTeamraceChannel, config.GetTeamraceChannel() - AUX2);
   setLuaTextSelectionValue(&luaTeamracePosition, config.GetTeamracePosition());
 
-#if defined(GPIO_PIN_PWM_OUTPUTS)
   if (OPT_HAS_SERVO_OUTPUT)
   {
     const rx_config_pwm_t *pwmCh = config.GetPwmChannel(luaMappingChannelOut.properties.u.value - 1);
@@ -628,7 +617,6 @@ static int event()
     setLuaTextSelectionValue(&luaMappingOutputMode, pwmCh->val.mode);
     setLuaTextSelectionValue(&luaMappingInverted, pwmCh->val.inverted);
   }
-#endif
 
   if (config.GetModelId() == 255)
   {

--- a/src/lib/MSPVTX/devMSPVTX.cpp
+++ b/src/lib/MSPVTX/devMSPVTX.cpp
@@ -1,4 +1,6 @@
 #include "targets.h"
+
+#if defined(PLATFORM_ESP32) || defined(UNIT_TEST)
 #include "common.h"
 #include "devMSPVTX.h"
 #include "devVTXSPI.h"
@@ -13,7 +15,9 @@
  * Original author: Jye Smith.
 **/
 
-#ifdef HAS_MSP_VTX
+#if !defined(OPT_HAS_VTX_SPI)
+#define OPT_HAS_VTX_SPI false
+#endif
 
 #define FC_QUERY_PERIOD_MS      200 // poll every 200ms
 #define MSP_VTX_FUNCTION_OFFSET 7
@@ -393,5 +397,4 @@ device_t MSPVTx_device = {
     .event = event,
     .timeout = timeout
 };
-
 #endif

--- a/src/lib/SerialUpdate/devSerialUpdate.cpp
+++ b/src/lib/SerialUpdate/devSerialUpdate.cpp
@@ -1,16 +1,12 @@
 #include "targets.h"
 
 #if defined(PLATFORM_ESP32) && defined(TARGET_RX)
-#include <Update.h>
-
 #include "devSerialUpdate.h"
 #include "common.h"
 #include "hwTimer.h"
 #include "POWERMGNT.h"
 #include "devVTXSPI.h"
 #include "devMSPVTX.h"
-
-#include "telemetry.h"
 
 extern void start_esp_upload();
 extern void stub_handle_rx_byte(char byte);
@@ -28,12 +24,8 @@ static int event()
     {
         running = false;
         hwTimer::stop();
-#ifdef HAS_VTX_SPI
         disableVTxSpi();
-#endif
-#ifdef HAS_MSP_VTX
         disableMspVtx();
-#endif
         POWERMGNT::setPower(MinPower);
         Radio.End();
         return DURATION_IMMEDIATELY;
@@ -58,7 +50,6 @@ static int timeout()
             stub_handle_rx_byte(buf[i]);
         }
     }
-    return DURATION_IMMEDIATELY;
 }
 
 device_t SerialUpdate_device = {

--- a/src/lib/ServoOutput/DShotRMT.cpp
+++ b/src/lib/ServoOutput/DShotRMT.cpp
@@ -1,4 +1,4 @@
-#if (defined(GPIO_PIN_PWM_OUTPUTS) && defined(PLATFORM_ESP32))
+#if defined(PLATFORM_ESP32)
 //
 // Name:		DShotRMT.cpp
 // Created: 	20.03.2021 00:49:15

--- a/src/lib/ServoOutput/DShotRMT.h
+++ b/src/lib/ServoOutput/DShotRMT.h
@@ -1,4 +1,4 @@
-#if (defined(GPIO_PIN_PWM_OUTPUTS) && defined(PLATFORM_ESP32))
+#if defined(PLATFORM_ESP32)
 //
 // Name:		DShotRMT.h
 // Created: 	20.03.2021 00:49:15

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -1,5 +1,3 @@
-#if defined(GPIO_PIN_PWM_OUTPUTS)
-
 #include "devServoOutput.h"
 #include "PWM.h"
 #include "CRSF.h"
@@ -11,7 +9,7 @@ static int8_t servoPins[PWM_MAX_CHANNELS];
 static pwm_channel_t pwmChannels[PWM_MAX_CHANNELS];
 static uint16_t pwmChannelValues[PWM_MAX_CHANNELS];
 
-#if (defined(PLATFORM_ESP32))
+#if defined(PLATFORM_ESP32)
 static DShotRMT *dshotInstances[PWM_MAX_CHANNELS] = {nullptr};
 const uint8_t RMT_MAX_CHANNELS = 8;
 #endif
@@ -268,5 +266,3 @@ device_t ServoOut_device = {
     .event = event,
     .timeout = timeout,
 };
-
-#endif

--- a/src/lib/ServoOutput/devServoOutput.h
+++ b/src/lib/ServoOutput/devServoOutput.h
@@ -1,19 +1,13 @@
 #pragma once
-#if defined(GPIO_PIN_PWM_OUTPUTS)
 
 #include "device.h"
 #include "common.h"
 
-#if (defined(PLATFORM_ESP32))
+#if defined(PLATFORM_ESP32)
 #include "DShotRMT.h"
 #endif
 
 extern device_t ServoOut_device;
-#define HAS_SERVO_OUTPUT
-#define OPT_HAS_SERVO_OUTPUT (GPIO_PIN_PWM_OUTPUTS_COUNT > 0)
 
 // Notify this unit that new channel data has arrived
 void servoNewChannelsAvailable();
-#else
-inline void servoNewChannelsAvailable(){};
-#endif

--- a/src/lib/Telemetry/telemetry.cpp
+++ b/src/lib/Telemetry/telemetry.cpp
@@ -306,7 +306,7 @@ bool Telemetry::AppendTelemetryPackage(uint8_t *package)
             targetIndex = payloadTypesCount - 2;
             targetFound = true;
 
-#if defined(PLATFORM_ESP32)
+#if defined(TARGET_RX)
             // this probably needs refactoring in the future, I think we should have this telemetry class inside the crsf module
             if (wifi2tcp.hasClient() && (header->type == CRSF_FRAMETYPE_MSP_RESP || header->type == CRSF_FRAMETYPE_MSP_REQ)) // if we have a client we probs wanna talk to it
             {

--- a/src/lib/Telemetry/telemetry.cpp
+++ b/src/lib/Telemetry/telemetry.cpp
@@ -8,16 +8,13 @@
 extern TCPSOCKET wifi2tcp;
 #endif
 
-#if defined(HAS_MSP_VTX) && defined(TARGET_RX)
+#if defined(TARGET_RX) || defined(UNIT_TEST)
 #include "devMSPVTX.h"
-#endif
 
 #if defined(UNIT_TEST)
 #include <iostream>
 using namespace std;
 #endif
-
-#if CRSF_RX_MODULE
 
 #include "crsf2msp.h"
 
@@ -309,17 +306,17 @@ bool Telemetry::AppendTelemetryPackage(uint8_t *package)
             targetIndex = payloadTypesCount - 2;
             targetFound = true;
 
-            #if defined(USE_MSP_WIFI) && defined(TARGET_RX)
-                // this probably needs refactoring in the future, I think we should have this telemetry class inside the crsf module
-                if (wifi2tcp.hasClient() && (header->type == CRSF_FRAMETYPE_MSP_RESP || header->type == CRSF_FRAMETYPE_MSP_REQ)) // if we have a client we probs wanna talk to it
-                {
-                    DBGLN("Got MSP frame, forwarding to client, len: %d", currentTelemetryByte);
-                    crsf2msp.parse(package);
-                }
-                else // if no TCP client we just want to forward MSP over the link
-            #endif
+#if defined(PLATFORM_ESP32)
+            // this probably needs refactoring in the future, I think we should have this telemetry class inside the crsf module
+            if (wifi2tcp.hasClient() && (header->type == CRSF_FRAMETYPE_MSP_RESP || header->type == CRSF_FRAMETYPE_MSP_REQ)) // if we have a client we probs wanna talk to it
             {
-#if defined(HAS_MSP_VTX) && defined(TARGET_RX)
+                DBGLN("Got MSP frame, forwarding to client, len: %d", currentTelemetryByte);
+                crsf2msp.parse(package);
+            }
+            else // if no TCP client we just want to forward MSP over the link
+#endif
+            {
+#if defined(PLATFORM_ESP32)
                 if (header->type == CRSF_FRAMETYPE_MSP_RESP)
                 {
                     mspVtxProcessPacket(package);

--- a/src/lib/VTXSPI/devVTXSPI.cpp
+++ b/src/lib/VTXSPI/devVTXSPI.cpp
@@ -1,7 +1,7 @@
-#if defined(HAS_VTX_SPI)
-
-#include "devVTXSPI.h"
 #include "targets.h"
+
+#if defined(TARGET_RX) && defined(PLATFORM_ESP32)
+#include "devVTXSPI.h"
 #include "common.h"
 #include "helpers.h"
 #include "hwTimer.h"
@@ -475,5 +475,4 @@ device_t VTxSPI_device = {
     .event = nullptr,
     .timeout = timeout
 };
-
 #endif

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -373,7 +373,6 @@ static void GetConfiguration(AsyncWebServerRequest *request)
     json["config"]["modelid"] = config.GetModelId();
     json["config"]["force-tlm"] = config.GetForceTlmOff();
     json["config"]["vbind"] = config.GetBindStorage();
-    #if defined(GPIO_PIN_PWM_OUTPUTS)
     for (int ch=0; ch<GPIO_PIN_PWM_OUTPUTS_COUNT; ++ch)
     {
       json["config"]["pwm"][ch]["config"] = config.GetPwmChannel(ch)->raw;
@@ -394,7 +393,6 @@ static void GetConfiguration(AsyncWebServerRequest *request)
       #endif
       json["config"]["pwm"][ch]["features"] = features;
     }
-    #endif
     #endif
     json["config"]["product_name"] = product_name;
     json["config"]["lua_name"] = device_name;
@@ -534,7 +532,6 @@ static void UpdateConfiguration(AsyncWebServerRequest *request, JsonVariant &jso
   config.SetBindStorage((rx_config_bindstorage_t)(json["vbind"] | 0));
   JsonUidToConfig(json);
 
-  #if defined(GPIO_PIN_PWM_OUTPUTS)
   JsonArray pwm = json["pwm"].as<JsonArray>();
   for(uint32_t channel = 0 ; channel < pwm.size() ; channel++)
   {
@@ -542,7 +539,6 @@ static void UpdateConfiguration(AsyncWebServerRequest *request, JsonVariant &jso
     //DBGLN("PWMch(%u)=%u", channel, val);
     config.SetPwmChannelRaw(channel, val);
   }
-  #endif
 
   config.Commit();
   request->send(200, "text/plain", "Configuration updated");

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -88,9 +88,7 @@ device_affinity_t ui_devices[] = {
   {&WIFI_device, 0},
   {&Button_device, 0},
   {&AnalogVbat_device, 0},
-#ifdef HAS_SERVO_OUTPUT
   {&ServoOut_device, 1},
-#endif
 #if defined(PLATFORM_ESP32)
 #ifdef HAS_BARO
   {&Baro_device, 0}, // must come after AnalogVbat_device to slow updates
@@ -2029,9 +2027,8 @@ void setup()
         setupConfigAndPocCheck();
         setupTarget();
 
-        #if defined(OPT_HAS_SERVO_OUTPUT)
         // If serial is not already defined, then see if there is serial pin configured in the PWM configuration
-        if (GPIO_PIN_RCSIGNAL_RX == UNDEF_PIN && GPIO_PIN_RCSIGNAL_TX == UNDEF_PIN)
+        if (OPT_HAS_SERVO_OUTPUT && GPIO_PIN_RCSIGNAL_RX == UNDEF_PIN && GPIO_PIN_RCSIGNAL_TX == UNDEF_PIN)
         {
             for (int i = 0 ; i < GPIO_PIN_PWM_OUTPUTS_COUNT ; i++)
             {
@@ -2043,7 +2040,6 @@ void setup()
                 }
             }
         }
-        #endif
         setupSerial();
         setupSerial1();
 

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -87,9 +87,7 @@ device_affinity_t ui_devices[] = {
   {&RGB_device, 0},
   {&WIFI_device, 0},
   {&Button_device, 0},
-#ifdef USE_ANALOG_VBAT
   {&AnalogVbat_device, 0},
-#endif
 #ifdef HAS_SERVO_OUTPUT
   {&ServoOut_device, 1},
 #endif

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -91,12 +91,8 @@ device_affinity_t ui_devices[] = {
   {&ServoOut_device, 1},
 #if defined(PLATFORM_ESP32)
   {&Baro_device, 0}, // must come after AnalogVbat_device to slow updates
-#ifdef HAS_VTX_SPI
   {&VTxSPI_device, 0},
-#endif
-#ifdef HAS_MSP_VTX
   {&MSPVTx_device, 0}, // dependency on VTxSPI_device
-#endif
   {&Thermal_device, 0},
 #endif
 };
@@ -1249,6 +1245,7 @@ void MspReceiveComplete()
                 UpdateModelMatch(MspData[9]);
                 break;
             }
+#if defined(PLATFORM_ESP32)
             else if (MspData[7] == MSP_SET_VTX_CONFIG)
             {
                 if (OPT_HAS_VTX_SPI) {
@@ -1260,14 +1257,13 @@ void MspReceiveComplete()
                     }
                     devicesTriggerEvent();
                     break;
-#if defined(PLATFORM_ESP32)
                 } else if (config.GetSerial1Protocol() == PROTOCOL_SERIAL1_TRAMP || config.GetSerial1Protocol() == PROTOCOL_SERIAL1_SMARTAUDIO) {
                     serial1IO->queueMSPFrameTransmission(MspData);
                     break;
-#endif
                 }
             }
             // FALLTHROUGH
+#endif
         default:
             if ((receivedHeader->dest_addr == CRSF_ADDRESS_BROADCAST || receivedHeader->dest_addr == CRSF_ADDRESS_CRSF_RECEIVER))
             {

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -36,15 +36,15 @@
 #include "devServoOutput.h"
 #include "devVTXSPI.h"
 #include "devAnalogVbat.h"
-#include "devSerialUpdate.h"
-#include "devBaro.h"
-#include "devMSPVTX.h"
-#include "devThermal.h"
 
 #if defined(PLATFORM_ESP8266)
 #include <user_interface.h>
 #include <FS.h>
 #elif defined(PLATFORM_ESP32)
+#include "devSerialUpdate.h"
+#include "devBaro.h"
+#include "devMSPVTX.h"
+#include "devThermal.h"
 #include <SPIFFS.h>
 #include "esp_task_wdt.h"
 #endif
@@ -90,9 +90,7 @@ device_affinity_t ui_devices[] = {
   {&AnalogVbat_device, 0},
   {&ServoOut_device, 1},
 #if defined(PLATFORM_ESP32)
-#ifdef HAS_BARO
   {&Baro_device, 0}, // must come after AnalogVbat_device to slow updates
-#endif
 #ifdef HAS_VTX_SPI
   {&VTxSPI_device, 0},
 #endif

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -34,7 +34,7 @@
 #include "devWIFI.h"
 #include "devButton.h"
 #include "devServoOutput.h"
-#include "devVTXSPI.h"
+#include "devBaro.h"
 #include "devAnalogVbat.h"
 
 #if defined(PLATFORM_ESP8266)
@@ -42,7 +42,7 @@
 #include <FS.h>
 #elif defined(PLATFORM_ESP32)
 #include "devSerialUpdate.h"
-#include "devBaro.h"
+#include "devVTXSPI.h"
 #include "devMSPVTX.h"
 #include "devThermal.h"
 #include <SPIFFS.h>
@@ -89,8 +89,8 @@ device_affinity_t ui_devices[] = {
   {&Button_device, 0},
   {&AnalogVbat_device, 0},
   {&ServoOut_device, 1},
-#if defined(PLATFORM_ESP32)
   {&Baro_device, 0}, // must come after AnalogVbat_device to slow updates
+#if defined(PLATFORM_ESP32)
   {&VTxSPI_device, 0},
   {&MSPVTx_device, 0}, // dependency on VTxSPI_device
   {&Thermal_device, 0},
@@ -2111,7 +2111,7 @@ void loop()
         DBGLN("Req air rate change %u->%u", ExpressLRS_currAirRate_Modparams->index, ExpressLRS_nextAirRateIndex);
         if (!isSupportedRFRate(ExpressLRS_nextAirRateIndex))
         {
-            DBGLN("Mode %u not supported, ignoring", get_elrs_airRateConfig(index)->interval);
+            DBGLN("Mode %u not supported, ignoring", ExpressLRS_nextAirRateIndex);
             ExpressLRS_nextAirRateIndex = ExpressLRS_currAirRate_Modparams->index;
         }
         LostConnection(true);


### PR DESCRIPTION
This one just cleans up a lot of the defines that were there to disable certain features that were not available to STM32 based receivers.