### PR TITLE
Dshot 3D mode, allowing for both forward and reverse rotation

### DIFF
--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -90,7 +90,9 @@ function updatePwmSettings(arPwm) {
     const modes = ['50Hz', '60Hz', '100Hz', '160Hz', '333Hz', '400Hz', '10KHzDuty', 'On/Off'];
     if (features & 16) {
       modes.push('DShot');
+      modes.push('DShot-3D');
     } else {
+      modes.push(undefined);
       modes.push(undefined);
     }
     if (features & 1) {

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -212,13 +212,14 @@ enum eServoOutputMode : uint8_t
     som10KHzDuty,   // 6:  10kHz duty
     somOnOff,       // 7:  Digital 0/1 mode
     somDShot,       // 8:  DShot300
-    somSerial,      // 9:  primary Serial
-    somSCL,         // 10: I2C clock signal
-    somSDA,         // 11: I2C data line
-    somPwm,         // 12: true PWM mode (NOT SUPPORTED)
+    somDShot3D,     // 9:  DShot300 3D
+    somSerial,      // 10:  primary Serial
+    somSCL,         // 11: I2C clock signal
+    somSDA,         // 12: I2C data line
+    somPwm,         // 13: true PWM mode (NOT SUPPORTED)
 #if defined(PLATFORM_ESP32)
-    somSerial1RX,   // 13: secondary Serial RX
-    somSerial1TX,   // 14: secondary Serial TX
+    somSerial1RX,   // 14: secondary Serial RX
+    somSerial1TX,   // 15: secondary Serial TX
 #endif
 };
 

--- a/src/lib/ServoOutput/DShotRMT.cpp
+++ b/src/lib/ServoOutput/DShotRMT.cpp
@@ -99,6 +99,10 @@ bool DShotRMT::begin(dshot_mode_t dshot_mode, bool is_bidirectional) {
 	return rmt_driver_install(dshot_tx_rmt_config.channel, 0, 0);
 }
 
+void DShotRMT::set_looping(bool x) {
+	rmt_set_tx_loop_mode(rmt_channel, x);
+}
+
 // ...the config part is done, now the calculating and sending part
 void DShotRMT::send_dshot_value(uint16_t throttle_value, telemetric_request_t telemetric_request) {
 	dshot_packet_t dshot_rmt_packet = { };

--- a/src/lib/ServoOutput/DShotRMT.h
+++ b/src/lib/ServoOutput/DShotRMT.h
@@ -95,6 +95,7 @@ public:
 
 	// ...safety first ...no parameters, no DShot
 	bool begin(dshot_mode_t dshot_mode = DSHOT_OFF, bool is_bidirectional = false);
+	void set_looping(bool);
 	void send_dshot_value(uint16_t throttle_value, telemetric_request_t telemetric_request = NO_TELEMETRIC);
 
 private:

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -51,12 +51,35 @@ static void servoWrite(uint8_t ch, uint16_t us)
 {
     const rx_config_pwm_t *chConfig = config.GetPwmChannel(ch);
 #if defined(PLATFORM_ESP32)
-    if ((eServoOutputMode)chConfig->val.mode == somDShot)
+    if ((eServoOutputMode)chConfig->val.mode == somDShot || (eServoOutputMode)chConfig->val.mode == somDShot3D)
     {
         // DBGLN("Writing DShot output: us: %u, ch: %d", us, ch);
         if (dshotInstances[ch])
         {
-            dshotInstances[ch]->send_dshot_value(((us - 1000) * 2) + 47); // Convert PWM signal in us to DShot value
+            if (us > 0) { // check if we actually want a pulse (for no-pulse failsafe)
+                if ((eServoOutputMode)chConfig->val.mode == somDShot) {
+                    uint16_t x = ((us - 1000) * 2) + (DSHOT_THROTTLE_MIN - 1); // Convert PWM signal in us to DShot value
+                    x = x <= DSHOT_THROTTLE_MIN ? 0 : (x > DSHOT_THROTTLE_MAX ? DSHOT_THROTTLE_MAX : x); // limit within range, and send special 0 for stop
+                    dshotInstances[ch]->send_dshot_value(x);
+                }
+                else if ((eServoOutputMode)chConfig->val.mode == somDShot3D) {
+                    uint16_t x;
+                    if (us == 1500) { // stopped
+                        x = 0;
+                    }
+                    else if (us > 1500) { // forward
+                        x = fmap(us, 1501, 2012, 1048, 2047);
+                    }
+                    else { // reverse
+                        x = fmap(us, 1499, 988, 48, 1047);
+                    }
+                    dshotInstances[ch]->send_dshot_value(x);
+                }
+            }
+            else {
+                // getting an actual zero microsecond command means the failsafe mode is no-pulse
+                dshotInstances[ch]->set_looping(false);
+            }
         }
     }
     else
@@ -169,7 +192,7 @@ static bool initialize()
             pin = UNDEF_PIN;
         }
 #if defined(PLATFORM_ESP32)
-        else if (mode == somDShot)
+        else if (mode == somDShot || mode == somDShot3D)
         {
             if (rmtCH < RMT_MAX_CHANNELS)
             {
@@ -214,7 +237,7 @@ static int start()
             pwmChannels[ch] = PWM.allocate(servoPins[ch], frequency);
         }
 #if defined(PLATFORM_ESP32)
-        else if (((eServoOutputMode)chConfig->val.mode) == somDShot)
+        else if (((eServoOutputMode)chConfig->val.mode) == somDShot || ((eServoOutputMode)chConfig->val.mode) == somDShot3D)
         {
             dshotInstances[ch]->begin(DSHOT300, false); // Set DShot protocol and bidirectional dshot bool
             dshotInstances[ch]->send_dshot_value(0);         // Set throttle low so the ESC can continue initialsation


### PR DESCRIPTION
DShot does not work linearly, when controlling a ESC configured for "3D", the values are not linear

The stop value is 0, but the lowest throttle value for forward rotation is 1048, the highest throttle forward is 2047. The lowest throttle while reversing is 49, and the highest throttle while reversing is 1047.

But this is also completely different for a ESC configured for single-direction rotation, where 0 means stop, 48 means low throttle, and 2047 means max throttle.

This PR adds a 3D mode for DShot, the user can choose this from the drop-down menu within the Wi-Fi web page user interface. The code in `lib\ServoOutput\devServoOutput.cpp` has been edited to remap the throttle values properly for the selected mode.
