### PR TITLE
Set power correctly when changing RF band

### DIFF
--- a/src/lib/LR1121Driver/LR1121.cpp
+++ b/src/lib/LR1121Driver/LR1121.cpp
@@ -207,6 +207,9 @@ void LR1121Driver::Config(uint8_t bw, uint8_t sf, uint8_t cr, uint32_t regfreq,
     ClearIrqStatus(radioNumber);
 
     SetPaConfig(isSubGHz, radioNumber); // Must be called after changing rf modes between subG and 2.4G.  This sets the correct rf amps, and txen pins to be used.
+#if defined(TARGET_RX)
+    pwrForceUpdate = true;  // force an update of the output power because the band may have changed, and we need to configure the power for the band.
+#endif
     CommitOutputPower();
 }
 


### PR DESCRIPTION
When changing band the telemetry output power on an RX was not set correctly for the new RF path.

I noticed when doing testing on an LR1121 RX that if I was on 2.4GHz and set the telemetry power to 10mW, then switched to 915MHz the power would jump up to the 'default' or previously set level on that band.