### PR TITLE
Fix for PWM fans not working correctly after device framework changes

### DIFF
--- a/src/lib/THERMAL/devThermal.cpp
+++ b/src/lib/THERMAL/devThermal.cpp
@@ -45,6 +45,10 @@ static bool initialize()
         pinMode(GPIO_PIN_FAN_EN, OUTPUT);
         enabled = true;
     }
+    else if (GPIO_PIN_FAN_PWM != UNDEF_PIN)
+    {
+        enabled = true;
+    }
     return enabled;
 }
 
@@ -246,6 +250,7 @@ device_t Thermal_device = {
     .initialize = initialize,
     .start = start,
     .event = event,
-    .timeout = timeout
+    .timeout = timeout,
+    .subscribe = EVENT_CONFIG_FAN_CHANGED
 };
 #endif


### PR DESCRIPTION
When the changes for the device framework were made in #3049, the thermal device didn't take into account PWM connected fans and so the thermal driver was shut down and the fan didn't work in devices like the Radiomaster Ranger.