### PR TITLE
Device/event framework optimisation

### DIFF
--- a/src/include/common.h
+++ b/src/include/common.h
@@ -2,6 +2,7 @@
 
 #ifndef UNIT_TEST
 #include "targets.h"
+#include <device.h>
 
 #if defined(RADIO_SX127X)
 #include "SX127xDriver.h"
@@ -322,10 +323,17 @@ extern bool connectionHasModelMatch;
 extern bool teamraceHasModelMatch;
 extern bool InBindingMode;
 extern uint8_t ExpressLRS_currTlmDenom;
-extern connectionState_e connectionState;
 extern expresslrs_mod_settings_s *ExpressLRS_currAirRate_Modparams;
 extern expresslrs_rf_pref_params_s *ExpressLRS_currAirRate_RFperfParams;
 extern uint32_t ChannelData[CRSF_NUM_CHANNELS]; // Current state of channels, CRSF format
+
+extern connectionState_e connectionState;
+#if !defined(UNIT_TEST)
+inline void setConnectionState(connectionState_e newState) {
+    connectionState = newState;
+    devicesTriggerEvent(EVENT_CONNECTION_CHANGED);
+}
+#endif
 
 uint32_t uidMacSeedGet();
 bool isDualRadio();
@@ -334,5 +342,5 @@ void EnterBindingModeSafely(); // defined in rx_main/tx_main
 #if defined(RADIO_LR1121)
 bool isSupportedRFRate(uint8_t index);
 #else
-inline bool isSupportedRFRate(uint8_t index) { return true; };
+inline bool isSupportedRFRate(uint8_t index) { return true; }
 #endif

--- a/src/lib/AnalogVbat/devAnalogVbat.cpp
+++ b/src/lib/AnalogVbat/devAnalogVbat.cpp
@@ -118,5 +118,5 @@ device_t AnalogVbat_device = {
     .start = start,
     .event = nullptr,
     .timeout = timeout,
-    .subscribe = 0
+    .subscribe = EVENT_NONE
 };

--- a/src/lib/AnalogVbat/devAnalogVbat.cpp
+++ b/src/lib/AnalogVbat/devAnalogVbat.cpp
@@ -118,4 +118,5 @@ device_t AnalogVbat_device = {
     .start = start,
     .event = nullptr,
     .timeout = timeout,
+    .subscribe = 0
 };

--- a/src/lib/AnalogVbat/devAnalogVbat.cpp
+++ b/src/lib/AnalogVbat/devAnalogVbat.cpp
@@ -34,12 +34,13 @@ void Vbat_enableSlowUpdate(bool enable)
     vbatUpdateScale = enable ? 2 : 1;
 }
 
+static bool initialize()
+{
+    return GPIO_ANALOG_VBAT != UNDEF_PIN;
+}
+
 static int start()
 {
-    if (GPIO_ANALOG_VBAT == UNDEF_PIN)
-    {
-        return DURATION_NEVER;
-    }
     vbatUpdateScale = 1;
 #if defined(PLATFORM_ESP32)
     analogReadResolution(12);
@@ -91,7 +92,7 @@ static void reportVbat()
 
 static int timeout()
 {
-    if (GPIO_ANALOG_VBAT == UNDEF_PIN || telemetry.GetCrsfBatterySensorDetected())
+    if (telemetry.GetCrsfBatterySensorDetected())
     {
         return DURATION_NEVER;
     }
@@ -113,7 +114,7 @@ static int timeout()
 }
 
 device_t AnalogVbat_device = {
-    .initialize = nullptr,
+    .initialize = initialize,
     .start = start,
     .event = nullptr,
     .timeout = timeout,

--- a/src/lib/BLE/devBLE.cpp
+++ b/src/lib/BLE/devBLE.cpp
@@ -73,11 +73,12 @@ void BluetoothJoystickBegin()
     bleGamepad->begin(gamepadConfig);
 }
 
-static void initialize()
+static bool initialize()
 {
   registerButtonFunction(ACTION_BLE_JOYSTICK, [](){
     connectionState = bleJoystick;
   });
+  return true;
 }
 
 static int timeout()

--- a/src/lib/BLE/devBLE.cpp
+++ b/src/lib/BLE/devBLE.cpp
@@ -76,7 +76,7 @@ void BluetoothJoystickBegin()
 static bool initialize()
 {
   registerButtonFunction(ACTION_BLE_JOYSTICK, [](){
-    connectionState = bleJoystick;
+    setConnectionState(bleJoystick);
   });
   return true;
 }
@@ -98,9 +98,10 @@ static int event()
 
 device_t BLE_device = {
   .initialize = initialize,
-  .start = NULL,
+  .start = nullptr,
   .event = event,
-  .timeout = timeout
+  .timeout = timeout,
+  .subscribe = EVENT_CONNECTION_CHANGED
 };
 
 #endif

--- a/src/lib/BUTTON/devButton.cpp
+++ b/src/lib/BUTTON/devButton.cpp
@@ -117,4 +117,5 @@ device_t Button_device = {
     .start = start,
     .event = event,
     .timeout = timeout,
-    .subscribe = EVENT_ARM_FLAG_CHANGED | EVENT_CONNECTION_CHANGED};
+    .subscribe = EVENT_ARM_FLAG_CHANGED | EVENT_CONNECTION_CHANGED
+};

--- a/src/lib/BUTTON/devButton.cpp
+++ b/src/lib/BUTTON/devButton.cpp
@@ -59,13 +59,13 @@ static void handlePress(uint8_t button, bool longPress, uint8_t count)
     }
 }
 
