### PR TITLE
A way of including alternative default EEPROM into firmware file

### DIFF
--- a/src/lib/OPTIONS/options.h
+++ b/src/lib/OPTIONS/options.h
@@ -57,6 +57,7 @@ constexpr size_t ELRSOPTS_PRODUCTNAME_SIZE = 128;
 constexpr size_t ELRSOPTS_DEVICENAME_SIZE = 16;
 constexpr size_t ELRSOPTS_OPTIONS_SIZE = 512;
 constexpr size_t ELRSOPTS_HARDWARE_SIZE = 2048;
+constexpr size_t ELRSOPTS_EEPROM_SIZE = 1024; // RESERVED_EEPROM_SIZE from elrs_eeprom.h is 1024
 
 #if defined(TARGET_UNIFIED_TX) || defined(TARGET_UNIFIED_RX)
 extern firmware_options_t firmwareOptions;


### PR DESCRIPTION
Imagine if somebody has some weird configurations for a project that he needs to build 10 of, or 1000s of. This robot has servos that need to failsafe into a weird position, some of them need servo-stretching enabled, maybe there are ESCs connected that need to use Dshot. Currently there is no way for a user to save this set of configurations so that he can build multiple ELRS systems quickly.

As a reminder, the way ELRS partitions its data:

 * all firmware files have a default options.json and default hardware.json, these are appended to the end of all firmware binaries
 * options.json and hardware.json will be written into SPIFFS if the user changes them over Wi-Fi
 * EEPROM is stored in NVS, completely separately
 * traditionally, updating the firmware does not update NVS or SPIFFS

There is no current existing way to carry EEPROM data via the firmware file

What this pull request does:

 * The firmware download mechanism has been modified slightly. If there is a copy of options.json and/or hardware.json inside SPIFFS, then the latest copy inside SPIFFS will be the ones appended to the firmware
 * The EEPROM content is also appended to the firmware, starting with a magic string "EEPROM"
 * If a firmware is uploaded, when the flashing completes, it is checked for the magic string "EEPROM", if the magic string exists, then immediately the EEPROM is populated with the data from the firmware file

This gives the user/manufacture a way of saving a set of configurations, and reapply the same configuration repeatedly very rapidly. To generate the newer formatted firmware file, simply download it through the same existing method over WiFi

(the original code allocated 4096 bytes of extra space, but not all of that is being used and there's more than enough room for the EEPROM payload)