### PR TITLE
Restore rx-as-tx for ESP32C3

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -36,7 +36,10 @@ void sendMAVLinkTelemetryToBackpack(uint8_t *) {}
 #include "TXOTAConnector.h"
 #include "TXUSBConnector.h"
 
-#if defined(PLATFORM_ESP8266)
+#if defined(PLATFORM_ESP32_S3) || defined(PLATFORM_ESP32_C3)
+#include "USB.h"
+#define USBSerial Serial
+#elif defined(PLATFORM_ESP8266)
 #include <user_interface.h>
 #endif
 
@@ -1272,6 +1275,10 @@ static void setupSerial()
   }
 #endif
   BackpackOrLogStrm = serialPort;
+
+#if defined(PLATFORM_ESP32_S3) || defined(PLATFORM_ESP32_C3)
+  Serial.begin(firmwareOptions.uart_baud);
+#endif
 
 // Setup TxUSB
 #if defined(PLATFORM_ESP32_S3) || defined(PLATFORM_ESP32_C3)

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -90,6 +90,7 @@ build_flags =
 	${env_common_esp32.build_flags}
 	-D PLATFORM_ESP32_C3=1
 	-D ARDUINO_USB_MODE
+	-D ARDUINO_USB_CDC_ON_BOOT
 
 [env_common_esp32rx]
 platform = espressif32@6.12.0


### PR DESCRIPTION
Fix #3478 by replacing a few sections removed in #3378. Tested on a Radiomaster XR1 rx-as-tx, I don't know how this will impact other esp32c3tx targets.