+static bool initialize()
+{
+    return GPIO_PIN_BUTTON != UNDEF_PIN || GPIO_PIN_BUTTON2 != UNDEF_PIN;
+}
+
 static int start()
 {
-    if (GPIO_PIN_BUTTON == UNDEF_PIN && GPIO_PIN_BUTTON2 == UNDEF_PIN)
-    {
-        return DURATION_NEVER;
-    }
-
     if (GPIO_PIN_BUTTON != UNDEF_PIN)
     {
         button1.init(GPIO_PIN_BUTTON);
@@ -84,10 +84,6 @@ static int start()
 
 static int event()
 {
-    if (GPIO_PIN_BUTTON == UNDEF_PIN && GPIO_PIN_BUTTON2 == UNDEF_PIN)
-    {
-        return DURATION_NEVER;
-    }
 #if defined(TARGET_TX)
     if (handset->IsArmed())
     {
@@ -117,7 +113,7 @@ static int timeout()
 }
 
 device_t Button_device = {
-    .initialize = nullptr,
+    .initialize = initialize,
     .start = start,
     .event = event,
     .timeout = timeout

--- a/src/lib/BUTTON/devButton.cpp
+++ b/src/lib/BUTTON/devButton.cpp
@@ -116,5 +116,5 @@ device_t Button_device = {
     .initialize = initialize,
     .start = start,
     .event = event,
-    .timeout = timeout
-};
+    .timeout = timeout,
+    .subscribe = EVENT_ARM_FLAG_CHANGED | EVENT_CONNECTION_CHANGED};

--- a/src/lib/Backpack/devBackpack.cpp
+++ b/src/lib/Backpack/devBackpack.cpp
@@ -306,29 +306,29 @@ void sendConfigToBackpack()
     MSP::sendPacket(&packet, TxBackpack); // send to tx-backpack as MSP
 }
 
-static void initialize()
+static bool initialize()
 {
-    if (GPIO_PIN_BACKPACK_EN != UNDEF_PIN)
+    if (OPT_USE_TX_BACKPACK)
     {
-        pinMode(GPIO_PIN_BOOT0, INPUT); // setup so we can detect pinchange for passthrough mode
-        pinMode(GPIO_PIN_BACKPACK_BOOT, OUTPUT);
-        pinMode(GPIO_PIN_BACKPACK_EN, OUTPUT);
-        // Shut down the backpack via EN pin and hold it there until the first event()
-        digitalWrite(GPIO_PIN_BACKPACK_EN, LOW);   // enable low
-        digitalWrite(GPIO_PIN_BACKPACK_BOOT, LOW); // bootloader pin high
-        delay(20);
-        // Rely on event() to boot
+        if (GPIO_PIN_BACKPACK_EN != UNDEF_PIN)
+        {
+            pinMode(GPIO_PIN_BOOT0, INPUT); // setup so we can detect pinchange for passthrough mode
+            pinMode(GPIO_PIN_BACKPACK_BOOT, OUTPUT);
+            pinMode(GPIO_PIN_BACKPACK_EN, OUTPUT);
+            // Shut down the backpack via EN pin and hold it there until the first event()
+            digitalWrite(GPIO_PIN_BACKPACK_EN, LOW);   // enable low
+            digitalWrite(GPIO_PIN_BACKPACK_BOOT, LOW); // bootloader pin high
+            delay(20);
+            // Rely on event() to boot
+        }
+        handset->setRCDataCallback(AuxStateToMSPOut);
     }
-    handset->setRCDataCallback(AuxStateToMSPOut);
+    return OPT_USE_TX_BACKPACK;
 }
 
 static int start()
 {
-    if (OPT_USE_TX_BACKPACK)
-    {
-        return DURATION_IMMEDIATELY;
-    }
-    return DURATION_NEVER;
+    return DURATION_IMMEDIATELY;
 }
 
 static int timeout()
@@ -382,7 +382,7 @@ static int timeout()
 
 static int event()
 {
-    if (OPT_USE_TX_BACKPACK && GPIO_PIN_BACKPACK_EN != UNDEF_PIN)
+    if (GPIO_PIN_BACKPACK_EN != UNDEF_PIN)
     {
         // EN should be HIGH to be active
         digitalWrite(GPIO_PIN_BACKPACK_EN, (config.GetBackpackDisable() || connectionState == bleJoystick || connectionState == wifiUpdate) ? LOW : HIGH);

--- a/src/lib/Baro/devBaro.cpp
+++ b/src/lib/Baro/devBaro.cpp
@@ -191,6 +191,7 @@ device_t Baro_device = {
     .start = start,
     .event = nullptr,
     .timeout = timeout,
+    .subscribe = 0
 };
 
 #endif

--- a/src/lib/Baro/devBaro.cpp
+++ b/src/lib/Baro/devBaro.cpp
@@ -117,16 +117,15 @@ static void Baro_PublishPressure(uint32_t pressuredPa)
     }
 }
 
+static bool initialize()
+{
+    return Baro_Detect();
+}
+
 static int start()
 {
-    if (Baro_Detect())
-    {
-        BaroReadState = brsUninitialized;
-        return BARO_STARTUP_INTERVAL;
-    }
-
-    BaroReadState = brsNoBaro;
-    return DURATION_NEVER;
+    BaroReadState = brsUninitialized;
+    return BARO_STARTUP_INTERVAL;
 }
 
 static int timeout()
@@ -188,7 +187,7 @@ static int timeout()
 }
 
 device_t Baro_device = {
-    .initialize = nullptr,
+    .initialize = initialize,
     .start = start,
     .event = nullptr,
     .timeout = timeout,

--- a/src/lib/Baro/devBaro.cpp
+++ b/src/lib/Baro/devBaro.cpp
@@ -191,7 +191,7 @@ device_t Baro_device = {
     .start = start,
     .event = nullptr,
     .timeout = timeout,
-    .subscribe = 0
+    .subscribe = EVENT_NONE
 };
 
 #endif

--- a/src/lib/CONFIG/config.h
+++ b/src/lib/CONFIG/config.h
@@ -105,7 +105,7 @@ class TxConfig
 public:
     TxConfig();
     void Load();
-    void Commit();
+    uint32_t Commit();
 
     // Getters
     uint8_t GetRate() const { return m_model->rate; }
@@ -117,7 +117,7 @@ public:
     uint8_t GetAntennaMode() const { return m_model->txAntenna; }
     uint8_t GetLinkMode() const { return m_model->linkMode; }
     bool GetModelMatch() const { return m_model->modelMatch; }
-    bool     IsModified() const { return m_modified; }
+    bool     IsModified() const { return m_modified != 0; }
     uint8_t  GetVtxBand() const { return m_config.vtxBand; }
     uint8_t  GetVtxChannel() const { return m_config.vtxChannel; }
     uint8_t  GetVtxPower() const { return m_config.vtxPower; }
@@ -175,7 +175,7 @@ private:
 
     tx_config_t m_config;
     ELRS_EEPROM *m_eeprom;
-    uint8_t     m_modified;
+    uint32_t     m_modified;
     model_config_t *m_model;
     uint8_t     m_modelId;
 #if defined(PLATFORM_ESP32)
@@ -246,7 +246,7 @@ public:
     RxConfig();
 
     void Load();
-    void Commit();
+    uint32_t Commit();
 
     // Getters
     bool     GetIsBound() const;
@@ -259,7 +259,7 @@ public:
     uint8_t  GetModelId() const { return m_config.modelId; }
     uint8_t GetPower() const { return m_config.power; }
     uint8_t GetAntennaMode() const { return m_config.antennaMode; }
-    bool     IsModified() const { return m_modified; }
+    bool     IsModified() const { return m_modified != 0; }
     const rx_config_pwm_t *GetPwmChannel(uint8_t ch) const { return &m_config.pwmChannels[ch]; }
     bool GetForceTlmOff() const { return m_config.forceTlmOff; }
     uint8_t GetRateInitialIdx() const { return m_config.rateInitialIdx; }
@@ -310,7 +310,7 @@ private:
 
     rx_config_t m_config;
     ELRS_EEPROM *m_eeprom;
-    bool        m_modified;
+    uint32_t    m_modified;
 };
 
 extern RxConfig config;

--- a/src/lib/DEVICE/device.cpp
+++ b/src/lib/DEVICE/device.cpp
@@ -64,8 +64,10 @@ void devicesInit()
 
     for(size_t i=0 ; i<deviceCount ; i++) {
         if (uiDevices[i].core == core || core == -1) {
-            if (uiDevices[i].device->initialize) {
-                (uiDevices[i].device->initialize)();
+            if (uiDevices[i].device->initialize && !(uiDevices[i].device->initialize)()) {
+                uiDevices[i].device->start = nullptr;
+                uiDevices[i].device->event = nullptr;
+                uiDevices[i].device->timeout = nullptr;
             }
         }
     }

--- a/src/lib/DEVICE/device.cpp
+++ b/src/lib/DEVICE/device.cpp
@@ -24,13 +24,10 @@
 
 ///////////////////////////////////////
 
-extern bool connectionHasModelMatch;
-
 static device_affinity_t *uiDevices;
 static uint8_t deviceCount;
 
-static bool eventFired[2] = {false, false};
-static connectionState_e lastConnectionState[2] = {disconnected, disconnected};
+static uint32_t eventFired[2] = {0, 0};
 static bool lastModelMatch[2] = {false, false};
 
 static unsigned long deviceTimeout[16] = {0};
@@ -39,7 +36,7 @@ static unsigned long deviceTimeout[16] = {0};
 static TaskHandle_t xDeviceTask = NULL;
 static SemaphoreHandle_t taskSemaphore;
 static SemaphoreHandle_t completeSemaphore;
-static void deviceTask(void *pvArgs);
+[[noreturn]] static void deviceTask(void *pvArgs);
 #define CURRENT_CORE  xPortGetCoreID()
 #else
 #define CURRENT_CORE -1
@@ -112,12 +109,12 @@ void devicesStop()
     #endif
 }
 
-void devicesTriggerEvent()
+void devicesTriggerEvent(uint32_t events)
 {
-    eventFired[0] = true;
-    eventFired[1] = true;
+    eventFired[0] |= events;
+    eventFired[1] |= events;
     #if MULTICORE
-    // Release teh semaphore so the tasks on core 0 run now
+    // Release the semaphore so the tasks on core 0 run now
     xSemaphoreGive(taskSemaphore);
     #endif
 }
@@ -128,15 +125,16 @@ static int _devicesUpdate(unsigned long now)
     const int32_t coreMulti = (core == -1) ? 0 : core;
 
     bool newModelMatch = connectionHasModelMatch && teamraceHasModelMatch;
-    bool handleEvents = eventFired[coreMulti] || lastConnectionState[coreMulti] != connectionState || lastModelMatch[coreMulti] != newModelMatch;
-    eventFired[coreMulti] = false;
-    lastConnectionState[coreMulti] = connectionState;
+    uint32_t events = eventFired[coreMulti];
+    eventFired[coreMulti] = 0;
+    bool handleEvents = events != 0 || lastModelMatch[coreMulti] != newModelMatch;
     lastModelMatch[coreMulti] = newModelMatch;
 
-    for(size_t i=0 ; i<deviceCount ; i++)
+    if (handleEvents)
     {
-        if (uiDevices[i].core == core || core == -1) {
-            if (handleEvents && uiDevices[i].device->event)
+        for(size_t i=0 ; i<deviceCount ; i++)
+        {
+            if ((uiDevices[i].core == core || core == -1) && (uiDevices[i].device->event && (uiDevices[i].device->subscribe & events) != 0))
             {
                 int delay = (uiDevices[i].device->event)();
                 if (delay != DURATION_IGNORE)
@@ -173,7 +171,7 @@ void devicesUpdate(unsigned long now)
 }
 
 #if MULTICORE
-static void deviceTask(void *pvArgs)
+[[noreturn]] static void deviceTask(void *pvArgs)
 {
     xSemaphoreTake(taskSemaphore, portMAX_DELAY);
     devicesInit();
@@ -184,7 +182,7 @@ static void deviceTask(void *pvArgs)
     for (;;)
     {
         int delay = _devicesUpdate(millis());
-        // sleep the core until the desired time or it's awakened by an event
+        // sleep the core until the desired time, or it's awakened by an event
         xSemaphoreTake(taskSemaphore, delay == DURATION_NEVER ? portMAX_DELAY : pdMS_TO_TICKS(delay));
     }
 }

--- a/src/lib/DEVICE/device.h
+++ b/src/lib/DEVICE/device.h
@@ -10,8 +10,11 @@
 typedef struct {
     /**
      * @brief Called at the beginning of setup() so the device can configure IO pins etc.
+     *
+     * Devices that return false will not have their start, event or timeout functions called.
+     * i.e. the devices is effectively disabled.
      */
-    void (*initialize)();
+    bool (*initialize)();
 
     /**
      * @brief called at the end of setup() and returns the number of milliseconds when

--- a/src/lib/DEVICE/device.h
+++ b/src/lib/DEVICE/device.h
@@ -8,6 +8,8 @@
 #define DURATION_IMMEDIATELY 0  // timeout() will be called each loop
 
 enum deviceEvent_t {
+    EVENT_NONE = 0,
+
     EVENT_ARM_FLAG_CHANGED = 1 << 0,
     EVENT_POWER_CHANGED = 1 << 1,
     EVENT_VTX_CHANGE = 1 << 2, // Triggers change on RX SPI VTX, or VTX send on TX
@@ -25,7 +27,9 @@ enum deviceEvent_t {
     EVENT_CONFIG_UID_CHANGED = 1 << 14,
     EVENT_CONFIG_POWER_COUNT_CHANGED = 1 << 15,
     EVENT_CONFIG_PWM_CHANGE = 1 << 16,
-    EVENT_CONFIG_SERIAL_CHANGE = 1 << 17
+    EVENT_CONFIG_SERIAL_CHANGE = 1 << 17,
+
+    EVENT_ALL = 0xFFFFFFFF
 };
 
 typedef struct {

--- a/src/lib/DEVICE/device.h
+++ b/src/lib/DEVICE/device.h
@@ -7,12 +7,30 @@
 #define DURATION_NEVER -1       // timeout() will not be called, only event()
 #define DURATION_IMMEDIATELY 0  // timeout() will be called each loop
 
+enum deviceEvent_t {
+    EVENT_ARM_FLAG_CHANGED = 1 << 0,
+    EVENT_POWER_CHANGED = 1 << 1,
+    EVENT_VTX_CHANGE = 1 << 2, // Triggers change on RX SPI VTX, or VTX send on TX
+    EVENT_ENTER_BIND_MODE = 1 << 3,
+    EVENT_EXIT_BIND_MODE = 1 << 4,
+    EVENT_MODEL_SELECTED = 1 << 5,
+    EVENT_CONNECTION_CHANGED = 1 << 6,
+
+    EVENT_CONFIG_MODEL_CHANGED = 1 << 8,
+    EVENT_CONFIG_VTX_CHANGED = 1 << 9,
+    EVENT_CONFIG_MAIN_CHANGED = 1 << 10, // catch-all for global config item
+    EVENT_CONFIG_FAN_CHANGED = 1 << 11,
+    EVENT_CONFIG_MOTION_CHANGED = 1 << 12,
+    EVENT_CONFIG_BUTTON_CHANGED = 1 << 13,
+    EVENT_CONFIG_UID_CHANGED = 1 << 14,
+    EVENT_CONFIG_POWER_COUNT_CHANGED = 1 << 15,
+    EVENT_CONFIG_PWM_CHANGE = 1 << 16,
+    EVENT_CONFIG_SERIAL_CHANGE = 1 << 17
+};
+
 typedef struct {
     /**
      * @brief Called at the beginning of setup() so the device can configure IO pins etc.
-     *
-     * Devices that return false will not have their start, event or timeout functions called.
-     * i.e. the devices is effectively disabled.
      */
     bool (*initialize)();
 
@@ -23,7 +41,7 @@ typedef struct {
     int (*start)();
 
     /**
-     * @brief An event was fired in the main code, perform any requierd action that this
+     * @brief An event was fired in the main code, perform any required action that this
      * device requires and return new duration for timeout() call.
      * If DURATION_IGNORE is returned, then the current timeout value kept and timeout()
      * will be called when it expires.
@@ -35,6 +53,12 @@ typedef struct {
      * a new duration, this function should not return DURATION_IGNORE.
      */
     int (*timeout)();
+
+    /**
+     * @brief a bitset telling the device framework which events this device should have it's
+     * event function called for.
+     */
+    uint32_t subscribe;
 } device_t;
 
 typedef struct {
@@ -57,21 +81,21 @@ typedef struct {
 void devicesRegister(device_affinity_t *devices, uint8_t count);
 
 /**
- * @brief Call initialize() on all the devices registered on their appropriately registerd core.
+ * @brief Call initialize() on all the devices registered on their appropriately registered core.
  */
 void devicesInit();
 
 /**
- * @brief Call start() on all the devices registered on their appropriately registerd core.
+ * @brief Call start() on all the devices registered on their appropriately registered core.
  */
 void devicesStart();
 
 /**
  * @brief This function is called in the main loop of the application and only
  * processes devices register to the loop-core. Devices registered on alternate core(s)
- * are processing in a seperate FreeRTOS task running on the alternate core(s).
+ * are processing in a separate FreeRTOS task running on the alternate core(s).
  *
- * @param now current time in millisecods
+ * @param now current time in milliseconds
  */
 void devicesUpdate(unsigned long now);
 
@@ -79,10 +103,10 @@ void devicesUpdate(unsigned long now);
  * @brief Notify the device framework that an event has occurred and on the next call to
  * deviceUpdate() the event() function of the devices should be called.
  */
-void devicesTriggerEvent();
+void devicesTriggerEvent(uint32_t events);
 
 /**
  * @brief Stop all the devices.
- * This destroys the FreeRTOS task runnin on the alternate core(s).
+ * This destroys the FreeRTOS task running on the alternate core(s).
  */
 void devicesStop();

--- a/src/lib/GSENSOR/devGsensor.cpp
+++ b/src/lib/GSENSOR/devGsensor.cpp
@@ -21,23 +21,18 @@ static int system_quiet_pre_state = GSENSOR_SYSTEM_STATE_MOVING;
 #define MULTIPLE_BUMP_INTERVAL 400U
 #define BUMP_COMMAND_IDLE_TIME 10000U
 
-static bool gSensorOk = false;
-
-static void initialize()
+static bool initialize()
 {
     if (OPT_HAS_GSENSOR)
     {
-        gSensorOk = gsensor.init();
+        return gsensor.init();
     }
+    return false;
 }
 
 static int start()
 {
-    if (OPT_HAS_GSENSOR && gSensorOk)
-    {
-        return DURATION_IMMEDIATELY;
-    }
-    return DURATION_NEVER;
+    return DURATION_IMMEDIATELY;
 }
 
 static int timeout()

--- a/src/lib/Handset/CRSFHandset.cpp
+++ b/src/lib/Handset/CRSFHandset.cpp
@@ -275,7 +275,7 @@ void CRSFHandset::RcPacketToChannelsData() // data is packed as 11 bits per chan
     // monitoring arming state
     if (lastArmCmd != armCmd) {
         #if defined(PLATFORM_ESP32)
-        devicesTriggerEvent();
+        devicesTriggerEvent(EVENT_ARM_FLAG_CHANGED);
         #endif
         lastArmCmd = armCmd;
     }

--- a/src/lib/Handset/devHandset.cpp
+++ b/src/lib/Handset/devHandset.cpp
@@ -52,5 +52,7 @@ device_t Handset_device = {
     .initialize = initialize,
     .start = start,
     .event = event,
-    .timeout = timeout};
+    .timeout = timeout,
+    .subscribe = EVENT_POWER_CHANGED
+};
 #endif

--- a/src/lib/Handset/devHandset.cpp
+++ b/src/lib/Handset/devHandset.cpp
@@ -13,16 +13,17 @@
 
 Handset *handset;
 
-static void initialize()
+static bool initialize()
 {
 #if defined(PLATFORM_ESP32)
     if (GPIO_PIN_RCSIGNAL_RX == GPIO_PIN_RCSIGNAL_TX)
     {
         handset = new AutoDetect();
-        return;
+        return true;
     }
 #endif
     handset = new CRSFHandset();
+    return true;
 }
 
 static int start()

--- a/src/lib/LED/devLED.cpp
+++ b/src/lib/LED/devLED.cpp
@@ -48,22 +48,26 @@ static uint16_t flashLED(int8_t pin, uint8_t pin_inverted, const uint8_t duratio
     return updateLED();
 }
 
-static void initialize()
+static bool initialize()
 {
+    bool hasLED = false;
     if (GPIO_PIN_LED_BLUE != UNDEF_PIN)
     {
         pinMode(GPIO_PIN_LED_BLUE, OUTPUT);
         digitalWrite(GPIO_PIN_LED_BLUE, LOW ^ GPIO_LED_BLUE_INVERTED);
+        hasLED = true;
     }
     if (GPIO_PIN_LED_GREEN != UNDEF_PIN)
     {
         pinMode(GPIO_PIN_LED_GREEN, OUTPUT);
         digitalWrite(GPIO_PIN_LED_GREEN, HIGH ^ GPIO_LED_GREEN_INVERTED);
+        hasLED = true;
     }
     if (GPIO_PIN_LED_RED != UNDEF_PIN)
     {
         pinMode(GPIO_PIN_LED_RED, OUTPUT);
         digitalWrite(GPIO_PIN_LED_RED, LOW ^ GPIO_LED_RED_INVERTED);
+        hasLED = true;
     }
     if (GPIO_PIN_LED_BLUE != UNDEF_PIN && GPIO_PIN_LED_GREEN != UNDEF_PIN && GPIO_PIN_LED_RED != UNDEF_PIN)
     {
@@ -76,6 +80,7 @@ static void initialize()
     {
         hasGBLeds = true;
     }
+    return hasLED || hasRGBLeds || hasGBLeds;
 }
 
 static int timeout()

--- a/src/lib/LED/devLED.cpp
+++ b/src/lib/LED/devLED.cpp
@@ -116,6 +116,11 @@ static void setPowerLEDs()
 }
 #endif
 
+static int start()
+{
+    return DURATION_IMMEDIATELY;
+}
+
 static int event()
 {
     #if defined(TARGET_TX)
@@ -218,7 +223,7 @@ static int event()
 
 device_t LED_device = {
     .initialize = initialize,
-    .start = event,
+    .start = start,
     .event = event,
-    .timeout = timeout
-};
+    .timeout = timeout,
+    .subscribe = EVENT_CONNECTION_CHANGED | EVENT_ENTER_BIND_MODE | EVENT_EXIT_BIND_MODE};

--- a/src/lib/LED/devLED.cpp
+++ b/src/lib/LED/devLED.cpp
@@ -116,11 +116,6 @@ static void setPowerLEDs()
 }
 #endif
 
-static int start()
-{
-    return DURATION_IMMEDIATELY;
-}
-
 static int event()
 {
     #if defined(TARGET_TX)
@@ -219,6 +214,11 @@ static int event()
     default:
         return DURATION_NEVER;
     }
+}
+
+static int start()
+{
+    return event();
 }
 
 device_t LED_device = {

--- a/src/lib/LED/devLED.cpp
+++ b/src/lib/LED/devLED.cpp
@@ -226,4 +226,5 @@ device_t LED_device = {
     .start = start,
     .event = event,
     .timeout = timeout,
-    .subscribe = EVENT_CONNECTION_CHANGED | EVENT_ENTER_BIND_MODE | EVENT_EXIT_BIND_MODE};
+    .subscribe = EVENT_CONNECTION_CHANGED | EVENT_ENTER_BIND_MODE | EVENT_EXIT_BIND_MODE
+};

--- a/src/lib/LED/devRGB.cpp
+++ b/src/lib/LED/devRGB.cpp
@@ -466,5 +466,5 @@ device_t RGB_device = {
     .initialize = initialize,
     .start = start,
     .event = timeout,
-    .timeout = timeout
-};
+    .timeout = timeout,
+    .subscribe = EVENT_CONNECTION_CHANGED | EVENT_ENTER_BIND_MODE | EVENT_EXIT_BIND_MODE};

--- a/src/lib/LED/devRGB.cpp
+++ b/src/lib/LED/devRGB.cpp
@@ -330,7 +330,7 @@ static int blinkyUpdate() {
     return 3000/(256/hueStepValue);
 }
 
-static void initialize()
+static bool initialize()
 {
     if (GPIO_PIN_LED_WS2812 != UNDEF_PIN)
     {
@@ -380,14 +380,11 @@ static void initialize()
         blinkyColor.s = 255;
         blinkyColor.v = 128;
     }
+    return GPIO_PIN_LED_WS2812 != UNDEF_PIN;
 }
 
 static int start()
 {
-    if (GPIO_PIN_LED_WS2812 == UNDEF_PIN)
-    {
-        return DURATION_NEVER;
-    }
     blinkyState = STARTUP;
     #if defined(PLATFORM_ESP32)
     // Only do the blinkies if it was NOT a software reboot
@@ -404,10 +401,6 @@ static int start()
 
 static int timeout()
 {
-    if (GPIO_PIN_LED_WS2812 == UNDEF_PIN)
-    {
-        return DURATION_NEVER;
-    }
     if (blinkyState == STARTUP && connectionState < FAILURE_STATES)
     {
         return blinkyUpdate();

--- a/src/lib/LED/devRGB.cpp
+++ b/src/lib/LED/devRGB.cpp
@@ -467,4 +467,5 @@ device_t RGB_device = {
     .start = start,
     .event = timeout,
     .timeout = timeout,
-    .subscribe = EVENT_CONNECTION_CHANGED | EVENT_ENTER_BIND_MODE | EVENT_EXIT_BIND_MODE};
+    .subscribe = EVENT_CONNECTION_CHANGED | EVENT_ENTER_BIND_MODE | EVENT_EXIT_BIND_MODE
+};

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -355,8 +355,11 @@ static void luaparamMappingChannelOut(struct luaPropertiesCommon *item, uint8_t 
         pwmModes[lastPos] = '\0';
     }
 
-    // Trigger an event to update the related fields to represent the selected channel
-    devicesTriggerEvent();
+    // update the related fields to represent the selected channel
+    const rx_config_pwm_t *pwmCh = config.GetPwmChannel(luaMappingChannelOut.properties.u.value - 1);
+    setLuaUint8Value(&luaMappingChannelIn, pwmCh->val.inputChannel + 1);
+    setLuaTextSelectionValue(&luaMappingOutputMode, pwmCh->val.mode);
+    setLuaTextSelectionValue(&luaMappingInverted, pwmCh->val.inverted);
 }
 
 static void luaparamMappingChannelIn(struct luaPropertiesCommon *item, uint8_t arg)
@@ -660,7 +663,8 @@ device_t LUA_device = {
   .initialize = nullptr,
   .start = start,
   .event = event,
-  .timeout = timeout
+  .timeout = timeout,
+  .subscribe = 0xFFFF // any and all events
 };
 
 #endif

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -664,7 +664,7 @@ device_t LUA_device = {
   .start = start,
   .event = event,
   .timeout = timeout,
-  .subscribe = 0xFFFF // any and all events
+  .subscribe = EVENT_ALL
 };
 
 #endif

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -282,7 +282,6 @@ static struct luaItem_string luaBackpackVersion = {
 //---------------------------- BACKPACK ------------------
 
 static char luaBadGoodString[10];
-static int event();
 
 extern TxConfig config;
 extern void VtxTriggerSend();
@@ -371,7 +370,7 @@ static void luadevUpdateBackpackOpts()
 
 static void setBleJoystickMode()
 {
-  connectionState = bleJoystick;
+  setConnectionState(bleJoystick);
 }
 
 static void luahandWifiBle(struct luaPropertiesCommon *item, uint8_t arg)
@@ -913,7 +912,8 @@ device_t LUA_device = {
   .initialize = nullptr,
   .start = start,
   .event = event,
-  .timeout = timeout
+  .timeout = timeout,
+  .subscribe = 0xFFFF // all events
 };
 
 #endif

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -913,7 +913,7 @@ device_t LUA_device = {
   .start = start,
   .event = event,
   .timeout = timeout,
-  .subscribe = 0xFFFF // all events
+  .subscribe = EVENT_ALL
 };
 
 #endif

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -910,7 +910,7 @@ static int start()
 }
 
 device_t LUA_device = {
-  .initialize = NULL,
+  .initialize = nullptr,
   .start = start,
   .event = event,
   .timeout = timeout

--- a/src/lib/MSPVTX/devMSPVTX.cpp
+++ b/src/lib/MSPVTX/devMSPVTX.cpp
@@ -407,5 +407,6 @@ device_t MSPVTx_device = {
     .start = start,
     .event = event,
     .timeout = timeout,
-    .subscribe = EVENT_VTX_CHANGE};
+    .subscribe = EVENT_VTX_CHANGE
+};
 #endif

--- a/src/lib/MSPVTX/devMSPVTX.cpp
+++ b/src/lib/MSPVTX/devMSPVTX.cpp
@@ -353,20 +353,19 @@ void disableMspVtx(void)
     mspState = STOP_MSPVTX;
 }
 
-static void initialize()
+static bool initialize()
 {
-    if (OPT_HAS_VTX_SPI)
-    {
-        mspState = GET_VTX_TABLE_SIZE;
-    }
+    return OPT_HAS_VTX_SPI;
+}
+
+static int start()
+{
+    mspState = GET_VTX_TABLE_SIZE;
+    return DURATION_IMMEDIATELY;
 }
 
 static int event(void)
 {
-    if (GPIO_PIN_SPI_VTX_NSS == UNDEF_PIN)
-    {
-        return DURATION_NEVER;
-    }
     return DURATION_IMMEDIATELY;
 }
 
@@ -389,7 +388,7 @@ static int timeout(void)
 
 device_t MSPVTx_device = {
     .initialize = initialize,
-    .start = nullptr,
+    .start = start,
     .event = event,
     .timeout = timeout
 };

--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -270,7 +270,7 @@ void POWERMGNT::setPower(PowerLevels_e Power)
 #endif
 
     CurrentPower = Power;
-    devicesTriggerEvent();
+    devicesTriggerEvent(EVENT_POWER_CHANGED);
 }
 
 #endif /* !UNIT_TEST */

--- a/src/lib/POWER_DETECT/devPDET.cpp
+++ b/src/lib/POWER_DETECT/devPDET.cpp
@@ -89,6 +89,7 @@ device_t PDET_device = {
     .initialize = initialize,
     .start = start,
     .event = event,
-    .timeout = timeout
+    .timeout = timeout,
+    .subscribe = EVENT_CONNECTION_CHANGED
 };
 #endif

--- a/src/lib/POWER_DETECT/devPDET.cpp
+++ b/src/lib/POWER_DETECT/devPDET.cpp
@@ -19,14 +19,15 @@ extern bool busyTransmitting;
 static pdet_storage_t PdetMvScaled;
 static uint8_t lastTargetPowerdBm;
 
+static bool initialize()
+{
+    return GPIO_PIN_PA_PDET != UNDEF_PIN;
+}
+
 static int start()
 {
-    if (GPIO_PIN_PA_PDET != UNDEF_PIN)
-    {
-        analogSetPinAttenuation(GPIO_PIN_PA_PDET, ADC_0db);
-        return DURATION_IMMEDIATELY;
-    }
-    return DURATION_NEVER;
+    analogSetPinAttenuation(GPIO_PIN_PA_PDET, ADC_0db);
+    return DURATION_IMMEDIATELY;
 }
 
 /**
@@ -40,7 +41,7 @@ static int start()
  */
 static int event()
 {
-    if (GPIO_PIN_PA_PDET == UNDEF_PIN || connectionState > connectionState_e::MODE_STATES)
+    if (connectionState > connectionState_e::MODE_STATES)
     {
         return DURATION_NEVER;
     }
@@ -85,7 +86,7 @@ static int timeout()
 }
 
 device_t PDET_device = {
-    .initialize = NULL,
+    .initialize = initialize,
     .start = start,
     .event = event,
     .timeout = timeout

--- a/src/lib/SCREEN/devScreen.cpp
+++ b/src/lib/SCREEN/devScreen.cpp
@@ -133,7 +133,7 @@ static int handle(void)
     return SCREEN_DURATION;
 }
 
-static void initialize()
+static bool initialize()
 {
     if (OPT_HAS_SCREEN)
     {
@@ -158,33 +158,22 @@ static void initialize()
             devicesTriggerEvent();
         });
     }
+    return OPT_HAS_SCREEN;
 }
 
 static int start()
 {
-    if (OPT_HAS_SCREEN)
-    {
-        return DURATION_IMMEDIATELY;
-    }
-    return DURATION_NEVER;
+    return DURATION_IMMEDIATELY;
 }
 
 static int event()
 {
-    if (OPT_HAS_SCREEN)
-    {
-        return handle();
-    }
-    return DURATION_NEVER;
+    return handle();
 }
 
 static int timeout()
 {
-    if (OPT_HAS_SCREEN)
-    {
-        return handle();
-    }
-    return DURATION_NEVER;
+    return handle();
 }
 
 device_t Screen_device = {

--- a/src/lib/SCREEN/devScreen.cpp
+++ b/src/lib/SCREEN/devScreen.cpp
@@ -151,11 +151,11 @@ static bool initialize()
 
         registerButtonFunction(ACTION_GOTO_VTX_BAND, [](){
             jumpToBandSelect = true;
-            devicesTriggerEvent();
+            handle();
         });
         registerButtonFunction(ACTION_GOTO_VTX_CHANNEL, [](){
             jumpToChannelSelect = true;
-            devicesTriggerEvent();
+            handle();
         });
     }
     return OPT_HAS_SCREEN;
