### PR TITLE
ADC sampling fix

### DIFF
--- a/src/lib/ADC/devADC.cpp
+++ b/src/lib/ADC/devADC.cpp
@@ -27,18 +27,18 @@ static int timeout()
     extern volatile bool busyTransmitting;
     static bool fullWait = true;
 
-    // if called because of a full-timeout and the main loop is NOT transmitting then we will
+    // if called because of a full-timeout and the main loop is transmitting then we will
     // leave the fullWait flag true and return with an immediate timeout so we can wait for
-    // the main loop to be transmitting, which will pop us into the next state.
-    if (fullWait && !busyTransmitting) return DURATION_IMMEDIATELY;
+    // the main loop to finish transmitting, which will pop us into the next state.
+    if (fullWait && busyTransmitting) return DURATION_IMMEDIATELY;
     fullWait = false;
 
-    // If the main loop is transmitting then return with an immediate timeout until it transitions
-    // to not transmitting
-    if (busyTransmitting) return DURATION_IMMEDIATELY;
+    // If the main loop is NOT transmitting then return with an immediate timeout until it transitions
+    // to transmitting
+    if (!busyTransmitting) return DURATION_IMMEDIATELY;
 
     // If we reach this point we are assured that the main loop has just transitioned from
-    // transmitting to not transmitting, so it's safe to read the ADC
+    // not transmitting to transmitting, so it's safe to read the ADC
 #if defined(GPIO_PIN_JOYSTICK)
     if (GPIO_PIN_JOYSTICK != UNDEF_PIN)
     {

--- a/src/lib/ADC/devADC.cpp
+++ b/src/lib/ADC/devADC.cpp
@@ -1,0 +1,41 @@
+#include "targets.h"
+#include "devADC.h"
+
+#define ADC_READING_PERIOD_MS 20
+
+static volatile int analogReadings[ADC_MAX_DEVICES];
+
+int getADCReading(adc_reading reading)
+{
+    return analogReadings[reading];
+}
+
+static int start()
+{
+    if (GPIO_PIN_JOYSTICK != UNDEF_PIN)
+    {
+        return DURATION_IMMEDIATELY;
+    }
+    return DURATION_NEVER;
+}
+
+static int timeout()
+{
+    extern volatile bool busyTransmitting;
+    if (busyTransmitting)
+    {
+        return DURATION_IMMEDIATELY;
+    }
+    if (GPIO_PIN_JOYSTICK != UNDEF_PIN)
+    {
+        analogReadings[ADC_JOYSTICK] = analogRead(GPIO_PIN_JOYSTICK);
+    }
+    return ADC_READING_PERIOD_MS;
+}
+
+device_t ADC_device = {
+    .initialize = nullptr,
+    .start = start,
+    .event = nullptr,
+    .timeout = timeout,
+};

--- a/src/lib/ADC/devADC.cpp
+++ b/src/lib/ADC/devADC.cpp
@@ -1,4 +1,5 @@
 #include "targets.h"
+#if defined(TARGET_TX)
 #include "devADC.h"
 
 #define ADC_READING_PERIOD_MS 20
@@ -12,10 +13,12 @@ int getADCReading(adc_reading reading)
 
 static int start()
 {
+#if defined(GPIO_PIN_JOYSTICK)
     if (GPIO_PIN_JOYSTICK != UNDEF_PIN)
     {
         return DURATION_IMMEDIATELY;
     }
+#endif
     return DURATION_NEVER;
 }
 
@@ -36,10 +39,12 @@ static int timeout()
 
     // If we reach this point we are assured that the main loop has just transitioned from
     // transmitting to not transmitting, so it's safe to read the ADC
+#if defined(GPIO_PIN_JOYSTICK)
     if (GPIO_PIN_JOYSTICK != UNDEF_PIN)
     {
         analogReadings[ADC_JOYSTICK] = analogRead(GPIO_PIN_JOYSTICK);
     }
+#endif
     fullWait = true;
     return ADC_READING_PERIOD_MS;
 }
