### PR TITLE
Update fullres OTA packing comment to reflect actual code

### DIFF
--- a/src/lib/OTA/OTA.cpp
+++ b/src/lib/OTA/OTA.cpp
@@ -232,9 +232,9 @@ static void ICACHE_RAM_ATTR GenerateChannelData8ch12ch(OTA_Packet8_s * const ota
     ota8->dbg_linkstats.packetNum = packetCnt++;
 #else
     // Sources:
-    // 8ch always: low=0 high=5
-    // 12ch isHighAux=false: low=0 high=5
-    // 12ch isHighAux=true:  low=0 high=9
+    // 8ch always: low=0 high=4
+    // 12ch isHighAux=false: low=0 high=4
+    // 12ch isHighAux=true:  low=0 high=8
     // 16ch isHighAux=false: low=0 high=4
     // 16ch isHighAux=true:  low=8 high=12
     uint8_t chSrcLow;


### PR DESCRIPTION
Just updates the comments to match the code. The code was updated in #3008 but the comments were missed.

Since the diff doesn't show the code the comment is for, here it is:
```cpp
    if (OtaSwitchModeCurrent == smHybridOr16ch)
    {
        // 16ch mode
        if (isHighAux)
        {
            chSrcLow = 8;
            chSrcHigh = 12;
        }
        else
        {
            chSrcLow = 0;
            chSrcHigh = 4;
        }
    }
    else
    {
        chSrcLow = 0;
        chSrcHigh = isHighAux ? 8 : 4;  //<--- this is the line the comments reference
    }
```