### PR TITLE
Fixing BF4.6 passthrough incompatibility issue

### DIFF
--- a/src/python/BFinitPassthrough.py
+++ b/src/python/BFinitPassthrough.py
@@ -49,7 +49,7 @@ def bf_passthrough_init(port, requestedBaudrate, half_duplex=False):
     rl = SerialHelper.SerialHelper(s, 3., ['CCC', "# "])
     rl.clear()
     # Send start command '#'
-    rl.write_str("#", half_duplex)
+    rl.write_str("#", half_duplex, False)
     start = rl.read_line(2.).strip()
     #dbg_print("BF INIT: '%s'" % start.replace("\r", ""))
     if "CCC" in start:
@@ -91,7 +91,7 @@ def bf_passthrough_init(port, requestedBaudrate, half_duplex=False):
         if line.startswith("serial"):
             if SCRIPT_DEBUG:
                 dbg_print("  '%s'" % line)
-            config = re.search('serial ([0-9]+) ([0-9]+) ', line)
+            config = re.search('serial ((?:UART)?[0-9]+) ([0-9]+) ', line)
             if config and (int(config.group(2)) & 64 == 64):
                 dbg_print("    ** Serial RX config detected: '%s'" % line)
                 SerialRXindex = config.group(1)

--- a/src/python/SerialHelper.py
+++ b/src/python/SerialHelper.py
@@ -74,8 +74,12 @@ class SerialHelper:
             #   All written data is read into RX buffer
             serial.read(cnt)
 
-    def write_str(self, data, half_duplex=None):
-        self.write(data+'\r\n', half_duplex)
+    def write_str(self, data, half_duplex=None, new_line=True):
+        if (new_line):
+            self.write(data+'\r\n', half_duplex)
+        else:
+            self.write(data, half_duplex)
+
 
     def __convert_to_str(self, data):
         try:


### PR DESCRIPTION
In the BetaFlight 4.6, several changes caused incompatibility of ELRS RX BF Passthrough flashing.

In the recent BF versions, 
- Issuing CLI mode should be set by writing single `#`, not `#\r\n` (newline automatically added from `SerialHelper.write_str()`). This PR modified `write_str()` to allow writing without newline characters.
- BF's UART refactor changes how serial resources are enumerated. (ref: https://github.com/betaflight/betaflight/pull/13585)
  Example) 
  ```# serial
   serial VCP 1 115200 57600 0 115200
   serial UART1 0 115200 57600 0 115200
   serial UART2 0 115200 57600 0 115200
   serial UART3 0 115200 57600 0 115200
   serial UART4 0 115200 57600 0 115200
   serial UART5 0 115200 57600 0 115200
   serial UART6 64 115200 57600 0 115200
   serial UART7 0 115200 57600 0 115200
   serial UART8 0 115200 57600 0 115200
   ```
   Previously it was enumerated as index numbers only (`0` instead of `UART1` ). ELRS BF Passthrough flashing parses those index numbers, but this breaking change prevented go get into passthrough mode. In this PR, I updated the regex expression to recognize the `UART\d` strings patterns.