### PR TITLE
解决通电时快速连接的问题Fix the quick connection problem during power-on

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1736,6 +1736,8 @@ static void cycleRfMode(unsigned long now)
         RFmodeLastCycled = now;
         LastSyncPacket = now;           // reset this variable
         SendLinkStatstoFCForcedSends = 2;
+		config.SetRateInitialIdx(scanIndex % RATE_MAX);
+        config.Commit();             //修复上电时的快速连接问题"Fix the quick connection problem during power-on"
         SetRFLinkRate(scanIndex % RATE_MAX, false); // switch between rates
         LQCalc.reset100();
         LQCalcDVDA.reset100();


### PR DESCRIPTION
在这之前的代码中，接收机的初始速率模式受控于LUA菜单的实时控制，当TX与RX断开连接时并修改了TX的速率模式，导致RX再次上电后不能快速连接，需要在单闪指示灯下循环遍历16个‘RATE_MAX'值去找到需要的速率模式，并且还不能记住此时建立连接的速率模式。这对于RX采用LR1121所支持的’RATE_MAX'来说是灾难性的，需要遍历寻找速率模式。在Gemini RX上会出现大于30秒的遍历寻找时间，而且在TX和RX非建立连接的情况下，RX每次上电都需要等待遍历寻找的时间。 以下我提交的代码并非是优秀的解决方案，他只是实现了处理此情况的方法之一，更好的优化可能还需要官方开发者重新审视和重写。 
Translation:
In the previous code, the initial rate mode of the receiver was controlled by the real-time control of the LUA menu. When the TX and RX were disconnected and the rate mode of the TX was modified, the RX could not connect quickly after being powered on again. It was necessary to cycle through 16 'RATE_MAX' values under the single flash indicator light to find the required rate mode, and it could not remember the rate mode established at this time. This is disastrous for the 'RATE_MAX' supported by the LR1121 used in the RX. It is necessary to search for the rate mode by iteration. On the Gemini RX, there will be a search time of more than 30 seconds by iteration, and each time the RX is powered on when the TX and RX are not connected, it needs to wait for the search time by iteration. The code I submit below is not an excellent solution. It is just one of the methods to deal with this situation. Better optimization may require the official developers to review and rewrite it.