### PR TITLE
Reduce RAM usage

### DIFF
--- a/src/lib/Telemetry/telemetry.cpp
+++ b/src/lib/Telemetry/telemetry.cpp
@@ -365,7 +365,7 @@ void Telemetry::AppendTelemetryPackage(uint8_t *package)
     }
 }
 
-bool Telemetry::GetNextPayload(uint8_t* nextPayloadSize, uint8_t **payloadData)
+bool Telemetry::GetNextPayload(uint8_t* nextPayloadSize, uint8_t *currentPayload)
 {
 #if defined(PLATFORM_ESP32) && SOC_CPU_CORES_NUM > 1
     std::lock_guard<std::mutex> lock(mutex);
@@ -399,7 +399,6 @@ bool Telemetry::GetNextPayload(uint8_t* nextPayloadSize, uint8_t **payloadData)
                     }
                     // set the pointers to the payload
                     *nextPayloadSize = CRSF_FRAME_SIZE(currentPayload[CRSF_TELEMETRY_LENGTH_INDEX]);
-                    *payloadData = currentPayload;
                     return true;
                 }
             }
@@ -421,12 +420,9 @@ bool Telemetry::GetNextPayload(uint8_t* nextPayloadSize, uint8_t **payloadData)
         }
         messagePayloads.popBytes(currentPayload, size);
         *nextPayloadSize = CRSF_FRAME_SIZE(currentPayload[CRSF_TELEMETRY_LENGTH_INDEX]);
-        *payloadData = currentPayload;
         return true;
     }
 
-    *nextPayloadSize = 0;
-    *payloadData = nullptr;
     return false;
 }
 

--- a/src/lib/Telemetry/telemetry.h
+++ b/src/lib/Telemetry/telemetry.h
@@ -39,7 +39,7 @@ public:
     void SetCrsfBaroSensorDetected();
     bool GetCrsfBaroSensorDetected() const { return crsfBaroSensorDetected; }
     uint8_t GetUpdatedModelMatch() const { return modelMatchId; }
-    bool GetNextPayload(uint8_t* nextPayloadSize, uint8_t **payloadData);
+    bool GetNextPayload(uint8_t* nextPayloadSize, uint8_t *payloadData);
     int UpdatedPayloadCount();
     void AppendTelemetryPackage(uint8_t *package);
     uint8_t GetFifoFullPct() { return (TELEMETRY_FIFO_SIZE - messagePayloads.free()) * 100 / TELEMETRY_FIFO_SIZE; }
@@ -48,8 +48,6 @@ private:
     std::mutex mutex;
 #endif
     TelemetryFifo messagePayloads;
-
-    uint8_t currentPayload[CRSF_MAX_PACKET_LEN] {};
 
     bool processInternalTelemetryPackage(uint8_t *package);
     uint8_t CRSFinBuffer[CRSF_MAX_PACKET_LEN];

--- a/src/src/rx-serial/SerialMavlink.cpp
+++ b/src/src/rx-serial/SerialMavlink.cpp
@@ -144,18 +144,17 @@ void SerialMavlink::forwardMessage(const uint8_t *data)
     mavlinkOutputBuffer.atomicPushBytes(data + 2, data[1]);
 }
 
