### PR TITLE
Fix PIO build

### DIFF
--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -58,10 +58,10 @@ build_flags =
 	-I ${PROJECTSRC_DIR}/hal
 build_src_filter = ${common_env_data.build_src_filter} -<ESP8266*.*> -<STM32*.*>
 lib_deps =
-	ottowinter/ESPAsyncWebServer-esphome @ 3.0.0
 	esphome/AsyncTCP-esphome @ 2.0.1 # use specific version - an update to this library breaks the build
-	lemmingdev/ESP32-BLE-Gamepad @ 0.5.2
+	ottowinter/ESPAsyncWebServer-esphome @ 3.0.0
 	h2zero/NimBLE-Arduino @ 1.4.1
+	lemmingdev/ESP32-BLE-Gamepad @ 0.5.2
 	bblanchon/ArduinoJson @ 7.0.4
 	${common_env_data.mavlink_lib_dep}
 oled_lib_deps =
@@ -100,8 +100,8 @@ build_flags =
 	-I ${PROJECTSRC_DIR}/hal
 build_src_filter = ${common_env_data.build_src_filter} -<ESP8266*.*> -<STM32*.*>
 lib_deps =
-	ottowinter/ESPAsyncWebServer-esphome @ 3.0.0
 	esphome/AsyncTCP-esphome @ 2.0.1 # use specific version - an update to this library breaks the build
+	ottowinter/ESPAsyncWebServer-esphome @ 3.0.0
 	bblanchon/ArduinoJson @ 7.0.4
 	${common_env_data.mavlink_lib_dep}
 


### PR DESCRIPTION
Another build issue thanks to updates to PIO!
Looks like they have changed the dependency resolution to be depth-first instead of breadth-first.

This breaks for us because some of the libraries we use don't specify the version of their dependencies, so we managed that in our platformio.ini files by putting the correct version of the dependency in our files... but we put them after the main library. So now that they changed it to depth-first, it goes and downloads the wrong version of the sub-dependency (latest) and then the one we specify and put a discriminator on the directory. So now theres two versions of the library and the build breaks.
By putting the correct version of the sub-dependency before the library that depends on it, when the main dependency comes to be resolved t sees there is already a library there for the sub-dependency and so doesn't download the wrong (latest) version.