### PR TITLE
Wide switch mode always 6 bit, boost to 1:2

### DIFF
--- a/src/lib/OTA/OTA.cpp
+++ b/src/lib/OTA/OTA.cpp
@@ -135,10 +135,8 @@ static uint8_t Hybrid8NextSwitchIndex;
 void OtaSetHybrid8NextSwitchIndex(uint8_t idx) { Hybrid8NextSwitchIndex = idx; }
 #endif
 void ICACHE_RAM_ATTR GenerateChannelDataHybrid8(OTA_Packet_s * const otaPktPtr, const uint32_t *channelData,
-                                                bool const TelemetryStatus, uint8_t const tlmDenom)
+                                                bool const TelemetryStatus)
 {
-    (void)tlmDenom;
-
     OTA_Packet4_s * const ota4 = &otaPktPtr->std;
     PackChannelDataHybridCommon(ota4, channelData);
 
@@ -166,17 +164,13 @@ void ICACHE_RAM_ATTR GenerateChannelDataHybrid8(OTA_Packet_s * const otaPktPtr, 
 
 /**
  * Return the OTA value respresentation of the switch contained in ChannelData
- * Switches 1-6 (AUX2-AUX7) are 6 or 7 bit depending on the lowRes parameter
+ * Switches 1-6 (AUX2-AUX7) are 6 bit
  */
-static uint8_t ICACHE_RAM_ATTR HybridWideSwitchToOta(const uint32_t *channelData, uint8_t const switchIdx, bool const lowRes)
+static uint8_t ICACHE_RAM_ATTR HybridWideSwitchToOta(const uint32_t *channelData, uint8_t const switchIdx)
 {
     uint16_t ch = channelData[switchIdx + 4];
-    uint8_t binCount = (lowRes) ? 64 : 128;
-    ch = CRSF_to_N(ch, binCount);
-    if (lowRes)
-        return ch & 0b111111; // 6-bit
-    else
-        return ch & 0b1111111; // 7-bit
+    ch = CRSF_to_N(ch, 64);
+    return ch & 0b111111; // 6-bit
 }
 
 /**
@@ -184,36 +178,28 @@ static uint8_t ICACHE_RAM_ATTR HybridWideSwitchToOta(const uint32_t *channelData
  *
  * Analog channels are reduced to 10 bits to allow for switch encoding
  * Switch[0] is sent on every packet.
- * A 6 or 7 bit switch value is used to send the remaining switches
+ * A 6 bit switch value is used to send the remaining switches
  * in a round-robin fashion.
  *
  * Inputs: cchannelData, TelemetryStatus
  * Outputs: OTA_Packet4_s
  **/
 void ICACHE_RAM_ATTR GenerateChannelDataHybridWide(OTA_Packet_s * const otaPktPtr, const uint32_t *channelData,
-                                                   bool const TelemetryStatus, uint8_t const tlmDenom)
+                                                   bool const TelemetryStatus)
 {
     OTA_Packet4_s * const ota4 = &otaPktPtr->std;
     PackChannelDataHybridCommon(ota4, channelData);
 
-    uint8_t telemBit = TelemetryStatus << 6;
     uint8_t nextSwitchIndex = HybridWideNonceToSwitchIndex(OtaNonce);
-    uint8_t value;
-    // Using index 7 means the telemetry bit will always be sent in the packet
-    // preceding the RX's telemetry slot for all tlmDenom >= 8
-    // For more frequent telemetry rates, include the bit in every
-    // packet and degrade the value to 6-bit
-    // (technically we could squeeze 7-bits in for 2 channels with tlmDenom=4)
+    uint8_t value = TelemetryStatus << 6;
+    // There are only 7 switches to round robin through, so the 8th slot is used to send TX power
     if (nextSwitchIndex == 7)
     {
-        value = telemBit | CRSF::LinkStatistics.uplink_TX_Power;
+        value |= CRSF::LinkStatistics.uplink_TX_Power;
     }
     else
     {
-        bool telemInEveryPacket = (tlmDenom > 1) && (tlmDenom < 8);
-        value = HybridWideSwitchToOta(channelData, nextSwitchIndex + 1, telemInEveryPacket);
-        if (telemInEveryPacket)
-            value |= telemBit;
+        value |= HybridWideSwitchToOta(channelData, nextSwitchIndex + 1);
     }
 
     ota4->rc.switches = value;
@@ -269,10 +255,8 @@ static void ICACHE_RAM_ATTR GenerateChannelData8ch12ch(OTA_Packet8_s * const ota
 #endif
 }
 
-static void ICACHE_RAM_ATTR GenerateChannelData8ch(OTA_Packet_s * const otaPktPtr, const uint32_t *channelData, bool const TelemetryStatus, uint8_t const tlmDenom)
+static void ICACHE_RAM_ATTR GenerateChannelData8ch(OTA_Packet_s * const otaPktPtr, const uint32_t *channelData, bool const TelemetryStatus)
 {
-    (void)tlmDenom;
-
     GenerateChannelData8ch12ch((OTA_Packet8_s * const)otaPktPtr, channelData, TelemetryStatus, false);
 }
 
@@ -280,10 +264,8 @@ static bool FullResIsHighAux;
 #if defined(UNIT_TEST)
 void OtaSetFullResNextChannelSet(bool next) { FullResIsHighAux = next; }
 #endif
-static void ICACHE_RAM_ATTR GenerateChannelData12ch(OTA_Packet_s * const otaPktPtr, const uint32_t *channelData, bool const TelemetryStatus, uint8_t const tlmDenom)
+static void ICACHE_RAM_ATTR GenerateChannelData12ch(OTA_Packet_s * const otaPktPtr, const uint32_t *channelData, bool const TelemetryStatus)
 {
-    (void)tlmDenom;
-
     // Every time this function is called, the opposite high Aux channels are sent
     // This tries to ensure a fair split of high and low aux channels packets even
     // at 1:2 ratio and around sync packets
@@ -365,11 +347,8 @@ static void ICACHE_RAM_ATTR UnpackChannelDataHybridCommon(OTA_Packet4_s const * 
  * Output: channelData
  * Returns: TelemetryStatus bit
  */
-bool ICACHE_RAM_ATTR UnpackChannelDataHybridSwitch8(OTA_Packet_s const * const otaPktPtr, uint32_t *channelData,
-                                                    uint8_t const tlmDenom)
+bool ICACHE_RAM_ATTR UnpackChannelDataHybridSwitch8(OTA_Packet_s const * const otaPktPtr, uint32_t *channelData)
 {
-    (void)tlmDenom;
-
     OTA_Packet4_s const * const ota4 = (OTA_Packet4_s const * const)otaPktPtr;
     UnpackChannelDataHybridCommon(ota4, channelData);
 
@@ -398,15 +377,14 @@ bool ICACHE_RAM_ATTR UnpackChannelDataHybridSwitch8(OTA_Packet_s const * const o
  *
  * Hybrid switches uses 10 bits for each analog channel,
  * 1 bits for the low latency switch[0]
- * 6 or 7 bits for the round-robin switch
- * 1 bit for the TelemetryStatus, which may be in every packet or just idx 7
+ * 6 bit for the round-robin switch
+ * 1 bit for the TelemetryStatus
  * depending on TelemetryRatio
  *
  * Output: channelData
  * Returns: TelemetryStatus bit
  */
-bool ICACHE_RAM_ATTR UnpackChannelDataHybridWide(OTA_Packet_s const * const otaPktPtr, uint32_t *channelData,
-                                                 uint8_t const tlmDenom)
+bool ICACHE_RAM_ATTR UnpackChannelDataHybridWide(OTA_Packet_s const * const otaPktPtr, uint32_t *channelData)
 {
     static bool TelemetryStatus = false;
 
@@ -415,39 +393,23 @@ bool ICACHE_RAM_ATTR UnpackChannelDataHybridWide(OTA_Packet_s const * const otaP
 
     // The round-robin switch, 6-7 bits with the switch index implied by the nonce
     const uint8_t switchByte = ota4->rc.switches;
-    bool telemInEveryPacket = (tlmDenom > 1) && (tlmDenom < 8);
     uint8_t switchIndex = HybridWideNonceToSwitchIndex(OtaNonce);
-    if (telemInEveryPacket || switchIndex == 7)
-          TelemetryStatus = (switchByte & 0b01000000) >> 6;
+    TelemetryStatus = (switchByte & 0b01000000) >> 6;
     if (switchIndex == 7)
     {
         CRSF::updateUplinkPower(switchByte & 0b111111);
     }
     else
     {
-        uint8_t bins;
-        uint16_t switchValue;
-        if (telemInEveryPacket)
-        {
-            bins = 63;
-            switchValue = switchByte & 0b111111; // 6-bit
-        }
-        else
-        {
-            bins = 127;
-            switchValue = switchByte & 0b1111111; // 7-bit
-        }
-
-        channelData[5 + switchIndex] = N_to_CRSF(switchValue, bins);
+        uint16_t switchValue = switchByte & 0b111111; // 6-bit
+        channelData[5 + switchIndex] = N_to_CRSF(switchValue, 63);
     }
 
     return TelemetryStatus;
 }
 
-bool ICACHE_RAM_ATTR UnpackChannelData8ch(OTA_Packet_s const * const otaPktPtr, uint32_t *channelData, uint8_t const tlmDenom)
+bool ICACHE_RAM_ATTR UnpackChannelData8ch(OTA_Packet_s const * const otaPktPtr, uint32_t *channelData)
 {
-    (void)tlmDenom;
-
     OTA_Packet8_s const * const ota8 = (OTA_Packet8_s const * const)otaPktPtr;
 
     isArmed = ota8->rc.isArmed;
@@ -482,7 +444,7 @@ bool ICACHE_RAM_ATTR UnpackChannelData8ch(OTA_Packet_s const * const otaPktPtr, 
     UnpackChannels4x10ToUInt11(&ota8->rc.chHigh, &channelData[chDstHigh]);
 
     // enable this for legacy behavior (digital ch5) for 8ch and 12ch mode
-    //channelData[4] = BIT_to_CRSF(isArmed); 
+    //channelData[4] = BIT_to_CRSF(isArmed);
 #endif
     // Restore the uplink_TX_Power range 0-7 -> 1-8
     CRSF::updateUplinkPower(ota8->rc.uplinkPower + 1);
@@ -518,7 +480,7 @@ bool ICACHE_RAM_ATTR ValidatePacketCrcStd(OTA_Packet_s * const otaPktPtr)
         ota_crc.calc((uint8_t*)otaPktPtr, OTA4_CRC_CALC_LEN, OtaCrcInitializer);
 
     otaPktPtr->std.crcHigh = backupCrcHigh;
-    
+
     return inCRC == calculatedCRC;
 }
 

--- a/src/lib/OTA/OTA.h
+++ b/src/lib/OTA/OTA.h
@@ -9,7 +9,7 @@
 #include "telemetry_protocol.h"
 #include "FIFO.h"
 
-#if TARGET_RX 
+#if TARGET_RX
 extern bool isArmed;
 #endif
 
@@ -190,7 +190,7 @@ extern GeneratePacketCrc_t OtaGeneratePacketCrc;
 #define ELRS_CRC16_POLY 0x3D65 // 0x9eb2
 
 #if defined(TARGET_TX) || defined(UNIT_TEST)
-typedef void (*PackChannelData_t)(OTA_Packet_s * const otaPktPtr, const uint32_t *channelData, bool TelemetryStatus, uint8_t tlmDenom);
+typedef void (*PackChannelData_t)(OTA_Packet_s * const otaPktPtr, const uint32_t *channelData, bool TelemetryStatus);
 extern PackChannelData_t OtaPackChannelData;
 #if defined(UNIT_TEST)
 void OtaSetHybrid8NextSwitchIndex(uint8_t idx);
@@ -199,7 +199,7 @@ void OtaSetFullResNextChannelSet(bool next);
 #endif
 
 #if defined(TARGET_RX) || defined(UNIT_TEST)
-typedef bool (*UnpackChannelData_t)(OTA_Packet_s const * const otaPktPtr, uint32_t *channelData, uint8_t tlmDenom);
+typedef bool (*UnpackChannelData_t)(OTA_Packet_s const * const otaPktPtr, uint32_t *channelData);
 extern UnpackChannelData_t OtaUnpackChannelData;
 #endif
 

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -958,7 +958,7 @@ static void ICACHE_RAM_ATTR ProcessRfPacket_RC(OTA_Packet_s const * const otaPkt
     if (connectionState != connected || SwitchModePending)
         return;
 
-    bool telemetryConfirmValue = OtaUnpackChannelData(otaPktPtr, ChannelData, ExpressLRS_currTlmDenom);
+    bool telemetryConfirmValue = OtaUnpackChannelData(otaPktPtr, ChannelData);
     TelemetrySender.ConfirmCurrentPayload(telemetryConfirmValue);
 
     // No channels packets to the FC or PWM pins if no model match
@@ -1600,7 +1600,7 @@ static void setupSerial1()
             Serial1.begin(115200, SERIAL_8N1, UNDEF_PIN, serial1TXpin, false);
             serial1IO = new SerialDisplayport(SERIAL1_PROTOCOL_TX, SERIAL1_PROTOCOL_RX);
             break;
-        case PROTOCOL_SERIAL1_GPS:        
+        case PROTOCOL_SERIAL1_GPS:
             Serial1.begin(115200, SERIAL_8N1, serial1RXpin, serial1TXpin, false);
             serial1IO = new SerialGPS(SERIAL1_PROTOCOL_TX, SERIAL1_PROTOCOL_RX);
             break;

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -198,17 +198,17 @@ bool ICACHE_RAM_ATTR ProcessTLMpacket(SX12xxDriverCommon::rx_status const status
   {
     OTA_Packet8_s * const ota8 = (OTA_Packet8_s * const)otaPktPtr;
     OTA_Packet8_s * const ota8Second = (OTA_Packet8_s * const)otaPktPtrSecond;
-    
+
     switch (otaPktPtr->std.type)
     {
       case PACKET_TYPE_LINKSTATS:
         LinkStatsFromOta(&ota8->tlm_dl.ul_link_stats.stats);
 
-        // The Rx only has a single radio.  Force the Tx out of Gemini mode. 
+        // The Rx only has a single radio.  Force the Tx out of Gemini mode.
         if (config.GetAntennaMode() == TX_RADIO_MODE_GEMINI && !ota8->tlm_dl.ul_link_stats.trueDiversityAvailable)
         {
             config.SetAntennaMode(TX_RADIO_MODE_SWITCH);
-        }    
+        }
 
         if (config.GetAntennaMode() == TX_RADIO_MODE_GEMINI)
         {
@@ -233,10 +233,10 @@ bool ICACHE_RAM_ATTR ProcessTLMpacket(SX12xxDriverCommon::rx_status const status
                 packageIndexRadio1 = ota8Second->tlm_dl.packageIndex;
                 memcpy(tlmSenderDoubleBuffer, ota8Second->tlm_dl.ul_link_stats.payload, sizeof(ota8Second->tlm_dl.ul_link_stats.payload));
             }
-            
+
             if (packageIndexRadio1 == packageIndexRadio2 && packageIndexRadio1 != 0xFF)
             {
-                TelemetryReceiver.ReceiveData(packageIndexRadio1 & ELRS8_TELEMETRY_MAX_PACKAGES, 
+                TelemetryReceiver.ReceiveData(packageIndexRadio1 & ELRS8_TELEMETRY_MAX_PACKAGES,
                     tlmSenderDoubleBuffer, 2 * sizeof(ota8->tlm_dl.ul_link_stats.payload));
                 packageIndexRadio1 = 0xFF;
                 packageIndexRadio2 = 0xFF;
@@ -279,11 +279,11 @@ bool ICACHE_RAM_ATTR ProcessTLMpacket(SX12xxDriverCommon::rx_status const status
                     packageIndexRadio1 = ota8Second->tlm_dl.packageIndex;
                     memcpy(tlmSenderDoubleBuffer, ota8Second->tlm_dl.payload, sizeof(ota8Second->tlm_dl.payload));
                 }
-                
+
                 if (packageIndexRadio1 == packageIndexRadio2 && packageIndexRadio1 != 0xFF)
                 {
                     MspSender.ConfirmCurrentPayload(ota8->tlm_dl.tlmConfirm);
-                    TelemetryReceiver.ReceiveData(packageIndexRadio1 & ELRS8_TELEMETRY_MAX_PACKAGES, 
+                    TelemetryReceiver.ReceiveData(packageIndexRadio1 & ELRS8_TELEMETRY_MAX_PACKAGES,
                         tlmSenderDoubleBuffer, 2 * sizeof(ota8->tlm_dl.payload));
                     packageIndexRadio1 = 0xFF;
                     packageIndexRadio2 = 0xFF;
@@ -307,7 +307,7 @@ bool ICACHE_RAM_ATTR ProcessTLMpacket(SX12xxDriverCommon::rx_status const status
       case PACKET_TYPE_LINKSTATS:
         LinkStatsFromOta(&otaPktPtr->std.tlm_dl.ul_link_stats.stats);
 
-        // The Rx only has a single radio.  Force the Tx out of Gemini mode. 
+        // The Rx only has a single radio.  Force the Tx out of Gemini mode.
         if (config.GetAntennaMode() == TX_RADIO_MODE_GEMINI && !otaPktPtr->std.tlm_dl.ul_link_stats.trueDiversityAvailable)
         {
             config.SetAntennaMode(TX_RADIO_MODE_SWITCH);
@@ -344,11 +344,11 @@ bool ICACHE_RAM_ATTR ProcessTLMpacket(SX12xxDriverCommon::rx_status const status
                     packageIndexRadio1 = otaPktPtrSecond->std.tlm_dl.packageIndex;
                     memcpy(tlmSenderDoubleBuffer, otaPktPtrSecond->std.tlm_dl.payload, sizeof(otaPktPtrSecond->std.tlm_dl.payload));
                 }
-                
+
                 if (packageIndexRadio1 == packageIndexRadio2 && packageIndexRadio1 != 0xFF)
                 {
                     MspSender.ConfirmCurrentPayload(otaPktPtr->std.tlm_dl.tlmConfirm);
-                    TelemetryReceiver.ReceiveData(packageIndexRadio1 & ELRS4_TELEMETRY_MAX_PACKAGES, 
+                    TelemetryReceiver.ReceiveData(packageIndexRadio1 & ELRS4_TELEMETRY_MAX_PACKAGES,
                         tlmSenderDoubleBuffer, 2 * sizeof(otaPktPtr->std.tlm_dl.payload));
                     packageIndexRadio1 = 0xFF;
                     packageIndexRadio2 = 0xFF;
@@ -385,18 +385,7 @@ expresslrs_tlm_ratio_e ICACHE_RAM_ATTR UpdateTlmRatioEffective()
   if (syncTelemBoostState == stbRequested)
   {
     syncTelemBoostState = stbBoosting;
-    // default to 1:2 telemetry ratio bump for non-wide modes and
-    // wide mode configured to 1:4
     retVal = TLM_RATIO_1_2;
-
-    if (!OtaIsFullRes && config.GetSwitchMode() == smWideOr8ch)
-    {
-      // avoid crossing the wide switch 7-bit to 6-bit boundary
-      if (ratioConfigured <= TLM_RATIO_1_8 || ratioConfigured == TLM_RATIO_DISARMED)
-      {
-        retVal = TLM_RATIO_1_8;
-      }
-    }
   }
   // If Armed, telemetry is disabled, otherwise use STD
   else if (ratioConfigured == TLM_RATIO_DISARMED)
@@ -665,7 +654,7 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
       // always enable msp after a channel package since the slot is only used if MspSender has data to send
       NextPacketIsMspData = true;
 
-      OtaPackChannelData(&otaPkt, ChannelData, TelemetryReceiver.GetCurrentConfirm(), ExpressLRS_currTlmDenom);
+      OtaPackChannelData(&otaPkt, ChannelData, TelemetryReceiver.GetCurrentConfirm());
     }
   }
 

--- a/src/test/test_ota/test_switches.cpp
+++ b/src/test/test_ota/test_switches.cpp
@@ -136,7 +136,7 @@ void test_encodingHybrid8(bool highResChannel)
 
     // encode it
     OtaUpdateSerializers(smHybridOr16ch, OTA4_PACKET_SIZE);
-    OtaPackChannelData(otaPktPtr, ChannelData, false, 0);
+    OtaPackChannelData(otaPktPtr, ChannelData, false);
 
     // check it looks right
     // 1st byte is CRC & packet type
@@ -216,10 +216,10 @@ void test_decodingHybrid8(uint8_t forceSwitch, uint8_t switchval)
     memcpy(ChannelsIn, ChannelData, sizeof(ChannelData));
     // use the encoding method to pack it into TXdataBuffer
     OtaUpdateSerializers(smHybridOr16ch, OTA4_PACKET_SIZE);
-    OtaPackChannelData(otaPktPtr, ChannelData, false, 0);
+    OtaPackChannelData(otaPktPtr, ChannelData, false);
 
     // run the decoder, results in crsf->PackedRCdataOut
-    OtaUnpackChannelData(otaPktPtr, ChannelData, 0);
+    OtaUnpackChannelData(otaPktPtr, ChannelData);
 
     // compare the unpacked results with the input data
     TEST_ASSERT_EQUAL(ChannelsIn[0], ChannelData[0]);
@@ -251,7 +251,7 @@ void test_decodingHybrid8_all()
 
 /* Check the HybridWide encoding of a packet for OTA tx
 */
-void test_encodingHybridWide(bool highRes, uint8_t nonce)
+void test_encodingHybridWide(uint8_t nonce)
 {
     uint8_t UID[6] = {0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE};
     uint8_t TXdataBuffer[OTA4_PACKET_SIZE] = {0};
@@ -280,10 +280,9 @@ void test_encodingHybridWide(bool highRes, uint8_t nonce)
     // Save the channels since they go into the same place
     memcpy(ChannelsIn, ChannelData, sizeof(ChannelData));
     // encode it
-    uint8_t tlmDenom = (highRes) ? 64 : 4;
     OtaUpdateSerializers(smWideOr8ch, OTA4_PACKET_SIZE);
     OtaNonce = nonce;
-    OtaPackChannelData(otaPktPtr, ChannelData, nonce % 2, tlmDenom);
+    OtaPackChannelData(otaPktPtr, ChannelData, nonce % 2);
 
     // check it looks right
     // 1st byte is CRC & packet type
@@ -300,9 +299,8 @@ void test_encodingHybridWide(bool highRes, uint8_t nonce)
 
     // High bit should be AUX1
     TEST_ASSERT_EQUAL(CRSF_to_BIT(ChannelsIn[4]), switches >> 7);
-    // If low res or slot 7, the bit 6 should be the telemetryack bit
-    if (!highRes || switchIdx == 7)
-        TEST_ASSERT_EQUAL(nonce % 2, (switches >> 6) & 1);
+    // bit 6 should be the telemetryack bit
+    TEST_ASSERT_EQUAL(nonce % 2, (switches >> 6) & 1);
 
     // If slot 7, the uplink_TX_Power should be in the low 6 bits
     if (switchIdx == 7)
@@ -310,30 +308,20 @@ void test_encodingHybridWide(bool highRes, uint8_t nonce)
     else
     {
         uint16_t ch = ChannelData[5+switchIdx];
-        if (highRes)
-            TEST_ASSERT_EQUAL(CRSF_to_N(ch, 128), switches & 0b1111111); // 7-bit
-        else
-            TEST_ASSERT_EQUAL(CRSF_to_N(ch, 64), switches & 0b111111); // 6-bit
+        TEST_ASSERT_EQUAL(CRSF_to_N(ch, 64), switches & 0b111111); // 6-bit
     }
-}
-
-void test_encodingHybridWide_high()
-{
-    constexpr int N_SWITCHES = 8;
-    for (int i=0; i<N_SWITCHES; ++i)
-        test_encodingHybridWide(true, i);
 }
 
 void test_encodingHybridWide_low()
 {
     constexpr int N_SWITCHES = 8;
     for (int i=0; i<N_SWITCHES; ++i)
-        test_encodingHybridWide(false, i);
+        test_encodingHybridWide(i);
 }
 
 /* Check the decoding of a packet after rx in HybridWide mode
 */
-void test_decodingHybridWide(bool highRes, uint8_t nonce, uint8_t forceSwitch, uint16_t forceVal)
+void test_decodingHybridWide(uint8_t nonce, uint8_t forceSwitch, uint16_t forceVal)
 {
     uint8_t UID[6] = {0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE};
     uint8_t TXdataBuffer[OTA4_PACKET_SIZE] = {0};
@@ -365,16 +353,15 @@ void test_decodingHybridWide(bool highRes, uint8_t nonce, uint8_t forceSwitch, u
     // Save the channels since they go into the same place
     memcpy(ChannelsIn, ChannelData, sizeof(ChannelData));
     // encode it
-    uint8_t tlmDenom = (highRes) ? 64 : 4;
     OtaUpdateSerializers(smWideOr8ch, OTA4_PACKET_SIZE);
     OtaNonce = nonce;
-    OtaPackChannelData(otaPktPtr, ChannelData, nonce % 2, tlmDenom);
+    OtaPackChannelData(otaPktPtr, ChannelData, nonce % 2);
 
     // Clear the LinkStatistics to receive it from the encoding
     CRSF::LinkStatistics.uplink_TX_Power = 0;
 
     // run the decoder, results in crsf->PackedRCdataOut
-    bool telemResult = OtaUnpackChannelData(otaPktPtr, ChannelData, tlmDenom);
+    bool telemResult = OtaUnpackChannelData(otaPktPtr, ChannelData);
 
     // compare the unpacked results with the input data
     TEST_ASSERT_EQUAL(ChannelsIn[0], ChannelData[0]);
@@ -387,8 +374,7 @@ void test_decodingHybridWide(bool highRes, uint8_t nonce, uint8_t forceSwitch, u
 
     uint8_t switchIdx = nonce % 8;
     // Validate the telemResult was unpacked properly
-    if (!highRes || switchIdx == 7)
-        TEST_ASSERT_EQUAL(telemResult, nonce % 2);
+    TEST_ASSERT_EQUAL(telemResult, nonce % 2);
 
     if (switchIdx == 7)
     {
@@ -396,10 +382,7 @@ void test_decodingHybridWide(bool highRes, uint8_t nonce, uint8_t forceSwitch, u
     }
     else
     {
-        if (highRes)
-            TEST_ASSERT_EQUAL(N_to_CRSF(CRSF_to_N(ChannelData[5+switchIdx], 128), 127), ChannelData[5+switchIdx]);
-        else
-            TEST_ASSERT_EQUAL(N_to_CRSF(CRSF_to_N(ChannelData[5+switchIdx], 64), 63), ChannelData[5+switchIdx]);
+        TEST_ASSERT_EQUAL(N_to_CRSF(CRSF_to_N(ChannelData[5+switchIdx], 64), 63), ChannelData[5+switchIdx]);
     }
 }
 
@@ -444,8 +427,8 @@ void test_encodingFullresPowerLevels()
         uint8_t crsfPower = powerToCrsfPower((PowerLevels_e)pwr);
         CRSF::LinkStatistics.uplink_TX_Power = crsfPower;
 
-        OtaPackChannelData(otaPktPtr, ChannelData, false, 0);
-        OtaUnpackChannelData(otaPktPtr, ChannelData, 0);
+        OtaPackChannelData(otaPktPtr, ChannelData, false);
+        OtaUnpackChannelData(otaPktPtr, ChannelData);
 
         TEST_ASSERT_EQUAL(crsfPower, CRSF::LinkStatistics.uplink_TX_Power);
     }
@@ -464,7 +447,7 @@ void test_encodingFullres8ch()
     // Save the channels since they go into the same place
     memcpy(ChannelsIn, ChannelData, sizeof(ChannelData));
     OtaUpdateSerializers(smWideOr8ch, OTA8_PACKET_SIZE);
-    OtaPackChannelData(otaPktPtr, ChannelData, false, 0);
+    OtaPackChannelData(otaPktPtr, ChannelData, false);
 
     // Low 4ch (CH1-CH4)
     uint8_t expected[5];
@@ -506,7 +489,7 @@ void test_encodingFullres16ch()
 
     // ** PACKET ONE **
     memset(TXdataBuffer, 0, sizeof(TXdataBuffer)); // "destChannels4x10 must be zeroed"
-    OtaPackChannelData(otaPktPtr, ChannelData, false, 0);
+    OtaPackChannelData(otaPktPtr, ChannelData, false);
     // Low 4ch (CH1-CH4)
     uint8_t expected[5];
     expected[0] = ((ChannelsIn[0] >> 1) >> 0);
@@ -525,7 +508,7 @@ void test_encodingFullres16ch()
 
     // ** PACKET TWO **
     memset(TXdataBuffer, 0, sizeof(TXdataBuffer)); // "destChannels4x10 must be zeroed"
-    OtaPackChannelData(otaPktPtr, ChannelData, false, 0);
+    OtaPackChannelData(otaPktPtr, ChannelData, false);
     // Low 4ch (CH9-CH12)
     expected[0] = ((ChannelsIn[8] >> 1) >> 0);
     expected[1] = ((ChannelsIn[8] >> 1) >> 8) | ((ChannelsIn[9] >> 1) << 2);
@@ -558,7 +541,7 @@ void test_encodingFullres12ch()
 
     // ** PACKET ONE **
     memset(TXdataBuffer, 0, sizeof(TXdataBuffer)); // "destChannels4x10 must be zeroed"
-    OtaPackChannelData(otaPktPtr, ChannelData, false, 0);
+    OtaPackChannelData(otaPktPtr, ChannelData, false);
     // Low 4ch (CH1-CH4)
     uint8_t expected[5];
     expected[0] = ((ChannelsIn[0] >> 1) >> 0);
@@ -577,7 +560,7 @@ void test_encodingFullres12ch()
 
     // ** PACKET TWO **
     memset(TXdataBuffer, 0, sizeof(TXdataBuffer)); // "destChannels4x10 must be zeroed"
-    OtaPackChannelData(otaPktPtr, ChannelData, false, 0);
+    OtaPackChannelData(otaPktPtr, ChannelData, false);
     // Low 4ch (CH1-CH4)
     expected[0] = ((ChannelsIn[0] >> 1) >> 0);
     expected[1] = ((ChannelsIn[0] >> 1) >> 8) | ((ChannelsIn[1] >> 1) << 2);
@@ -610,8 +593,8 @@ void test_decodingFullres16chLow()
 
     // ** PACKET ONE **
     memset(TXdataBuffer, 0, sizeof(TXdataBuffer)); // "destChannels4x10 must be zeroed"
-    OtaPackChannelData(otaPktPtr, ChannelData, false, 0);
-    OtaUnpackChannelData(otaPktPtr, ChannelData, 0);
+    OtaPackChannelData(otaPktPtr, ChannelData, false);
+    OtaUnpackChannelData(otaPktPtr, ChannelData);
     for (unsigned ch=0; ch<8; ++ch)
     {
         TEST_ASSERT_EQUAL(ChannelsIn[ch] & 0b11111111110, ChannelData[ch]);
@@ -619,8 +602,8 @@ void test_decodingFullres16chLow()
 
     // ** PACKET TWO **
     memset(TXdataBuffer, 0, sizeof(TXdataBuffer)); // "destChannels4x10 must be zeroed"
-    OtaPackChannelData(otaPktPtr, ChannelData, false, 0);
-    OtaUnpackChannelData(otaPktPtr, ChannelData, 0);
+    OtaPackChannelData(otaPktPtr, ChannelData, false);
+    OtaUnpackChannelData(otaPktPtr, ChannelData);
     for (unsigned ch=9; ch<16; ++ch)
     {
         TEST_ASSERT_EQUAL(ChannelsIn[ch] & 0b11111111110, ChannelData[ch]);
@@ -630,22 +613,15 @@ void test_decodingFullres16chLow()
 void test_decodingHybridWide_AUX1()
 {
     // Switch 0 is 2 pos, also tests the uplink_TX_Power
-    test_decodingHybridWide(true, 7, 0, CRSF_CHANNEL_VALUE_1000);
-    test_decodingHybridWide(true, 7, 0, CRSF_CHANNEL_VALUE_2000);
-}
-
-void test_decodingHybridWide_AUXX_high()
-{
-    constexpr int N_SWITCHES = 8;
-    for (int i=0; i<N_SWITCHES; ++i)
-        test_decodingHybridWide(true, i, 0, CRSF_CHANNEL_VALUE_1000);
+    test_decodingHybridWide(7, 0, CRSF_CHANNEL_VALUE_1000);
+    test_decodingHybridWide(7, 0, CRSF_CHANNEL_VALUE_2000);
 }
 
 void test_decodingHybridWide_AUXX_low()
 {
     constexpr int N_SWITCHES = 8;
     for (int i=0; i<N_SWITCHES; ++i)
-        test_decodingHybridWide(false, i, 0, CRSF_CHANNEL_VALUE_1000);
+        test_decodingHybridWide(i, 0, CRSF_CHANNEL_VALUE_1000);
 }
 
 // Unity setup/teardown
@@ -665,10 +641,8 @@ int main(int argc, char **argv)
     RUN_TEST(test_encodingHybrid8_7);
     RUN_TEST(test_decodingHybrid8_all);
 
-    RUN_TEST(test_encodingHybridWide_high);
     RUN_TEST(test_encodingHybridWide_low);
     RUN_TEST(test_decodingHybridWide_AUX1);
-    RUN_TEST(test_decodingHybridWide_AUXX_high);
     RUN_TEST(test_decodingHybridWide_AUXX_low);
 
     RUN_TEST(test_encodingFullresPowerLevels);


### PR DESCRIPTION
Removes the 7-bit mode for Wide switches when running at low telemetry ratios, making the Wide switches always 6-bit. This also returns TLMBoost to the original 1:2, removing the triage fix from #3210 that limited it to 1:8 to prevent it from crossing the boundary.

I feel like this is less confusing and returns the telemetry boost performance lost. **REGRESSION**: users may be upset about the lower resolution of the channels, making them maybe unsuitable for some control surfaces or head tracking.

### Question

Should I also revert the TLMBoost request/active code that was added in #3222? The advantage to keeping it is slight and it does add minor code complexity.
* Downside to keeping it: TLMBoost usually lasts around 2x sync cycles which is a waste if there's only a small amount of downlink data to send
* Downside to removing it: TLMBoost may run for less than 1x complete cycle which could be insufficient downlink bandwidth.

Also tagged For Discussion because if we want to keep the terrible TLMBoost bandwidth and keep 7-bit Wide switches, I'm cool with that and just closing this PR.