### PR TITLE
Allow choosing the RF Band on LR1121 modules

### DIFF
--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -20,9 +20,11 @@
     "D50Hz(-112dBm);25Hz(-123dBm);50Hz(-120dBm);100Hz(-117dBm);100Hz Full(-112dBm);200Hz(-112dBm)"
 #elif defined(RADIO_LR1121)
 #define STR_LUA_PACKETRATES \
-    "X100F;X150;" \
-    "50 2.4G;100F 2.4G;150 2.4G;250 2.4G;333F 2.4G;500 2.4G;DK250 2.4G;DK500 2.4G;K1000 2.4G;" \
-    "D50 Low;25 Low;50 Low;100 Low;100F Low;200 Low;200F Low;250 Low;K1000F Low"
+    "100Hz Full(-112dBm);150Hz(-112dBm);" \
+    "50Hz(-115dBm);100Hz Full(-112dBm);150Hz(-112dBm);250Hz(-108dBm);333Hz Full(-105dBm);500Hz(-105dBm);" \
+    "DK250(-103dBm);DK500(-103dBm);K1000(-103dBm);" \
+    "D50Hz(-112dBm);25Hz(-123dBm);50Hz(-120dBm);100Hz(-117dBm);100Hz Full(-112dBm);200Hz(-112dBm);200Hz Full(-111dBm);250Hz(-111dBm);" \
+    "K1000 Full(-101dBm)"
 #elif defined(RADIO_SX128X)
 #define STR_LUA_PACKETRATES \
     "50Hz(-115dBm);100Hz Full(-112dBm);150Hz(-112dBm);250Hz(-108dBm);333Hz Full(-105dBm);500Hz(-105dBm);" \


### PR DESCRIPTION
This separates the RF band selection from the packet rate do reduce the number of options.
It also allows us to use consistent packet names across the bands.
Brings back the dBm text for consistency with 900 and 2.4 only modules.

The RF Band selection has the following
- 433/866/868/900MHz (depends on the regulatory domain configured)
- 2.4GHz
- X-Band (only available on Dual LR1121 modules)

If you select a different RF band, the packet rate will change to the highest supported packet rate for that band as a default, taking into account UART baud rate etc.

![IMG_0976 Medium](https://github.com/user-attachments/assets/95a5a406-2e37-4920-a032-443009a5def6)