@@ -180,5 +180,7 @@ device_t Screen_device = {
     .initialize = initialize,
     .start = start,
     .event = event,
-    .timeout = timeout};
+    .timeout = timeout,
+    .subscribe = EVENT_CONNECTION_CHANGED | EVENT_ARM_FLAG_CHANGED
+};
 #endif

--- a/src/lib/SCREEN/menu.cpp
+++ b/src/lib/SCREEN/menu.cpp
@@ -336,7 +336,7 @@ static void executeBLE(bool init)
 {
     if (init)
     {
-        connectionState = bleJoystick;
+        setConnectionState(bleJoystick);
         display->displayBLEStatus();
     }
     else

--- a/src/lib/SerialUpdate/devSerialUpdate.cpp
+++ b/src/lib/SerialUpdate/devSerialUpdate.cpp
@@ -13,9 +13,10 @@ extern void stub_handle_rx_byte(char byte);
 
 static bool running = false;
 
-static void initialize()
+static bool initialize()
 {
     running = true;
+    return true;
 }
 
 static int event()

--- a/src/lib/SerialUpdate/devSerialUpdate.cpp
+++ b/src/lib/SerialUpdate/devSerialUpdate.cpp
@@ -53,5 +53,6 @@ device_t SerialUpdate_device = {
     .start = nullptr,
     .event = event,
     .timeout = timeout,
-    .subscribe = EVENT_CONNECTION_CHANGED};
+    .subscribe = EVENT_CONNECTION_CHANGED
+};
 #endif

