### PR TITLE
Allows updating backpack firmware via USB

### DIFF
--- a/src/lib/Backpack/devBackpack.cpp
+++ b/src/lib/Backpack/devBackpack.cpp
@@ -7,7 +7,6 @@
 #include "CRSFHandset.h"
 #include "config.h"
 #include "logging.h"
-#include "MAVLink.h"
 
 #define BACKPACK_TIMEOUT 20    // How often to check for backpack commands
 
@@ -43,28 +42,13 @@ bool lastRecordingState = false;
     Stream *uplink = &CRSFHandset::Port;
 
     uint32_t baud = PASSTHROUGH_BAUD == -1 ? BACKPACK_LOGGING_BAUD : PASSTHROUGH_BAUD;
+
     // get ready for passthrough
-    if (GPIO_PIN_RCSIGNAL_RX == GPIO_PIN_RCSIGNAL_TX)
+    if (useUSB)
     {
-        #if defined(PLATFORM_ESP32_S3)
-        // if UART0 is connected to the backpack then use the USB for the uplink
-        if (useUSB)
-        {
-            uplink = &Serial;
-            Serial.setTxBufferSize(1024);
-            Serial.setRxBufferSize(16384);
-        }
-        else
-        {
-            CRSFHandset::Port.begin(baud, SERIAL_8N1, 44, 43);  // pins are configured as 44 and 43
-            CRSFHandset::Port.setTxBufferSize(1024);
-            CRSFHandset::Port.setRxBufferSize(16384);
-        }
-        #else
-        CRSFHandset::Port.begin(baud, SERIAL_8N1, 3, 1);  // default pin configuration 3 and 1
-        CRSFHandset::Port.setTxBufferSize(1024);
-        CRSFHandset::Port.setRxBufferSize(16384);
-        #endif
+        uplink = &Serial;
+        Serial.setTxBufferSize(1024);
+        Serial.setRxBufferSize(16384);
     }
     else
     {
@@ -72,6 +56,7 @@ bool lastRecordingState = false;
         CRSFHandset::Port.setTxBufferSize(1024);
         CRSFHandset::Port.setRxBufferSize(16384);
     }
+
     disableLoopWDT();
 
     const auto backpack = (HardwareSerial*)TxBackpack;


### PR DESCRIPTION
The reason for this is that I used an ESP32S3 to create a built-in ELRS radio, using full-duplex communication. I wanted to update the backpack firmware directly via the ESP32S3's USB port, and that's when I encountered this problem.

The community may have its own opinions on this design, but I think this approach is perhaps more universal and scientific.