### PR TITLE
Remove unused/unnecessary parameter

### DIFF
--- a/src/lib/LR1121Driver/LR1121.cpp
+++ b/src/lib/LR1121Driver/LR1121.cpp
@@ -566,7 +566,7 @@ void ICACHE_RAM_ATTR LR1121Driver::TXnbISR()
     TXdoneCallback();
 }
 
-void ICACHE_RAM_ATTR LR1121Driver::TXnb(uint8_t *data, const uint8_t size, const bool sendGeminiBuffer, uint8_t *dataGemini, const SX12XX_Radio_Number_t radioNumber)
+void ICACHE_RAM_ATTR LR1121Driver::TXnb(uint8_t *data, const bool sendGeminiBuffer, uint8_t *dataGemini, const SX12XX_Radio_Number_t radioNumber)
 {
     transmittingRadio = radioNumber;
 

--- a/src/lib/LR1121Driver/LR1121.h
+++ b/src/lib/LR1121Driver/LR1121.h
@@ -39,7 +39,7 @@ public:
     // bool FrequencyErrorAvailable() const { return modeSupportsFei && (LastPacketSNRRaw > 0); }
     bool FrequencyErrorAvailable() const { return false; }
 
-    void TXnb(uint8_t *data, uint8_t size, bool sendGeminiBuffer, uint8_t * dataGemini, SX12XX_Radio_Number_t radioNumber);
+    void TXnb(uint8_t *data, bool sendGeminiBuffer, uint8_t * dataGemini, SX12XX_Radio_Number_t radioNumber);
     void RXnb();
 
     uint32_t GetIrqStatus(SX12XX_Radio_Number_t radioNumber);

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -390,7 +390,7 @@ void ICACHE_RAM_ATTR SX127xDriver::TXnbISR()
   TXdoneCallback();
 }
 
