### PR TITLE
More DShot channels for ESP32-C3

### DIFF
--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -90,7 +90,9 @@ function updatePwmSettings(arPwm) {
     const modes = ['50Hz', '60Hz', '100Hz', '160Hz', '333Hz', '400Hz', '10KHzDuty', 'On/Off'];
     if (features & 16) {
       modes.push('DShot');
+      modes.push('DShot-3D');
     } else {
+      modes.push(undefined);
       modes.push(undefined);
     }
     if (features & 1) {

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -212,13 +212,14 @@ enum eServoOutputMode : uint8_t
     som10KHzDuty,   // 6:  10kHz duty
     somOnOff,       // 7:  Digital 0/1 mode
     somDShot,       // 8:  DShot300
-    somSerial,      // 9:  primary Serial
-    somSCL,         // 10: I2C clock signal
-    somSDA,         // 11: I2C data line
-    somPwm,         // 12: true PWM mode (NOT SUPPORTED)
+    somDShot3D,     // 9:  DShot300 3D
+    somSerial,      // 10:  primary Serial
+    somSCL,         // 11: I2C clock signal
+    somSDA,         // 12: I2C data line
+    somPwm,         // 13: true PWM mode (NOT SUPPORTED)
 #if defined(PLATFORM_ESP32)
-    somSerial1RX,   // 13: secondary Serial RX
-    somSerial1TX,   // 14: secondary Serial TX
+    somSerial1RX,   // 14: secondary Serial RX
+    somSerial1TX,   // 15: secondary Serial TX
 #endif
 };
 

--- a/src/lib/ServoOutput/DShotRMT.cpp
+++ b/src/lib/ServoOutput/DShotRMT.cpp
@@ -99,6 +99,10 @@ bool DShotRMT::begin(dshot_mode_t dshot_mode, bool is_bidirectional) {
 	return rmt_driver_install(dshot_tx_rmt_config.channel, 0, 0);
 }
 
+void DShotRMT::set_looping(bool x) {
+	rmt_set_tx_loop_mode(rmt_channel, x);
+}
+
 // ...the config part is done, now the calculating and sending part
 void DShotRMT::send_dshot_value(uint16_t throttle_value, telemetric_request_t telemetric_request) {
 	dshot_packet_t dshot_rmt_packet = { };

--- a/src/lib/ServoOutput/DShotRMT.cpp
+++ b/src/lib/ServoOutput/DShotRMT.cpp
@@ -1,4 +1,5 @@
 #if defined(PLATFORM_ESP32)
+
 //
 // Name:		DShotRMT.cpp
 // Created: 	20.03.2021 00:49:15
@@ -6,22 +7,55 @@
 //
 
 #include "DShotRMT.h"
+#include "common.h"
+#include "config.h"
+#include "logging.h"
 
-DShotRMT::DShotRMT(gpio_num_t gpio, rmt_channel_t rmtChannel) : gpio_num(gpio), rmt_channel(rmtChannel) {
-	// ...create clean packet
-	encode_dshot_to_rmt(DSHOT_NULL_PACKET);
+static const rmt_channel_t rmt_channel = (rmt_channel_t)0; // instead of using many RMT channels, we are using just one, channel 0 is capable of transmitting on both ESP32-classic and ESP32-C3 so we pick 0
+
+static DShotRMT *head_node = NULL, *cur_node = NULL, *tail_node; // linked list of all initailized RMT instances
+
+static int prev_pin = -1; // we need to remember what the previous GPIO pin used was to remove it from the RMT (setting a new RMT pin does not unset the previous pin)
+
+// latch status to indicate if the RMT driver has been installed or uninstalled, so we don't do it twice 
+static bool has_inited = false;
+static bool has_deinited = false;
+
+static rmt_item32_t dshot_tx_rmt_item[DSHOT_PACKET_LENGTH + 1];
+
+DShotRMT::DShotRMT(gpio_num_t gpio, int idx) : gpio_num(gpio), my_idx(idx) {
 }
 
 DShotRMT::~DShotRMT() {
+	if (has_deinited) {
+		// only allow uninstall once, not important but prevents errors over the debug log
+		return;
+	}
 	rmt_tx_stop(rmt_channel);
 	rmt_driver_uninstall(rmt_channel);
+	has_deinited = true;
+	head_node = NULL; // this isn't proper but all the instances are deleted at once anyways
+	cur_node = NULL;
 }
 
 bool DShotRMT::begin(dshot_mode_t dshot_mode, bool is_bidirectional) {
+
+	if (head_node == NULL) {
+		// first one, initialize linked list
+		head_node = this;
+		tail_node = this;
+		cur_node = this;
+		this->next_node = (DShotRMT*)this;
+	}
+	else {
+		// not the first node, so insert it as the next node
+		tail_node->next_node = (DShotRMT*)this;
+		tail_node = this;
+		this->next_node = head_node;
+	}
+
 	mode = dshot_mode;
 	bidirectional = is_bidirectional;
-
-	uint16_t ticks_per_bit;
 
 	switch (mode) {
 		case DSHOT150:
@@ -67,24 +101,12 @@ bool DShotRMT::begin(dshot_mode_t dshot_mode, bool is_bidirectional) {
 		.clk_div = DSHOT_CLK_DIVIDER,
 		.mem_block_num = uint8_t(RMT_CHANNEL_MAX - uint8_t(rmt_channel)),
 		.tx_config = {
-        	.idle_level = bidirectional ? RMT_IDLE_LEVEL_HIGH : RMT_IDLE_LEVEL_LOW,
+			.idle_level = bidirectional ? RMT_IDLE_LEVEL_HIGH : RMT_IDLE_LEVEL_LOW,
 			.carrier_en = false,
-			.loop_en = true,
+			.loop_en = false,
 			.idle_output_en = true,
 		},
 	};
-
-	// ...pause "bit" added to each frame
-    if (bidirectional) {
-        dshot_tx_rmt_item[DSHOT_PAUSE_BIT].level0 = HIGH;
-        dshot_tx_rmt_item[DSHOT_PAUSE_BIT].level1 = HIGH;
-    } else {
-        dshot_tx_rmt_item[DSHOT_PAUSE_BIT].level0 = LOW;
-        dshot_tx_rmt_item[DSHOT_PAUSE_BIT].level1 = LOW;
-    }
-
-	dshot_tx_rmt_item[DSHOT_PAUSE_BIT].duration1 = 0;
-	dshot_tx_rmt_item[DSHOT_PAUSE_BIT].duration0 = 10000 - (16*ticks_per_bit) - 1;
 
 	// setup the RMT end marker
 	dshot_tx_rmt_item[DSHOT_PACKET_LENGTH-1].duration0 = 0;
@@ -92,23 +114,40 @@ bool DShotRMT::begin(dshot_mode_t dshot_mode, bool is_bidirectional) {
 	dshot_tx_rmt_item[DSHOT_PACKET_LENGTH-1].duration1 = 0;
 	dshot_tx_rmt_item[DSHOT_PACKET_LENGTH-1].level1 = LOW;
 
+	if (has_inited) { // only do installation once
+		return true;
+	}
+
 	// ...setup selected dshot mode
 	rmt_config(&dshot_tx_rmt_config);
 
 	// ...essential step, return the result
-	return rmt_driver_install(dshot_tx_rmt_config.channel, 0, 0);
+	esp_err_t ret = rmt_driver_install(dshot_tx_rmt_config.channel, 0, 0);
+
+	if (ret == ESP_OK) {
+		 // only do installation once
+		has_inited = true;
+		has_deinited = false;
+		encode_dshot_to_rmt(DSHOT_NULL_PACKET); // cache default timings
+		#ifdef DSHOTC3_DEBUG_INIT
+		DBGLN("Dshot RMT installed");
+		#endif
+		return true;
+	}
+	else {
+		DBGLN("Dshot RMT install failed - err %d", ret);
+		return false;
+	}
 }
 
 void DShotRMT::set_looping(bool x) {
-	rmt_set_tx_loop_mode(rmt_channel, x);
+	looping = x;
 }
 
 // ...the config part is done, now the calculating and sending part
 void DShotRMT::send_dshot_value(uint16_t throttle_value, telemetric_request_t telemetric_request) {
-	dshot_packet_t dshot_rmt_packet = { };
-	
 	if (throttle_value == 0) {
-		dshot_rmt_packet.throttle_value = 0;
+		next_packet.throttle_value = 0;
 	} else {
 		if (throttle_value < DSHOT_THROTTLE_MIN) {
 			throttle_value = DSHOT_THROTTLE_MIN;
@@ -119,54 +158,61 @@ void DShotRMT::send_dshot_value(uint16_t throttle_value, telemetric_request_t te
 		}
 
 		// ...packets are the same for bidirectional mode
-		dshot_rmt_packet.throttle_value = throttle_value;
+		next_packet.throttle_value = throttle_value;
 	}
 	
-	dshot_rmt_packet.telemetric_request = telemetric_request;
-	dshot_rmt_packet.checksum = this->calc_dshot_chksum(dshot_rmt_packet);
+	next_packet.telemetric_request = telemetric_request;
+	next_packet.checksum = this->calc_dshot_chksum(next_packet);
 
-	output_rmt_data(dshot_rmt_packet);
+	has_new_data = true;
+	// only cache the next packet but don't need to encode it or send it yet, it'll be sent later
 }
 
 rmt_item32_t* DShotRMT::encode_dshot_to_rmt(uint16_t parsed_packet) {
-    // ...is bidirecional mode activated
-    if (bidirectional) {
-        // ..."invert" the signal duration
-        for (int i = 0; i < DSHOT_PAUSE_BIT; i++, parsed_packet <<= 1) 	{
-		    if (parsed_packet & 0b1000000000000000) {
-			    // set one
-			    dshot_tx_rmt_item[i].duration0 = ticks_one_low;
-			    dshot_tx_rmt_item[i].duration1 = ticks_one_high;
-		    }
-		    else {
-			    // set zero
-			    dshot_tx_rmt_item[i].duration0 = ticks_zero_low;
-			    dshot_tx_rmt_item[i].duration1 = ticks_zero_high;
-		    }
+	dshot_tx_rmt_item[DSHOT_PAUSE_BIT].duration1 = 0;
+	dshot_tx_rmt_item[DSHOT_PAUSE_BIT].duration0 = 10000 - (16*ticks_per_bit) - 1;
+
+	if (bidirectional) {
+		dshot_tx_rmt_item[DSHOT_PAUSE_BIT].level0 = HIGH; // ...pause "bit" added to each frame
+		dshot_tx_rmt_item[DSHOT_PAUSE_BIT].level1 = HIGH;
+		// ..."invert" the signal duration
+		for (int i = 0; i < DSHOT_PAUSE_BIT; i++, parsed_packet <<= 1) 	{
+			if (parsed_packet & 0b1000000000000000) {
+				// set one
+				dshot_tx_rmt_item[i].duration0 = ticks_one_low;
+				dshot_tx_rmt_item[i].duration1 = ticks_one_high;
+			}
+			else {
+				// set zero
+				dshot_tx_rmt_item[i].duration0 = ticks_zero_low;
+				dshot_tx_rmt_item[i].duration1 = ticks_zero_high;
+			}
 
 			dshot_tx_rmt_item[i].level0 = LOW;
 			dshot_tx_rmt_item[i].level1 = HIGH;
-        }
-    }
-
-    // ..."normal" DShot mode / "bidirectional" mode OFF
-    else {
-        for (int i = 0; i < DSHOT_PAUSE_BIT; i++, parsed_packet <<= 1) 	{
-		    if (parsed_packet & 0b1000000000000000) {
-			    // set one
-			    dshot_tx_rmt_item[i].duration0 = ticks_one_high;
-			    dshot_tx_rmt_item[i].duration1 = ticks_one_low;
-		    }
-		    else {
-			    // set zero
-			    dshot_tx_rmt_item[i].duration0 = ticks_zero_high;
-			    dshot_tx_rmt_item[i].duration1 = ticks_zero_low;
-		    }
+		}
+	}
+	// ..."normal" DShot mode / "bidirectional" mode OFF
+	else {
+		dshot_tx_rmt_item[DSHOT_PAUSE_BIT].level0 = LOW;
+		dshot_tx_rmt_item[DSHOT_PAUSE_BIT].level1 = LOW;
+	
+		for (int i = 0; i < DSHOT_PAUSE_BIT; i++, parsed_packet <<= 1) 	{
+			if (parsed_packet & 0b1000000000000000) {
+				// set one
+				dshot_tx_rmt_item[i].duration0 = ticks_one_high;
+				dshot_tx_rmt_item[i].duration1 = ticks_one_low;
+			}
+			else {
+				// set zero
+				dshot_tx_rmt_item[i].duration0 = ticks_zero_high;
+				dshot_tx_rmt_item[i].duration1 = ticks_zero_low;
+			}
 
 			dshot_tx_rmt_item[i].level0 = HIGH;
 			dshot_tx_rmt_item[i].level1 = LOW;
-        }
-    }
+		}
+	}
 
 	return dshot_tx_rmt_item;
 }
@@ -189,7 +235,7 @@ uint16_t DShotRMT::calc_dshot_chksum(const dshot_packet_t& dshot_packet) {
 uint16_t DShotRMT::prepare_rmt_data(const dshot_packet_t& dshot_packet) {
 	auto chksum = calc_dshot_chksum(dshot_packet);
 
-    // ..."construct" the packet
+	// ..."construct" the packet
 	uint16_t prepared_to_encode = (dshot_packet.throttle_value << 1) | dshot_packet.telemetric_request;
 	prepared_to_encode = (prepared_to_encode << 4) | chksum;
 
@@ -197,11 +243,57 @@ uint16_t DShotRMT::prepare_rmt_data(const dshot_packet_t& dshot_packet) {
 }
 
 // ...finally output using ESP32 RMT
-void DShotRMT::output_rmt_data(const dshot_packet_t& dshot_packet) {
-	encode_dshot_to_rmt(prepare_rmt_data(dshot_packet));
-
+void DShotRMT::output_rmt_data() {
 	rmt_tx_stop(rmt_channel);
+	set_pin();
+	encode_dshot_to_rmt(prepare_rmt_data(next_packet));
 	rmt_fill_tx_items(rmt_channel, dshot_tx_rmt_item, DSHOT_PACKET_LENGTH, 0);
 	rmt_tx_start(rmt_channel, true);
+	has_new_data = false;
 }
+
+void DShotRMT::set_pin() {
+	if (prev_pin >= 0) { // if there was a previously used pin that needs to be decoupled from RMT
+		// rmt_set_pin and rmt_config only seems to add pins to the RMT mux
+		// they do not remove pins
+		// so we must manually remove the previous pin from the mux
+		pinMode(prev_pin, INPUT);
+		if (bidirectional == false) {
+			digitalWrite(prev_pin, LOW);
+			pinMode(prev_pin, OUTPUT);
+		}
+	}
+	pinMode(gpio_num, OUTPUT);
+	rmt_set_gpio(rmt_channel, RMT_MODE_TX, gpio_num, false);
+	rmt_set_idle_level(rmt_channel, bidirectional ? false : true, bidirectional ? RMT_IDLE_LEVEL_HIGH : RMT_IDLE_LEVEL_LOW);
+	prev_pin = gpio_num;
+}
+
+void DShotRMT::poll() {
+	if (cur_node == NULL) { // no instances initalized, do nothing
+		return;
+	}
+	static uint32_t last_time_us = 0;
+	uint32_t now_us = micros();
+	if ((now_us - last_time_us) < 500) {
+		// make sure enough time has passed (RMT driver does not indicate end of transmission at the right time)
+		// the number 500 is found by using a logic analyzer to see how often a dshot packet gets cut off
+		return;
+	}
+	rmt_channel_status_result_t status;
+	if (rmt_get_channel_status(&status) != ESP_OK || status.status[rmt_channel] != RMT_CHANNEL_IDLE) {
+		// make sure RMT is actually idle
+		return;
+	}
+	DShotRMT* inst = cur_node;
+	cur_node = (DShotRMT*)inst->next_node; // cycle through linked list
+	if (inst->has_new_data || //  send if required
+		(inst->looping && (now_us - inst->last_send_time) >= 2000) // limit looping speed
+		) {
+		inst->output_rmt_data(); // actually send the data, this will set the pin first, and clear the has_new_data flag
+		inst->last_send_time = now_us;
+		last_time_us = now_us;
+	}
+}
+
 #endif

--- a/src/lib/ServoOutput/DShotRMT.h
+++ b/src/lib/ServoOutput/DShotRMT.h
@@ -95,6 +95,7 @@ public:
 
 	// ...safety first ...no parameters, no DShot
 	bool begin(dshot_mode_t dshot_mode = DSHOT_OFF, bool is_bidirectional = false);
+	void set_looping(bool);
 	void send_dshot_value(uint16_t throttle_value, telemetric_request_t telemetric_request = NO_TELEMETRIC);
 
 private:

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -127,6 +127,9 @@ static void servosFailsafe()
 static void servosUpdate(unsigned long now)
 {
     static uint32_t lastUpdate;
+
+    DShotRMT::poll();
+
     if (newChannelsAvailable)
     {
         newChannelsAvailable = false;

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -51,12 +51,35 @@ static void servoWrite(uint8_t ch, uint16_t us)
 {
     const rx_config_pwm_t *chConfig = config.GetPwmChannel(ch);
 #if defined(PLATFORM_ESP32)
-    if ((eServoOutputMode)chConfig->val.mode == somDShot)
+    if ((eServoOutputMode)chConfig->val.mode == somDShot || (eServoOutputMode)chConfig->val.mode == somDShot3D)
     {
         // DBGLN("Writing DShot output: us: %u, ch: %d", us, ch);
         if (dshotInstances[ch])
         {
-            dshotInstances[ch]->send_dshot_value(((us - 1000) * 2) + 47); // Convert PWM signal in us to DShot value
+            if (us > 0) { // check if we actually want a pulse (for no-pulse failsafe)
+                if ((eServoOutputMode)chConfig->val.mode == somDShot) {
+                    uint16_t x = ((us - 1000) * 2) + (DSHOT_THROTTLE_MIN - 1); // Convert PWM signal in us to DShot value
+                    x = x <= DSHOT_THROTTLE_MIN ? 0 : (x > DSHOT_THROTTLE_MAX ? DSHOT_THROTTLE_MAX : x); // limit within range, and send special 0 for stop
+                    dshotInstances[ch]->send_dshot_value(x);
+                }
+                else if ((eServoOutputMode)chConfig->val.mode == somDShot3D) {
+                    uint16_t x;
+                    if (us == 1500) { // stopped
+                        x = 0;
+                    }
+                    else if (us > 1500) { // forward
+                        x = fmap(us, 1501, 2012, 1048, 2047);
+                    }
+                    else { // reverse
+                        x = fmap(us, 1499, 988, 48, 1047);
+                    }
+                    dshotInstances[ch]->send_dshot_value(x);
+                }
+            }
+            else {
+                // getting an actual zero microsecond command means the failsafe mode is no-pulse
+                dshotInstances[ch]->set_looping(false);
+            }
         }
     }
     else
@@ -169,7 +192,7 @@ static bool initialize()
             pin = UNDEF_PIN;
         }
 #if defined(PLATFORM_ESP32)
-        else if (mode == somDShot)
+        else if (mode == somDShot || mode == somDShot3D)
         {
             if (rmtCH < RMT_MAX_CHANNELS)
             {
@@ -214,7 +237,7 @@ static int start()
             pwmChannels[ch] = PWM.allocate(servoPins[ch], frequency);
         }
 #if defined(PLATFORM_ESP32)
-        else if (((eServoOutputMode)chConfig->val.mode) == somDShot)
+        else if (((eServoOutputMode)chConfig->val.mode) == somDShot || ((eServoOutputMode)chConfig->val.mode) == somDShot3D)
         {
             dshotInstances[ch]->begin(DSHOT300, false); // Set DShot protocol and bidirectional dshot bool
             dshotInstances[ch]->send_dshot_value(0);         // Set throttle low so the ESC can continue initialsation


### PR DESCRIPTION
DShot is sent by the DShotRMT library. The problem is: ESP32-C3 only has two RMT channels that are capable of transmission. 

In contrast, the Xtensa ESP32 has 8 RMT channels and is capable of outputting 8 DShot channels.

In order to add more DShot channels to ESP32-C3, I rewrote DShotRMT to use only one RMT channel, but change the pin that the RMT is connected to in a round robin fashion. This means one RMT channel can be used to output nearly unlimited number of DShot channels.

(the code is still hard coded with a 8 channel limit)
