### PR TITLE
[RELAY-ONLY FEATURE] Add a TX module button action to toggle between two models

### DIFF
--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -1020,6 +1020,7 @@ function appendRow(b,p,v) {
       <option value='5' ${v['action']===5 ? 'selected' : ''}>Start WiFi</option>
       <option value='6' ${v['action']===6 ? 'selected' : ''}>Enter Binding Mode</option>
       <option value='7' ${v['action']===7 ? 'selected' : ''}>Start BLE Joystick</option>
+      <option value='9' ${v['action']===9 ? 'selected' : ''}>Toggle Selected Model</option>
     </select>
     <label>Action</label>
   </div>

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -197,6 +197,7 @@ typedef enum : uint8_t {
     ACTION_BIND,
     ACTION_BLE_JOYSTICK,
     ACTION_RESET_REBOOT,
+    ACTION_TOGGLE_MODEL_ID,
 
     ACTION_LAST
 } action_e;

--- a/src/lib/CONFIG/config.h
+++ b/src/lib/CONFIG/config.h
@@ -134,6 +134,7 @@ public:
     model_config_t const &GetModelConfig(uint8_t model) const { return m_config.model_config[model]; }
     uint8_t GetPTRStartChannel() const { return m_model->ptrStartChannel; }
     uint8_t GetPTREnableChannel() const { return m_model->ptrEnableChannel; }
+    uint8_t  GetModelId() const { return m_modelId; }
 
     // Setters
     void SetRate(uint8_t rate);

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -864,10 +864,10 @@ static void ChangeRadioParams()
   ResetPower();
 }
 
-void ModelUpdateReq()
+void ModelUpdateReqWithId(int modelId)
 {
   // Force synspam with the current rate parameters in case already have a connection established
-  if (config.SetModelId(CRSFHandset::getModelID()))
+  if (config.SetModelId(modelId))
   {
     syncSpamCounter = syncSpamAmount;
     syncSpamCounterAfterRateChange = syncSpamAmountAfterRateChange;
@@ -882,6 +882,18 @@ void ModelUpdateReq()
   {
     setConnectionState(disconnected);
   }
+}
+
+void ModelUpdateReq()
+{
+  ModelUpdateReqWithId(CRSFHandset::getModelID());
+}
+
+void ToggleModelID()
+{
+  // This function is called as a button action to toggle models
+  // It acts as a simple wrapper to ModelUpdateReqWithId, but passes the opposite (odd/even) model ID
+  ModelUpdateReqWithId(config.GetModelId() ^ 1);
 }
 
 static void ConfigChangeCommit()
@@ -1490,6 +1502,7 @@ void setup()
 
   registerButtonFunction(ACTION_BIND, EnterBindingMode);
   registerButtonFunction(ACTION_INCREASE_POWER, cyclePower);
+  registerButtonFunction(ACTION_TOGGLE_MODEL_ID, ToggleModelID);
 
   devicesStart();
 


### PR DESCRIPTION
This is a new feature to help users that want to use a relay setup with ELRS, for example, if you want to mount you TX module on a tripod or mast, or outside the car (for cold / hot weather) etc:
E.g. something like this:
![Screenshot_5](https://github.com/user-attachments/assets/1896d401-1379-4684-8c57-7caf1a81b5d5)


One of the challenges with using a relay setup is that changing the relay TX's power output and packet rate is very difficult. This is because the relay TX cannot be accessed via the LUA (you can only see the settings for the handset TX).

This is particularly frustrating if you are using the new LR1121 hardware, for example the RM Nomad, and you'd like to use K1000 for the nice fast data rate during MAVLink param download (i.e. after you first power up), but then you want to switch to 200hz-full right before you fly, for the long range LoRa advantages (at a slower data rate). Without access to the relay TX's LUA, this is impossible.

This feature adds a new button action that can be assigned to the buttons on a TX module which allows you to toggle between model 0 and model 1.

![Screenshot_4](https://github.com/user-attachments/assets/1e947c73-604f-4fc6-ba18-55327a548601)

The idea is:

1. You plug the relay TX into a handset for one-time setup
2. You activate model 0 in ETX
3. You jump into the LUA and setup the RF settings you want when you power up (i.e. K1000, F1000, on 10mW etc.)
4. You change to model 1 in ETX
5. You setup the RF settings you want for flight (i.e. 200hz-full on 1W etc.)
6. You mount your relay TX on the tripod / wherever, and when you power up, you will be in model 0
7. You download params, the mission, etc.
8. When you are ready to launch, you hold the button on the relay TX to toggle to model 1, and now you're in your desired RF params for flight.

Quick demo video of the model toggling:
https://github.com/user-attachments/assets/c2e638d0-c8d4-446f-99c7-a87c166a021c

