### PR TITLE
Adhere to the CRSF spec for folders

### DIFF
--- a/src/lib/LUA/lua.cpp
+++ b/src/lib/LUA/lua.cpp
@@ -28,8 +28,18 @@ static uint8_t parameterIndex;
 static uint8_t parameterArg;
 static volatile bool UpdateParamReq = false;
 
-static struct luaPropertiesCommon *paramDefinitions[LUA_MAX_PARAMS] = {0}; // array of luaItem_*
-static luaCallback paramCallbacks[LUA_MAX_PARAMS] = {0};
+static luaItem_folder luaAgentLite = {
+    .common = {
+        .name = "HooJ",
+        .type = CRSF_FOLDER,
+        .id = 0,
+        .parent = 0
+      },
+  };
+
+static luaPropertiesCommon *paramDefinitions[LUA_MAX_PARAMS] = {(luaPropertiesCommon *)&luaAgentLite, nullptr}; // array of luaItem_*
+static luaCallback paramCallbacks[LUA_MAX_PARAMS] = {nullptr};
+
 static uint8_t lastLuaField = 0;
 static uint8_t nextStatusChunk = 0;
 
@@ -326,23 +336,7 @@ void luaParamUpdateReq(uint8_t type, uint8_t index, uint8_t arg)
 
 void registerLUAParameter(void *definition, luaCallback callback, uint8_t parent)
 {
-  if (definition == nullptr)
-  {
-    static struct luaItem_folder luaAgentLite = {
-        .common = {
-          .name = "HooJ",
-          .type = CRSF_FOLDER,
-          .id = 0,
-          .parent = 0
-        },
-    };
-
-    paramDefinitions[0] = (struct luaPropertiesCommon *)&luaAgentLite;
-    paramCallbacks[0] = nullptr;
-    return;
-  }
-
-  struct luaPropertiesCommon *p = (struct luaPropertiesCommon *)definition;
+  luaPropertiesCommon *p = (struct luaPropertiesCommon *)definition;
   lastLuaField++;
   p->id = lastLuaField;
   p->parent = parent;

--- a/src/lib/LUA/rx_devLUA.cpp
+++ b/src/lib/LUA/rx_devLUA.cpp
@@ -608,7 +608,6 @@ static void registerLuaParameters()
 
   registerLUAParameter(&luaModelNumber);
   registerLUAParameter(&luaELRSversion);
-  registerLUAParameter(nullptr);
 }
 
 static void updateBindModeLabel()

--- a/src/lib/LUA/tx_devLUA.cpp
+++ b/src/lib/LUA/tx_devLUA.cpp
@@ -866,7 +866,6 @@ static void registerLuaParameters()
   }
   strlcat(version_domain, FHSSconfig->domain, sizeof(version_domain));
   registerLUAParameter(&luaELRSversion);
-  registerLUAParameter(NULL);
 }
 
 static int event()


### PR DESCRIPTION
As described in #3121, ELRS was not correctly forming the folder parameter response packets.
As a side benefit, this fix makes TBS Agent lite much more usable with ELRS!

## AgentLite prior to this PR
![screen-2025-03-28-102628](https://github.com/user-attachments/assets/de43a987-9550-4035-989a-fcad30a54019)

## AgentLite after this PR
![screen-2025-03-28-103025](https://github.com/user-attachments/assets/65be94c8-55ae-49c5-b114-353daa3a12f6)
![screen-2025-03-28-103032](https://github.com/user-attachments/assets/46003a87-6ffa-4875-a183-4fa7e662f70e)
![screen-2025-03-28-103042](https://github.com/user-attachments/assets/fdacbc5c-74ec-46f8-9ac6-ac9861d369d1)
