### PR TITLE
Only use the low bit of the extended channels packet for arm status

### DIFF
--- a/src/lib/CrsfProtocol/crsf_protocol.h
+++ b/src/lib/CrsfProtocol/crsf_protocol.h
@@ -198,6 +198,11 @@ typedef struct crsf_channels_s
     unsigned ch15 : 11;
 } PACKED crsf_channels_t;
 
+/**
+ * Bits used in the byte following crsf_channels_t in the ExpressLRS extended CHANNELS_PACKED packet
+ */
+#define CRSF_CHANNELS_STATUS_FLAG_ARM       bit(0)
+
 typedef struct deviceInformationPacket_s
 {
     uint32_t serialNo;

--- a/src/lib/tx-crsf/TXModuleEndpoint.cpp
+++ b/src/lib/tx-crsf/TXModuleEndpoint.cpp
@@ -122,7 +122,9 @@ void TXModuleEndpoint::RcPacketToChannelsData(const crsf_header_t *message) // d
     // frame len 24 -> arming mode CH5: use channel 5 value
     // frame len 25 -> arming mode Switch: use commanded arming status in extra byte
     //
-    armCmd = message->frame_size == 24 ? CRSF_to_BIT(localChannelData[4]) : payload[readByteIndex];
+    armCmd = message->frame_size == CRSF_FRAME_SIZE(sizeof(crsf_channels_t))
+        ? CRSF_to_BIT(localChannelData[AUX1])
+        : (payload[readByteIndex] & CRSF_CHANNELS_STATUS_FLAG_ARM);
 
     // monitoring arming state
     if (lastArmCmd != armCmd)


### PR DESCRIPTION
Modifies processing of the `CRSF_FRAMETYPE_RC_CHANNELS_PACKED` extended packet such that only the low bit of the extended byte is used to detect arm status instead of the entire byte. Without this change, the entire byte will be dedicated to just carrying one bit for all time.

The idea here is that EdgeTX can include other information in the other bits at a later date, and if we don't mask the bit off before 4.0 then it will be entirely locked to that purpose.