### PR TITLE
Fix ADC/Joystick when no handset connected

### DIFF
--- a/src/lib/ADC/devADC.cpp
+++ b/src/lib/ADC/devADC.cpp
@@ -1,5 +1,6 @@
 #include "targets.h"
 #if defined(TARGET_TX)
+#include "common.h"
 #include "devADC.h"
 
 #define ADC_READING_PERIOD_MS 20
@@ -30,12 +31,12 @@ static int timeout()
     // if called because of a full-timeout and the main loop is transmitting then we will
     // leave the fullWait flag true and return with an immediate timeout so we can wait for
     // the main loop to finish transmitting, which will pop us into the next state.
-    if (fullWait && busyTransmitting) return DURATION_IMMEDIATELY;
+    if (fullWait && busyTransmitting && connectionState < MODE_STATES) return DURATION_IMMEDIATELY;
     fullWait = false;
 
     // If the main loop is NOT transmitting then return with an immediate timeout until it transitions
     // to transmitting
-    if (!busyTransmitting) return DURATION_IMMEDIATELY;
+    if (!busyTransmitting && connectionState < MODE_STATES) return DURATION_IMMEDIATELY;
 
     // If we reach this point we are assured that the main loop has just transitioned from
     // not transmitting to transmitting, so it's safe to read the ADC


### PR DESCRIPTION
Fixes a bug introduced in PR #3112 

The ADC should always be allowed when the state is above MODE_STATES.
This allows the use of the joystick when not connected to a radio.

