### PR TITLE
Remove DSHOT_PAUSE_BIT to fix DSHOT outputting 18 bits

### DIFF
--- a/src/lib/ServoOutput/DShotRMT.h
+++ b/src/lib/ServoOutput/DShotRMT.h
@@ -119,7 +119,7 @@ private:
 	uint32_t last_send_time = 0;
 
 	rmt_item32_t* encode_dshot_to_rmt(uint16_t parsed_packet);
-	uint16_t calc_dshot_chksum(const dshot_packet_t& dshot_packet);
+	uint16_t calc_dshot_chksum(uint16_t packet);
 	uint16_t prepare_rmt_data(const dshot_packet_t& dshot_packet);
 	void output_rmt_data();
 	void set_pin();


### PR DESCRIPTION
Removes the extra 2 bits appearing in the DSHOT output after #3140. Also adjusts DSHOT 300 timing:
| Name | DSHOT 300 | Was | Now |
|--|--|--|--|
| Bit Period | 3.33us | 3.20us | 3.30us |
| 1 High Time | 2.50us | 2.40us | 2.50us |
| 0 High Time | 1.25us | 1.20us | 1.30us |

### Bad DSHOT data

In addition to the bit timing being too short, there were extra  bits appearing in the output of each frame. There should be 16 "high" sections in a DSHOT packet

<img width="517" height="241" alt="image" src="https://github.com/user-attachments/assets/5c016ed2-f649-4b77-8169-faa9cada323b" />

The timing was also a little short, with each bit period being 0.13us too short and each "high" period being 0.10-0.15us too short. I don't believe this is an issue for ESCs but the decoder I downloaded for Logic didn't appreciate it so I've increased the all high bits and the bit period by 0.1us.

<img width="395" height="254" alt="image" src="https://github.com/user-attachments/assets/2e3aa653-647b-4716-86b0-38092478e1d6" />

To fix the output, I just removed the `DSHOT_PAUSE_BIT`, which was supposed to be a blank RMT item that assured there was a delay between each DSHOT packet when sent in hardware RMT looping mode. As the looping is now handled in software, the delay isn't needed as we can adjust the timing as we see fit. I have no idea what the original author of DShotRMT was smoking when they set the delay to `10000 - (16*ticks_per_bit) - 1`. The desired amount is 21 bit periods or 69.93us. That formula gives 9487 ticks or 948.7us or 0.9487ms. It should be just `DSHOT_PAUSE * ticks_per_bit`, which also fixed the bad DSHOT data, but again, we don't need the pause at this time. EDIT: Oh I figured it out. They were setting a 1ms looping period.

### RMT Busy Time

The RMT stays "busy" for 240us to 460us as measured by using another pin to flag the start of `output_rmt_data()` to the time where `rmt_wait_tx_done()` doesn't return TIMEOUT any more. It is usually in the 240-250us range but there are some anomalies, possibly due to our giant packet-receiving ISR blocking the measurement code from executing. I swapped out all the existing 500us fixed delay and `rmt_get_channel_status()` for just querying the single channel's TX status since it seemed more direct. I did not test this on a C3-based RX though.

### DSHOT Packet Interleaving

The behavior of the old DSHOT use all the RMT units and just loop sending the output every 1ms. Now only one RMT is used and each channel is sent out every 2ms, or if it has been updated since the last send. This may present a logic analyzer trace that looks broken compared to the old behavior, but this should be fine for ESCs. Betaflight outputs DSHOT anywhere from 0.125us (8KHz) to 2ms (500Hz). This code operates up to 1KHz per ExpressLRS output and can probably do 4000 updates per second total (250Hz x 16 channels) but we might need to optimize a little to hit that.

### Refactoring

This code needs some cleanup but in the interest of just trying to fix the bad output, I've only modified what was needed.