### PR TITLE
Fix broken I2C on 8285 based receivers

### DIFF
--- a/src/include/target/Unified_ESP8285_TX.h
+++ b/src/include/target/Unified_ESP8285_TX.h
@@ -64,6 +64,9 @@
 #define WS2812_BOOT_LEDS_COUNT hardware_int(HARDWARE_ledidx_rgb_boot_count)
 
 // Unsupported TX features for an 8285 TX
+#define GPIO_PIN_SCL UNDEF_PIN
+#define GPIO_PIN_SDA UNDEF_PIN
+
 #define OPT_HAS_THERMAL false
 #define GPIO_PIN_FAN_EN UNDEF_PIN
 #define GPIO_PIN_FAN_PWM UNDEF_PIN

--- a/src/src/rxtx_common.cpp
+++ b/src/src/rxtx_common.cpp
@@ -24,7 +24,6 @@ boolean i2c_enabled = false;
 
 static void setupWire()
 {
-#if defined(PLATFORM_ESP32)
     int gpio_scl = GPIO_PIN_SCL;
     int gpio_sda = GPIO_PIN_SDA;
 
@@ -60,7 +59,6 @@ static void setupWire()
         Wire.setClock(400000);
         i2c_enabled = true;
     }
-#endif
 }
 
 void setupTargetCommon()


### PR DESCRIPTION
As part of the removal of STM32 it appears that the 8285 I2C support was broken.