### PR TITLE
Slow Other Devices loading if at all on 3.5.5

### DIFF
--- a/src/lib/CrsfProtocol/crsf_protocol.h
+++ b/src/lib/CrsfProtocol/crsf_protocol.h
@@ -428,7 +428,6 @@ enum {
     CRSF_FRAME_BARO_ALTITUDE_PAYLOAD_SIZE = sizeof(crsf_sensor_baro_vario_t),
     CRSF_FRAME_BATTERY_SENSOR_PAYLOAD_SIZE = sizeof(crsf_sensor_battery_t),
     CRSF_FRAME_ATTITUDE_PAYLOAD_SIZE = sizeof(crsf_sensor_attitude_t),
-    CRSF_FRAME_DEVICE_INFO_PAYLOAD_SIZE = (CRSF_PAYLOAD_SIZE_MAX - CRSF_FRAME_LENGTH_EXT_TYPE_CRC),
     CRSF_FRAME_FLIGHT_MODE_PAYLOAD_SIZE = sizeof(crsf_flight_mode_t),
     CRSF_FRAME_AIRSPEED_PAYLOAD_SIZE = sizeof(crsf_sensor_airspeed_t),
     CRSF_FRAME_RPM_PAYLOAD_SIZE = sizeof(crsf_sensor_rpm_t),

--- a/src/lib/LUA/lua.cpp
+++ b/src/lib/LUA/lua.cpp
@@ -245,7 +245,7 @@ static uint8_t sendCRSFparam(uint8_t fieldChunk, struct luaPropertiesCommon *lua
   CRSF::SetExtendedHeaderAndCrc(packetBuf, CRSF_FRAMETYPE_PARAMETER_SETTINGS_ENTRY,
       chunkSize + CRSF_FRAME_LENGTH_EXT_TYPE_CRC + 2, CRSF_ADDRESS_CRSF_RECEIVER, CRSF_ADDRESS_CRSF_TRANSMITTER);
 
-  telemetry.RequestFlightControllerPause();
+  telemetry.RequestPauseForLuaInfo();
   if (!telemetry.AppendTelemetryPackage(packetBuf))
     return SENDCRSFPARAM_ERROR;
 #endif

--- a/src/lib/LUA/lua.cpp
+++ b/src/lib/LUA/lua.cpp
@@ -154,7 +154,12 @@ static uint8_t *luaFolderStructToArray(const void *luaStruct, uint8_t *next)
   return childParameters;
 }
 
-static uint8_t sendCRSFparam(crsf_frame_type_e frameType, uint8_t fieldChunk, struct luaPropertiesCommon *luaData)
+#define SENDCRSFPARAM_ERROR (0xff)
+/***
+ * @brief: Turn a lua param structure into a chunk of CRSF_FRAMETYPE_PARAMETER_SETTINGS_ENTRY frame and queue it
+ * @returns: Number of chunks left to send after this one, or SENDCRSFPARAM_ERROR if there's no space to queue it currently
+ */
+static uint8_t sendCRSFparam(uint8_t fieldChunk, struct luaPropertiesCommon *luaData)
 {
   uint8_t dataType = luaData->type & CRSF_FIELD_TYPE_MASK;
 
@@ -173,7 +178,6 @@ static uint8_t sendCRSFparam(crsf_frame_type_e frameType, uint8_t fieldChunk, st
   }
 #else
   chunkBuffer[3] |= luaData->type;
-  uint8_t paramInformation[DEVICE_INFORMATION_LENGTH];
 #endif
 
   // Copy the name to the buffer starting at chunkBuffer[4]
@@ -232,22 +236,32 @@ static uint8_t sendCRSFparam(crsf_frame_type_e frameType, uint8_t fieldChunk, st
   chunkStart[0] = luaData->id;                 // FieldId
   chunkStart[1] = chunkCnt - (fieldChunk + 1); // ChunksRemain
 #ifdef TARGET_TX
-  CRSFHandset::packetQueueExtended(frameType, chunkStart, chunkSize + 2);
+  CRSFHandset::packetQueueExtended(CRSF_FRAMETYPE_PARAMETER_SETTINGS_ENTRY, chunkStart, chunkSize + 2);
 #else
-  memcpy(paramInformation + sizeof(crsf_ext_header_t),chunkStart,chunkSize + 2);
+  // Buffer for just this chunk with header/extheader/CRC
+  uint8_t packetBuf[CRSF_MAX_PACKET_LEN];
+  memcpy(packetBuf + sizeof(crsf_ext_header_t), chunkStart, chunkSize + 2);
 
-  CRSF::SetExtendedHeaderAndCrc(paramInformation, frameType, chunkSize + CRSF_FRAME_LENGTH_EXT_TYPE_CRC + 2, CRSF_ADDRESS_CRSF_RECEIVER, CRSF_ADDRESS_CRSF_TRANSMITTER);
+  CRSF::SetExtendedHeaderAndCrc(packetBuf, CRSF_FRAMETYPE_PARAMETER_SETTINGS_ENTRY,
+      chunkSize + CRSF_FRAME_LENGTH_EXT_TYPE_CRC + 2, CRSF_ADDRESS_CRSF_RECEIVER, CRSF_ADDRESS_CRSF_TRANSMITTER);
 
-  telemetry.AppendTelemetryPackage(paramInformation);
+  if (!telemetry.AppendTelemetryPackage(packetBuf))
+    return SENDCRSFPARAM_ERROR;
 #endif
+
   return chunkCnt - (fieldChunk+1);
 }
 
 static void pushResponseChunk(struct luaItem_command *cmd) {
   DBGVLN("sending response for [%s] chunk=%u step=%u", cmd->common.name, nextStatusChunk, cmd->step);
-  if (sendCRSFparam(CRSF_FRAMETYPE_PARAMETER_SETTINGS_ENTRY, nextStatusChunk, (struct luaPropertiesCommon *)cmd) == 0) {
+
+  uint8_t ret = sendCRSFparam(nextStatusChunk, (struct luaPropertiesCommon *)cmd);
+  if (ret == 0)
+  {
     nextStatusChunk = 0;
-  } else {
+  }
+  else if (ret != SENDCRSFPARAM_ERROR)
+  {
     nextStatusChunk++;
   }
 }
@@ -405,7 +419,9 @@ bool luaHandleUpdateParameter()
             field->step = lcsIdle;
             field->info = "";
           }
-          sendCRSFparam(CRSF_FRAMETYPE_PARAMETER_SETTINGS_ENTRY, fieldChunk, &field->common);
+          // Queue the parameter chunk. If it fails, just keep UpdateParamReq true
+          if (sendCRSFparam(fieldChunk, &field->common) == SENDCRSFPARAM_ERROR)
+            return false;
         }
       }
       break;

