### PR TITLE
Use the Strongest receiving radio for sending in diversity mode

### DIFF
--- a/src/lib/LBT/LBT.cpp
+++ b/src/lib/LBT/LBT.cpp
@@ -204,7 +204,7 @@ SX12XX_Radio_Number_t ICACHE_RAM_ATTR LbtChannelIsClear(SX12XX_Radio_Number_t ra
     }
   }
 
-  if (radioNumber & SX12XX_Radio_2)
+  if (isDualRadio() && radioNumber & SX12XX_Radio_2)
   {
     rssiInst2 = Radio.GetRssiInst(SX12XX_Radio_2);
 

--- a/src/lib/LR1121Driver/LR1121.cpp
+++ b/src/lib/LR1121Driver/LR1121.cpp
@@ -41,7 +41,7 @@ LR1121Driver::LR1121Driver(): SX12xxDriverCommon()
 {
     useFSK = false;
     instance = this;
-    lastSuccessfulPacketRadio = SX12XX_Radio_1;
+    strongestReceivingRadio = SX12XX_Radio_1;
     fallBackMode = LR1121_MODE_FS;
     useFEC = false;
 }
@@ -728,8 +728,8 @@ void ICACHE_RAM_ATTR LR1121Driver::GetLastPacketStats()
 {
     const SX12XX_Radio_Number_t radioNumber = processingPacketRadio == SX12XX_Radio_1 ? SX12XX_Radio_2 : SX12XX_Radio_1;
 
-    // by default, set the last successful packet radio to be the current processing radio (which got a successful packet)
-    lastSuccessfulPacketRadio = processingPacketRadio;
+    // by default, set the strongest receiving radio to be the current processing radio (which got a successful packet)
+    strongestReceivingRadio = processingPacketRadio;
     DecodeRssiSnr(processingPacketRadio, rx_buf);
 #if defined(DEBUG_RCVR_SIGNAL_STATS)
     irq_count_or++;
@@ -771,8 +771,8 @@ void ICACHE_RAM_ATTR LR1121Driver::GetLastPacketStats()
                 const int8_t firstSNR = LastPacketSNRRaw;
                 DecodeRssiSnr(radioNumber, rx_buf);
                 LastPacketSNRRaw = fuzzy_snr(LastPacketSNRRaw, firstSNR, FuzzySNRThreshold);
-                // Update the last successful packet radio to be the one with better signal strength
-                lastSuccessfulPacketRadio = LastPacketRSSI>LastPacketRSSI2 ? SX12XX_Radio_1 : SX12XX_Radio_2;
+                // Update the strongest receiving radio to be the one with better signal strength
+                strongestReceivingRadio = LastPacketRSSI>LastPacketRSSI2 ? SX12XX_Radio_1 : SX12XX_Radio_2;
 #if defined(DEBUG_RCVR_SIGNAL_STATS)
                 irq_count_both++;
             }

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -49,7 +49,7 @@ SX127xDriver::SX127xDriver(): SX12xxDriverCommon()
   headerExplMode = false;
   crcEnabled = false;
   lowFrequencyMode = SX1278_HIGH_FREQ;
-  lastSuccessfulPacketRadio = SX12XX_Radio_1;
+  strongestReceivingRadio = SX12XX_Radio_1;
 }
 
 bool SX127xDriver::Begin(uint32_t minimumFrequency, uint32_t maximumFrequency)
@@ -514,15 +514,15 @@ void ICACHE_RAM_ATTR SX127xDriver::GetLastPacketStats()
     }
   }
 
-  // by default, set the last successful packet radio to be the current processing radio (which got a successful packet)
-  instance->lastSuccessfulPacketRadio = instance->processingPacketRadio;
+  // by default, set the strongest receiving radio to be the current processing radio (which got a successful packet)
+  instance->strongestReceivingRadio = instance->processingPacketRadio;
 
   // when both radio got the packet, use the better RSSI one
   if (gotRadio[0] && gotRadio[1])
   {
     LastPacketSNRRaw = instance->fuzzy_snr(snr[0], snr[1], instance->FuzzySNRThreshold);
-    // Update the last successful packet radio to be the one with better signal strength
-    instance->lastSuccessfulPacketRadio = (rssi[0] > rssi[1]) ? radio[0] : radio[1];
+    // Update the strongest receiving radio to be the one with better signal strength
+    instance->strongestReceivingRadio = (rssi[0] > rssi[1]) ? radio[0] : radio[1];
   }
 
 #if defined(DEBUG_RCVR_SIGNAL_STATS)

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -59,7 +59,7 @@ SX1280Driver::SX1280Driver(): SX12xxDriverCommon()
 {
     instance = this;
     currOpmode = SX1280_MODE_SLEEP;
-    lastSuccessfulPacketRadio = SX12XX_Radio_1;
+    strongestReceivingRadio = SX12XX_Radio_1;
     fallBackMode = SX1280_MODE_STDBY_RC;
 }
 
