### PR TITLE
Add isArmed as CH14

### DIFF
--- a/src/lib/OTA/OTA.cpp
+++ b/src/lib/OTA/OTA.cpp
@@ -342,6 +342,8 @@ static void ICACHE_RAM_ATTR UnpackChannelDataHybridCommon(OTA_Packet4_s const * 
         channelData[ch] = UINT10_to_CRSF(rawChannelData[ch] >> 1);
     }
     channelData[4] = BIT_to_CRSF(isArmed);
+    // Copy the armed flag into CH14/AUX10 for consistency with fullres
+    channelData[13] = channelData[4];
 #endif
 }
 
@@ -444,8 +446,8 @@ bool ICACHE_RAM_ATTR UnpackChannelData8ch(OTA_Packet_s const * const otaPktPtr, 
     {
         chDstLow = 0;
         chDstHigh = (ota8->rc.isHighAux) ? 8 : 4;
-        // For 8ch and 12ch mode, Arm status is placed in CH13/AUX8
-        channelData[AUX8] = BIT_to_CRSF(isArmed);
+        // For 8ch and 12ch mode, Arm status is placed in CH14/AUX10 just like non-fullres
+        channelData[13] = BIT_to_CRSF(isArmed);
     }
 
     // Analog channels packed 10bit covering the entire CRSF extended range (i.e. not just 988-2012)


### PR DESCRIPTION
Adds reporting the isArmed status in fullres modes as CH14 / AUX10

The alternative arming method PR fixed the issue of CH5 being a nightmare for fixed wing users, but it also effectively removes a channel from our output in fullres modes. The old system had 9 or 13 channels, but with one CH5 being one bit. We're still transmitting the value over the air even if we're not stuffing it in CH5, we might as well put it out somewhere.

I sort of realized this as I was typing the release notes that this would be considered a regression, and I realized most my iNav setups use 8ch mode + arm and now would have to use 12ch mode for no reason. 😅

~~If not CH13, maybe CH14? We have 15 and 16 used for RSSI/LQ and might be better to group all the "internal" stuff together?~~ Moved to CH14