### PR TITLE
Bug: DShot full throttle at low us

### DIFF
--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -58,7 +58,7 @@ static void servoWrite(uint8_t ch, uint16_t us)
         // DBGLN("Writing DShot output: us: %u, ch: %d", us, ch);
         if (dshotInstances[ch])
         {
-            dshotInstances[ch]->send_dshot_value(((us - 1000) * 2) + 47); // Convert PWM signal in us to DShot value
+            dshotInstances[ch]->send_dshot_value(max(((us - 1000) * 2) + 47, 0)); // Convert PWM signal in us to DShot value
         }
     }
     else


### PR DESCRIPTION
Fixed bug where us values below 977 would result in full throttle instead of no throttle.

WARNING: When using DShot for throttle, make sure the PWM signal coming out of the outputs screen on EdgeTX cannot go below 977us.
This will cause the motor to go to full throttle!!!

Explanation:
Using a value below 976.5us will cause the uint to underflow and reach an incredibly high value. Take for example 900us: the formula will result in -153, but this underflows to 65383. When the DShot code sends this to the ESC it clamps this to the max value of 2047; thus full throttle.

https://discord.com/channels/596350022191415318/797109686285107241/1390915563936809001