### PR TITLE
Extend TcpMspConnector idle timeout

### DIFF
--- a/src/lib/WIFI/TcpMspConnector.cpp
+++ b/src/lib/WIFI/TcpMspConnector.cpp
@@ -25,29 +25,30 @@ void TcpMspConnector::begin()
 
 void TcpMspConnector::handleNewClient(void *arg, AsyncClient *client)
 {
-    DBGLN("\nTCPSOCKET client (%x) connected ip: %s", client, client->remoteIP().toString().c_str());
+    DBGLN("TCP(%x) connected ip %s", client, client->remoteIP().toString().c_str());
     ((TcpMspConnector *)arg)->clientConnect(client);
 }
 
 void TcpMspConnector::handleDataIn(void *arg, AsyncClient *client, void *data, const size_t len)
 {
+    DBGLN("TCP(%x) read %u", client, len);
     ((TcpMspConnector *)arg)->processData(client, data, len);
 }
 
 void TcpMspConnector::handleDisconnect(void *arg, AsyncClient *client)
 {
-    DBGLN("\n client %s disconnected \n", client->remoteIP().toString().c_str());
+    DBGLN("TCP(%x) disconnected", client);
     ((TcpMspConnector *)arg)->clientDisconnect(client);
 }
 
 void TcpMspConnector::handleTimeOut(void *arg, AsyncClient *client, uint32_t time)
 {
-    DBGLN("\nclient ACK timeout ip: %s", client->remoteIP().toString().c_str());
+    DBGLN("TCP(%x) timeout", client);
 }
 
 void TcpMspConnector::handleError(void *arg, AsyncClient *client, int8_t error)
 {
-    DBGLN("\nclient %x connection error %s", client, client->errorToString(error));
+    DBGLN("TCP(%x) connection error %s", client, client->errorToString(error));
     ((TcpMspConnector *)arg)->clientDisconnect(client);
 }
 
@@ -92,8 +93,10 @@ void TcpMspConnector::forwardMessage(const crsf_header_t *message)
 {
     if (TCPclient != nullptr && (message->type == CRSF_FRAMETYPE_MSP_RESP || message->type == CRSF_FRAMETYPE_MSP_REQ))
     {
+        DBGLN("TCP(CRSF) msg %u", message->frame_size);
         crsf2msp->parse((uint8_t *)message, [&](const uint8_t *data, const size_t len) {
             TCPclient->write((const char *)data, len);
+            DBGLN("TCP(%x) write %u", TCPclient, len);
         });
     }
 }

--- a/src/lib/WIFI/TcpMspConnector.h
+++ b/src/lib/WIFI/TcpMspConnector.h
@@ -29,7 +29,7 @@ private:
     static void handleDisconnect(void *arg, AsyncClient *client);
     static void handleTimeOut(void *arg, AsyncClient *client, uint32_t time);
     static void handleError(void *arg, AsyncClient *client, int8_t error);
-    static constexpr uint32_t clientTimeoutS = 2U;
+    static constexpr uint32_t clientTimeoutS = 10U;
 
     void clientConnect(AsyncClient * client);
     void clientDisconnect(AsyncClient *client);


### PR DESCRIPTION
Extend the timeout of the socket MSP connection from 2s to 10s. This is to prevent disconnects when the link is underutilized by the flight controller Configurator apps.

Fixes #3410? This can also be backported to 3.x.x-maintenance with just a 2 byte change in TCPSOCKET.

### Details

In the 3.5.5 socket MSP system, the code would just memory leak the socket pointer if the connection was idle more than 2s. If new data would come in, the pointer would be reattached to the pump process. This meant there was effectively no timeout on incoming data as the connection would just sort of fix itself on the next packet.

When I refactored the code and fixed the memory leaks, this made some Configurators unreliable. In particular the test case of Rotorflight 4.5.1 with Configurator 2.2.1 has pauses you can drive a truck through. Any time the Configurator would stop loading mid-way through a tab, we'd drop the connection and force it closed. You can see these happening in Wireshark

<img width="275" height="341" alt="image" src="https://github.com/user-attachments/assets/5e7abb80-5e99-4d2c-a2ec-119d926efecc" />

The first one there was just 90ms of idle time away from us dropping the connection while we (x.x.x.151) waited on the next command request from the Configurator (x.x.x.145). The one further down was over a second waiting to get the MSP data from the FC to reply with.

This RF Configurator shows tab load times all over the place and I see a lot of redundant data being requested so it is likely this could be improved on the Configurator side to increase the performance. The upcoming betaflight PWA Android app loads things much more consistently and did not need any timeout extension. Here's RF tab load times before this PR

| Tab | 3.5.5 | 3.6.2 | 4.0-RC1 |
|--|--|--|--|
|Status |4.18s |2.01s| 2.03s|
|Setup |4.18s |7.46s |1.01s|
|Config |3.45s |5.53s |7.72s|
|Receiver| 6.91s| 4.13s (disconnected once) |14.61s (disconnected 8x, increased timeout)|
|Failsafe| 9.19s |9.23s| 9.15s|
|Power |4.27s |2.57s |2.13s|
|Motors |7.93s |6.06s |3.43s|

### Quick Fix

I just upped the timeout from 2s to 10s and now can not reproduce the issue. The 2s was chosen because it matched the old leaky code, but it seems like 2s might also be the Rotorflight Configurator's internal timeout or something because I saw quite a few ~2s pauses during my testing. We can even make this longer, but because we don't maintain the currently active socket list I'd be wary of setting it too long and having multiple connections getting their data mixed somehow, as we only have one pipe to the flight controller. We also could force a connection closed if a new one comes in, but let's go with this for now.

### Debug

I also returned some debug messages from before the 4.0 refactor and cleaned up the existing ones to be shorter and consistent.
```bash
TCP(3fcc2500) read 6
TCP(CRSF) msg 37
TCP(3fcc2500) write 36
TCP(3fcc2500) read 6
TCP(CRSF) msg 37
TCP(3fcc2500) write 36
TCP(3fcc2500) read 6
TCP(CRSF) msg 37
TCP(3fcc2500) write 36
TCP(3fcc2500) read 6
TCP(3fcc2500) read 6
TCP(CRSF) msg 62
TCP(CRSF) msg 62
TCP(CRSF) msg 39
TCP(3fcc2500) write 152
TCP(3fcc2500) read 6
TCP(3fcc2500) read 7
TCP(CRSF) msg 62
TCP(CRSF) msg 62
TCP(CRSF) msg 39
TCP(3fcc2500) write 152
TCP(3fcc2500) read 7
TCP(CRSF) msg 7
TCP(3fcc2500) write 6
TCP(3fcc2500) disconnected
```