--- a/src/lib/SerialUpdate/devSerialUpdate.cpp
+++ b/src/lib/SerialUpdate/devSerialUpdate.cpp
@@ -31,16 +31,11 @@ static int event()
         Radio.End();
         return DURATION_IMMEDIATELY;
     }
-    return DURATION_IGNORE;
+    return DURATION_NEVER;
 }
 
 static int timeout()
 {
-    if (connectionState != serialUpdate)
-    {
-        return DURATION_NEVER;
-    }
-
     start_esp_upload();
     while (true)
     {
@@ -57,6 +52,6 @@ device_t SerialUpdate_device = {
     .initialize = initialize,
     .start = nullptr,
     .event = event,
-    .timeout = timeout
-};
+    .timeout = timeout,
+    .subscribe = EVENT_CONNECTION_CHANGED};
 #endif

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -266,4 +266,4 @@ device_t ServoOut_device = {
     .start = start,
     .event = event,
     .timeout = timeout,
-};
+    .subscribe = EVENT_CONNECTION_CHANGED};

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -140,11 +140,11 @@ static void servosUpdate(unsigned long now)
     }
 }
 
-static void initialize()
+static bool initialize()
 {
     if (!OPT_HAS_SERVO_OUTPUT)
     {
-        return;
+        return false;
     }
 
 #if defined(PLATFORM_ESP32)
@@ -200,6 +200,7 @@ static void initialize()
             digitalWrite(pin, LOW);
         }
     }
