### PR TITLE
Use 100% BW for mavlink telemetry data in standalone mode

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -567,7 +567,12 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
     {
       OtaPackAirportData(&otaPkt, &apInputBuffer);
     }
-    else if ((NextPacketIsDataUl && DataUlSender.IsActive()) || dontSendChannelData)
+    /* When in MAVLink standalone mode, force DATA packets in every OTA slot so
+     * the link is dedicated to telemetry/MAVLink (100% telemetry).
+     * This suppresses RC packets for the duration that the TX advertises MAVLink mode.
+     */
+    else if ((config.GetLinkMode() == TX_MAVLINK_MODE) || ((NextPacketIsDataUl && DataUlSender.IsActive()) || dontSendChannelData))    
+    //else if ((NextPacketIsDataUl && DataUlSender.IsActive()) || dontSendChannelData)
     {
       otaPkt.std.type = PACKET_TYPE_DATA;
       if (OtaIsFullRes)


### PR DESCRIPTION
Idea is that the mavlink standalone mode could be used for a pure mavlink telemetry link (there is another TX+RX link used for actual channel control data). In this case we can use the full capacity of the bandwidth for actual mavlink telemetry data. This PR tries to do this.