@@ -549,7 +549,7 @@ void ICACHE_RAM_ATTR SX1280Driver::GetStatus(SX12XX_Radio_Number_t radioNumber)
 bool ICACHE_RAM_ATTR SX1280Driver::GetFrequencyErrorbool()
 {
     // Only need the highest bit of the 20-bit FEI to determine the direction
-    uint8_t feiMsb = hal.ReadRegister(SX1280_REG_LR_ESTIMATED_FREQUENCY_ERROR_MSB, lastSuccessfulPacketRadio);
+    uint8_t feiMsb = hal.ReadRegister(SX1280_REG_LR_ESTIMATED_FREQUENCY_ERROR_MSB, strongestReceivingRadio);
     // fei & (1 << 19) and flip sign if IQinverted
     if (feiMsb & 0x08)
         return IQinverted;
@@ -650,15 +650,15 @@ void ICACHE_RAM_ATTR SX1280Driver::GetLastPacketStats()
         }
     }
 
-    // by default, set the last successful packet radio to be the current processing radio (which got a successful packet)
-    instance->lastSuccessfulPacketRadio = instance->processingPacketRadio;
+    // by default, set the strongest receiving radio to be the current processing radio (which got a successful packet)
+    instance->strongestReceivingRadio = instance->processingPacketRadio;
 
     // when both radio got the packet, use the better RSSI one
     if(gotRadio[0] && gotRadio[1])
     {
         LastPacketSNRRaw = instance->fuzzy_snr(snr[0], snr[1], instance->FuzzySNRThreshold);
-        // Update the last successful packet radio to be the one with better signal strength
-        instance->lastSuccessfulPacketRadio = (rssi[0]>rssi[1])? radio[0]: radio[1];
+        // Update the strongest receiving radio to be the one with better signal strength
+        instance->strongestReceivingRadio = (rssi[0]>rssi[1])? radio[0]: radio[1];
     }
 
 #if defined(DEBUG_RCVR_SIGNAL_STATS)

--- a/src/lib/SX12xxDriverCommon/SX12xxDriverCommon.h
+++ b/src/lib/SX12xxDriverCommon/SX12xxDriverCommon.h
@@ -44,10 +44,10 @@ public:
     bool IQinverted;
 
     SX12XX_Radio_Number_t processingPacketRadio;
-    SX12XX_Radio_Number_t lastSuccessfulPacketRadio;
     SX12XX_Radio_Number_t transmittingRadio;
+    SX12XX_Radio_Number_t strongestReceivingRadio;
     SX12XX_Radio_Number_t GetProcessingPacketRadio() { return processingPacketRadio; }
-    SX12XX_Radio_Number_t GetLastSuccessfulPacketRadio() { return lastSuccessfulPacketRadio; }
+    SX12XX_Radio_Number_t GetStrongestReceivingRadio() { return strongestReceivingRadio; }
     SX12XX_Radio_Number_t GetLastTransmitRadio() {return transmittingRadio; }
 
     /////////////Packet Stats//////////

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -562,19 +562,13 @@ bool ICACHE_RAM_ATTR HandleSendTelemetryResponse()
     {
         transmittingRadio = SX12XX_Radio_NONE;
     }
-    else if (isDualRadio())
-    {
-        transmittingRadio = SX12XX_Radio_All;
-    }
     else
     {
-        transmittingRadio = Radio.GetLastSuccessfulPacketRadio();
-    }
-    transmittingRadio = LbtChannelIsClear(transmittingRadio);   // weed out the radio(s) if channel in use
-
-    if (!geminiMode && transmittingRadio == SX12XX_Radio_All) // If the receiver is in diversity mode, only send TLM on a single radio.
-    {
-        transmittingRadio = Radio.LastPacketRSSI > Radio.LastPacketRSSI2 ? SX12XX_Radio_1 : SX12XX_Radio_2; // Pick the radio with best rf connection to the tx.
+        transmittingRadio = LbtChannelIsClear(SX12XX_Radio_All);   // weed out the radio(s) if channel in use
+        if (isDualRadio() && !geminiMode && transmittingRadio == SX12XX_Radio_All) // If the receiver is in diversity mode, only send TLM on a single radio.
+        {
+            transmittingRadio = Radio.GetStrongestReceivingRadio(); // Pick the radio with best rf connection to the tx.
+        }
     }
 
     Radio.TXnb((uint8_t*)&otaPkt, transmittingRadio);

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -585,7 +585,7 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
   ///// Next, Calculate the CRC and put it into the buffer /////
   OtaGeneratePacketCrc(&otaPkt);
 
-  SX12XX_Radio_Number_t transmittingRadio = Radio.GetLastSuccessfulPacketRadio();
+  SX12XX_Radio_Number_t transmittingRadio = Radio.GetStrongestReceivingRadio();
 
   if (isDualRadio())
   {


### PR DESCRIPTION
A couple of issues found in the master line which need fixing here in 3.x.x as well.

1. LBT reading second radio when there isn't one causing TLM lost/recovered loop
2. The logic around choosing which radio to use in diversity mode was very broken see #3383 

Fixes #3383  