+    return true;
 }
 
 static int start()
@@ -225,7 +226,7 @@ static int start()
 
 static int event()
 {
-    if (!OPT_HAS_SERVO_OUTPUT || connectionState == disconnected)
+    if (connectionState == disconnected)
     {
         // Disconnected should come after failsafe on the RX,
         // so it is safe to shut down when disconnected

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -266,4 +266,5 @@ device_t ServoOut_device = {
     .start = start,
     .event = event,
     .timeout = timeout,
-    .subscribe = EVENT_CONNECTION_CHANGED};
+    .subscribe = EVENT_CONNECTION_CHANGED
+};

--- a/src/lib/THERMAL/devThermal.cpp
+++ b/src/lib/THERMAL/devThermal.cpp
@@ -27,20 +27,25 @@ static uint16_t currentRPM = 0;
 void init_rpm_counter(int pin);
 uint32_t get_rpm();
 
-static void initialize()
+static bool initialize()
 {
+    bool enabled = false;
 #if defined(PLATFORM_ESP32_S3)
     thermal.init();
+    enabled = true;
 #else
     if (OPT_HAS_THERMAL_LM75A && GPIO_PIN_SCL != UNDEF_PIN && GPIO_PIN_SDA != UNDEF_PIN)
     {
         thermal.init();
+        enabled = true;
     }
 #endif
     if (GPIO_PIN_FAN_EN != UNDEF_PIN)
     {
         pinMode(GPIO_PIN_FAN_EN, OUTPUT);
+        enabled = true;
     }
+    return enabled;
 }
 
 static void timeoutThermal()

--- a/src/lib/VTX/devVTX.cpp
+++ b/src/lib/VTX/devVTX.cpp
@@ -96,9 +96,10 @@ static void VtxConfigToMSPOut()
     }
 }
 
