### PR TITLE
Esp8266 airport uart

### DIFF
--- a/src/lib/Handset/CRSFHandset.cpp
+++ b/src/lib/Handset/CRSFHandset.cpp
@@ -78,11 +78,15 @@ void CRSFHandset::Begin()
         if (RecvModelUpdate) RecvModelUpdate();
     }
 #elif defined(PLATFORM_ESP8266)
-    // Uses default UART pins
-    CRSFHandset::Port.begin(UARTrequestedBaud);
-    // Invert RX/TX (not done, connection is full duplex uninverted)
-    //USC0(UART0) |= BIT(UCRXI) | BIT(UCTXI);
-    // No log message because this is our only UART
+    if (!firmwareOptions.is_airport) {
+        // Uses default UART pins
+        CRSFHandset::Port.begin(UARTrequestedBaud);
+        // Invert RX/TX (not done, connection is full duplex uninverted)
+        //USC0(UART0) |= BIT(UCRXI) | BIT(UCTXI);
+        // No log message because this is our only UART
+    } else {
+        CRSFHandset::Port.begin(firmwareOptions.uart_baud);
+    }
 #endif
 }
 

--- a/src/lib/Handset/NullHandset.cpp
+++ b/src/lib/Handset/NullHandset.cpp
@@ -1,0 +1,32 @@
+#include "NullHandset.h"
+#include <options.h>
+
+HardwareSerial Port(0);
+
+void NullHandset::Begin()
+{
+    Port.begin(firmwareOptions.uart_baud);
+}
+
+void NullHandset::End()
+{
+}
+
+bool NullHandset::IsArmed()
+{
+    return false;
+}
+
+void NullHandset::handleInput()
+{
+}
+
+void NullHandset::write(uint8_t *data, uint8_t len)
+{
+    Port.write(data, len);
+}
+
+uint8_t NullHandset::readBytes(uint8_t *data, uint8_t len)
+{
+    return Port.readBytes(data, len);
+}

--- a/src/lib/Handset/NullHandset.h
+++ b/src/lib/Handset/NullHandset.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "handset.h"
+
+// NullHandset is a class that represents a null object for the Handset interface, used when the Handset UART is consumed by Airport
+class NullHandset final : public Handset
+{
+public:
+    void Begin() override;
+    void End() override;
+    bool IsArmed() override;
+    void handleInput() override;
+    void write(uint8_t *data, uint8_t len) override;
+    uint8_t readBytes(uint8_t *data, uint8_t len) override;
+};

--- a/src/lib/Handset/devHandset.cpp
+++ b/src/lib/Handset/devHandset.cpp
@@ -4,6 +4,7 @@
 
 #include "CRSF.h"
 #include "CRSFHandset.h"
+#include "NullHandset.h"
 #include "POWERMGNT.h"
 #include "devHandset.h"
 
@@ -21,9 +22,18 @@ static bool initialize()
         handset = new AutoDetect();
         return true;
     }
-#endif
+#elif defined(PLATFORM_ESP8266)
+    // The 8266 only has one UART, so we can't use it for handset and airport
+    if (!firmwareOptions.is_airport) {
+        handset = new CRSFHandset();
+        return true;
+    }
+    handset = new NullHandset();
+    return true;
+#else
     handset = new CRSFHandset();
     return true;
+#endif
 }
 
 static int start()

--- a/src/lib/Handset/handset.h
+++ b/src/lib/Handset/handset.h
@@ -95,6 +95,16 @@ public:
      */
     uint32_t GetRCdataLastRecv() const { return RCdataLastRecv; }
 
+    /**
+     * @brief Called to send raw data to the handset object (if supported)
+     */
+    virtual void write(uint8_t *data, uint8_t len) {}
+
+    /**
+     * @brief Called to read raw data from the handset object (if supported)
+     */
+    virtual uint8_t readBytes(uint8_t *data, uint8_t len) { return 0; }
+
 #if defined(DEBUG_TX_FREERUN)
     /**
      * @brief Can be used to force a connected callback for debugging

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1194,7 +1194,11 @@ static void HandleUARTout()
       apOutputBuffer.lock();
       apOutputBuffer.popBytes(buf, size);
       apOutputBuffer.unlock();
+#if defined(PLATFORM_ESP8266)
+      handset->write(buf, size);
+#else
       TxUSB->write(buf, size);
+#endif
     }
   }
 }
@@ -1210,7 +1214,11 @@ static void HandleUARTin()
       if (size > 0)
       {
         uint8_t buf[size];
+#if defined(PLATFORM_ESP8266)
+        handset->readBytes(buf, size);
+#else
         TxUSB->readBytes(buf, size);
+#endif
         apInputBuffer.lock();
         apInputBuffer.pushBytes(buf, size);
         apInputBuffer.unlock();


### PR DESCRIPTION
ESP8266 RXes used as TXes can't be used for Airport since airport sends data out the TxUSB UART rather than the "main" UART, and ESP8266es don't have a TxUSB by default (or well kinda sorta but it's unidirectional in the best case so that's not very useful, now is it).

This nulls out the handset use of the main UART when in airport mode, and and stuffs airport data in/out that port instead.

TESTED=lol