### PR TITLE
Disable PA in TXRXdisable() whether in rx_enable or tx_enable state for esp8285

### DIFF
--- a/src/lib/RFAMP/RFAMP_hal.cpp
+++ b/src/lib/RFAMP/RFAMP_hal.cpp
@@ -211,15 +211,15 @@ void ICACHE_RAM_ATTR RFAMP_hal::TXRXdisable()
     }
     if (tx_enabled)
     {
-        if (GPIO_PIN_PA_ENABLE != UNDEF_PIN)
-        {
-            digitalWrite(GPIO_PIN_PA_ENABLE, LOW);
-        }
         if (GPIO_PIN_TX_ENABLE != UNDEF_PIN)
         {
             digitalWrite(GPIO_PIN_TX_ENABLE, LOW);
         }
         tx_enabled = false;
+    }
+    if (GPIO_PIN_PA_ENABLE != UNDEF_PIN)
+    {
+        digitalWrite(GPIO_PIN_PA_ENABLE, LOW);
     }
 #endif
 }


### PR DESCRIPTION
Hi, 
For now, we only disable PA in tx_enable state in 8285.
This patch disable PA in all situation when call TXRXdisable.

And Why to do this change:
Actually I'm making a RX hardware which could let esp8285 use SX1280's antenna by a RF switch.
(I'm fed up with the terrible Wi-Fi signal in current ESP8285 hardware because I often use
the msp2wifi function to configure INav FC)

and I try to find a PIN which could control the RF Switch when wifi enable, PA_ENABLE is fitable.
and I find the PA_ENABLE never be lower when in rx_enable state, so do this change.

On the other hand, to keep the behavior consistency with esp32 and esp32C3, we should also do it.

Thank you! feel free to comment.

