### PR TITLE
Prevent interference from calling RXdoneISR

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -847,7 +847,8 @@ static void CheckConfigChangePending()
 
 bool ICACHE_RAM_ATTR RXdoneISR(SX12xxDriverCommon::rx_status const status)
 {
-  if (LQCalc.currentIsSet())
+  // busyTransmitting is required here to prevent accidential rxdone IRQs due to interference calling RXdoneISR.
+  if (LQCalc.currentIsSet() || busyTransmitting)
   {
     return false; // Already received tlm, do not run ProcessTLMpacket() again.
   }
@@ -859,7 +860,7 @@ bool ICACHE_RAM_ATTR RXdoneISR(SX12xxDriverCommon::rx_status const status)
     SetClearChannelAssessmentTime();
   }
 #endif
-  busyTransmitting = false;
+
   return packetSuccessful;
 }
 

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -847,7 +847,7 @@ static void CheckConfigChangePending()
 
 bool ICACHE_RAM_ATTR RXdoneISR(SX12xxDriverCommon::rx_status const status)
 {
-  // busyTransmitting is required here to prevent accidential rxdone IRQs due to interference calling RXdoneISR.
+  // busyTransmitting is required here to prevent accidental rxdone IRQs due to interference triggering RXdoneISR.
   if (LQCalc.currentIsSet() || busyTransmitting)
   {
     return false; // Already received tlm, do not run ProcessTLMpacket() again.


### PR DESCRIPTION
Under heavy noise/interference there is a chance that a 'fake' packet can be received by the TX module.  If this is done during setup for transmitting the next packet it can cause busyTransmitting to be set to false, and the following TXdoneISR() to also be cancelled.

This is bad.  Mainly due to HandleFHSS() not being run and the frequency not hopping.  This causes the Rx to no longer be in sync and disconnect, or have a very low LQ.

Below is an example of dio going high due to a rxdone, immediately after starting the cmds for transmitting the next packet.

Red highlights tx cmds, yellow rxdone cmds due to interference.

![image](https://github.com/user-attachments/assets/1235c1f1-c0e5-442e-ac6c-1829cd0db195)
