### PR TITLE
Fix inverted IQ check

### DIFF
--- a/src/lib/LR1121Driver/LR1121.cpp
+++ b/src/lib/LR1121Driver/LR1121.cpp
@@ -171,11 +171,12 @@ void LR1121Driver::Config(uint8_t bw, uint8_t sf, uint8_t cr, uint32_t regfreq,
     if (radioNumber & SX12XX_Radio_2)
         radio2isSubGHz = isSubGHz;
 
-    IQinverted = InvertIQ ? LR11XX_RADIO_LORA_IQ_INVERTED : LR11XX_RADIO_LORA_IQ_STANDARD;
-    // IQinverted is always STANDARD for 900 and SX1276
+    IQinverted = InvertIQ;
+    lr11xx_radio_lora_iq_t inverted = InvertIQ ? LR11XX_RADIO_LORA_IQ_INVERTED : LR11XX_RADIO_LORA_IQ_STANDARD;
+    // IQinverted is always STANDARD for 900
     if (isSubGHz)
     {
-        IQinverted = LR11XX_RADIO_LORA_IQ_STANDARD;
+        inverted = LR11XX_RADIO_LORA_IQ_STANDARD;
     }
 
     SetRxTimeoutUs(interval);
@@ -218,7 +219,7 @@ void LR1121Driver::Config(uint8_t bw, uint8_t sf, uint8_t cr, uint32_t regfreq,
         lr11xx_RadioLoRaPacketLengthsModes_t packetLengthType = LR1121_LORA_PACKET_FIXED_LENGTH;
     #endif
 
-        SetPacketParamsLoRa(PreambleLength, packetLengthType, PayloadLength, IQinverted, radioNumber);
+        SetPacketParamsLoRa(PreambleLength, packetLengthType, PayloadLength, inverted, radioNumber);
     }
 
     SetFrequencyHz(regfreq, radioNumber);

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -376,8 +376,17 @@ void SetRFLinkRate(uint8_t index) // Set speed of RF link
   bool invertIQ = InBindingMode || (UID[5] & 0x01);
   OtaSwitchMode_e newSwitchMode = (OtaSwitchMode_e)config.GetSwitchMode();
 
+  bool subGHz = FHSSgetInitialFreq() < 1000000000;
+#if defined(RADIO_LR1121)
+  if (FHSSuseDualBand && subGHz)
+  {
+      subGHz = FHSSgetInitialGeminiFreq() < 1000000000;
+  }
+#endif
+
   if ((ModParams == ExpressLRS_currAirRate_Modparams)
     && (RFperf == ExpressLRS_currAirRate_RFperfParams)
+    && (subGHz || invertIQ == Radio.IQinverted)
     && (OtaSwitchModeCurrent == newSwitchMode))
     return;
 

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -376,18 +376,19 @@ void SetRFLinkRate(uint8_t index) // Set speed of RF link
   bool invertIQ = InBindingMode || (UID[5] & 0x01);
   OtaSwitchMode_e newSwitchMode = (OtaSwitchMode_e)config.GetSwitchMode();
 
-  bool subGHz = FHSSgetInitialFreq() < 1000000000;
+  bool subGHz = FHSSconfig->freq_center < 1000000000;
 #if defined(RADIO_LR1121)
   if (FHSSuseDualBand && subGHz)
   {
-      subGHz = FHSSgetInitialGeminiFreq() < 1000000000;
+      subGHz = FHSSconfigDualBand->freq_center < 1000000000;
   }
 #endif
 
   if ((ModParams == ExpressLRS_currAirRate_Modparams)
     && (RFperf == ExpressLRS_currAirRate_RFperfParams)
     && (subGHz || invertIQ == Radio.IQinverted)
-    && (OtaSwitchModeCurrent == newSwitchMode))
+    && (OtaSwitchModeCurrent == newSwitchMode)
+    && (!InBindingMode))  // binding mode must always execute code below to set frequency
     return;
 
   DBGLN("set rate %u", index);


### PR DESCRIPTION
# Problem
When binding in 50Hz 2.4GHz and the UID[5] bit 0 is unset, the radio config command would be ignored because logic for checking the InvertedIQ flag was removed and in binding mode the invertedIQ flag is always true. 

- Fix the inverted IQ check. 
- Bonus: fix LR1121 passing wrong value to command.

This was a little more complicated than reverting #3014 because of 900MHz and LR1121 being dual band!