@@ -50,3 +55,4 @@ device_t ADC_device = {
     .event = nullptr,
     .timeout = timeout,
 };
+#endif

--- a/src/lib/ADC/devADC.cpp
+++ b/src/lib/ADC/devADC.cpp
@@ -45,6 +45,12 @@ static int timeout()
         analogReadings[ADC_JOYSTICK] = analogRead(GPIO_PIN_JOYSTICK);
     }
 #endif
+#if defined(GPIO_PIN_PA_PDET)
+    if (GPIO_PIN_PA_PDET != UNDEF_PIN)
+    {
+        analogReadings[ADC_PA_PDET] = analogReadMilliVolts(GPIO_PIN_PA_PDET);
+    }
+#endif
     fullWait = true;
     return ADC_READING_PERIOD_MS;
 }

--- a/src/lib/ADC/devADC.h
+++ b/src/lib/ADC/devADC.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "targets.h"
+#include "device.h"
+
+enum adc_reading {
+    ADC_JOYSTICK,
+    ADC_MAX_DEVICES
+};
+
+extern int getADCReading(adc_reading reading);
+extern device_t ADC_device;

--- a/src/lib/ADC/devADC.h
+++ b/src/lib/ADC/devADC.h
@@ -5,6 +5,7 @@
 
 enum adc_reading {
     ADC_JOYSTICK,
+    ADC_PA_PDET,
     ADC_MAX_DEVICES
 };
 

--- a/src/lib/SCREEN/FiveWayButton/FiveWayButton.cpp
+++ b/src/lib/SCREEN/FiveWayButton/FiveWayButton.cpp
@@ -1,5 +1,6 @@
 #ifdef HAS_FIVE_WAY_BUTTON
 #include "FiveWayButton.h"
+#include "devADC.h"
 
 #if defined(GPIO_PIN_JOYSTICK)
 #if !defined(JOY_ADC_VALUES)
@@ -68,7 +69,7 @@ int FiveWayButton::readKey()
 #if defined(GPIO_PIN_JOYSTICK)
     if (GPIO_PIN_JOYSTICK != UNDEF_PIN)
     {
-        uint16_t value = analogRead(GPIO_PIN_JOYSTICK);
+        const uint16_t value = getADCReading(ADC_JOYSTICK);
 
         constexpr uint8_t IDX_TO_INPUT[N_JOY_ADC_VALUES - 1] =
             {INPUT_KEY_UP_PRESS, INPUT_KEY_DOWN_PRESS, INPUT_KEY_LEFT_PRESS, INPUT_KEY_RIGHT_PRESS, INPUT_KEY_OK_PRESS};

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -10,6 +10,7 @@
 #include "stubborn_sender.h"
 
 #include "devHandset.h"
+#include "devADC.h"
 #include "devLED.h"
 #include "devScreen.h"
 #include "devBuzzer.h"
@@ -101,6 +102,7 @@ device_affinity_t ui_devices[] = {
   {&RGB_device, 0},
 #endif
   {&LUA_device, 1},
+  {&ADC_device, 1},
 #if defined(USE_TX_BACKPACK)
   {&Backpack_device, 0},
 #endif


### PR DESCRIPTION
# Problem
`analogRead` for the joystick (when run on the second core) interferes with the main codepath SPI and/or interrupts, causing the link to skip out of alignment i.e. the packet sequence becomes out-of-step.

This manifested itself on 333Hz mode on LR1121 based TX modules with an OLED and Joystick.

# Solution
Create a new device to handle the ADC reads for the TX module. The device will guarantee that reads only occur on the rising edge of the `busyTransmitting`, once the ISR completes, this is when there is the most "dead time" in the main loop.

The PA PowerDetect device has also been changed to use the ADC device to get analog values for power detection.