-static void initialize()
+static bool initialize()
 {
     registerButtonFunction(ACTION_SEND_VTX, VtxTriggerSend);
+    return true;
 }
 
 static int event()

--- a/src/lib/VTX/devVTX.cpp
+++ b/src/lib/VTX/devVTX.cpp
@@ -35,7 +35,7 @@ void VtxTriggerSend()
 {
     VtxSendState = VTXSS_MODIFIED;
     sendEepromWrite = true;
-    devicesTriggerEvent();
+    devicesTriggerEvent(EVENT_VTX_CHANGE);
 }
 
 void VtxPitmodeSwitchUpdate()
@@ -175,5 +175,6 @@ device_t VTX_device = {
     .initialize = initialize,
     .start = NULL,
     .event = event,
-    .timeout = timeout
+    .timeout = timeout,
+    .subscribe = EVENT_CONNECTION_CHANGED | EVENT_VTX_CHANGE
 };

--- a/src/lib/VTXSPI/devVTXSPI.cpp
+++ b/src/lib/VTXSPI/devVTXSPI.cpp
@@ -343,14 +343,14 @@ void disableVTxSpi()
 }
 
 
-static void initialize()
+static bool initialize()
 {
     VpdSetPointArray25mW = VPD_VALUES_25MW;
     VpdSetPointArray100mW = VPD_VALUES_100MW;
     PwmArray25mW = PWM_VALUES_25MW;
     PwmArray100mW = PWM_VALUES_100MW;
 
-    if (GPIO_PIN_SPI_VTX_NSS != UNDEF_PIN)
+    if (OPT_HAS_VTX_SPI)
     {
         if (GPIO_PIN_SPI_VTX_SCK != UNDEF_PIN && GPIO_PIN_SPI_VTX_SCK != GPIO_PIN_SCK)
         {
@@ -390,15 +390,11 @@ static void initialize()
         #endif
         setPWM();
     }
+    return OPT_HAS_VTX_SPI;
 }
 
 static int start()
 {
-    if (GPIO_PIN_SPI_VTX_NSS == UNDEF_PIN)
-    {
-        return DURATION_NEVER;
-    }
-
 #if defined(VTX_OUTPUT_CALIBRATION)
     rtc6705SetFrequency(VpdFreqArray[calibFreqIndex]); // Set to the first calib frequency
     vtxSPIPitmodeCurrent = 0;
@@ -412,7 +408,7 @@ static int start()
 
 static int timeout()
 {
-    if ((GPIO_PIN_SPI_VTX_NSS == UNDEF_PIN) || stopVtxMonitoring)
+    if (stopVtxMonitoring)
     {
         return DURATION_NEVER;
     }

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -904,7 +904,7 @@ static void HandleContinuousWave(AsyncWebServerRequest *request) {
   }
 }
 
-static void initialize()
+static bool initialize()
 {
   wifiStarted = false;
   WiFi.disconnect(true);
@@ -915,6 +915,7 @@ static void initialize()
   registerButtonFunction(ACTION_START_WIFI, [](){
     setWifiUpdateMode();
   });
+  return true;
 }
 
 static void startWiFi(unsigned long now)

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -107,7 +107,7 @@ void setWifiUpdateMode()
   // No need to ExitBindingMode(), the radio will be stopped stopped when start the Wifi service.
   // Need to change this before the mode change event so the LED is updated
   InBindingMode = false;
-  connectionState = wifiUpdate;
+  setConnectionState(wifiUpdate);
 }
 
 /** Is this an IP? */
@@ -1336,5 +1336,5 @@ device_t WIFI_device = {
   .initialize = initialize,
   .start = start,
   .event = event,
-  .timeout = timeout
-};
+  .timeout = timeout,
+  .subscribe = EVENT_CONNECTION_CHANGED};

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -1337,4 +1337,5 @@ device_t WIFI_device = {
   .start = start,
   .event = event,
   .timeout = timeout,
-  .subscribe = EVENT_CONNECTION_CHANGED};
+  .subscribe = EVENT_CONNECTION_CHANGED
+};

