### PR TITLE
Optimise MAVLink SS packet size

### DIFF
--- a/src/src/rx-serial/SerialMavlink.h
+++ b/src/src/rx-serial/SerialMavlink.h
@@ -2,8 +2,9 @@
 #include "FIFO.h"
 #include "telemetry_protocol.h"
 
-#define MAV_INPUT_BUF_LEN   1024
-#define MAV_OUTPUT_BUF_LEN  512
+#define MAV_INPUT_BUF_LEN       1024
+#define MAV_OUTPUT_BUF_LEN      512
+#define MAV_PAYLOAD_SIZE_MAX    60
 
 // Variables / constants
 extern FIFO<MAV_INPUT_BUF_LEN> mavlinkInputBuffer;

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -2178,7 +2178,8 @@ void loop()
     uint16_t count = mavlinkInputBuffer.size();
     if (count > 0 && !TelemetrySender.IsActive())
     {
-        count = std::min(count, (uint16_t)CRSF_PAYLOAD_SIZE_MAX); // Constrain to CRSF max payload size to match SS
+        uint16_t maxMavPayloadSize = (uint16_t)MAV_PAYLOAD_SIZE_MAX - CRSF_FRAME_NOT_COUNTED_BYTES; // Constrain to multiplication of the OTA payload size e.g. 5, 10, and 20B.
+        count = std::min(count, maxMavPayloadSize);
         // First 2 bytes conform to crsf_header_s format
         mavlinkSSBuffer[0] = CRSF_ADDRESS_USB; // device_addr - used on TX to differentiate between std tlm and mavlink
         mavlinkSSBuffer[1] = count;


### PR DESCRIPTION
This changes the MAVLink SS data packet size to be multiples of the OTA payload size.  Now data fits into an integer number of OTA packets, and we stop sending packets that are only partially filled.

100F before and after
![image](https://github.com/user-attachments/assets/a70a3527-3284-40f5-bbee-a516d882102f)

333F before and after
![image](https://github.com/user-attachments/assets/d4156274-f74b-4e64-8a2e-e0f65dbf2367)

K1000F before and after
![image](https://github.com/user-attachments/assets/515046b4-cc35-461b-b3c3-907719cc5edb)
