### PR TITLE
Faster Lua field timeout for TX modules

### DIFF
--- a/src/lua/elrsV3.lua
+++ b/src/lua/elrsV3.lua
@@ -6,7 +6,7 @@
 ---- # License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html               #
 ---- #                                                                       #
 ---- #########################################################################
-local EXITVER = "-- EXIT (Lua r15) --"
+local EXITVER = "-- EXIT (Lua r16) --"
 local deviceId = 0xEE
 local handsetId = 0xEF
 local deviceName = "Loading..."
@@ -572,7 +572,7 @@ local function refreshNext(skipPush)
   elseif time > fieldTimeout and fields_count ~= 0 then
     if #loadQ > 0 then
       crossfireTelemetryPush(0x2C, { deviceId, handsetId, loadQ[#loadQ], fieldChunk })
-      fieldTimeout = time + 500 -- 5s
+      fieldTimeout = time + (deviceIsELRS_TX and 50 or 500) -- 0.5s for local / 5s for remote devices
     end
   end
 


### PR DESCRIPTION
Partially semi-reverts changes from #3222 which increased the Lua field loading timeout from 0.5s to 5.0s, changing it back to 0.5s for local TX modules and 5.0s for any other device.

The value was increased due to the lua hammering the link re-requesting the same field chunk ID when trying to load the RX's lua parameters. However, on both EdgeTX 2.11.3 (most recent) and 3.0 (development) some requests are still being lost going to the TX module, leading to painfully long stalling loading the lua. This at least hides it with a short delay instead of it being obvious things are broken. The RX lua parameter load can still be delayed, but with no OTA chunked chunks status information exposed to the lua, we have to just wait and see. 

If anyone else has any small changes for the lua v16, PR them for the version bump!