### PR TITLE
Only use the default UART0 for passthrough flashing

### DIFF
--- a/src/lib/Backpack/devBackpack.cpp
+++ b/src/lib/Backpack/devBackpack.cpp
@@ -71,7 +71,7 @@ static uint32_t lastPTRValidTimeMs;
     }
     else
     {
-        CRSFHandset::Port.begin(baud, SERIAL_8N1, GPIO_PIN_RCSIGNAL_RX, GPIO_PIN_RCSIGNAL_TX);
+        CRSFHandset::Port.begin(baud, SERIAL_8N1, U0RXD_GPIO_NUM, U0TXD_GPIO_NUM);
         CRSFHandset::Port.setTxBufferSize(1024);
         CRSFHandset::Port.setRxBufferSize(16384);
     }


### PR DESCRIPTION
If a TX module has 2 UARTs and UART0 is used for the updates and a secondary UART is used for CRSF comms, then you can't update the backpack via passthrough.
This change is backward compatible with all existing TX modules, both internal and external.