### PR TITLE
Fix LR1121 not committing power change when switching band

### DIFF
--- a/src/lib/LR1121Driver/LR1121.cpp
+++ b/src/lib/LR1121Driver/LR1121.cpp
@@ -233,9 +233,7 @@ void LR1121Driver::Config(uint8_t bw, uint8_t sf, uint8_t cr, uint32_t regfreq,
     ClearIrqStatus(radioNumber);
 
     SetPaConfig(isSubGHz, radioNumber); // Must be called after changing rf modes between subG and 2.4G.  This sets the correct rf amps, and txen pins to be used.
-#if defined(TARGET_RX)
     pwrForceUpdate = true;  // force an update of the output power because the band may have changed, and we need to configure the power for the band.
-#endif
     CommitOutputPower();
 }
 


### PR DESCRIPTION
I noticed this when testing a LR1121 based external TX module this morning, when switching from 900M to 2.4G, the power level was not set correctly. It used whatever the default for the LR1121 was on the 2.4GHz side i.e. -18 which ended up far too low!

We should probably backport this to 3.x.x as well