### PR TITLE
Missed a couple html callback references in 3.x.x merge

### DIFF
--- a/src/html/scan.js
+++ b/src/html/scan.js
@@ -716,9 +716,9 @@ function setupNetwork(event) {
 }
 
 @@if not isTX:
-_('reset-model').addEventListener('click', callback('Reset Model Settings', 'An error occurred resetting model settings', '/reset?model', null));
+_('reset-model').addEventListener('click', postWithFeedback('Reset Model Settings', 'An error occurred resetting model settings', '/reset?model', null));
 @@end
-_('reset-options').addEventListener('click', callback('Reset Runtime Options', 'An error occurred resetting runtime options', '/reset?options', null));
+_('reset-options').addEventListener('click', postWithFeedback('Reset Runtime Options', 'An error occurred resetting runtime options', '/reset?options', null));
 
 _('sethome').addEventListener('submit', setupNetwork);
 _('connect').addEventListener('click', postWithFeedback('Connect to Home Network', 'An error occurred connecting to the Home network', '/connect', null));


### PR DESCRIPTION
The merge replaced `callback()` in scan.js with `postWithFeedback()` but missed a couple of them due to them only being in master so the merge didn't update them.

Noticed many of the buttons were doing their default actions instead of doing XHR requests, e.g. the Button Actions SAVE and Options SAVE. This is due to the onload not finishing the click binds due to callback being undefined.