### PR TITLE
Revert removal of #ifdefs

### DIFF
--- a/src/lib/ServoOutput/DShotRMT.cpp
+++ b/src/lib/ServoOutput/DShotRMT.cpp
@@ -1,4 +1,4 @@
-#if defined(PLATFORM_ESP32)
+#if defined(GPIO_PIN_PWM_OUTPUTS) && defined(PLATFORM_ESP32)
 //
 // Name:		DShotRMT.cpp
 // Created: 	20.03.2021 00:49:15

--- a/src/lib/ServoOutput/DShotRMT.cpp
+++ b/src/lib/ServoOutput/DShotRMT.cpp
@@ -1,4 +1,4 @@
-#if defined(GPIO_PIN_PWM_OUTPUTS) && defined(PLATFORM_ESP32)
+#if defined(TARGET_RX) && defined(PLATFORM_ESP32)
 //
 // Name:		DShotRMT.cpp
 // Created: 	20.03.2021 00:49:15

--- a/src/lib/ServoOutput/DShotRMT.h
+++ b/src/lib/ServoOutput/DShotRMT.h
@@ -1,4 +1,4 @@
-#if defined(GPIO_PIN_PWM_OUTPUTS) && defined(PLATFORM_ESP32)
+#if defined(TARGET_RX) && defined(PLATFORM_ESP32)
 //
 // Name:		DShotRMT.h
 // Created: 	20.03.2021 00:49:15

--- a/src/lib/ServoOutput/DShotRMT.h
+++ b/src/lib/ServoOutput/DShotRMT.h
@@ -1,4 +1,4 @@
-#if defined(PLATFORM_ESP32)
+#if defined(GPIO_PIN_PWM_OUTPUTS) && defined(PLATFORM_ESP32)
 //
 // Name:		DShotRMT.h
 // Created: 	20.03.2021 00:49:15

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -1,3 +1,5 @@
+#if defined(GPIO_PIN_PWM_OUTPUTS)
+
 #include "devServoOutput.h"
 #include "PWM.h"
 #include "CRSF.h"
@@ -268,3 +270,5 @@ device_t ServoOut_device = {
     .timeout = timeout,
     .subscribe = EVENT_CONNECTION_CHANGED
 };
+
+#endif

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -1,4 +1,4 @@
-#if defined(GPIO_PIN_PWM_OUTPUTS)
+#if defined(TARGET_RX)
 
 #include "devServoOutput.h"
 #include "PWM.h"

--- a/src/lib/ServoOutput/devServoOutput.h
+++ b/src/lib/ServoOutput/devServoOutput.h
@@ -1,5 +1,5 @@
 #pragma once
-#if defined(GPIO_PIN_PWM_OUTPUTS)
+#if defined(TARGET_RX)
 
 #include "device.h"
 #include "common.h"

--- a/src/lib/ServoOutput/devServoOutput.h
+++ b/src/lib/ServoOutput/devServoOutput.h
@@ -1,4 +1,5 @@
 #pragma once
+#if defined(GPIO_PIN_PWM_OUTPUTS)
 
 #include "device.h"
 #include "common.h"
@@ -11,3 +12,5 @@ extern device_t ServoOut_device;
 
 // Notify this unit that new channel data has arrived
 void servoNewChannelsAvailable();
+
+#endif


### PR DESCRIPTION
The #ifdef was removed as part of #3027 but PIO chose to include devServoOutput.cpp in it's dependencies for TX target. Reverts the #ifdefs for all servo output files.