### PR TITLE
No MAVLink for you STM32!

### DIFF
--- a/src/lib/LUA/lua.cpp
+++ b/src/lib/LUA/lua.cpp
@@ -18,7 +18,11 @@ static uint8_t luaWarningFlags = 0b00000000; //8 flag, 1 bit for each flag. set 
 static void (*devicePingCallback)() = nullptr;
 #endif
 
+#if defined(TARGET_RX) && defined(PLATFORM_STM32)
+#define LUA_MAX_PARAMS 16
+#else
 #define LUA_MAX_PARAMS 64
+#endif
 static uint8_t parameterType;
 static uint8_t parameterIndex;
 static uint8_t parameterArg;

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -21,7 +21,11 @@ static char pwmModes[] = "50Hz;60Hz;100Hz;160Hz;333Hz;400Hz;10kHzDuty;On/Off;DSh
 static struct luaItem_selection luaSerialProtocol = {
     {"Protocol", CRSF_TEXT_SELECTION},
     0, // value
+#if defined(PLATFORM_STM32)
+    "CRSF;Inverted CRSF;SBUS;Inverted SBUS;SUMD;DJI RS Pro",
+#else
     "CRSF;Inverted CRSF;SBUS;Inverted SBUS;SUMD;DJI RS Pro;HoTT Telemetry;MAVLink",
+#endif
     STR_EMPTYSPACE
 };
 
@@ -41,6 +45,7 @@ static struct luaItem_selection luaSBUSFailsafeMode = {
     STR_EMPTYSPACE
 };
 
+#if !defined(PLATFORM_STM32)
 static struct luaItem_int8 luaTargetSysId = {
   {"Target SysID", CRSF_UINT8},
   {
@@ -63,6 +68,7 @@ static struct luaItem_int8 luaSourceSysId = {
   },
   STR_EMPTYSPACE
 };
+#endif
 
 #if defined(POWER_OUTPUT_VALUES)
 static struct luaItem_selection luaTlmPower = {
@@ -538,12 +544,14 @@ static void registerLuaParameters()
     config.SetFailsafeMode((eFailsafeMode)arg);
   });
 
+#if !defined(PLATFORM_STM32)
   registerLUAParameter(&luaTargetSysId, [](struct luaPropertiesCommon* item, uint8_t arg){
     config.SetTargetSysId((uint8_t)arg);
   });
   registerLUAParameter(&luaSourceSysId, [](struct luaPropertiesCommon* item, uint8_t arg){
     config.SetSourceSysId((uint8_t)arg);
   });
+#endif
 
   if (GPIO_PIN_ANT_CTRL != UNDEF_PIN)
   {
@@ -666,6 +674,7 @@ static int event()
   setLuaTextSelectionValue(&luaBindStorage, config.GetBindStorage());
   updateBindModeLabel();
 
+#if !defined(PLATFORM_STM32)
   if (config.GetSerialProtocol() == PROTOCOL_MAVLINK)
   {
     setLuaUint8Value(&luaSourceSysId, config.GetSourceSysId() == 0 ? 255 : config.GetSourceSysId());  //display Source sysID if 0 display 255 to mimic logic in SerialMavlink.cpp
@@ -678,6 +687,7 @@ static int event()
     LUA_FIELD_HIDE(luaSourceSysId)
     LUA_FIELD_HIDE(luaTargetSysId)
   }
+#endif
 
   return DURATION_IMMEDIATELY;
 }

--- a/src/src/rx-serial/SerialMavlink.cpp
+++ b/src/src/rx-serial/SerialMavlink.cpp
@@ -1,4 +1,4 @@
-#if defined(TARGET_RX)
+#if defined(TARGET_RX) && !defined(PLATFORM_STM32)
 
 #include "SerialMavlink.h"
 #include "device.h"
@@ -11,39 +11,6 @@
 // Variables / constants for Mavlink //
 FIFO<MAV_INPUT_BUF_LEN> mavlinkInputBuffer;
 FIFO<MAV_OUTPUT_BUF_LEN> mavlinkOutputBuffer;
-
-#if defined(PLATFORM_STM32)
-// This is a dummy implementation for STM32, since we don't use Mavlink on STM32
-
-    SerialMavlink::SerialMavlink(Stream &out, Stream &in):
-    SerialIO(&out, &in),
-    // These init values don't matter here for STM32, since we don't use them
-    this_system_id(255),
-    this_component_id(0),
-    target_system_id(1),
-    target_component_id(1)
-{
-}
-
-uint32_t SerialMavlink::sendRCFrame(bool frameAvailable, bool frameMissed, uint32_t *channelData)
-{
-    return DURATION_NEVER;
-}
-
-int SerialMavlink::getMaxSerialReadSize()
-{
-    return 0;
-}
-
-void SerialMavlink::processBytes(uint8_t *bytes, u_int16_t size)
-{
-}
-
-void SerialMavlink::sendQueuedData(uint32_t maxBytesToSend)
-{
-}
-
-#else // ESP-based targets
 
 #define MAVLINK_COMM_NUM_BUFFERS 1
 #include "common/mavlink.h"
@@ -176,6 +143,4 @@ void SerialMavlink::sendQueuedData(uint32_t maxBytesToSend)
     }
 }
 
-#endif // defined(PLATFORM_STM32)
-
-#endif // defined(TARGET_RX)
+#endif // defined(TARGET_RX) && !defined(PLATFORM_STM32)


### PR DESCRIPTION
MAVLink on STM32 was effectively disabled by having a stub implementation, but... users could still select MAVLink in the Lua script and be confused as to why it's not working. This PR removes it completely.
Also, some of the big-fat buffers were still allocated and reduced the available memory and cause issues for memory limited STM32 devices and they would also crash/fail to start!

Fixes #3085 