### PR TITLE
Extend VTX Admin disconnect debounce

### DIFF
--- a/src/lib/VTX/devVTX.cpp
+++ b/src/lib/VTX/devVTX.cpp
@@ -21,7 +21,7 @@
 // reset between the user switching equipment. This is so we don't get into
 // a loop of connect -> send -> write eeprom -> disconnect -> ...
 // See https://github.com/ExpressLRS/ExpressLRS/issues/2976
-#define VTX_DISCONNECT_DEBOUNCE_MS (1 * 1000)
+#define VTX_DISCONNECT_DEBOUNCE_MS (10 * 1000)
 
 static int pitmodeAuxState = PITMODE_NOT_INITIALISED;
 static bool sendEepromWrite = true;


### PR DESCRIPTION
Returns DEBOUNCE duration for VTX Admin back to 10s up from 1s (lowered in #3079) to allow a longer time for the RX to reconnect without pushing the VTX Admin MSP again. 50Hz reconnects too slowly.

Reported in bug-reports on Discord for 3.6.2 but I was able to reproduce on 3.x.x-maint and master.

### Details

Part of the initial commit for #3079 lowers the VTX Admin debounce timer to 1s, meaning the RX has to reconnect in under 1s or else the VTX Admin will take it as a new connection and push the MSP again. I do not know why this was changed to be so short. The duration has to be long enough to be able to tell a user switching batteries (needs new VTX Admin) and just general disconnect/reconnects due to range or the previous VTX Admin change knocking the RX off. 1s is not always long enough for 50Hz to reconnected (and observed less often in other packet rates such as 250Hz).

```
$X<Y 385564 lost connection
385587 event to DEBOUNCE
386588 timeout to VTXSS_UNKNOWN
386588 going NEVER
387641 got downlink conn  <-- disconnected for 2077ms
387653 event to SENDING
Sending VtxConfig
$X<Y Sending VtxConfig
$X<Y Sending VtxConfig
$X<Y 391964 lost connection
391968 event to DEBOUNCE
392969 timeout to VTXSS_UNKNOWN
392969 going NEVER
394041 got downlink conn <-- 2077ms
394059 event to SENDING
Sending VtxConfig
$X<Y Sending VtxConfig
$X<Y Sending VtxConfig
$X<Y 398364 lost connection
398375 event to DEBOUNCE
399376 timeout to VTXSS_UNKNOWN
399376 going NEVER
400441 got downlink conn  <-- 2077ms
400441 event to SENDING
Sending VtxConfig
$X<Y Sending VtxConfig
$X<Y Sending VtxConfig
$X<Y 
```

The symptom is that SPI RXes will keep reconnecting then disconnecting and we can see here that if it triggers, it becomes quite consistent in the timing and will probably never stop. It doesn't do it every time either. Even at 50Hz it has a pretty good chance of reconnecting quickly and avoiding the condition. Faster rates, which connect faster in general, show it less frequently but will also get stuck in a loop once it starts.

### Backport

This needs a backport to 3.x.x-maint 