### PR TITLE
Dual band binding happening on wrong rate

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1569,7 +1569,7 @@ void loop()
 #if defined(RADIO_LR1121)
     // Send half of the bind packets on the 2.4GHz domain
     if (BindingSendCount == BindingSpamAmount / 2) {
-      SetRFLinkRate(RATE_DUALBAND_BINDING);
+      SetRFLinkRate(enumRatetoIndex(RATE_DUALBAND_BINDING));
       // Increment BindingSendCount so that SetRFLinkRate is only called once.
       BindingSendCount++;
     }


### PR DESCRIPTION
Resolves Team2.4-only RXes not being able to traditional bind with a Dual Band TX, due to the TX being on the wrong packet rate.

The TX actually switches to RATE_MAX which is RATE_LORA_DUAL_100HZ_8CH
```
wTimer stop
set rate 6
hwTimer interval: 20000
Config LoRa
Adjusted max packet size 64-128
hwTimer resume
Entered binding mode at freq = 915500000
e9 1 9 93 80 ce
e9 1 9 93 80 ce
e9 1 9 93 80 ce
e9 1 9 93 80 ce
e9 1 9 93 80 ce
e9 1 9 93 80 ce
e9 1 9 93 80 ce
e9 1 9 93 80 ce
e9 1 9 93 80 ce
e9 1 9 93 80 ce
e9 1 9 93 80 ce
e9 1 9 93 80 ce
set rate 21  <--- Wrong index
hwTimer interval: 10000  <-- 100Hz?! 
Config LoRa <-- dual band
Config LoRa <-- dual band
Adjusted max packet size 64-128
9 9 93 80 ce 77  <-- 8ch packet encoding
9 9 93 80 ce 77
9 9 93 80 ce 77
9 9 93 80 ce 77
9 9 93 80 ce 77
9 9 93 80 ce 77
9 9 93 80 ce 77
9 9 93 80 ce 77
9 9 93 80 ce 77
9 9 93 80 ce 77
9 9 93 80 ce 77
9 9 93 80 ce 77
9 9 93 80 ce 77
```

### Backport

This does NOT need a backport to 3.x as 3.x mixes the references such that the first binding uses `enumRatetoIndex(enum)` and the second uses a direct index. Although we could backport it to use enums both places if we want to get our PR count up!