### PR TITLE
Constraining PPMHandset ppm value within the CRSF limits

### DIFF
--- a/src/lib/CrsfProtocol/crsf_protocol.h
+++ b/src/lib/CrsfProtocol/crsf_protocol.h
@@ -442,7 +442,7 @@ enum {
 
 static uint16_t ICACHE_RAM_ATTR fmap(uint16_t x, uint16_t in_min, uint16_t in_max, uint16_t out_min, uint16_t out_max)
 {
-    return ((constrain(x, in_min, in_max) - in_min) * (out_max - out_min) * 2 / (in_max - in_min) + out_min * 2 + 1) / 2;
+    return ((x - in_min) * (out_max - out_min) * 2 / (in_max - in_min) + out_min * 2 + 1) / 2;
 }
 
 // Scale a -100& to +100% crossfire value to 988-2012 (Taranis channel uS)

--- a/src/lib/CrsfProtocol/crsf_protocol.h
+++ b/src/lib/CrsfProtocol/crsf_protocol.h
@@ -442,7 +442,7 @@ enum {
 
 static uint16_t ICACHE_RAM_ATTR fmap(uint16_t x, uint16_t in_min, uint16_t in_max, uint16_t out_min, uint16_t out_max)
 {
-    return ((x - in_min) * (out_max - out_min) * 2 / (in_max - in_min) + out_min * 2 + 1) / 2;
+    return ((constrain(x, in_min, in_max) - in_min) * (out_max - out_min) * 2 / (in_max - in_min) + out_min * 2 + 1) / 2;
 }
 
 // Scale a -100& to +100% crossfire value to 988-2012 (Taranis channel uS)

--- a/src/lib/CrsfProtocol/crsf_protocol.h
+++ b/src/lib/CrsfProtocol/crsf_protocol.h
@@ -442,7 +442,8 @@ enum {
 
 static uint16_t ICACHE_RAM_ATTR fmap(uint16_t x, uint16_t in_min, uint16_t in_max, uint16_t out_min, uint16_t out_max)
 {
-    return ((x - in_min) * (out_max - out_min) * 2 / (in_max - in_min) + out_min * 2 + 1) / 2;
+    int32_t result = ((int32_t)(x - in_min) * (out_max - out_min) * 2 / (in_max - in_min) + out_min * 2 + 1)/2;
+    return result < 0 ? 0 : (result > 65535 ? 65535 : result);
 }
 
 // Scale a -100& to +100% crossfire value to 988-2012 (Taranis channel uS)

--- a/src/lib/Handset/PPMHandset.cpp
+++ b/src/lib/Handset/PPMHandset.cpp
@@ -62,7 +62,7 @@ void PPMHandset::handleInput()
             }
             channelCount ++;
             const auto ppm = (item.duration0 + item.duration1) / RMT_TICKS_PER_US;
-            ChannelData[i] = fmap(constrain(ppm, 988, 2012), 988, 2012, CRSF_CHANNEL_VALUE_MIN, CRSF_CHANNEL_VALUE_MAX);
+            ChannelData[i] = fmap(ppm, 988, 2012, CRSF_CHANNEL_VALUE_MIN, CRSF_CHANNEL_VALUE_MAX);
         }
         numChannels = channelCount;
         vRingbufferReturnItem(rb, static_cast<void *>(items));

--- a/src/lib/Handset/PPMHandset.cpp
+++ b/src/lib/Handset/PPMHandset.cpp
@@ -62,7 +62,7 @@ void PPMHandset::handleInput()
             }
             channelCount ++;
             const auto ppm = (item.duration0 + item.duration1) / RMT_TICKS_PER_US;
-            ChannelData[i] = fmap(ppm, 988, 2012, CRSF_CHANNEL_VALUE_MIN, CRSF_CHANNEL_VALUE_MAX);
+            ChannelData[i] = fmap(constrain(ppm, 988, 2012), 988, 2012, CRSF_CHANNEL_VALUE_MIN, CRSF_CHANNEL_VALUE_MAX);
         }
         numChannels = channelCount;
         vRingbufferReturnItem(rb, static_cast<void *>(items));

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -76,7 +76,7 @@ static void servoWrite(uint8_t ch, uint16_t us)
         }
         else
         {
-            PWM.setMicroseconds(map(pwmChannels[ch], 987, 1023, 1100, 1900), us / (chConfig->val.narrow + 1));
+            PWM.setMicroseconds(pwmChannels[ch], us / (chConfig->val.narrow + 1));
         }
     }
 }

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -76,7 +76,7 @@ static void servoWrite(uint8_t ch, uint16_t us)
         }
         else
         {
-            PWM.setMicroseconds(pwmChannels[ch], us / (chConfig->val.narrow + 1));
+            PWM.setMicroseconds(map(pwmChannels[ch], 987, 1023, 1100, 1900), us / (chConfig->val.narrow + 1));
         }
     }
 }


### PR DESCRIPTION
## Bug

The `fmap` implementation in `crsf_protocol.h` is at risk of underflow errors when the `x` is fed less than `in_min`.

```cpp
static uint16_t ICACHE_RAM_ATTR fmap(uint16_t x, uint16_t in_min, uint16_t in_max, uint16_t out_min, uint16_t out_max)
{
    return ((x - in_min) * (out_max - out_min) * 2 / (in_max - in_min) + out_min * 2 + 1) / 2;
}
```

For example, calling `fmap(5, 10, 20, 100, 200)` will be result in:
```(5-10)*(200-100)*2 ...```

However, as the variables are defined as unsigned types, 5-10 = -5 will be wrapped into `65535-5` = `65530`, which gives an erroneously large value.

With some old PPM handset, the values could be go outside the defined range.

## Fix
Straightforward, constrain the x within in_min -- in_max range.

## Story
The bug was discovered when testing an old PPM radio with an ELRS TX; the control surfaces are flipped all the way to the other side when the stick was deflected to its minimum position.

Close investigation revealed that the PPM signal from the radio was outside the hard-coded range of (988, 2012) in PPMHandset.cpp, causing the underflow.

PS. ELRS module installation on an old Futaba radio which discovered this defect:
![IMG_8497](https://github.com/user-attachments/assets/a0c9289c-d96d-42cd-891e-6627c4fb25ca)
![IMG_8496](https://github.com/user-attachments/assets/d6266764-06b6-480a-a6e0-63029721a3a1)
![IMG_8498](https://github.com/user-attachments/assets/60d9e5e5-d5de-4bdf-b460-f7847f63b4c2)
