### PR TITLE
Store the RXs initrate during connect, not disconnect

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -854,7 +854,6 @@ void LostConnection(bool resumeRx)
 {
     DBGLN("lost conn fc=%d fo=%d", FreqCorrection, hwTimer::getFreqOffset());
 
-    RFmodeCycleMultiplier = 1;
     connectionState = disconnected; //set lost connection
     RXtimerState = tim_disconnected;
     hwTimer::resetFreqOffset();
@@ -895,8 +894,14 @@ void ICACHE_RAM_ATTR TentativeConnection(unsigned long now)
     LPF_Offset.init(0);
     SnrMean.reset();
     RFmodeLastCycled = now; // give another 3 sec for lock to occur
+
     // Use this rate as the initial rate next time if we connected on it
     config.SetRateInitialIdx(ExpressLRS_nextAirRateIndex);
+    // And stop counting toward binding mode
+    if (config.GetPowerOnCounter() != 0)
+    {
+        config.SetPowerOnCounter(0);
+    }
 
     // The caller MUST call hwTimer::resume(). It is not done here because
     // the timer ISR will fire immediately and preempt any other code
@@ -2200,12 +2205,6 @@ void loop()
 
     CheckConfigChangePending();
     executeDeferredFunction(micros());
-
-    // Clear the power-on-count
-    if ((connectionState == connected || connectionState == tentative) && config.GetPowerOnCounter() != 0)
-    {
-        config.SetPowerOnCounter(0);
-    }
 
     if (connectionState > MODE_STATES)
     {


### PR DESCRIPTION
Moves the storage of the RX's Initial Rate (the packet rate it boots starting from) to during the connect process instead of the disconnect process.

It is inconvenient that the RX only stores the packet rate it expects a connection on when it disconnects. For most users, the TX starts on, they plug in an RX and wait for it to connect, fly, then unplug the RX before it ever experiences a disconnect. This does not update the initrate and they have to wait on the next battery to cycle through the rates again to find it. This PR saves the initrate as soon as the first matching SYNC packet comes in, rather than waiting for a disconnect. This is in line with what the user expects to happen, rather than knowing that "_ExpressLRS does it weird, you have to turn off the TX now to 'lock' the packet rate_"

The downside to doing this is the first time the RX gets a connection, the EEPROM write will cause a hiccup in the connection process and a delay in connecting, which is why it was done on disconnect. This hiccup will only occur when the rate changes:
* When selecting a new rate in the lua
* When connecting a model that previously had been used at a different rate, but only the first time it connects

The first case above can be reduced by leaving the old code in as well as adding the new line, but the hiccup is so short I don't think it justifies the maintenance burden of duplicating the code.

### Log
```
Req air rate change 9->6
lost conn fc=0 fo=2
Config LoRa New TLMrate 1:64
tentative conn       <--- initial SYNC
lost conn fc=0 fo=0
Config LoRa COMMIT  <--- EEPROM write
tentative conn     <-- needs a second SYNC because the timer is now slightly off
got conn
Timer locked
```

### 3.5?!

I'd love to get this in 3.x because 3.x is going to probably hang around for a long time despite 4.0 coming soon and it would be nice to have this confusing behavior gone in the final 3.x version.