--- a/src/lib/LUA/lua.cpp
+++ b/src/lib/LUA/lua.cpp
@@ -245,6 +245,7 @@ static uint8_t sendCRSFparam(uint8_t fieldChunk, struct luaPropertiesCommon *lua
   CRSF::SetExtendedHeaderAndCrc(packetBuf, CRSF_FRAMETYPE_PARAMETER_SETTINGS_ENTRY,
       chunkSize + CRSF_FRAME_LENGTH_EXT_TYPE_CRC + 2, CRSF_ADDRESS_CRSF_RECEIVER, CRSF_ADDRESS_CRSF_TRANSMITTER);
 
+  telemetry.RequestFlightControllerPause();
   if (!telemetry.AppendTelemetryPackage(packetBuf))
     return SENDCRSFPARAM_ERROR;
 #endif

--- a/src/lib/Telemetry/telemetry.cpp
+++ b/src/lib/Telemetry/telemetry.cpp
@@ -81,7 +81,7 @@ void Telemetry::CheckCrsfBaroSensorDetected()
     }
 }
 
-PAYLOAD_DATA(GPS, BATTERY_SENSOR, ATTITUDE, DEVICE_INFO, FLIGHT_MODE, VARIO, BARO_ALTITUDE, AIRSPEED, RPM, TEMP, CELLS);
+PAYLOAD_DATA(GPS, BATTERY_SENSOR, ATTITUDE, FLIGHT_MODE, VARIO, BARO_ALTITUDE, AIRSPEED, RPM, TEMP, CELLS);
 
 bool Telemetry::GetNextPayload(uint8_t* nextPayloadSize, uint8_t **payloadData)
 {

--- a/src/lib/Telemetry/telemetry.cpp
+++ b/src/lib/Telemetry/telemetry.cpp
@@ -376,8 +376,9 @@ bool Telemetry::AppendTelemetryPackage(uint8_t *package)
     {
         memcpy(payloadTypes[targetIndex].data, package, CRSF_FRAME_SIZE(package[CRSF_TELEMETRY_LENGTH_INDEX]));
         payloadTypes[targetIndex].updated = true;
+        return true;
     }
 
-    return targetFound;
+    return false;
 }
 #endif

