### PR TITLE
Lower STM32L432 SPI clock to spec

### DIFF
--- a/src/lib/SX1280Driver/SX1280_hal.cpp
+++ b/src/lib/SX1280Driver/SX1280_hal.cpp
@@ -90,10 +90,18 @@ void SX1280Hal::init()
     SPIEx.setMISO(GPIO_PIN_MISO);
     SPIEx.setSCLK(GPIO_PIN_SCK);
     SPIEx.begin();
-    // For the exact frequency, check the system clock tree (sysclk, ahb, apb1/apb2 prescaler)
-    // Some MCUs: 72 / 4 = 18 MHz
-    // STM32L432: APB1/APB2 = 80Mhz, 80 / 4 = 20Mhz
+
+    // SX1280 Datasheet, Rev 3.2, Section 9.3 "SPI Interface"
+    // "The SPI runs on the external SCK clock to allow high speed up to 18 MHz."
+    //
+    #if defined(STM32L432xx)
+    // STM32L432: APB1/APB2 = 80Mhz, 80 / 8 = 10Mhz (DIV4 results in 20Mhz, which is too fast)
+    SPIEx.setClockDivider(SPI_CLOCK_DIV8);
+    #else 
+    // Older STM32 MCUs: 72 / 4 = 18 MHz
+    // For the exact frequency, check the system clock tree (sysclk, ahb, apb1/apb2 prescaler and appropriate peripheral clock dividers)
     SPIEx.setClockDivider(SPI_CLOCK_DIV4);
+    #endif
 #endif
 
     //attachInterrupt(digitalPinToInterrupt(GPIO_PIN_BUSY), this->busyISR, CHANGE); //not used atm


### PR DESCRIPTION
1) Uart debug comms was using the default uart pins.

The 'DIY_2400_RX_STM32_CCG_Nano_v0.5' uses non-default UART pins.

2) SX1280 clock speed calculation assumed system clock of 72Mhz, L432 runs at 80Mhz.
3) Comms errors observed at 20Mhz on L432.

at 20Mhz, I get:
```
Read Vers sx1280 #1: 65023
```
at 1.25Mhz (DIV64) I get:
```
Read Vers sx1280 #1: 43447
```
at 10Mhz (DIV8) I get:
```
Read Vers sx1280 #1: 43447
```
And yes, I did remove scope probes for the 10 and 20Mhz tests, and yes and kept the breadboard and module wires as short as I could.

<img width="1169" height="1559" alt="image" src="https://github.com/user-attachments/assets/c4a221a6-472a-4b50-8837-da9f41992332" />

