### PR TITLE
Double-free on TCPclient timeout

### DIFF
--- a/src/lib/TCPSOCKET/tcpsocket.cpp
+++ b/src/lib/TCPSOCKET/tcpsocket.cpp
@@ -90,14 +90,6 @@ void TCPSOCKET::handle()
         return;
     }
 
-    // check timeout
-    if (millis() - clientTimeoutLastData > clientTimeoutPeriod)
-    {
-        DBGLN("TCP client timeout");
-        clientDisconnect(TCPclient);
-        return;
-    }
-
     pumpData();
 
     // check if there is data to send out the TCP port
@@ -141,7 +133,6 @@ void TCPSOCKET::write(uint8_t *data, uint16_t len) // doesn't send, just ques it
 
 void TCPSOCKET::handleDataIn(void *arg, AsyncClient *client, void *data, size_t len)
 {
-    instance->clientTimeoutLastData = millis();
     instance->TCPclient = client;
 
     if (instance->FIFOin->available(len + 2)) // +2 because it takes 2 bytes to store the size of the FIFO chunk
@@ -192,7 +183,10 @@ void TCPSOCKET::clientConnect(AsyncClient *client)
         msp2crsf = new MSP2CROSSFIRE();
     }
 
-    clientTimeoutLastData = millis();
+    if (hasClient())
+    {
+        TCPclient->close();
+    }
     TCPclient = client;
 }
 
@@ -218,6 +212,7 @@ void TCPSOCKET::handleNewClient(void *arg, AsyncClient *client)
     client->onError(handleError, NULL);
     client->onDisconnect(handleDisconnect, NULL);
     client->onTimeout(handleTimeOut, NULL);
+    client->setRxTimeout(clientTimeoutS);
 }
 
 #endif

--- a/src/lib/TCPSOCKET/tcpsocket.cpp
+++ b/src/lib/TCPSOCKET/tcpsocket.cpp
@@ -102,7 +102,6 @@ void TCPSOCKET::handle()
             uint8_t data[len];
             FIFOout->popBytes(data, len);
             TCPclient->write((const char *)data, len);
-            TCPclient->send();
             DBGLN("TCP OUT SENT: Sent!: len: %u", len);
         }
         else

--- a/src/lib/TCPSOCKET/tcpsocket.h
+++ b/src/lib/TCPSOCKET/tcpsocket.h
@@ -21,8 +21,7 @@ private:
 
     AsyncServer *TCPserver = nullptr;
     AsyncClient *TCPclient = nullptr;
-    const uint32_t clientTimeoutPeriod = 2000;
-    uint32_t clientTimeoutLastData = 0;
+    static const uint32_t clientTimeoutS = 2U;
 
     static void handleNewClient(void *arg, AsyncClient *client);
     static void handleDataIn(void *arg, AsyncClient *client, void *data, size_t len);

--- a/src/src/rx-serial/SerialCRSF.cpp
+++ b/src/src/rx-serial/SerialCRSF.cpp
@@ -17,7 +17,7 @@ void SerialCRSF::sendQueuedData(uint32_t maxBytesToSend)
     uint32_t bytesWritten = 0;
     #if defined(USE_MSP_WIFI)
     uint8_t OutPktLen;
-    while (OutPktLen = wifi2tcp.crsfCrsfOutAvailable(maxBytesToSend - bytesWritten))
+    while ((OutPktLen = wifi2tcp.crsfCrsfOutAvailable(maxBytesToSend - bytesWritten)))
     {
         uint8_t OutData[OutPktLen];
         wifi2tcp.crsfCrsfOutPop(OutData);


### PR DESCRIPTION
I done f-ed up, ya'll. In the cleanup for #3240 I added a double-free condition when we detect no activity on a client. The call to `clientDisconnect()` would call close() which would then trigger the event callback for close which would re-enter and free the client, and then try to free it again when the stack unwinds.  This would often cause the RX to reboot if a timeout happened since that PR.

This could be fixed with instead just calling `TCPclient->close()` but instead I changed the code to use AsyncClient's built in feature for tracking this which just calls close itself. The code guarantees there is only 1 connected client at any time so the client's timeout is sufficient to do this all for us. 4 more free bytes of RAM yo!

Also fixes a warning about putting parens around an assignment that is my fault as well.