--- a/src/lib/Telemetry/telemetry.cpp
+++ b/src/lib/Telemetry/telemetry.cpp
@@ -278,9 +278,9 @@ bool Telemetry::processInternalTelemetryPackage(uint8_t *package)
     return false;
 }
 
-void Telemetry::RequestFlightControllerPause()
+void Telemetry::RequestPauseForLuaInfo()
 {
-    flightControllerPauseStart = millis();
+    luaInfoPauseStart = millis();
 }
 
 bool Telemetry::AppendTelemetryPackage(uint8_t *package)
@@ -289,25 +289,26 @@ bool Telemetry::AppendTelemetryPackage(uint8_t *package)
         return true;
 
     const crsf_header_t *header = (crsf_header_t *) package;
+    const uint8_t crsfType = header->type;
 
-    // Block all telemetry traffic for 10s during parameterinfo
-    if (flightControllerPauseStart && (millis() - flightControllerPauseStart) < 10000)
+    // Block all other telemetry traffic for 10s during deviceinfo and parameterinfo
+    if (luaInfoPauseStart && (millis() - luaInfoPauseStart) < 10000)
     {
-        if (header->type != CRSF_FRAMETYPE_PARAMETER_SETTINGS_ENTRY)
+        if (!(crsfType == CRSF_FRAMETYPE_DEVICE_INFO || crsfType == CRSF_FRAMETYPE_PARAMETER_SETTINGS_ENTRY))
             return false;
     }
     else
     {
-        flightControllerPauseStart = 0;
+        luaInfoPauseStart = 0;
     }
 
     uint8_t targetIndex = 0;
     bool targetFound = false;
