### PR TITLE
Use wifi MAC as default UID for ESP8285 TX

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -29,6 +29,8 @@
 #if defined(PLATFORM_ESP32_S3) || defined(PLATFORM_ESP32_C3)
 #include "USB.h"
 #define USBSerial Serial
+#elif defined(PLATFORM_ESP8266)
+#include <user_interface.h>
 #endif
 
 //// CONSTANTS ////
@@ -1373,6 +1375,8 @@ static void setupBindingFromConfig()
   {
 #ifdef PLATFORM_ESP32
     esp_read_mac(UID, ESP_MAC_WIFI_STA);
+#elif PLATFORM_ESP8266
+    wifi_get_macaddr(STATION_IF, UID);
 #elif PLATFORM_STM32
     UID[0] = (uint8_t)HAL_GetUIDw0();
     UID[1] = (uint8_t)(HAL_GetUIDw0() >> 8);


### PR DESCRIPTION
For ESP8285 RX as TX, the default UID (when not flashed) was using all zeros, which is incorrect.
This PR set's the default UID to the MAC address like the ES32 does.