### PR TITLE
Revert #3140 (DSHOT round robin)

### DIFF
--- a/src/lib/ServoOutput/DShotRMT.cpp
+++ b/src/lib/ServoOutput/DShotRMT.cpp
@@ -6,57 +6,22 @@
 //
 
 #include "DShotRMT.h"
-#include "common.h"
-#include "config.h"
-#include "logging.h"
 
-static const rmt_channel_t rmt_channel = (rmt_channel_t)0; // instead of using many RMT channels, we are using just one, channel 0 is capable of transmitting on both ESP32-classic and ESP32-C3 so we pick 0
-
-static DShotRMT *head_node = NULL, *cur_node = NULL, *tail_node; // linked list of all initailized RMT instances
-
-static int prev_pin = -1; // we need to remember what the previous GPIO pin used was to remove it from the RMT (setting a new RMT pin does not unset the previous pin)
-
-// latch status to indicate if the RMT driver has been installed or uninstalled, so we don't do it twice
-static bool has_inited = false;
-static bool has_deinited = false;
-
-static rmt_item32_t dshot_tx_rmt_item[DSHOT_PACKET_LENGTH + 1];
-
-static void unassign_prev_pin(int pin, bool bidir);
-
-DShotRMT::DShotRMT(gpio_num_t gpio, int idx) : gpio_num(gpio), my_idx(idx) {
+DShotRMT::DShotRMT(gpio_num_t gpio, rmt_channel_t rmtChannel) : gpio_num(gpio), rmt_channel(rmtChannel) {
+	// ...create clean packet
+	encode_dshot_to_rmt(DSHOT_NULL_PACKET);
 }
 
 DShotRMT::~DShotRMT() {
-	if (has_deinited) {
-		// only allow uninstall once, not important but prevents errors over the debug log
-		return;
-	}
 	rmt_tx_stop(rmt_channel);
 	rmt_driver_uninstall(rmt_channel);
-	has_deinited = true;
-	head_node = NULL; // this isn't proper but all the instances are deleted at once anyways
-	cur_node = NULL;
 }
 
 bool DShotRMT::begin(dshot_mode_t dshot_mode, bool is_bidirectional) {
-
-	if (head_node == NULL) {
-		// first one, initialize linked list
-		head_node = this;
-		tail_node = this;
-		cur_node = this;
-		this->next_node = (DShotRMT*)this;
-	}
-	else {
-		// not the first node, so insert it as the next node
-		tail_node->next_node = (DShotRMT*)this;
-		tail_node = this;
-		this->next_node = head_node;
-	}
-
 	mode = dshot_mode;
 	bidirectional = is_bidirectional;
+
+	uint16_t ticks_per_bit;
 
 	switch (mode) {
 		case DSHOT150:
@@ -102,12 +67,24 @@ bool DShotRMT::begin(dshot_mode_t dshot_mode, bool is_bidirectional) {
 		.clk_div = DSHOT_CLK_DIVIDER,
 		.mem_block_num = uint8_t(RMT_CHANNEL_MAX - uint8_t(rmt_channel)),
 		.tx_config = {
-			.idle_level = bidirectional ? RMT_IDLE_LEVEL_HIGH : RMT_IDLE_LEVEL_LOW,
+        	.idle_level = bidirectional ? RMT_IDLE_LEVEL_HIGH : RMT_IDLE_LEVEL_LOW,
 			.carrier_en = false,
-			.loop_en = false,
+			.loop_en = true,
 			.idle_output_en = true,
 		},
 	};
+
+	// ...pause "bit" added to each frame
+    if (bidirectional) {
+        dshot_tx_rmt_item[DSHOT_PAUSE_BIT].level0 = HIGH;
+        dshot_tx_rmt_item[DSHOT_PAUSE_BIT].level1 = HIGH;
+    } else {
+        dshot_tx_rmt_item[DSHOT_PAUSE_BIT].level0 = LOW;
+        dshot_tx_rmt_item[DSHOT_PAUSE_BIT].level1 = LOW;
+    }
+
+	dshot_tx_rmt_item[DSHOT_PAUSE_BIT].duration1 = 0;
+	dshot_tx_rmt_item[DSHOT_PAUSE_BIT].duration0 = 10000 - (16*ticks_per_bit) - 1;
 
 	// setup the RMT end marker
 	dshot_tx_rmt_item[DSHOT_PACKET_LENGTH-1].duration0 = 0;
@@ -115,105 +92,72 @@ bool DShotRMT::begin(dshot_mode_t dshot_mode, bool is_bidirectional) {
 	dshot_tx_rmt_item[DSHOT_PACKET_LENGTH-1].duration1 = 0;
 	dshot_tx_rmt_item[DSHOT_PACKET_LENGTH-1].level1 = LOW;
 
-	if (has_inited) { // only do installation once
-		return true;
-	}
-
 	// ...setup selected dshot mode
 	rmt_config(&dshot_tx_rmt_config);
 
 	// ...essential step, return the result
-	esp_err_t ret = rmt_driver_install(dshot_tx_rmt_config.channel, 0, 0);
-
-	if (ret == ESP_OK) {
-		 // only do installation once
-		has_inited = true;
-		has_deinited = false;
-		encode_dshot_to_rmt(DSHOT_NULL_PACKET); // cache default timings
-		#ifdef DSHOTC3_DEBUG_INIT
-		DBGLN("Dshot RMT installed");
-		#endif
-		return true;
-	}
-	else {
-		DBGLN("Dshot RMT install failed - err %d", ret);
-		return false;
-	}
+	return rmt_driver_install(dshot_tx_rmt_config.channel, 0, 0);
 }
 
 void DShotRMT::set_looping(bool x) {
-	looping = x;
+	rmt_set_tx_loop_mode(rmt_channel, x);
 }
 
 // ...the config part is done, now the calculating and sending part
 void DShotRMT::send_dshot_value(uint16_t throttle_value, telemetric_request_t telemetric_request) {
-	if (throttle_value == 0) {
-		next_packet.throttle_value = 0;
+	dshot_packet_t dshot_rmt_packet = { };
+
+	if (throttle_value == DSHOT_THROTTLE_MIN) {
+		dshot_rmt_packet.throttle_value = 0;
 	} else {
-		if (throttle_value < DSHOT_THROTTLE_MIN) {
-			throttle_value = DSHOT_THROTTLE_MIN;
-		}
-
-		if (throttle_value > DSHOT_THROTTLE_MAX) {
-			throttle_value = DSHOT_THROTTLE_MAX;
-		}
-
 		// ...packets are the same for bidirectional mode
-		next_packet.throttle_value = throttle_value;
+		dshot_rmt_packet.throttle_value = throttle_value;
 	}
+	dshot_rmt_packet.telemetric_request = telemetric_request;
+	dshot_rmt_packet.checksum = this->calc_dshot_chksum(dshot_rmt_packet);
 
-	next_packet.telemetric_request = telemetric_request;
-	next_packet.checksum = this->calc_dshot_chksum(next_packet);
-
-	has_new_data = true;
-	// only cache the next packet but don't need to encode it or send it yet, it'll be sent later
+	output_rmt_data(dshot_rmt_packet);
 }
 
 rmt_item32_t* DShotRMT::encode_dshot_to_rmt(uint16_t parsed_packet) {
-	dshot_tx_rmt_item[DSHOT_PAUSE_BIT].duration1 = 0;
-	dshot_tx_rmt_item[DSHOT_PAUSE_BIT].duration0 = 10000 - (16*ticks_per_bit) - 1;
-
-	if (bidirectional) {
-		dshot_tx_rmt_item[DSHOT_PAUSE_BIT].level0 = HIGH; // ...pause "bit" added to each frame
-		dshot_tx_rmt_item[DSHOT_PAUSE_BIT].level1 = HIGH;
-		// ..."invert" the signal duration
-		for (int i = 0; i < DSHOT_PAUSE_BIT; i++, parsed_packet <<= 1) 	{
-			if (parsed_packet & 0b1000000000000000) {
-				// set one
-				dshot_tx_rmt_item[i].duration0 = ticks_one_low;
-				dshot_tx_rmt_item[i].duration1 = ticks_one_high;
-			}
-			else {
-				// set zero
-				dshot_tx_rmt_item[i].duration0 = ticks_zero_low;
-				dshot_tx_rmt_item[i].duration1 = ticks_zero_high;
-			}
+    // ...is bidirecional mode activated
+    if (bidirectional) {
+        // ..."invert" the signal duration
+        for (int i = 0; i < DSHOT_PAUSE_BIT; i++, parsed_packet <<= 1) 	{
+		    if (parsed_packet & 0b1000000000000000) {
+			    // set one
+			    dshot_tx_rmt_item[i].duration0 = ticks_one_low;
+			    dshot_tx_rmt_item[i].duration1 = ticks_one_high;
+		    }
+		    else {
+			    // set zero
+			    dshot_tx_rmt_item[i].duration0 = ticks_zero_low;
+			    dshot_tx_rmt_item[i].duration1 = ticks_zero_high;
+		    }
 
 			dshot_tx_rmt_item[i].level0 = LOW;
 			dshot_tx_rmt_item[i].level1 = HIGH;
-		}
-	}
-	// ..."normal" DShot mode / "bidirectional" mode OFF
-	else {
-		dshot_tx_rmt_item[DSHOT_PAUSE_BIT].level0 = LOW;
-		dshot_tx_rmt_item[DSHOT_PAUSE_BIT].level1 = LOW;
+        }
+    }
 
-		for (int i = 0; i < DSHOT_PAUSE_BIT; i++, parsed_packet <<= 1) 	{
-			if (parsed_packet & 0b1000000000000000) {
-				// set one
-				dshot_tx_rmt_item[i].duration0 = ticks_one_high;
-				dshot_tx_rmt_item[i].duration1 = ticks_one_low;
-			}
-			else {
-				// set zero
-				dshot_tx_rmt_item[i].duration0 = ticks_zero_high;
-				dshot_tx_rmt_item[i].duration1 = ticks_zero_low;
-			}
+    // ..."normal" DShot mode / "bidirectional" mode OFF
+    else {
+        for (int i = 0; i < DSHOT_PAUSE_BIT; i++, parsed_packet <<= 1) 	{
+		    if (parsed_packet & 0b1000000000000000) {
+			    // set one
+			    dshot_tx_rmt_item[i].duration0 = ticks_one_high;
+			    dshot_tx_rmt_item[i].duration1 = ticks_one_low;
+		    }
+		    else {
+			    // set zero
+			    dshot_tx_rmt_item[i].duration0 = ticks_zero_high;
+			    dshot_tx_rmt_item[i].duration1 = ticks_zero_low;
+		    }
 
 			dshot_tx_rmt_item[i].level0 = HIGH;
 			dshot_tx_rmt_item[i].level1 = LOW;
-		}
-	}
+        }
+    }
 
 	return dshot_tx_rmt_item;
 }
@@ -236,7 +180,7 @@ uint16_t DShotRMT::calc_dshot_chksum(const dshot_packet_t& dshot_packet) {
 uint16_t DShotRMT::prepare_rmt_data(const dshot_packet_t& dshot_packet) {
 	auto chksum = calc_dshot_chksum(dshot_packet);
 
-	// ..."construct" the packet
+    // ..."construct" the packet
 	uint16_t prepared_to_encode = (dshot_packet.throttle_value << 1) | dshot_packet.telemetric_request;
 	prepared_to_encode = (prepared_to_encode << 4) | chksum;
 
@@ -244,73 +188,11 @@ uint16_t DShotRMT::prepare_rmt_data(const dshot_packet_t& dshot_packet) {
 }
 
 // ...finally output using ESP32 RMT
-void DShotRMT::output_rmt_data() {
+void DShotRMT::output_rmt_data(const dshot_packet_t& dshot_packet) {
+	encode_dshot_to_rmt(prepare_rmt_data(dshot_packet));
+
 	rmt_tx_stop(rmt_channel);
-	set_pin();
-	encode_dshot_to_rmt(prepare_rmt_data(next_packet));
 	rmt_fill_tx_items(rmt_channel, dshot_tx_rmt_item, DSHOT_PACKET_LENGTH, 0);
 	rmt_tx_start(rmt_channel, true);
-	has_new_data = false;
 }
-
-void DShotRMT::set_pin() {
-	if (prev_pin >= 0) { // if there was a previously used pin that needs to be decoupled from RMT
-		// rmt_set_pin and rmt_config only seems to add pins to the RMT mux
-		// they do not remove pins
-		// so we must manually remove the previous pin from the mux
-		unassign_prev_pin(prev_pin, bidirectional);
-	}
-	pinMode(gpio_num, OUTPUT);
-	rmt_set_gpio(rmt_channel, RMT_MODE_TX, gpio_num, false);
-	rmt_set_idle_level(rmt_channel, bidirectional ? false : true, bidirectional ? RMT_IDLE_LEVEL_HIGH : RMT_IDLE_LEVEL_LOW);
-	prev_pin = gpio_num;
-}
-
-void DShotRMT::poll() {
-	if (cur_node == NULL) { // no instances initalized, do nothing
-		return;
-	}
-	static uint32_t last_time_us = 0;
-	uint32_t now_us = micros();
-	if ((now_us - last_time_us) < 500) {
-		// make sure enough time has passed (RMT driver does not indicate end of transmission at the right time)
-		// the number 500 is found by using a logic analyzer to see how often a dshot packet gets cut off
-		return;
-	}
-	rmt_channel_status_result_t status;
-	if (rmt_get_channel_status(&status) != ESP_OK || status.status[rmt_channel] != RMT_CHANNEL_IDLE) {
-		// make sure RMT is actually idle
-		return;
-	}
-	DShotRMT* inst = cur_node;
-	cur_node = (DShotRMT*)inst->next_node; // cycle through linked list
-	if (inst->has_new_data || //  send if required
-		(inst->looping && (now_us - inst->last_send_time) >= 2000) // limit looping speed
-		) {
-		inst->output_rmt_data(); // actually send the data, this will set the pin first, and clear the has_new_data flag
-		inst->last_send_time = now_us;
-		last_time_us = now_us;
-	}
-}
-
-static void unassign_prev_pin(int pin, bool bidir)
-{
-	if (bidir == false) {
-		gpio_set_level((gpio_num_t)pin, 0);
-	}
-
-	gpio_config_t conf = {
-		.pin_bit_mask = (1ULL<<pin),
-		.mode = bidir ? GPIO_MODE_DISABLE : GPIO_MODE_OUTPUT,
-		.pull_up_en = bidir ? GPIO_PULLUP_ENABLE : GPIO_PULLUP_DISABLE,
-		.pull_down_en = bidir ? GPIO_PULLDOWN_DISABLE : GPIO_PULLDOWN_ENABLE,
-		.intr_type = GPIO_INTR_DISABLE
-	};
-	gpio_config(&conf);
-
-	if (bidir == false) {
-		gpio_set_level((gpio_num_t)pin, 0);
-	}
-}
-
 #endif

--- a/src/lib/ServoOutput/DShotRMT.h
+++ b/src/lib/ServoOutput/DShotRMT.h
@@ -90,7 +90,7 @@ typedef struct dshot_config_s {
 
 class DShotRMT {
 public:
-	DShotRMT(gpio_num_t gpio, int idx);
+	DShotRMT(gpio_num_t gpio, rmt_channel_t rmtChannel);
 	~DShotRMT();
 
 	// ...safety first ...no parameters, no DShot
@@ -98,32 +98,22 @@ public:
 	void set_looping(bool);
 	void send_dshot_value(uint16_t throttle_value, telemetric_request_t telemetric_request = NO_TELEMETRIC);
 
-	static void poll(); // call this as often as possible (or about every 150us)
-
 private:
 	gpio_num_t gpio_num;
-	int my_idx;
-	void* next_node = NULL; // linked list next node
-
-	dshot_packet_t next_packet; // stores the data to be sent when the turn comes
+	rmt_channel_t rmt_channel;
+	rmt_item32_t dshot_tx_rmt_item[DSHOT_PACKET_LENGTH + 1];
 
 	dshot_mode_t mode = DSHOT_OFF;
 	bool bidirectional = false;
-	uint16_t ticks_per_bit = 0;
 	uint16_t ticks_zero_high = 0;
 	uint16_t ticks_zero_low = 0;
 	uint16_t ticks_one_high = 0;
 	uint16_t ticks_one_low = 0;
 
-	bool has_new_data = false;
-	bool looping = true;
-	uint32_t last_send_time = 0;
-
 	rmt_item32_t* encode_dshot_to_rmt(uint16_t parsed_packet);
 	uint16_t calc_dshot_chksum(const dshot_packet_t& dshot_packet);
 	uint16_t prepare_rmt_data(const dshot_packet_t& dshot_packet);
-	void output_rmt_data();
-	void set_pin();
-};
 
+	void output_rmt_data(const dshot_packet_t& dshot_packet);
+};
 #endif

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -72,7 +72,7 @@ static void servoWriteDshot(eServoOutputMode chMode, uint8_t ch, uint16_t us)
             }
             else {
                 dshotVal = fmap(us, 1001, 2000, DSHOT_THROTTLE_MIN, DSHOT_THROTTLE_MAX); // Convert PWM signal in us to DShot value
-            }         
+            }
         }
         else // somDShot3D
         {
@@ -195,10 +195,6 @@ void servoCurrentToFailsafeConfig()
 static void servosUpdate(unsigned long now)
 {
     static uint32_t lastUpdate;
-
-    #if defined(PLATFORM_ESP32)
-    DShotRMT::poll();
-    #endif
 
     if (newChannelsAvailable)
     {


### PR DESCRIPTION
Reverting this PR due to it sending too many bits in the DSHOT packet and the timing is way too temperamental. 

* We can't just delay for 500us between each DSHOT output, as this will limit the number of channels we can output with 2ms update rate to just 4 outputs, virtually eliminating all benefits of the PR.
* Bidirectional DSHOT needs to switch the RMT to receive mode immediately after the last bit, with only a 26us window to perform the transition. The polling nature of the PR makes meeting this goal questionable, even without the fixed 500us delay. That means we'll have to rejigger the internals of #3140 anyway, so why are we bashing our heads against the wall trying to get it to work knowing it will be replaced immediately anyway.