-bool SerialMavlink::GetNextPayload(uint8_t* nextPayloadSize, uint8_t **payloadData)
+bool SerialMavlink::GetNextPayload(uint8_t* nextPayloadSize, uint8_t *payloadData)
 {
     if (mavlinkInputBuffer.size() == 0)
     {
         return false;
     }
     const uint16_t count = std::min(mavlinkInputBuffer.size(), (uint16_t)CRSF_PAYLOAD_SIZE_MAX); // Constrain to CRSF max payload size to match SS
-    mavlinkSSBuffer[0] = CRSF_ADDRESS_USB; // device_addr - used on TX to differentiate between std tlm and mavlink
-    mavlinkSSBuffer[1] = count;
+    payloadData[0] = CRSF_ADDRESS_USB; // device_addr - used on TX to differentiate between std tlm and mavlink
+    payloadData[1] = count;
     // The following 'n' bytes are just raw mavlink
-    mavlinkInputBuffer.popBytes(mavlinkSSBuffer + CRSF_FRAME_NOT_COUNTED_BYTES, count);
-    *payloadData = mavlinkSSBuffer;
+    mavlinkInputBuffer.popBytes(payloadData + CRSF_FRAME_NOT_COUNTED_BYTES, count);
     *nextPayloadSize = count + CRSF_FRAME_NOT_COUNTED_BYTES;
     return true;
 }

--- a/src/src/rx-serial/SerialMavlink.h
+++ b/src/src/rx-serial/SerialMavlink.h
@@ -1,7 +1,5 @@
 #include "FIFO.h"
 #include "SerialIO.h"
-#include "crsf_protocol.h"
-#include "telemetry_protocol.h"
 
 #define MAV_INPUT_BUF_LEN   1024
 #define MAV_OUTPUT_BUF_LEN  512
@@ -23,7 +21,7 @@ public:
     void sendQueuedData(uint32_t maxBytesToSend) override;
 
     void forwardMessage(const uint8_t *data);
-    bool GetNextPayload(uint8_t* nextPayloadSize, uint8_t **payloadData);
+    bool GetNextPayload(uint8_t *nextPayloadSize, uint8_t *payloadData);
 
 private:
     void processBytes(uint8_t *bytes, u_int16_t size) override;
@@ -39,6 +37,4 @@ private:
     // Variables / constants for Mavlink //
     FIFO<MAV_INPUT_BUF_LEN> mavlinkInputBuffer;
     FIFO<MAV_OUTPUT_BUF_LEN> mavlinkOutputBuffer;
-
-    uint8_t mavlinkSSBuffer[CRSF_MAX_PACKET_LEN]; // Buffer for current stubborn sender packet (mavlink only)
 };

--- a/src/src/rx-serial/SerialMavlink.h
+++ b/src/src/rx-serial/SerialMavlink.h
@@ -1,5 +1,6 @@
-#include "SerialIO.h"
 #include "FIFO.h"
+#include "SerialIO.h"
+#include "crsf_protocol.h"
 #include "telemetry_protocol.h"
 
 #define MAV_INPUT_BUF_LEN   1024
@@ -21,6 +22,9 @@ public:
     int getMaxSerialReadSize() override;
     void sendQueuedData(uint32_t maxBytesToSend) override;
 
+    void forwardMessage(const uint8_t *data);
+    bool GetNextPayload(uint8_t* nextPayloadSize, uint8_t **payloadData);
+
 private:
     void processBytes(uint8_t *bytes, u_int16_t size) override;
 
@@ -31,4 +35,10 @@ private:
     const uint8_t target_component_id;
 
     uint32_t lastSentFlowCtrl = 0;
+
+    // Variables / constants for Mavlink //
+    FIFO<MAV_INPUT_BUF_LEN> mavlinkInputBuffer;
+    FIFO<MAV_OUTPUT_BUF_LEN> mavlinkOutputBuffer;
+
+    uint8_t mavlinkSSBuffer[CRSF_MAX_PACKET_LEN]; // Buffer for current stubborn sender packet (mavlink only)
 };

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -184,8 +184,6 @@ static uint8_t telemetryBurstMax;
 StubbornReceiver MspReceiver;
 uint8_t MspData[ELRS_MSP_BUFFER];
 
-uint8_t mavlinkSSBuffer[CRSF_MAX_PACKET_LEN]; // Buffer for current stubbon sender packet (mavlink only)
-
 static bool tlmSent = false;
 static uint8_t NextTelemetryType = ELRS_TELEMETRY_TYPE_LINK;
 static bool telemBurstValid;