--- a/src/src/rx-serial/devSerialIO.cpp
+++ b/src/src/rx-serial/devSerialIO.cpp
@@ -277,16 +277,16 @@ device_t Serial0_device = {
     .initialize = nullptr,
     .start = start,
     .event = event0,
-    .timeout = timeout0
-};
+    .timeout = timeout0,
+    .subscribe = EVENT_CONNECTION_CHANGED};
 
 #if defined(PLATFORM_ESP32)
 device_t Serial1_device = {
     .initialize = nullptr,
     .start = start,
     .event = event1,
-    .timeout = timeout1
-};
+    .timeout = timeout1,
+    .subscribe = EVENT_CONNECTION_CHANGED};
 #endif
 
 #endif

--- a/src/src/rx-serial/devSerialIO.cpp
+++ b/src/src/rx-serial/devSerialIO.cpp
@@ -278,7 +278,8 @@ device_t Serial0_device = {
     .start = start,
     .event = event0,
     .timeout = timeout0,
-    .subscribe = EVENT_CONNECTION_CHANGED};
+    .subscribe = EVENT_CONNECTION_CHANGED
+};
 
 #if defined(PLATFORM_ESP32)
 device_t Serial1_device = {
@@ -286,7 +287,8 @@ device_t Serial1_device = {
     .start = start,
     .event = event1,
     .timeout = timeout1,
-    .subscribe = EVENT_CONNECTION_CHANGED};
+    .subscribe = EVENT_CONNECTION_CHANGED
+};
 #endif
 
 #endif

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -831,7 +831,7 @@ void LostConnection(bool resumeRx)
         config.SetRateInitialIdx(ExpressLRS_nextAirRateIndex);
 
     RFmodeCycleMultiplier = 1;
