### PR TITLE
Don't write every byte of log messages individually

### DIFF
--- a/src/lib/logging/logging.cpp
+++ b/src/lib/logging/logging.cpp
@@ -21,7 +21,7 @@ void debugPrintf(const char* fmt, ...)
   c = GETCHAR;
   while(c) {
     if (c == '%') {
-      if (v) LOGGING_UART.write(v, fmt - v);
+      if (v) LOGGING_UART.write((uint8_t*)v, fmt - v);
       fmt++;
       c = GETCHAR;
       v = buf;
@@ -60,7 +60,7 @@ void debugPrintf(const char* fmt, ...)
     c = GETCHAR;
   }
   va_end(vlist);
-  if (v) LOGGING_UART.write(v, fmt - v);
+  if (v) LOGGING_UART.write((uint8_t*)v, fmt - v);
 }
 
 #if defined(DEBUG_INIT)


### PR DESCRIPTION
Speeds DBGLN printing by not outputting every character individually via Stream.write() and instead gathers the largest contiguous string and writes it with a single call.

| Message | Old (us) | New (us) |
|--|--|--|
| TLM crc error | 250 | 15-45 |
| Set parameter [Enable WiFi]=%u | 310 | 75 |
| Adjusted max packet size %u-%u |430 | 135 |
