### PR TITLE
Clear the FEC encode buffer before use

### DIFF
--- a/src/lib/LR1121Driver/LR1121.cpp
+++ b/src/lib/LR1121Driver/LR1121.cpp
@@ -34,6 +34,7 @@ public:
 
 void ICACHE_RAM_ATTR FECCodec::encode(uint8_t *out, uint8_t *in, uint32_t len)
 {
+    memset(out, 0, len); // ensure that the buffer is zeroed to start
     FECEncode(in, out);
 }
 
@@ -643,7 +644,7 @@ void ICACHE_RAM_ATTR LR1121Driver::TXnb(uint8_t *data, const bool sendGeminiBuff
     }
 
     WORD_ALIGNED_ATTR uint8_t outBuffer[32] = {0};
-    const uint8_t length = PayloadLength+3;
+    const uint8_t length = PayloadLength + 3; // 3 extra zero bytes for the 24-bit timeout
     codec->encode(outBuffer, data, PayloadLength);
     if (sendGeminiBuffer)
     {


### PR DESCRIPTION
The FEC codec or's the data into the output buffer so it is assumed that the buffer is initialised to zeroes!
I've put a `memset` as the first line of the function so this is no longer a requirement on the caller.