### PR TITLE
Fix SPI FC problem with looping connection loss, reestablishment

### DIFF
--- a/src/lib/LUA/lua.h
+++ b/src/lib/LUA/lua.h
@@ -139,6 +139,7 @@ void luaRegisterDevicePingCallback(void (*callback)());
 
 #define LUA_FIELD_HIDE(fld) { fld.common.type = (crsf_value_type_e)((uint8_t)fld.common.type | CRSF_FIELD_HIDDEN); }
 #define LUA_FIELD_SHOW(fld) { fld.common.type = (crsf_value_type_e)((uint8_t)fld.common.type & ~CRSF_FIELD_HIDDEN); }
+#define LUA_FIELD_VISIBLE(fld, cond) { if (cond) LUA_FIELD_SHOW(fld) else LUA_FIELD_HIDE(fld) }
 
 void sendLuaCommandResponse(struct luaItem_command *cmd, luaCmdStep_e step, const char *message);
 

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -907,6 +907,8 @@ static int event()
   setLuaTextSelectionValue(&luaVtxBand, config.GetVtxBand());
   setLuaUint8Value(&luaVtxChannel, config.GetVtxChannel() + 1);
   setLuaTextSelectionValue(&luaVtxPwr, config.GetVtxPower());
+  // Pit mode can only be sent as part of the power byte
+  LUA_FIELD_VISIBLE(luaVtxPit, config.GetVtxPower() != 0);
   setLuaTextSelectionValue(&luaVtxPit, config.GetVtxPitmode());
   if (OPT_USE_TX_BACKPACK)
   {

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -908,8 +908,6 @@ static void UpdateConnectDisconnectStatus()
       apInputBuffer.flush();
       apOutputBuffer.flush();
       uartInputBuffer.flush();
-
-      VtxTriggerSend();
     }
   }
   // If past RX_LOSS_CNT, or in awaitingModelId state for longer than DisconnectTimeoutMs, go to disconnected


### PR DESCRIPTION
This is a fix for the issue with Betaflight ELRS SPI flight controllers that exhibit an issue when using the VTX admin.
Upon RF connection, the TX sends the current VTX settings and a EEPROM save, which causes the link to drop. The connection is reestablished, and we send another VTX packet with EEPROM save ad infinitum.

The fix is to properly detect disconnected state and start the debounce timer so if the connection is reestablished before the debounce time (1 second) the VTX Admin packets are not sent again, thus stopping another disconnect/reconnect cycle.

This issue was introduced in PR #2965 and fixes #2976