### PR TITLE
STM32 and 8285 do NOT support two RF paths

### DIFF
--- a/src/lib/RFAMP/RFAMP_hal.cpp
+++ b/src/lib/RFAMP/RFAMP_hal.cpp
@@ -3,7 +3,7 @@
 #include "RFAMP_hal.h"
 #include "logging.h"
 
-RFAMP_hal *RFAMP_hal::instance = NULL;
+RFAMP_hal *RFAMP_hal::instance = nullptr;
 
 RFAMP_hal::RFAMP_hal()
 {
@@ -52,8 +52,7 @@ void RFAMP_hal::init()
     rx_enable_clr_bits |= SET_BIT(GPIO_PIN_TX_ENABLE_2);
 #else
     rx_enabled = false;
-    tx1_enabled = false;
-    tx2_enabled = false;
+    tx_enabled = false;
 #endif
 
     if (GPIO_PIN_PA_ENABLE != UNDEF_PIN)
@@ -136,7 +135,7 @@ void ICACHE_RAM_ATTR RFAMP_hal::TXenable(SX12XX_Radio_Number_t radioNumber)
         GPIO.out1_w1tc.data = tx1_enable_clr_bits >> 32;
     }
 #else
-    if (!tx1_enabled && !tx2_enabled && !rx_enabled)
+    if (!tx_enabled && !rx_enabled)
     {
         if (GPIO_PIN_PA_ENABLE != UNDEF_PIN)
         {
@@ -149,37 +148,15 @@ void ICACHE_RAM_ATTR RFAMP_hal::TXenable(SX12XX_Radio_Number_t radioNumber)
         {
             digitalWrite(GPIO_PIN_RX_ENABLE, LOW);
         }
-        if (GPIO_PIN_RX_ENABLE_2 != UNDEF_PIN)
-        {
-            digitalWrite(GPIO_PIN_RX_ENABLE_2, LOW);
-        }
         rx_enabled = false;
     }
-    if (radioNumber == SX12XX_Radio_1 && !tx1_enabled)
+    if (!tx_enabled)
     {
         if (GPIO_PIN_TX_ENABLE != UNDEF_PIN)
         {
             digitalWrite(GPIO_PIN_TX_ENABLE, HIGH);
         }
-        if (GPIO_PIN_TX_ENABLE_2 != UNDEF_PIN)
-        {
-            digitalWrite(GPIO_PIN_TX_ENABLE_2, LOW);
-        }
-        tx1_enabled = true;
-        tx2_enabled = false;
-    }
-    if (radioNumber == SX12XX_Radio_2 && !tx2_enabled)
-    {
-        if (GPIO_PIN_TX_ENABLE != UNDEF_PIN)
-        {
-            digitalWrite(GPIO_PIN_TX_ENABLE, LOW);
-        }
-        if (GPIO_PIN_TX_ENABLE_2 != UNDEF_PIN)
-        {
-            digitalWrite(GPIO_PIN_TX_ENABLE_2, HIGH);
-        }
-        tx1_enabled = false;
-        tx2_enabled = true;
+        tx_enabled = true;
     }
 #endif
 }
@@ -198,30 +175,19 @@ void ICACHE_RAM_ATTR RFAMP_hal::RXenable()
 #else
     if (!rx_enabled)
     {
-        if (!tx1_enabled && !tx2_enabled && GPIO_PIN_PA_ENABLE != UNDEF_PIN)
+        if (!tx_enabled && GPIO_PIN_PA_ENABLE != UNDEF_PIN)
             digitalWrite(GPIO_PIN_PA_ENABLE, HIGH);
 
-        if (tx1_enabled && GPIO_PIN_TX_ENABLE != UNDEF_PIN)
+        if (tx_enabled && GPIO_PIN_TX_ENABLE != UNDEF_PIN)
         {
             digitalWrite(GPIO_PIN_TX_ENABLE, LOW);
-            tx1_enabled = false;
-        }
-
-        if (tx2_enabled && GPIO_PIN_TX_ENABLE_2 != UNDEF_PIN)
-        {
-            digitalWrite(GPIO_PIN_TX_ENABLE_2, LOW);
-            tx2_enabled = false;
+            tx_enabled = false;
         }
 
         if (GPIO_PIN_RX_ENABLE != UNDEF_PIN)
         {
             digitalWrite(GPIO_PIN_RX_ENABLE, HIGH);
         }
-        if (GPIO_PIN_RX_ENABLE_2 != UNDEF_PIN)
-        {
-            digitalWrite(GPIO_PIN_RX_ENABLE_2, HIGH);
-        }
-
         rx_enabled = true;
     }
 #endif
@@ -241,13 +207,9 @@ void ICACHE_RAM_ATTR RFAMP_hal::TXRXdisable()
         {
             digitalWrite(GPIO_PIN_RX_ENABLE, LOW);
         }
-        if (GPIO_PIN_RX_ENABLE_2 != UNDEF_PIN)
-        {
-            digitalWrite(GPIO_PIN_RX_ENABLE_2, LOW);
-        }
         rx_enabled = false;
     }
-    if (tx1_enabled)
+    if (tx_enabled)
     {
         if (GPIO_PIN_PA_ENABLE != UNDEF_PIN)
         {
@@ -257,19 +219,7 @@ void ICACHE_RAM_ATTR RFAMP_hal::TXRXdisable()
         {
             digitalWrite(GPIO_PIN_TX_ENABLE, LOW);
         }
-        tx1_enabled = false;
-    }
-    if (tx2_enabled)
-    {
-        if (GPIO_PIN_PA_ENABLE != UNDEF_PIN)
-        {
-            digitalWrite(GPIO_PIN_PA_ENABLE, LOW);
-        }
-        if (GPIO_PIN_TX_ENABLE_2 != UNDEF_PIN)
-        {
-            digitalWrite(GPIO_PIN_TX_ENABLE_2, LOW);
-        }
-        tx2_enabled = false;
+        tx_enabled = false;
     }
 #endif
 }

--- a/src/lib/RFAMP/RFAMP_hal.h
+++ b/src/lib/RFAMP/RFAMP_hal.h
@@ -28,7 +28,6 @@ private:
     uint64_t rx_enable_clr_bits;
 #else
     bool rx_enabled;
-    bool tx1_enabled;
-    bool tx2_enabled;
+    bool tx_enabled;
 #endif
 };


### PR DESCRIPTION
# Problem
Some of the refactoring/optimisation had the radio number set to RadioAll, this caused an issue where the PA was NOT enabled when transmitting because the code path on the STM32 and ESP8285 does not actually support 2 radios.

# Solution
Remove all the old code that that operated on the second RF AMP, even though it couldn't actually be supported. Now if RadioAll is passed in it handles it as Radio1, which is "All" on STM32 and ESP8285.

This needs to merged to the `master` branch which will fix #3395 