-    if (header->type >= CRSF_FRAMETYPE_DEVICE_PING)
+    if (crsfType >= CRSF_FRAMETYPE_DEVICE_PING)
     {
         const crsf_ext_header_t *extHeader = (crsf_ext_header_t *) package;
 
-        if (header->type == CRSF_FRAMETYPE_ARDUPILOT_RESP)
+        if (crsfType == CRSF_FRAMETYPE_ARDUPILOT_RESP)
         {
             // reserve last slot for adrupilot custom frame with the sub type status text: this is needed to make sure the important status messages are not lost
             if (package[CRSF_TELEMETRY_TYPE_INDEX + 1] == CRSF_AP_CUSTOM_TELEM_STATUS_TEXT)
@@ -327,7 +328,7 @@ bool Telemetry::AppendTelemetryPackage(uint8_t *package)
 
             #if defined(USE_MSP_WIFI) && defined(TARGET_RX)
                 // this probably needs refactoring in the future, I think we should have this telemetry class inside the crsf module
-                if (wifi2tcp.hasClient() && (header->type == CRSF_FRAMETYPE_MSP_RESP || header->type == CRSF_FRAMETYPE_MSP_REQ)) // if we have a client we probs wanna talk to it
+                if (wifi2tcp.hasClient() && (crsfType == CRSF_FRAMETYPE_MSP_RESP || crsfType == CRSF_FRAMETYPE_MSP_REQ)) // if we have a client we probs wanna talk to it
                 {
                     DBGLN("Got MSP frame, forwarding to client, len: %d", currentTelemetryByte);
                     crsf2msp.parse(package);
@@ -336,7 +337,7 @@ bool Telemetry::AppendTelemetryPackage(uint8_t *package)
             #endif
             {
 #if defined(HAS_MSP_VTX) && defined(TARGET_RX)
-                if (header->type == CRSF_FRAMETYPE_MSP_RESP)
+                if (crsfType == CRSF_FRAMETYPE_MSP_RESP)
                 {
                     mspVtxProcessPacket(package);
                 }
@@ -370,7 +371,7 @@ bool Telemetry::AppendTelemetryPackage(uint8_t *package)
     {
         for (int8_t i = 0; i < payloadTypesCount - 2; i++)
         {
-            if (header->type == payloadTypes[i].type)
+            if (crsfType == payloadTypes[i].type)
             {
                 if (CRSF_FRAME_SIZE(package[CRSF_TELEMETRY_LENGTH_INDEX]) <= payloadTypes[i].size)
                 {

--- a/src/lib/Telemetry/telemetry.cpp
+++ b/src/lib/Telemetry/telemetry.cpp
@@ -147,9 +147,9 @@ void Telemetry::ResetState()
     twoslotLastQueueIndex = 0;
     receivedPackages = 0;
 
-    uint8_t offset = 0;
+    uint32_t offset = 0;
 
-    for (int8_t i = 0; i < payloadTypesCount; i++)
+    for (unsigned i = 0; i < payloadTypesCount; i++)
     {
         payloadTypes[i].locked = false;
         payloadTypes[i].updated = false;

--- a/src/lib/Telemetry/telemetry.h
+++ b/src/lib/Telemetry/telemetry.h
@@ -24,7 +24,7 @@ typedef struct crsf_telemetry_package_t {
     uint8_t *data;
 } crsf_telemetry_package_t;
 
-#define PAYLOAD_DATA(type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10)\
+#define PAYLOAD_DATA(type0, type1, type2, type3, type4, type5, type6, type7, type8, type9)\
     uint8_t PayloadData[\
         CRSF_TELEMETRY_TOTAL_SIZE(CRSF_FRAME_##type0##_PAYLOAD_SIZE) + \
         CRSF_TELEMETRY_TOTAL_SIZE(CRSF_FRAME_##type1##_PAYLOAD_SIZE) + \
@@ -36,7 +36,6 @@ typedef struct crsf_telemetry_package_t {
         CRSF_TELEMETRY_TOTAL_SIZE(CRSF_FRAME_##type7##_PAYLOAD_SIZE) + \
         CRSF_TELEMETRY_TOTAL_SIZE(CRSF_FRAME_##type8##_PAYLOAD_SIZE) + \
         CRSF_TELEMETRY_TOTAL_SIZE(CRSF_FRAME_##type9##_PAYLOAD_SIZE) + \
-        CRSF_TELEMETRY_TOTAL_SIZE(CRSF_FRAME_##type10##_PAYLOAD_SIZE) + \
         CRSF_TELEMETRY_TOTAL_SIZE(CRSF_FRAME_GENERAL_RESP_PAYLOAD_SIZE) + \
         CRSF_TELEMETRY_TOTAL_SIZE(CRSF_FRAME_GENERAL_RESP_PAYLOAD_SIZE)]; \
     crsf_telemetry_package_t payloadTypes[] = {\
@@ -50,7 +49,6 @@ typedef struct crsf_telemetry_package_t {
     {CRSF_FRAMETYPE_##type7, CRSF_TELEMETRY_TOTAL_SIZE(CRSF_FRAME_##type7##_PAYLOAD_SIZE), false, false, 0},\
     {CRSF_FRAMETYPE_##type8, CRSF_TELEMETRY_TOTAL_SIZE(CRSF_FRAME_##type8##_PAYLOAD_SIZE), false, false, 0},\
     {CRSF_FRAMETYPE_##type9, CRSF_TELEMETRY_TOTAL_SIZE(CRSF_FRAME_##type9##_PAYLOAD_SIZE), false, false, 0},\
-    {CRSF_FRAMETYPE_##type10, CRSF_TELEMETRY_TOTAL_SIZE(CRSF_FRAME_##type10##_PAYLOAD_SIZE), false, false, 0},\
     {0, CRSF_TELEMETRY_TOTAL_SIZE(CRSF_FRAME_GENERAL_RESP_PAYLOAD_SIZE), false, false, 0},\
     {0, CRSF_TELEMETRY_TOTAL_SIZE(CRSF_FRAME_GENERAL_RESP_PAYLOAD_SIZE), false, false, 0}};\
     const uint8_t payloadTypesCount = (sizeof(payloadTypes)/sizeof(crsf_telemetry_package_t))

--- a/src/lib/Telemetry/telemetry.h
+++ b/src/lib/Telemetry/telemetry.h
@@ -73,7 +73,7 @@ public:
     bool GetNextPayload(uint8_t* nextPayloadSize, uint8_t **payloadData);
     uint8_t UpdatedPayloadCount();
     uint8_t ReceivedPackagesCount();
-    void RequestFlightControllerPause();
+    void RequestPauseForLuaInfo();
     bool AppendTelemetryPackage(uint8_t *package);
 private:
     bool processInternalTelemetryPackage(uint8_t *package);
@@ -92,5 +92,5 @@ private:
     bool crsfBatterySensorDetected;
     bool crsfBaroSensorDetected;
     uint8_t modelMatchId;
-    uint32_t flightControllerPauseStart;
+    uint32_t luaInfoPauseStart;
 };

--- a/src/lib/Telemetry/telemetry.h
+++ b/src/lib/Telemetry/telemetry.h
@@ -73,6 +73,7 @@ public:
     bool GetNextPayload(uint8_t* nextPayloadSize, uint8_t **payloadData);
     uint8_t UpdatedPayloadCount();
     uint8_t ReceivedPackagesCount();
+    void RequestFlightControllerPause();
     bool AppendTelemetryPackage(uint8_t *package);
 private:
     bool processInternalTelemetryPackage(uint8_t *package);
@@ -91,4 +92,5 @@ private:
     bool crsfBatterySensorDetected;
     bool crsfBaroSensorDetected;
     uint8_t modelMatchId;
+    uint32_t flightControllerPauseStart;
 };

--- a/src/lua/elrsV3.lua
+++ b/src/lua/elrsV3.lua
@@ -6,6 +6,7 @@
 ---- # License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html               #
 ---- #                                                                       #
 ---- #########################################################################
+local EXITVER = "-- EXIT (Lua v15) --"
 local deviceId = 0xEE
 local handsetId = 0xEF
 local deviceName = "Loading..."
@@ -47,7 +48,7 @@ local function allocateFields()
     fields[i] = { }
   end
   fields[#fields+1] = {id=fields_count+1, name="Other Devices", parent=255, type=16}
-  fields[#fields+1] = {name="----EXIT----", type=14}
+  fields[#fields+1] = {name=EXITVER, type=14}
 end
 
 local function createDeviceFields() -- put other devices in the field list
@@ -362,7 +363,7 @@ local function fieldBackExec(field)
     lineIndex = field.li or 1
     pageOffset = field.po or 0
 
-    field.name = "----EXIT----"
+    field.name = EXITVER
     field.parent = nil
     field.li = nil
     field.po = nil

--- a/src/lua/elrsV3.lua
+++ b/src/lua/elrsV3.lua
@@ -41,14 +41,26 @@ local textSize
 local barTextSpacing
 
 local function allocateFields()
+  -- fields table is real fields, then the Other Devices item, then devices, then Exit/Back
   fields = {}
-  for i=1, fields_count + 2 + #devices do
+  for i=1, fields_count do
     fields[i] = { }
   end
-  fields[#fields] = {name="----EXIT----", type=14}
+  fields[#fields+1] = {id=fields_count+1, name="Other Devices", parent=255, type=16}
+  fields[#fields+1] = {name="----EXIT----", type=14}
+end
+
+local function createDeviceFields() -- put other devices in the field list
+  -- move back button to the end of the list, so it will always show up at the bottom.
+  fields[fields_count + #devices + 2] = fields[#fields]
+  for i=1, #devices do
+    local parent = (devices[i].id == deviceId) and 255 or (fields_count+1)
+    fields[fields_count + 1 + i] = {id=devices[i].id, name=devices[i].name, parent=parent, type=15}
+  end
 end
 
 local function reloadAllField()
+  fieldTimeout = 0
   fieldChunk = 0
   fieldData = nil
   -- loadQ is actually a stack
@@ -155,10 +167,10 @@ local function fieldGetStrOrOpts(data, offset, last, isOpts)
   return (r or opt), offset, vcnt, collectgarbage("collect")
 end
 
-local function getDevice(name)
-  for i=1, #devices do
-    if devices[i].name == name then
-      return devices[i]
+local function getDevice(id)
+  for _, device in ipairs(devices) do
+    if device.id == id then
+      return device
     end
   end
 end
@@ -308,7 +320,9 @@ local function fieldFolderOpen(field)
 end
 
 local function fieldFolderDeviceOpen(field)
-  crossfireTelemetryPush(0x28, { 0x00, 0xEA }) --broadcast with standard handset ID to get all node respond correctly
+  -- crossfireTelemetryPush(0x28, { 0x00, 0xEA }) --broadcast with standard handset ID to get all node respond correctly
+  -- Make sure device fields are in the folder when it opens
+  createDeviceFields()
   return fieldFolderOpen(field)
 end
 
@@ -360,7 +374,6 @@ end
 
 local function changeDeviceId(devId) --change to selected device ID
   currentFolderId = nil
-  deviceIsELRS_TX = nil
   elrsFlags = 0
   --if the selected device ID (target) is a TX Module, we use our Lua ID, so TX Flag that user is using our LUA
   if devId == 0xEE then
@@ -368,49 +381,42 @@ local function changeDeviceId(devId) --change to selected device ID
   else --else we would act like the legacy lua
     handsetId = 0xEA
   end
-  deviceId = devId
-  fields_count = 0  --set this because next target wouldn't have the same count, and this trigger to request the new count
+
+  local device = getDevice(devId)
+  local fullReload = deviceId ~= devId or fields_count ~= device.fldcnt
+  if fullReload then
+    deviceName = device.name
+    deviceIsELRS_TX = device.isElrs and devId == 0xEE or nil -- ELRS and ID is TX module
+    fields_count = device.fldcnt
+    deviceId = devId
+
+    allocateFields()
+    reloadAllField()
+  end
 end
 
 local function fieldDeviceIdSelect(field)
-  local device = getDevice(field.name)
-  changeDeviceId(device.id)
-  crossfireTelemetryPush(0x28, { 0x00, 0xEA })
-end
-
-local function createDeviceFields() -- put other devices in the field list
-  -- move back button to the end of the list, so it will always show up at the bottom.
-  fields[fields_count + 2 + #devices] = fields[#fields]
-  for i=1, #devices do
-    local parent = (devices[i].id == deviceId) and 255 or (fields_count+1)
-    fields[fields_count+1+i] = {name=devices[i].name, parent=parent, type=15}
-  end
+  changeDeviceId(field.id)
 end
 
 local function parseDeviceInfoMessage(data)
-  local offset
   local id = data[2]
-  local newName
-  newName, offset = fieldGetStrOrOpts(data, 3)
-  local device = getDevice(newName)
+  local newName, offset = fieldGetStrOrOpts(data, 3)
+  local device = getDevice(id)
   if device == nil then
-    device = { id = id, name = newName }
+    device = { id = id }
     devices[#devices + 1] = device
   end
+  device.name = newName
+  device.fldcnt = data[offset + 12]
+  device.isElrs = fieldGetValue(data, offset, 4) == 0x454C5253 -- SerialNumber = 'E L R S'
+
   if deviceId == id then
-    deviceName = newName
-    deviceIsELRS_TX = ((fieldGetValue(data,offset,4) == 0x454C5253) and (deviceId == 0xEE)) or nil -- SerialNumber = 'E L R S' and ID is TX module
-    local newFieldCount = data[offset+12]
-    if newFieldCount ~= fields_count or newFieldCount == 0 then
-      fields_count = newFieldCount
-      allocateFields()
-      reloadAllField()
-      fields[fields_count+1] = {id = fields_count+1, name="Other Devices", parent = 255, type=16} -- add other devices folders
-      if newFieldCount == 0 then
-        -- This device has no fields so the Loading code never starts
-        createDeviceFields()
-      end
-    end
+    changeDeviceId(id)
+  end
+  -- DeviceList change while in Other Devices, refresh list
+  if currentFolderId == fields_count + 1 then
+    createDeviceFields()
   end
 end
 
@@ -486,11 +492,6 @@ local function parseParameterInfoMessage(data)
     fieldChunk = 0
     fieldData = nil
 
-    -- Last field loaded, add the list of devices to the end
-    if #loadQ == 0 then
-      createDeviceFields()
-    end
-
     -- Return value is if the screen should be updated
     -- If deviceId is TX module, then the Bad/Good drives the update; for other
     -- devices update each new item. and always update when the queue empties
@@ -565,16 +566,16 @@ local function refreshNext()
     devicesRefreshTimeout = time + 100 -- 1s
     crossfireTelemetryPush(0x28, { 0x00, 0xEA })
   elseif time > linkstatTimeout then
-    if not deviceIsELRS_TX and #loadQ == 0 then
-      goodBadPkt = ""
-    else
+    if deviceIsELRS_TX then
       crossfireTelemetryPush(0x2D, { deviceId, handsetId, 0x0, 0x0 }) --request linkstat
+    else
+      goodBadPkt = ""
     end
     linkstatTimeout = time + 100
   elseif time > fieldTimeout and fields_count ~= 0 then
     if #loadQ > 0 then
       crossfireTelemetryPush(0x2C, { deviceId, handsetId, loadQ[#loadQ], fieldChunk })
-      fieldTimeout = time + 50 -- 0.5s
+      fieldTimeout = time + 500 -- 5s
     end
   end
 
@@ -847,7 +848,7 @@ local function setLCDvar()
   if major ~= 1 then
     popupCompat = popupConfirmation
   end
-  
+
   if (lcd.RGB ~= nil) then
     local ver, radio, maj, minor, rev, osname = getVersion()
 

--- a/src/lua/elrsV3.lua
+++ b/src/lua/elrsV3.lua
@@ -6,7 +6,7 @@
 ---- # License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html               #
 ---- #                                                                       #
 ---- #########################################################################
-local EXITVER = "-- EXIT (Lua v15) --"
+local EXITVER = "-- EXIT (Lua r15) --"
 local deviceId = 0xEE
 local handsetId = 0xEF
 local deviceName = "Loading..."


### PR DESCRIPTION
Attempts to resolve issues since #3210 in Lua loading Other Devices and the underlying OTA issues which cause them when running in Wide switch mode at 1:16 ratio or slower.

### Issue 1: Too many syncs / too short TlmBoost

Changes to tx_main.cpp. TlmBoost is correctly activating since the previous PR, but the logic that requests a SYNC packet to signal the RX to change ratios expected to go to 1:2 ratio, and therefore would request a ratio change for each piece of data it wanted to send. The extra sync packets would then immediately disable boost mode and set the ratio back to the user-configured value as soon as the upload was complete, leaving the downlink in slow mode. This caused the DEVICE_INFO packets from the RX to take 20-30s to arrive at 1:128, and even longer for any flight controller's DEVICE_INFO.

### Issue 2: Lua expects all DEVICE_INFO to arrive before it finishes loading

Changes to elrsv3.lua. If you wait long enough, "Other Devices" will appear in the Lua, but clicking on it has 0 items in the list. This is because it only populates the list at the end of loading the main set of parameters, and the overly slowed remote info wouldn't arrive in time. I've rearranged the code so that the list is populated when the Other Devices folder is populated, as well as if a new DEVICE_INFO is received while in that folder.

The field re-request timeout has also been extended from 0.5s to 5.0s, as requesting every 0.5s at slow 50Hz 1:8 telemetry caused an abundance of repeated parameter chunks to be downloaded from the remote side.

**These changes are not required** as after the other fixes, the list almost always loads the Other Devices properly. However, loading of the RX's lua is roughly half the speed due to all the duplicated requests, and I believe the Other Devices list should more reliably populate.

### Issue 3: Requesting next parameter before the previous has completed downloading

Changes to telemetry.cpp / lua.cpp. When stubborn_receiver completes a download from the RX, the data is forwarded to the lua as soon as the transfer is completed. However, the RX still has the telemetry slot locked until it receives the final ACK. With Wide switch mode, the telemetry ack bit is only sent every 8 channels packets, which has a 50/50 chance of falling on the telemetry slot, which causes it to get pushed to every 16 packets. Before that 16 packet timeframe, the lua will have requested the next parameter chunk. However, since the receiver still has the slot locked, there is nowhere to put it and the response is discarded. This leads to the loading stalling until a re-request of the parameter chunk.

The receiver code has been updated to retry queueing the parameter every 4 packets until it is successful, or another request has come in (which will replace the pending request).

### New Behavior

If the RX ever queues a PARAM_INFO message all other telemetry is now paused (dropped) for 10 seconds. During this time, only DEVICE_INFO and PARAM_INFO type messages will be allowed into the queue. This is to speed up the loading of the remote lua while under load coming from a connected flight controller (such as rotorflight which does a good job of using the entirety of the downstream bandwidth). While the remote lua is loading, users will experience "sensor lost" messages from EdgeTX.

### Bugfixes

* There was a stack overrun issue in `sendCRSFparam()` on the RX where the buffer (`paramInformation`) for the is only DEVICE_INFORMATION_LENGTH (~32 bytes). This can not hold the full 64 bytes as needed for a full parameter chunk. 
* telemetry.cpp allocates a 64 byte slot for DEVICE_INFO which is not used. All DEVICE_INFO packets go into the 2-slot slots, with the RX forced to use slot 2, and the Flight Controller using whichever slot is open. The extra buffer has been removed.
* Telemetry on the RX was using overlapping buffer areas for its queue, leading to the 2-slot buffer actually reusing the fixed slots. This caused corruption of DEVICE_INFO and PARAM_INFO packets from the RX, or corruption and dropping of standard telemetry items when the 2-slot was used. This overlap has been resolved.

### Going mad with power 

This also adds a version number to the lua so users can tell what they are running. It appears in the EXIT line and we'll have to manually tag it in the source file.
![IMG_20250518_125812](https://github.com/user-attachments/assets/54403236-7195-4e1c-b4d6-479f2fa8f140)
