### PR TITLE
Allow DShot to send zero value to allow for AM32 initialization

### DIFF
--- a/src/lib/ServoOutput/DShotRMT.cpp
+++ b/src/lib/ServoOutput/DShotRMT.cpp
@@ -102,17 +102,22 @@ bool DShotRMT::begin(dshot_mode_t dshot_mode, bool is_bidirectional) {
 // ...the config part is done, now the calculating and sending part
 void DShotRMT::send_dshot_value(uint16_t throttle_value, telemetric_request_t telemetric_request) {
 	dshot_packet_t dshot_rmt_packet = { };
+	
+	if (throttle_value == 0) {
+		dshot_rmt_packet.throttle_value = 0;
+	} else {
+		if (throttle_value < DSHOT_THROTTLE_MIN) {
+			throttle_value = DSHOT_THROTTLE_MIN;
+		}
 
-	if (throttle_value < DSHOT_THROTTLE_MIN) {
-		throttle_value = DSHOT_THROTTLE_MIN;
+		if (throttle_value > DSHOT_THROTTLE_MAX) {
+			throttle_value = DSHOT_THROTTLE_MAX;
+		}
+
+		// ...packets are the same for bidirectional mode
+		dshot_rmt_packet.throttle_value = throttle_value;
 	}
-
-	if (throttle_value > DSHOT_THROTTLE_MAX) {
-		throttle_value = DSHOT_THROTTLE_MAX;
-	}
-
-	// ...packets are the same for bidirectional mode
-	dshot_rmt_packet.throttle_value = throttle_value;
+	
 	dshot_rmt_packet.telemetric_request = telemetric_request;
 	dshot_rmt_packet.checksum = this->calc_dshot_chksum(dshot_rmt_packet);
 


### PR DESCRIPTION
Some ESC firmware implementations require an initial DShot command of `0` (disarmed) before allowing arming. 

devServoOutput.cpp sent a DShot value of 0 during start: https://github.com/ExpressLRS/ExpressLRS/blob/2e61e33723b3247300f95ed46ceee9648d536137/src/lib/ServoOutput/devServoOutput.cpp#L220

But this value was being overwritten by DSHOT_THROTTLE_MIN in DShotRMT.cpp. This adds an additional check to see if throttle_value = 0 and prevents it from being overwritten with DSHOT_THROTTLE_MIN. 