### PR TITLE
Show lua version and mod type in loading... message

### DIFF
--- a/src/lua/elrsV3.lua
+++ b/src/lua/elrsV3.lua
@@ -895,7 +895,10 @@ local function checkCrsfModule()
   for modIdx = 0, 1 do
     local mod = model.getModule(modIdx)
     if mod and (mod.Type == nil or mod.Type == 5) then
-      -- CRSF found
+      -- CRSF found, put module type in Loading message
+      local modDescrip = (mod.Type == nil) and " awaiting" or (modIdx == 0) and " Internal" or " External"
+      -- Prefix with "Lua rXXX" from between EXITVER parens
+      deviceName = string.match(EXITVER, "%((.*)%)") .. modDescrip .. " TX..."
       checkCrsfModule = nil
       return 0
     end
@@ -932,8 +935,6 @@ local function init()
   setMock()
   setLCDvar = nil
   setMock = nil
-  -- Extract the "Lua rXXX" from the parens
-  deviceName = string.match(EXITVER, "%((.*)%)") .. " loading..."
 end
 
 -- Main


### PR DESCRIPTION
Changes "Loading..." to display "Lua r16 [CRSF moduletype] TX..." while the script is doing the initial device pings. 3x different options [shown below](https://github.com/ExpressLRS/ExpressLRS/pull/3365#issuecomment-3415776008)

From @mha1's great suggestion in #3357 
https://github.com/ExpressLRS/ExpressLRS/pull/3357#issuecomment-3415323841

~~I guess there's a chance that a user might be confused that the lua itself isn't loading, but am I wrong that 100% of the time they come looking for support for "Loading..." they say "The lua isn't loading" anyway?~~