### PR TITLE
Bind after connection fix

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1657,13 +1657,15 @@ static void EnterBindingMode()
         return;
     }
 
-    // Binding uses 50Hz, and InvertIQ
-    OtaCrcInitializer = OTA_VERSION_ID;
-    InBindingMode = true;
     // Any method of entering bind resets a loan
     // Model can be reloaned immediately by binding now
     config.ReturnLoan();
     config.Commit();
+
+    // Binding uses 50Hz, and InvertIQ
+    OtaCrcInitializer = OTA_VERSION_ID;
+    OtaNonce = 0;
+    InBindingMode = true;
 
     // Start attempting to bind
     // Lock the RF rate and freq while binding


### PR DESCRIPTION
When a connection is made to a TX, the OtaNonce starts counting. When Binding is then started (after a connection) i.e. to release a loaned model or other things... :thinking:, then the nonce needs to be reset to zero as the TX binding does. Otherwise, who knows what it will be and the bind can never succeed!

# Testing
1. Connect to a RX
2. Power off the TX
3. Press the bind button on the RX till it enter bind mode
4. Power the TX and select [Bind] in the Lua script
5. 😢 if it's before this PR; 😄 if this PR is used