-void ICACHE_RAM_ATTR SX127xDriver::TXnb(uint8_t * data, uint8_t size, bool sendGeminiBuffer, uint8_t * dataGemini, SX12XX_Radio_Number_t radioNumber)
+void ICACHE_RAM_ATTR SX127xDriver::TXnb(uint8_t * data, bool sendGeminiBuffer, uint8_t * dataGemini, SX12XX_Radio_Number_t radioNumber)
 {
   // if (currOpmode == SX127x_OPMODE_TX)
   // {
@@ -422,12 +422,12 @@ void ICACHE_RAM_ATTR SX127xDriver::TXnb(uint8_t * data, uint8_t size, bool sendG
   hal.writeRegister(SX127X_REG_FIFO_ADDR_PTR, SX127X_FIFO_TX_BASE_ADDR_MAX, radioNumber);
   if (sendGeminiBuffer)
   {
-    hal.writeRegister(SX127X_REG_FIFO, data, size, SX12XX_Radio_1);
-    hal.writeRegister(SX127X_REG_FIFO, dataGemini, size, SX12XX_Radio_2);
+    hal.writeRegister(SX127X_REG_FIFO, data, PayloadLength, SX12XX_Radio_1);
+    hal.writeRegister(SX127X_REG_FIFO, dataGemini, PayloadLength, SX12XX_Radio_2);
   }
   else
   {
-    hal.writeRegister(SX127X_REG_FIFO, data, size, radioNumber);
+    hal.writeRegister(SX127X_REG_FIFO, data, PayloadLength, radioNumber);
   }
 
   SetMode(SX127x_OPMODE_TX, radioNumber);

--- a/src/lib/SX127xDriver/SX127x.h
+++ b/src/lib/SX127xDriver/SX127x.h
@@ -71,7 +71,7 @@ public:
     void CheckForSecondPacket();
 
     ////////////Non-blocking TX related Functions/////////////////
-    void TXnb(uint8_t * data, uint8_t size, bool sendGeminiBuffer, uint8_t * dataGemini, SX12XX_Radio_Number_t radioNumber);
+    void TXnb(uint8_t * data, bool sendGeminiBuffer, uint8_t * dataGemini, SX12XX_Radio_Number_t radioNumber);
     /////////////Non-blocking RX related Functions///////////////
     void RXnb();
 

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -158,7 +158,7 @@ void SX1280Driver::Config(uint8_t bw, uint8_t sf, uint8_t cr, uint32_t regfreq,
     {
         DBG("Config FLRC ");
         ConfigModParamsFLRC(bw, cr, sf);
-        SetPacketParamsFLRC(SX1280_FLRC_PACKET_FIXED_LENGTH, PreambleLength, _PayloadLength, flrcSyncWord, flrcCrcSeed, cr);
+        SetPacketParamsFLRC(SX1280_FLRC_PACKET_FIXED_LENGTH, PreambleLength, flrcSyncWord, flrcCrcSeed, cr);
     }
     else
     {
@@ -169,7 +169,7 @@ void SX1280Driver::Config(uint8_t bw, uint8_t sf, uint8_t cr, uint32_t regfreq,
 #else
         SX1280_RadioLoRaPacketLengthsModes_t packetLengthType = SX1280_LORA_PACKET_FIXED_LENGTH;
 #endif
-        SetPacketParamsLoRa(PreambleLength, packetLengthType, _PayloadLength, InvertIQ);
+        SetPacketParamsLoRa(PreambleLength, packetLengthType, InvertIQ);
     }
     SetFrequencyReg(regfreq, SX12XX_Radio_All);
 
@@ -295,8 +295,7 @@ void SX1280Driver::ConfigModParamsLoRa(uint8_t bw, uint8_t sf, uint8_t cr)
     // hal.WriteRegister(SX1280_REG_FREQ_ERR_CORRECTION, 0x03, SX12XX_Radio_All);
 }
 
-void SX1280Driver::SetPacketParamsLoRa(uint8_t PreambleLength, SX1280_RadioLoRaPacketLengthsModes_t HeaderType,
-                                       uint8_t PayloadLength, uint8_t InvertIQ)
+void SX1280Driver::SetPacketParamsLoRa(uint8_t PreambleLength, SX1280_RadioLoRaPacketLengthsModes_t HeaderType, uint8_t InvertIQ)
 {
     uint8_t buf[7];
 
@@ -322,7 +321,6 @@ void SX1280Driver::ConfigModParamsFLRC(uint8_t bw, uint8_t cr, uint8_t bt)
 
 void SX1280Driver::SetPacketParamsFLRC(uint8_t HeaderType,
                                        uint8_t PreambleLength,
-                                       uint8_t PayloadLength,
                                        uint32_t syncWord,
                                        uint16_t crcSeed,
                                        uint8_t cr)
@@ -443,7 +441,7 @@ void ICACHE_RAM_ATTR SX1280Driver::TXnbISR()
     TXdoneCallback();
 }
 
-void ICACHE_RAM_ATTR SX1280Driver::TXnb(uint8_t * data, uint8_t size, bool sendGeminiBuffer, uint8_t * dataGemini, SX12XX_Radio_Number_t radioNumber)
+void ICACHE_RAM_ATTR SX1280Driver::TXnb(uint8_t * data, bool sendGeminiBuffer, uint8_t * dataGemini, SX12XX_Radio_Number_t radioNumber)
 {
     transmittingRadio = radioNumber;
 
@@ -491,12 +489,12 @@ void ICACHE_RAM_ATTR SX1280Driver::TXnb(uint8_t * data, uint8_t size, bool sendG
     RFAMP.TXenable(radioNumber); // do first to allow PA stablise
     if (sendGeminiBuffer)
     {
-        hal.WriteBuffer(0x00, data, size, SX12XX_Radio_1);
-        hal.WriteBuffer(0x00, dataGemini, size, SX12XX_Radio_2);
+        hal.WriteBuffer(0x00, data, PayloadLength, SX12XX_Radio_1);
+        hal.WriteBuffer(0x00, dataGemini, PayloadLength, SX12XX_Radio_2);
     }
     else
     {
-        hal.WriteBuffer(0x00, data, size, radioNumber);
+        hal.WriteBuffer(0x00, data, PayloadLength, radioNumber);
     }
 
     instance->SetMode(SX1280_MODE_TX, radioNumber);

--- a/src/lib/SX1280Driver/SX1280.h
+++ b/src/lib/SX1280Driver/SX1280.h
@@ -32,7 +32,7 @@ public:
     bool GetFrequencyErrorbool(SX12XX_Radio_Number_t radioNumber);
     bool FrequencyErrorAvailable() const { return modeSupportsFei && (LastPacketSNRRaw > 0); }
 
-    void TXnb(uint8_t * data, uint8_t size, bool sendGeminiBuffer, uint8_t * dataGemini, SX12XX_Radio_Number_t radioNumber);
+    void TXnb(uint8_t * data, bool sendGeminiBuffer, uint8_t * dataGemini, SX12XX_Radio_Number_t radioNumber);
     void RXnb();
 
     uint16_t GetIrqStatus(SX12XX_Radio_Number_t radioNumber);
@@ -63,12 +63,11 @@ private:
     // LoRa functions
     void ConfigModParamsLoRa(uint8_t bw, uint8_t sf, uint8_t cr);
     void SetPacketParamsLoRa(uint8_t PreambleLength, SX1280_RadioLoRaPacketLengthsModes_t HeaderType,
-                             uint8_t PayloadLength, uint8_t InvertIQ);
+                             uint8_t InvertIQ);
     // FLRC functions
     void ConfigModParamsFLRC(uint8_t bw, uint8_t cr, uint8_t bt=SX1280_FLRC_BT_0_5);
     void SetPacketParamsFLRC(uint8_t HeaderType,
                              uint8_t PreambleLength,
-                             uint8_t PayloadLength,
                              uint32_t syncWord,
                              uint16_t crcSeed,
                              uint8_t cr);

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -598,11 +598,11 @@ bool ICACHE_RAM_ATTR HandleSendTelemetryResponse()
     // GemX does not switch due to the time required to reconfigure the LR1121 params.
     if ((OtaNonce/ExpressLRS_currAirRate_Modparams->FHSShopInterval) % 2 == 0 || !sendGeminiBuffer || FHSSuseDualBand)
     {
-        Radio.TXnb((uint8_t*)&otaPkt, ExpressLRS_currAirRate_Modparams->PayloadLength, sendGeminiBuffer, (uint8_t*)&otaPktGemini, transmittingRadio);
+        Radio.TXnb((uint8_t*)&otaPkt, sendGeminiBuffer, (uint8_t*)&otaPktGemini, transmittingRadio);
     }
     else
     {
-        Radio.TXnb((uint8_t*)&otaPktGemini, ExpressLRS_currAirRate_Modparams->PayloadLength, sendGeminiBuffer, (uint8_t*)&otaPkt, transmittingRadio);
+        Radio.TXnb((uint8_t*)&otaPktGemini, sendGeminiBuffer, (uint8_t*)&otaPkt, transmittingRadio);
     }
 
     if (transmittingRadio == SX12XX_Radio_NONE)

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -686,7 +686,7 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
   else
 #endif
   {
-    Radio.TXnb((uint8_t*)&otaPkt, ExpressLRS_currAirRate_Modparams->PayloadLength, false, (uint8_t*)&otaPkt, transmittingRadio);
+    Radio.TXnb((uint8_t*)&otaPkt, false, (uint8_t*)&otaPkt, transmittingRadio);
   }
 }
 


### PR DESCRIPTION
During the refactoring of the radio code for the latest round of LBT debugging, I also notice that the `size` parameter to `TXnb` was either not used and was the member variable `PayloadLength`. Or was always passed as `ExpressLRS_currAirRate_Modparams->PayloadLength` which was also passed to the `Config` method and stored as `PayloadLength` in the class.

So I just deleted it as a parameter to `TXnb` and simplified the lot to use the member variable.