### PR TITLE
Clean up MSP_STATUS for DJI O4

### DIFF
--- a/src/src/rx-serial/SerialDisplayport.h
+++ b/src/src/rx-serial/SerialDisplayport.h
@@ -21,19 +21,19 @@ CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
 #define MSP_STATUS_EX       150
 #define MSP_MSG_PERIOD_MS   100
 
-// MSP_STATUS_DJI
-struct msp_status_DJI_t
+struct msp_status_t
 {
-    uint16_t cycleTime;
-    uint16_t i2cErrorCounter;
-    uint16_t sensor;                    // MSP_STATUS_SENSOR_...
-    uint32_t flightModeFlags;           // see getActiveModes()
-    uint8_t  configProfileIndex;
-    uint16_t averageSystemLoadPercent;  // 0...100
-    uint16_t armingFlags;   //0x0103 or 0x0301
-    uint8_t  accCalibrationAxisFlags;  //0
-    uint8_t  DJI_ARMING_DISABLE_FLAGS_COUNT; //25
-    uint32_t djiPackArmingDisabledFlags; //(1 << 24)
+    uint16_t task_delta_time;
+    uint16_t i2c_error_count;
+    uint16_t sensor_status;
+    uint32_t flight_mode_flags;
+    uint8_t pid_profile;
+    uint16_t system_load;
+    uint16_t gyro_cycle_time;
+    uint8_t box_mode_flags;
+    uint8_t arming_disable_flags_count;
+    uint32_t arming_disable_flags;
+    uint8_t extra_flags;
 } __attribute__ ((packed));
 
 ////////////////////////////


### PR DESCRIPTION
The DJI arming feature (allows you to arm / disarm an air unit via ELRS without needing a flight controller) was broken on O4.
Turned out is was just janky code, and the `MSP_STATUS` message was a bit wonky.
This PR cleans it up, so that it works on both O3 and O4.

Tested on the bench on O3 with goggles 2, as well as O4 with goggles 2.