### PR TITLE
DShot safety on PWM RX

### DIFF
--- a/src/lib/ServoOutput/DShotRMT.cpp
+++ b/src/lib/ServoOutput/DShotRMT.cpp
@@ -103,16 +103,12 @@ bool DShotRMT::begin(dshot_mode_t dshot_mode, bool is_bidirectional) {
 void DShotRMT::send_dshot_value(uint16_t throttle_value, telemetric_request_t telemetric_request) {
 	dshot_packet_t dshot_rmt_packet = { };
 
-	if (throttle_value < DSHOT_THROTTLE_MIN) {
-		throttle_value = DSHOT_THROTTLE_MIN;
+	if (throttle_value == DSHOT_THROTTLE_MIN) {
+		dshot_rmt_packet.throttle_value = 0;
+	} else {
+		// ...packets are the same for bidirectional mode
+		dshot_rmt_packet.throttle_value = throttle_value;
 	}
-
-	if (throttle_value > DSHOT_THROTTLE_MAX) {
-		throttle_value = DSHOT_THROTTLE_MAX;
-	}
-
-	// ...packets are the same for bidirectional mode
-	dshot_rmt_packet.throttle_value = throttle_value;
 	dshot_rmt_packet.telemetric_request = telemetric_request;
 	dshot_rmt_packet.checksum = this->calc_dshot_chksum(dshot_rmt_packet);
 

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -59,7 +59,8 @@ static void servoWrite(uint8_t ch, uint16_t us)
         // DBGLN("Writing DShot output: us: %u, ch: %d", us, ch);
         if (dshotInstances[ch])
         {
-            dshotInstances[ch]->send_dshot_value(((constrain(us, 1000, 2000) - 1000) * 2) + 47); // Convert PWM signal in us to DShot value
+            us = fmap(constrain(us, 1000, 2000), 1000, 2000, DSHOT_THROTTLE_MIN, DSHOT_THROTTLE_MAX); // Convert PWM signal in us to DShot value
+            dshotInstances[ch]->send_dshot_value(us);
         }
     }
     else
@@ -271,7 +272,6 @@ static int event()
             else if ((eServoOutputMode)chConfig->val.mode == somDShot)
             {
                 dshotInstances[ch]->begin(DSHOT300, false); // Set DShot protocol and bidirectional dshot bool
-                dshotInstances[ch]->send_dshot_value(0);    // Set throttle low so the ESC can continue initialization
             }
 #endif
         }

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -218,7 +218,6 @@ static int start()
         else if (((eServoOutputMode)chConfig->val.mode) == somDShot)
         {
             dshotInstances[ch]->begin(DSHOT300, false); // Set DShot protocol and bidirectional dshot bool
-            dshotInstances[ch]->send_dshot_value(0);         // Set throttle low so the ESC can continue initialsation
         }
 #endif
     }


### PR DESCRIPTION
Delays initialisation of PWM and DShot pins till the first connection. The Dshot "0" command is not sent unless the TX sends 1000us signal.
On startup the PWM/DShot pins are set to Open Drain in the High Impedance (floating) state as an extra safety measure. This is so that an ESC can out the pin in it's own expected idle state rather than the RX deciding what's best on boot up.

Fixes #3298 

@pitts-mo can you validate that this fixes the safety issue for you. I will also refactor and retarget the other DShot PRs fir the master/4.x line once this is tested and merged for 3.6.0