### PR TITLE
Add 0x0E Volt sensor for VBat, reduce VBat telemetry bandwidth

### DIFF
--- a/src/lib/AnalogVbat/devAnalogVbat.cpp
+++ b/src/lib/AnalogVbat/devAnalogVbat.cpp
@@ -77,7 +77,7 @@ static void reportVbat()
     int32_t vbat_mV;
     // For negative offsets, anything between abs(OFFSET) and 0 is considered 0
     if (ANALOG_VBAT_OFFSET < 0 && adc <= -ANALOG_VBAT_OFFSET)
-	{	
+	{
         vbat_mV = 0;
 	}
     else
@@ -97,16 +97,16 @@ static void reportVbat()
             CRSF_MK_FRAME_T(crsf_sensor_battery_t) crsfbatt = { 0 };
             crsfbatt.p.voltage = htobe16((uint16_t)vbat_mV / 100);  // VBat, 100mV resolution, BigEndian
                                                                     // No values for current, capacity, or remaining available
-            crsfRouter.SetHeaderAndCrc((crsf_header_t *)&crsfbatt, CRSF_FRAMETYPE_BATTERY_SENSOR, CRSF_FRAME_SIZE(sizeof(crsf_sensor_battery_t)));
+            crsfRouter.SetHeaderAndCrc(&crsfbatt.h, CRSF_FRAMETYPE_BATTERY_SENSOR, CRSF_FRAME_SIZE(sizeof(crsf_sensor_battery_t)));
             crsfRouter.deliverMessageTo(CRSF_ADDRESS_RADIO_TRANSMITTER, &crsfbatt.h);
         }
 
         // CRSF_FRAMETYPE_CELLS (0x0E)
         CRSF_MK_FRAME_T(crsf_sensor_cells_t) crsfcells = { 0 };
-        crsfcells.p.source_id = 128 + 0;                        // Volt sensor ID 0 
+        crsfcells.p.source_id = 128 + 0;                        // Volt sensor ID 0
         crsfcells.p.cell[0] = htobe16((uint16_t)(vbat_mV));     // VBat, 1mV resolution, BigEndian
         constexpr size_t payloadLen = sizeof(crsfcells.p.source_id) + sizeof(crsfcells.p.cell[0]);
-        crsfRouter.SetHeaderAndCrc((crsf_header_t *)&crsfcells, CRSF_FRAMETYPE_CELLS, CRSF_FRAME_SIZE(payloadLen));
+        crsfRouter.SetHeaderAndCrc(&crsfcells.h, CRSF_FRAMETYPE_CELLS, CRSF_FRAME_SIZE(payloadLen));
         crsfRouter.deliverMessageTo(CRSF_ADDRESS_RADIO_TRANSMITTER, &crsfcells.h);
 
         lastVBatSentMs = now;


### PR DESCRIPTION
Changes:
- add Volt sensor ID0 reporting VBat at 1mV precision. Note: ADCs might have a lower precision
- send the ID0 Volt sensor in addition to the battery packets reporting VBat in RxBt
- stop sending battery packets if external device is sending battery packets. ID0 Volt will continue sending VBat
- limits VBat telemetry bandwidth by only sending data if VBat has changed but will send VBat telemetry at least every 5s to avoid sensor lost messaged

Tested on BetaFPV SuperP 14ch and RadioMaster ER6

Expample: RadioMaster ER6 reporting its own VCC (Volt ID0) and the status of a 2s LiFe (RxBT) via an external HoTT telemetry device sending battery packets. Sensor updates only on change of measured VBat value.

![WhatsApp Image 2026-02-21 at 11 19 40](https://github.com/user-attachments/assets/c3db540b-abf6-4611-80bc-b69baa21f03c)

https://github.com/user-attachments/assets/4ba71f07-6d70-4977-a768-adbbb6c41be5


