### PR TITLE
Mavlink dynamic sysIDv3

### DIFF
--- a/src/lib/DEVICE/device.h
+++ b/src/lib/DEVICE/device.h
@@ -76,7 +76,39 @@ void devicesUpdate(unsigned long now);
  * @brief Notify the device framework that an event has occurred and on the next call to
  * deviceUpdate() the event() function of the devices should be called.
  */
+
+/**
+ * @brief Event type bitmask, if multiple events should be triggered, triggers can be added together.
+ */
+enum eEventType:uint32_t{
+  DEVEVENT_UNKNOWN = 1,  // Event not yet classified
+  DEVEVENT_FAILSAFE = 2, // Failsafe state changed
+  DEVEVENT_CONFIGCHANGED = 4,// Configuration changed
+  DEVEVENT_POWERCHANGED = 8, // Power changed
+  DEVEVENT_ARMING = 16, //Arming state changed
+  DEVEVENT_VTXSS = 32, //VTXSS Trigger
+  DEVEVENT_VTXCONFIG = 64, //VTX config received over MSP
+  DEVEVENT_BINDINGSTART = 128, //Binding started 
+  DEVEVENT_BINDINGSTOP = 256, //Binding stopped
+  DEVEVENT_BLUETOOTHENABLECHANGED = 512, // Bluetooth enable state changed
+  DEVEVENT_PWMCONFIGCHANGED = 1024, // PWM config changed
+};
 void devicesTriggerEvent();
+
+/**
+ * @brief Notify the device framework that an event has occurred and on the next call to
+ * deviceUpdate() the event() function of the devices should be called.
+ * 
+ * @param event event type 
+ */
+void devicesTriggerEvent(eEventType event);
+
+/**
+ * @brief Check if event of given type(s) was triggered, for multiple event types use |
+ * 
+ * @param event event type
+ */
+bool devicesCheckEvent(eEventType event);
 
 /**
  * @brief Stop all the devices.

--- a/src/lib/Handset/CRSFHandset.cpp
+++ b/src/lib/Handset/CRSFHandset.cpp
@@ -271,7 +271,7 @@ void CRSFHandset::RcPacketToChannelsData() // data is packed as 11 bits per chan
     if (prev_AUX1 != ChannelData[4])
     {
         #if defined(PLATFORM_ESP32)
-        devicesTriggerEvent();
+        devicesTriggerEvent(DEVEVENT_ARMING);
         #endif
     }
 }

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -366,7 +366,7 @@ static void luaparamMappingChannelOut(struct luaPropertiesCommon *item, uint8_t 
     }
 
     // Trigger an event to update the related fields to represent the selected channel
-    devicesTriggerEvent();
+    devicesTriggerEvent(DEVEVENT_PWMCONFIGCHANGED);
 }
 
 static void luaparamMappingChannelIn(struct luaPropertiesCommon *item, uint8_t arg)

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -270,7 +270,7 @@ void POWERMGNT::setPower(PowerLevels_e Power)
 #endif
 
     CurrentPower = Power;
-    devicesTriggerEvent();
+    devicesTriggerEvent(DEVEVENT_POWERCHANGED);
 }
 
 #endif /* !UNIT_TEST */

--- a/src/lib/SCREEN/devScreen.cpp
+++ b/src/lib/SCREEN/devScreen.cpp
@@ -151,11 +151,11 @@ static void initialize()
 
         registerButtonFunction(ACTION_GOTO_VTX_BAND, [](){
             jumpToBandSelect = true;
-            devicesTriggerEvent();
+            devicesTriggerEvent();  //possibly should be DEVEVENT_VTX_CONFIG
         });
         registerButtonFunction(ACTION_GOTO_VTX_CHANNEL, [](){
             jumpToChannelSelect = true;
-            devicesTriggerEvent();
+            devicesTriggerEvent();  //possibly should be DEVEVENT_VTX_CONFIG
         });
     }
 }

--- a/src/lib/VTX/devVTX.cpp
+++ b/src/lib/VTX/devVTX.cpp
@@ -35,7 +35,7 @@ void VtxTriggerSend()
 {
     VtxSendState = VTXSS_MODIFIED;
     sendEepromWrite = true;
-    devicesTriggerEvent();
+    devicesTriggerEvent(DEVEVENT_VTXSS);
 }
 
 void VtxPitmodeSwitchUpdate()

--- a/src/src/rx-serial/SerialIO.h
+++ b/src/src/rx-serial/SerialIO.h
@@ -104,6 +104,11 @@ public:
      */
     virtual bool sendImmediateRC() { return false; }
 