@@ -1261,7 +1259,10 @@ void MspReceiveComplete()
 #if !defined(PLATFORM_STM32)
     case MSP_ELRS_MAVLINK_TLM: // 0xFD
         // raw mavlink data
-        mavlinkOutputBuffer.atomicPushBytes(&MspData[2], MspData[1]);
+        if (config.GetSerialProtocol() == PROTOCOL_MAVLINK)
+        {
+            ((SerialMavlink *)serialIO)->forwardMessage(MspData);
+        }
         break;
 #endif
     default:
@@ -2263,17 +2264,8 @@ void loop()
     }
 
 #if !defined(PLATFORM_STM32)
-    uint16_t count = mavlinkInputBuffer.size();
-    if (count > 0 && !TelemetrySender.IsActive())
+    if (config.GetSerialProtocol() == PROTOCOL_MAVLINK && !TelemetrySender.IsActive() && ((SerialMavlink *)serialIO)->GetNextPayload(&nextPlayloadSize, &nextPayload))
     {
-        count = std::min(count, (uint16_t)CRSF_PAYLOAD_SIZE_MAX); // Constrain to CRSF max payload size to match SS
-        // First 2 bytes conform to crsf_header_s format
-        mavlinkSSBuffer[0] = CRSF_ADDRESS_USB; // device_addr - used on TX to differentiate between std tlm and mavlink
-        mavlinkSSBuffer[1] = count;
-        // Following n bytes are just raw mavlink
-        mavlinkInputBuffer.popBytes(mavlinkSSBuffer + CRSF_FRAME_NOT_COUNTED_BYTES, count);
-        nextPayload = mavlinkSSBuffer;
-        nextPlayloadSize = count + CRSF_FRAME_NOT_COUNTED_BYTES;
         TelemetrySender.SetDataToTransmit(nextPayload, nextPlayloadSize);
     }
 #endif

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -177,6 +177,7 @@ SerialIO *serialIO = nullptr;
     #define SERIAL1_PROTOCOL_RX Serial1
 #endif
 
+uint8_t currentTelemetryPayload[CRSF_MAX_PACKET_LEN];
 StubbornSender TelemetrySender;
 static uint8_t telemetryBurstCount;
 static uint8_t telemetryBurstMax;
@@ -2256,17 +2257,16 @@ void loop()
         DBGLN("Timer locked");
     }
 
-    uint8_t *nextPayload = 0;
     uint8_t nextPlayloadSize = 0;
-    if (!TelemetrySender.IsActive() && telemetry.GetNextPayload(&nextPlayloadSize, &nextPayload))
+    if (!TelemetrySender.IsActive() && telemetry.GetNextPayload(&nextPlayloadSize, currentTelemetryPayload))
     {
-        TelemetrySender.SetDataToTransmit(nextPayload, nextPlayloadSize);
+        TelemetrySender.SetDataToTransmit(currentTelemetryPayload, nextPlayloadSize);
     }
 
 #if !defined(PLATFORM_STM32)
-    if (config.GetSerialProtocol() == PROTOCOL_MAVLINK && !TelemetrySender.IsActive() && ((SerialMavlink *)serialIO)->GetNextPayload(&nextPlayloadSize, &nextPayload))
+    if (config.GetSerialProtocol() == PROTOCOL_MAVLINK && !TelemetrySender.IsActive() && ((SerialMavlink *)serialIO)->GetNextPayload(&nextPlayloadSize, currentTelemetryPayload))
     {
-        TelemetrySender.SetDataToTransmit(nextPayload, nextPlayloadSize);
+        TelemetrySender.SetDataToTransmit(currentTelemetryPayload, nextPlayloadSize);
     }
 #endif
 


### PR DESCRIPTION
Moving the _giant_ MAVLink FIFO into the SerialMAVLink class and having a shared telemetry buffer allows us to reduce the RAM using in both CRSF mode and MAVLink mode.