### PR TITLE
Misreporting FHSS in DEBUG_RCVR_LINKSTATS for LR1121 2G4

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -296,7 +296,7 @@ void ICACHE_RAM_ATTR getRFlinkInfo()
     #if defined(DEBUG_RCVR_LINKSTATS)
     // DEBUG_RCVR_LINKSTATS gets full precision SNR, override the value
     linkStats.uplink_SNR = Radio.LastPacketSNRRaw;
-    debugRcvrLinkstatsFhssIdx = FHSSsequence[FHSSptr];
+    debugRcvrLinkstatsFhssIdx = FHSSusePrimaryFreqBand ? FHSSsequence[FHSSptr] : FHSSsequence_DualBand[FHSSptr];
     #endif
 }
 


### PR DESCRIPTION
When compiled with DEBUG_RCVR_LINKSTATS the FHSS is misreported and shows the subGhz FHSS index, not the 2.4GHz FHSS index. This is obvious when looking at the output that never goes above 40 in FCC915 when it should go to 80.

Not a big deal but interesting to compare that SX1280 RXes always show a dip in SNR/RSSI at the center channel of the band, but LR1121 do not.