### PR TITLE
When PWM pins are also defined as serial, default to serial

### DIFF
--- a/src/include/targets.h
+++ b/src/include/targets.h
@@ -24,6 +24,9 @@
 #endif
 #define ICACHE_RAM_ATTR //nothing//
 #else
+#if defined(PLATFORM_ESP32)
+#include <soc/uart_pins.h>
+#endif
 #undef ICACHE_RAM_ATTR //fix to allow both esp32 and esp8266 to use ICACHE_RAM_ATTR for mapping to IRAM
 #define ICACHE_RAM_ATTR IRAM_ATTR
 #endif

--- a/src/lib/CONFIG/config.cpp
+++ b/src/lib/CONFIG/config.cpp
@@ -1093,6 +1093,10 @@ RxConfig::SetDefaults(bool commit)
             {
                 mode = somSDA;
             }
+            else if (GPIO_PIN_PWM_OUTPUTS[ch] == U0RXD_GPIO_NUM || GPIO_PIN_PWM_OUTPUTS[ch] == U0TXD_GPIO_NUM)
+            {
+                mode = somSerial;
+            }
         }
         SetPwmChannel(ch, 512, ch, false, mode, false);
     }


### PR DESCRIPTION
In the hardware JSON serial pins can be user selected as serial or PWM.
So if the 'default' serial pins are defined only in the PWM section then they default to PWM, but can be selected as Serial outputs.
If they are defined in the PWM section and the serial definition then they default to serial output, but the user can change them to PWM on the PWM page in the web UI.

This is useful for targets that wish to have dual use pins, but default to serial rather than PWM.
This also aligns more with how the I2C pins are done in the hardware JSON file.