### PR TITLE
Fix DShot overflow issue

### DIFF
--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -58,7 +58,7 @@ static void servoWrite(uint8_t ch, uint16_t us)
         // DBGLN("Writing DShot output: us: %u, ch: %d", us, ch);
         if (dshotInstances[ch])
         {
-            dshotInstances[ch]->send_dshot_value(((us - 1000) * 2) + 47); // Convert PWM signal in us to DShot value
+            dshotInstances[ch]->send_dshot_value(((constrain(us, 1000, 2000) - 1000) * 2) + 47); // Convert PWM signal in us to DShot value
         }
     }
     else


### PR DESCRIPTION
As reported on discord, the us value can be outside the range 1000-2000 and will cause an overflow which will in turn cause the ESC to go full power.