### PR TITLE
Fix Airport - TX module in Airport mode initialized to wrong baud rate

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1204,7 +1204,13 @@ static void setupSerial()
 // Setup TxBackpack
 #if defined(PLATFORM_ESP32)
   Stream *serialPort;
-  if (GPIO_PIN_DEBUG_RX != UNDEF_PIN && GPIO_PIN_DEBUG_TX != UNDEF_PIN)
+  
+  if(firmwareOptions.is_airport) 
+  {
+    serialPort = new HardwareSerial(1);
+    ((HardwareSerial *)serialPort)->begin(firmwareOptions.uart_baud, SERIAL_8N1, U0RXD_GPIO_NUM, U0TXD_GPIO_NUM);
+  }  
+  else if (GPIO_PIN_DEBUG_RX != UNDEF_PIN && GPIO_PIN_DEBUG_TX != UNDEF_PIN)
   {
     serialPort = new HardwareSerial(2);
     ((HardwareSerial *)serialPort)->begin(BACKPACK_LOGGING_BAUD, SERIAL_8N1, GPIO_PIN_DEBUG_RX, GPIO_PIN_DEBUG_TX);
@@ -1254,9 +1260,9 @@ static void setupSerial()
   USBSerial.begin(firmwareOptions.uart_baud);
   TxUSB = &USBSerial;
 #elif defined(PLATFORM_ESP32)
-  if (GPIO_PIN_DEBUG_RX == 3 && GPIO_PIN_DEBUG_TX == 1)
+  if (GPIO_PIN_DEBUG_RX == U0RXD_GPIO_NUM && GPIO_PIN_DEBUG_TX == U0TXD_GPIO_NUM)
   {
-    // The backpack is already assigned on UART0 (pins 3, 1)
+    // The backpack or Airpoirt is already assigned on UART0 (pins 3, 1)
     // This is also USB on modules that use DIPs
     // Set TxUSB to TxBackpack so that data goes to the same place
     TxUSB = TxBackpack;
@@ -1271,7 +1277,7 @@ static void setupSerial()
     // The backpack is on a separate UART to UART0
     // Set TxUSB to pins 3, 1 so that we can access TxUSB and TxBackpack independantly
     TxUSB = new HardwareSerial(1);
-    ((HardwareSerial *)TxUSB)->begin(firmwareOptions.uart_baud, SERIAL_8N1, 3, 1);
+    ((HardwareSerial *)TxUSB)->begin(firmwareOptions.uart_baud, SERIAL_8N1, U0RXD_GPIO_NUM, U0TXD_GPIO_NUM);
   }
 #else
   TxUSB = new NullStream();


### PR DESCRIPTION
PR 2753 removed some code for Airport in tx_main.cpp/setupSerial() which led to Airport disregarding the TX WebUI Airport baud rate setting. Instead the TX module is initialized using the baud rate defined in hardware.html for the backpack. This sort of broke Airport because setting baud rates on the TX and RX to Airport compatible values, e.g. 9600/9600 and setting terminal programs/MCUs on both ends to the expected 9600/9600 doesn't establish Airport communication.