### PR TITLE
Fix GPS Lat/Lon parser

### DIFF
--- a/src/src/rx-serial/SerialGPS.cpp
+++ b/src/src/rx-serial/SerialGPS.cpp
@@ -29,7 +29,7 @@ int32_t parseDecimalToScaled(const char* str, int32_t scale) {
         }
 
         // Process up to scaleDecimals digits
-        for (int i = 0; i < scaleDecimals && dec[i] >= '0' && dec[i] <= '9'; i++) {
+        for (int i = 0; i < scaleDecimals && dec[i] != ','; i++) {
             decimalPart = decimalPart * 10 + (dec[i] - '0');
             divisor *= 10;
         }


### PR DESCRIPTION
The GPS NMEA parser assumed lat/lon degrees be a fixed 2 digits which causes minute decoding errors for lat/lon coordinates <10° or >99°. This fix changes the logic how minutes are extracted.

Fixes #3494 