### PR TITLE
Allow developer selection of single band LR1121 targets

### DIFF
--- a/src/python/UnifiedConfiguration.py
+++ b/src/python/UnifiedConfiguration.py
@@ -101,7 +101,7 @@ def doConfiguration(file, defines, config, moduletype, frequency, platform, devi
             for k in jmespath.search(f'[*."{moduletype}_900".*][][?platform==`{platform}`][]', targets):
                 if '_LR1121_' in k['firmware']:
                     products.append(k)
-        # Sort the list by product name, case insenstive, and print the list
+        # Sort the list by product name, case insensitive, and print the list
         products = sorted(products, key=lambda p: p['product_name'].casefold())
         for i, p in enumerate(products):
             print(f"{i+1}) {p['product_name']}")


### PR DESCRIPTION
This a QoL feature for the devs when working with LR1121 targets that support a single frequency band