### PR TITLE
Return TX to configured RF mode after binding

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1028,8 +1028,10 @@ static void ExitBindingMode()
   // Reset CRCInit to UID-defined value
   OtaUpdateCrcInitFromUid();
   InBindingMode = false; // Clear binding mode before SetRFLinkRate() for correct IQ
-  
+
   UARTconnected();
+  
+  SetRFLinkRate(config.GetRate()); //return to original rate
 
   DBGLN("Exiting binding mode");
 }


### PR DESCRIPTION
Some numpty (me) deleted a useful line in this PR https://github.com/ExpressLRS/ExpressLRS/pull/2998 which returns the TX module back to the configured RF mode after binding.

Fixes https://github.com/ExpressLRS/ExpressLRS/issues/3034