-    connectionState = disconnected; //set lost connection
+    setConnectionState(disconnected); //set lost connection
     RXtimerState = tim_disconnected;
     hwTimer::resetFreqOffset();
     PfdPrevRawOffset = 0;
@@ -863,7 +863,7 @@ void LostConnection(bool resumeRx)
 void ICACHE_RAM_ATTR TentativeConnection(unsigned long now)
 {
     PFDloop.reset();
-    connectionState = tentative;
+    setConnectionState(tentative);
     connectionHasModelMatch = false;
     RXtimerState = tim_disconnected;
     DBGLN("tentative conn");
@@ -885,7 +885,7 @@ void GotConnection(unsigned long now)
 
     LockRFmode = firmwareOptions.lock_on_first_connection;
 
-    connectionState = connected; //we got a packet, therefore no lost connection
+    setConnectionState(connected); //we got a packet, therefore no lost connection
     RXtimerState = tim_tentative;
     GotConnectionMillis = now;
     webserverPreventAutoStart = true;
@@ -1270,7 +1270,7 @@ void MspReceiveComplete()
                         vtxSPIPowerIdx = MspData[10];
                         vtxSPIPitmode = MspData[11];
                     }
-                    devicesTriggerEvent();
+                    devicesTriggerEvent(EVENT_VTX_CHANGE);
                     break;
                 } else if (config.GetSerial1Protocol() == PROTOCOL_SERIAL1_TRAMP || config.GetSerial1Protocol() == PROTOCOL_SERIAL1_SMARTAUDIO) {
                     serial1IO->queueMSPFrameTransmission(MspData);
@@ -1609,7 +1609,7 @@ static void setupRadio()
     if (!init_success)
     {
         DBGLN("Failed to detect RF chipset!!!");
-        connectionState = radioFailed;
+        setConnectionState(radioFailed);
         return;
     }
 
@@ -1708,7 +1708,7 @@ static void EnterBindingMode()
     Radio.RXnb();
 
     DBGLN("Entered binding mode at freq = %d", Radio.currFreq);
-    devicesTriggerEvent();
+    devicesTriggerEvent(EVENT_ENTER_BIND_MODE);
 }
 
 static void ExitBindingMode()
@@ -1741,7 +1741,7 @@ static void ExitBindingMode()
     // if we're in binding mode
     InBindingMode = false;
     DBGLN("Exiting binding mode");
-    devicesTriggerEvent();
+    devicesTriggerEvent(EVENT_EXIT_BIND_MODE);
 }
 
 static void updateBindingMode(unsigned long now)
@@ -1803,7 +1803,7 @@ static void updateBindingMode(unsigned long now)
                 config.Commit(); // prevents CheckConfigChangePending() re-enabling radio
                 Radio.End();
                 // Enter a completely invalid state for a receiver, to prevent wifi or radio enabling
-                connectionState = noCrossfire;
+                setConnectionState(noCrossfire);
                 return;
             }
             // if the InitRate config item was changed by LostConnection
@@ -1949,8 +1949,8 @@ static void CheckConfigChangePending()
     if (config.IsModified() && !InBindingMode && connectionState < NO_CONFIG_SAVE_STATES)
     {
         LostConnection(false);
-        config.Commit();
-        devicesTriggerEvent();
+        uint32_t changes = config.Commit();
+        devicesTriggerEvent(changes);
 #if defined(Regulatory_Domain_EU_CE_2400)
         LBTEnabled = (config.GetPower() > PWR_10mW);
 #endif
@@ -2005,7 +2005,7 @@ void setup()
         devicesRegister(wifi_device, ARRAY_SIZE(wifi_device));
         devicesInit();
 
-        connectionState = hardwareUndefined;
+        setConnectionState(hardwareUndefined);
     }
     else
     {
@@ -2210,6 +2210,6 @@ void reset_into_bootloader(void)
     ESP.rebootIntoUartDownloadMode();
 #elif defined(PLATFORM_ESP32)
     delay(100);
-    connectionState = serialUpdate;
+    setConnectionState(serialUpdate);
 #endif
 }


### PR DESCRIPTION
Two parts to this PR.
1. Devices that are not supported by the hardware can return `false` from their `init` function and the device framework will not call their `start`, `timeout` or `event` functions during the main loop.
2. Event publish/subscribe
   - Events fired from the code now pass an event type so only subscribers to that event type will be notified, reducing the number of calls in the main loop.
   - Device event framework extended to allow device handlers to subscribe to certain events and their `event` function will only be called if that type of event is fired.
