### PR TITLE
Set LQ=0 when handset disconnects

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -717,6 +717,8 @@ static void UARTdisconnected()
 {
   hwTimer::stop();
   setConnectionState(noCrossfire);
+  // Since not going from connected -> disconnected, set LQ=0 to make sure the handset knows we stopped TXing when it comes back
+  linkStats.uplink_Link_quality = 0;
 }
 
 static void UARTconnected()


### PR DESCRIPTION
Forces the `uplink_Link_quality` to 0 if the handset ever disconnects. Due to never going from connected -> disconnected, this means if the TX module stays powered while the handset is turned off / on, we keep reporting the last linkstats values and the handset thinks the connection is up.

This should be a fairly rare condition, but modules do have external power connectors so it is possible the handset could reboot and the module stays powered. I saw this while having a USB cable plugged into the TX module while rebooting the handset.