### PR TITLE
Fix Head Tracker Disable command not being sent

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -459,7 +459,7 @@ void injectBackpackPanTiltRollData(uint32_t const now)
 {
 #if !defined(CRITICAL_FLASH)
   // Do not override channels if the backpack is NOT communicating or PanTiltRoll is disabled
-  if (config.GetPTREnableChannel() == HT_OFF || backpackVersion[0] == 0)
+  if ((!headTrackingEnabled && config.GetPTREnableChannel() == HT_OFF) || backpackVersion[0] == 0)
   {
     return;
   }


### PR DESCRIPTION
# Problem
When disabling the HT function, the command was not sent to the googles/head-tracker and so it would uselessly send the PTR positions which would then be ignored on the TX side.

# Solution
Only ignore the command if the HT config is OFF _and_ the head-tracker is disabled. Otherwise send the command.