### PR TITLE
Extract joystick to separate device

### DIFF
--- a/src/lib/SCREEN/FiveWayButton/FiveWayButton.h
+++ b/src/lib/SCREEN/FiveWayButton/FiveWayButton.h
@@ -22,6 +22,8 @@ private:
     int keyInProcess;
     uint32_t keyDownStart;
     bool isLongPressed;
+    volatile int key = INPUT_KEY_NO_PRESS;
+
 #if defined(JOY_ADC_VALUES)
     static uint16_t joyAdcValues[N_JOY_ADC_VALUES];
     uint16_t fuzzValues[N_JOY_ADC_VALUES];
@@ -34,7 +36,10 @@ public:
     FiveWayButton();
     void init();
     void update(int *keyValue, bool *keyLongPressed);
+    void sample();
 
     static constexpr uint32_t KEY_DEBOUNCE_MS = 25;
     static constexpr uint32_t KEY_LONG_PRESS_MS = 1000;
 };
+
+extern FiveWayButton fivewaybutton;

--- a/src/lib/SCREEN/devScreen.cpp
+++ b/src/lib/SCREEN/devScreen.cpp
@@ -16,7 +16,6 @@ Display *display;
 
 #ifdef HAS_FIVE_WAY_BUTTON
 #include "FiveWayButton/FiveWayButton.h"
-FiveWayButton fivewaybutton;
 #endif
 
 #ifdef HAS_GSENSOR
@@ -146,9 +145,6 @@ static int handle(void)
 
 static void initialize()
 {
-#ifdef HAS_FIVE_WAY_BUTTON
-    fivewaybutton.init();
-#endif
     if (OPT_USE_OLED_I2C || OPT_USE_OLED_SPI || OPT_USE_OLED_SPI_SMALL || OPT_HAS_TFT_SCREEN)
     {
         if (OPT_HAS_TFT_SCREEN)

--- a/src/lib/SCREEN/devScreen.h
+++ b/src/lib/SCREEN/devScreen.h
@@ -3,3 +3,4 @@
 #include "device.h"
 
 extern device_t Screen_device;
+extern device_t Joystick_device;

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -119,6 +119,9 @@ device_affinity_t ui_devices[] = {
 #ifdef HAS_SCREEN
   {&Screen_device, 0},
 #endif
+#ifdef HAS_FIVE_WAY_BUTTON
+  {&Joystick_device, 1},
+#endif
 #ifdef HAS_GSENSOR
   {&Gsensor_device, 0},
 #endif


### PR DESCRIPTION
This is necessary because the analogRead for the joystick (when run on the second core) appears to interfere with the main codepath SPI and/or interrupts, causing the link to drop. It looks like slipped timer to me.
This only appeared on 333Hz mode on LR1121 based TX modules with an OLED and Joystick.

The solution/work-around is to extract the reading of the Joystick analog signal to a seperate device then can run on the main core and so will not be called when ISR code is running.