+    /**
+     * @brief This method is called on events, for example settings changed.
+     */
+    virtual void event() {}
+
 protected:
     /// @brief the output stream for the serial port
     Stream *_outputPort;

--- a/src/src/rx-serial/SerialMavlink.cpp
+++ b/src/src/rx-serial/SerialMavlink.cpp
@@ -143,4 +143,13 @@ void SerialMavlink::sendQueuedData(uint32_t maxBytesToSend)
     }
 }
 
+void SerialMavlink::event()
+{
+    if(devicesCheckEvent(DEVEVENT_CONFIGCHANGED))
+    {
+        this_system_id = config.GetSourceSysId() ? config.GetSourceSysId() : 255;
+        target_system_id = config.GetTargetSysId() ? config.GetTargetSysId() : 1;
+    }
+}
+
 #endif // defined(TARGET_RX)

--- a/src/src/rx-serial/SerialMavlink.h
+++ b/src/src/rx-serial/SerialMavlink.h
@@ -20,14 +20,14 @@ public:
 
     int getMaxSerialReadSize() override;
     void sendQueuedData(uint32_t maxBytesToSend) override;
-
+    void event();
 private:
     void processBytes(uint8_t *bytes, u_int16_t size) override;
 
-    const uint8_t this_system_id;
+    uint8_t this_system_id;
     const uint8_t this_component_id;
 
-    const uint8_t target_system_id;
+    uint8_t target_system_id;
     const uint8_t target_component_id;
 
     uint32_t lastSentFlowCtrl = 0;

--- a/src/src/rx-serial/devSerialIO.cpp
+++ b/src/src/rx-serial/devSerialIO.cpp
@@ -72,6 +72,7 @@ static int event(devserial_ctx_t *ctx)
         {
             (*(ctx->io))->setFailsafe(connectionState == disconnected);
         }
+        (*(ctx->io))->event();
     }
 
     ctx->lastConnectionState = connectionState;

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1287,7 +1287,7 @@ void MspReceiveComplete()
                         vtxSPIPowerIdx = MspData[10];
                         vtxSPIPitmode = MspData[11];
                     }
-                    devicesTriggerEvent();
+                    devicesTriggerEvent(DEVEVENT_VTXCONFIG);
                     break;
 #if defined(PLATFORM_ESP32)
                 } else if (config.GetSerial1Protocol() == PROTOCOL_SERIAL1_TRAMP || config.GetSerial1Protocol() == PROTOCOL_SERIAL1_SMARTAUDIO) {
@@ -1731,7 +1731,7 @@ static void EnterBindingMode()
     Radio.RXnb();
 
     DBGLN("Entered binding mode at freq = %d", Radio.currFreq);
-    devicesTriggerEvent();
+    devicesTriggerEvent(DEVEVENT_BINDINGSTART);
 }
 
 static void ExitBindingMode()
@@ -1766,7 +1766,7 @@ static void ExitBindingMode()
     // if we're in binding mode
     InBindingMode = false;
     DBGLN("Exiting binding mode");
-    devicesTriggerEvent();
+    devicesTriggerEvent(DEVEVENT_BINDINGSTOP);
 }
 
 static void updateBindingMode(unsigned long now)
@@ -1979,7 +1979,7 @@ static void CheckConfigChangePending()
     {
         LostConnection(false);
         config.Commit();
-        devicesTriggerEvent();
+        devicesTriggerEvent(DEVEVENT_CONFIGCHANGED);
 #if defined(Regulatory_Domain_EU_CE_2400)
         LBTEnabled = (config.GetPower() > PWR_10mW);
 #endif

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -754,7 +754,7 @@ void ModelUpdateReq()
     ModelUpdatePending = true;
   }
 
-  devicesTriggerEvent();
+  devicesTriggerEvent(DEVEVENT_CONFIGCHANGED);
 
   // Jump from awaitingModelId to transmitting to break the startup delay now
   // that the ModelID has been confirmed by the handset
@@ -778,7 +778,7 @@ static void ConfigChangeCommit()
   commitInProgress = false;
   // UpdateFolderNames is expensive so it is called directly instead of in event() which gets called a lot
   luadevUpdateFolderNames();
-  devicesTriggerEvent();
+  devicesTriggerEvent(DEVEVENT_CONFIGCHANGED);
 }
 
 static void CheckConfigChangePending()


### PR DESCRIPTION
Makes source and target SysID dynamic
Adds event handler to SerialMavlink that updates SysIDs when the config is changed
Requires #3031 