### PR TITLE
LR1121 init power config

### DIFF
--- a/src/lib/LR1121Driver/LR1121.cpp
+++ b/src/lib/LR1121Driver/LR1121.cpp
@@ -383,6 +383,8 @@ void ICACHE_RAM_ATTR LR1121Driver::CommitOutputPower()
 void ICACHE_RAM_ATTR LR1121Driver::WriteOutputPower(uint8_t power, bool isSubGHz, SX12XX_Radio_Number_t radioNumber)
 {
     uint8_t Txbuf[2] = {power, LR11XX_RADIO_RAMP_48_US};
+    
+    // 9.5.2 SetTxParams
     hal.WriteCommand(LR11XX_RADIO_SET_TX_PARAMS_OC, Txbuf, sizeof(Txbuf), radioNumber);
 }
 
@@ -391,7 +393,6 @@ void ICACHE_RAM_ATTR LR1121Driver::SetPaConfig(bool isSubGHz, SX12XX_Radio_Numbe
     uint8_t Pabuf[4] = {0};
 
     // 9.5.1 SetPaConfig
-    // 9.5.2 SetTxParams
     if (isSubGHz)
     {
         // 900M low power RF Amp

--- a/src/lib/LR1121Driver/LR1121.cpp
+++ b/src/lib/LR1121Driver/LR1121.cpp
@@ -135,6 +135,7 @@ void LR1121Driver::startCWTest(uint32_t freq, SX12XX_Radio_Number_t radioNumber)
     // Set a basic Config that can be used for both 2.4G and SubGHz bands.
     Config(LR11XX_RADIO_LORA_BW_62, LR11XX_RADIO_LORA_SF6, LR11XX_RADIO_LORA_CR_4_8, freq, 12, false, 8, 0, false, 0, 0, radioNumber);
     CommitOutputPower();
+    SetPaConfig(freq < 1000000000, radioNumber);
     hal.WriteCommand(LR11XX_RADIO_SET_TX_CW_OC, radioNumber);
 }
 
@@ -208,6 +209,9 @@ void LR1121Driver::Config(uint8_t bw, uint8_t sf, uint8_t cr, uint32_t regfreq,
     pwrForceUpdate = true; // Must be called after changing rf modes between subG and 2.4G.  This sets the correct rf amps, and txen pins to be used.
     
     ClearIrqStatus(radioNumber);
+
+    SetPaConfig(isSubGHz, radioNumber);
+    CommitOutputPower();
 }
 
 void LR1121Driver::ConfigModParamsFSK(uint32_t Bitrate, uint8_t BWF, uint32_t Fdev, SX12XX_Radio_Number_t radioNumber)
@@ -382,8 +386,13 @@ void ICACHE_RAM_ATTR LR1121Driver::CommitOutputPower()
 
 void ICACHE_RAM_ATTR LR1121Driver::WriteOutputPower(uint8_t power, bool isSubGHz, SX12XX_Radio_Number_t radioNumber)
 {
-    uint8_t Pabuf[4] = {0};
     uint8_t Txbuf[2] = {power, LR11XX_RADIO_RAMP_48_US};
+    hal.WriteCommand(LR11XX_RADIO_SET_TX_PARAMS_OC, Txbuf, sizeof(Txbuf), radioNumber);
+}
+
+void ICACHE_RAM_ATTR LR1121Driver::SetPaConfig(bool isSubGHz, SX12XX_Radio_Number_t radioNumber)
+{
+    uint8_t Pabuf[4] = {0};
 
     // 9.5.1 SetPaConfig
     // 9.5.2 SetTxParams
@@ -421,7 +430,6 @@ void ICACHE_RAM_ATTR LR1121Driver::WriteOutputPower(uint8_t power, bool isSubGHz
     }
 
     hal.WriteCommand(LR11XX_RADIO_SET_PA_CFG_OC, Pabuf, sizeof(Pabuf), radioNumber);
-    hal.WriteCommand(LR11XX_RADIO_SET_TX_PARAMS_OC, Txbuf, sizeof(Txbuf), radioNumber);
 }
 
 void LR1121Driver::SetMode(lr11xx_RadioOperatingModes_t OPmode, SX12XX_Radio_Number_t radioNumber)

--- a/src/lib/LR1121Driver/LR1121.cpp
+++ b/src/lib/LR1121Driver/LR1121.cpp
@@ -134,8 +134,6 @@ void LR1121Driver::startCWTest(uint32_t freq, SX12XX_Radio_Number_t radioNumber)
 {
     // Set a basic Config that can be used for both 2.4G and SubGHz bands.
     Config(LR11XX_RADIO_LORA_BW_62, LR11XX_RADIO_LORA_SF6, LR11XX_RADIO_LORA_CR_4_8, freq, 12, false, 8, 0, false, 0, 0, radioNumber);
-    CommitOutputPower();
-    SetPaConfig(freq < 1000000000, radioNumber);
     hal.WriteCommand(LR11XX_RADIO_SET_TX_CW_OC, radioNumber);
 }
 
@@ -206,11 +204,9 @@ void LR1121Driver::Config(uint8_t bw, uint8_t sf, uint8_t cr, uint32_t regfreq,
 
     SetFrequencyHz(regfreq, radioNumber);
 
-    pwrForceUpdate = true; // Must be called after changing rf modes between subG and 2.4G.  This sets the correct rf amps, and txen pins to be used.
-    
     ClearIrqStatus(radioNumber);
 
-    SetPaConfig(isSubGHz, radioNumber);
+    SetPaConfig(isSubGHz, radioNumber); // Must be called after changing rf modes between subG and 2.4G.  This sets the correct rf amps, and txen pins to be used.
     CommitOutputPower();
 }
 

--- a/src/lib/LR1121Driver/LR1121.h
+++ b/src/lib/LR1121Driver/LR1121.h
@@ -89,4 +89,5 @@ private:
     void TXnbISR(); // ISR for non-blocking TX routine
     void CommitOutputPower();
     void WriteOutputPower(uint8_t pwr, bool isSubGHz, SX12XX_Radio_Number_t radioNumber);
+    void SetPaConfig(bool isSubGHz, SX12XX_Radio_Number_t radioNumber);
 };

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1684,7 +1684,7 @@ static void setupRadio()
         return;
     }
 
-    DynamicPower_UpdateRx(true);
+    DynamicPower_UpdateRx(true);  // Call before SetRFLinkRate(). The LR1121 Radio lib can now set the correct output power in Config().
 
 #if defined(Regulatory_Domain_EU_CE_2400)
     LBTEnabled = (config.GetPower() > PWR_10mW);

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -759,8 +759,8 @@ void ResetPower()
 static void ChangeRadioParams()
 {
   ModelUpdatePending = false;
+  ResetPower(); // Call before SetRFLinkRate(). The LR1121 Radio lib can now set the correct output power in Config().
   SetRFLinkRate(config.GetRate());
-  ResetPower();
 }
 
 void ModelUpdateReq()


### PR DESCRIPTION
RF power for the SX12xx is currently done after txdone.  This is a good time to do it for things like dyn power as time is available for the spi commands. 

However the LR1121 also has a number of RF amps and they must be configured correctly for each frequency domain.  Waiting until after the first packet has been sent and for the txdone isr isn't ideal, the wrong Dio pins can be used for txen on this first packet. 

This PR also makes sure the correct amp is set for the first bind packet, and during CW.

SPI traffic is also reduced during dyn power changes as now only the power is set and not the RF amp configuration.