### PR TITLE
SX1280 - Avoid sending unitialized data when reading registers.

### DIFF
--- a/src/lib/SX1280Driver/SX1280_hal.cpp
+++ b/src/lib/SX1280Driver/SX1280_hal.cpp
@@ -201,7 +201,9 @@ void ICACHE_RAM_ATTR SX1280Hal::ReadRegister(uint16_t address, uint8_t *buffer, 
 
 uint8_t ICACHE_RAM_ATTR SX1280Hal::ReadRegister(uint16_t address, SX12XX_Radio_Number_t radioNumber)
 {
-    uint8_t data;
+    // this buffer is SENT over SPI too, initialize it to avoid sending unitialized data over the SPI bus.
+    uint8_t data = 0;
+
     ReadRegister(address, &data, 1, radioNumber);
     return data;
 }


### PR DESCRIPTION
A picture, they say, is worth a thousand words.

before (note the `0x4c` uninitialised data):

<img width="1281" height="803" alt="Screenshot_20260109_215635" src="https://github.com/user-attachments/assets/b4b64779-bb41-4add-8803-c9947ab4c152" />

after:

<img width="1812" height="909" alt="Screenshot_20260109_220732" src="https://github.com/user-attachments/assets/421d3532-2c31-4a4a-9eaa-a9028965fdb7" />


