### PR TITLE
Reduce frequency of "Telemetry Lost" callout

### DIFF
--- a/src/lib/CrsfProtocol/CRSFRouter.h
+++ b/src/lib/CrsfProtocol/CRSFRouter.h
@@ -106,11 +106,11 @@ public:
     /**
      * Constructs a CRSF link statistics packet and populates the provided buffer.
      *
-     * @param buffer Pointer to the buffer where the constructed packet will be stored.
+     * @param frame  Pointer to the frame buffer where the constructed packet will be stored.
      *               It is the caller's responsibility to ensure that the buffer
-     *               has sufficient size to hold the generated packet.
+     *               has sufficient size to hold the entire generated packet.
      */
-    void makeLinkStatisticsPacket(uint8_t *buffer);
+    void makeLinkStatisticsPacket(crsf_header_t *frame);
 
     /**
      * Constructs an MSPv2 request frame and initializes it with the provided function and payload.

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1823,11 +1823,10 @@ static void checkSendLinkStatsToFc(uint32_t now)
         if ((connectionState != disconnected && connectionHasModelMatch && teamraceHasModelMatch) ||
             SendLinkStatstoFCForcedSends)
         {
-            size_t linkStatsSize = sizeof(crsfLinkStatistics_t);
-            uint8_t linkStatisticsFrame[CRSF_FRAME_NOT_COUNTED_BYTES + CRSF_FRAME_SIZE(linkStatsSize)];
-            crsfRouter.makeLinkStatisticsPacket(linkStatisticsFrame);
+            CRSF_MK_FRAME_T(crsfLinkStatistics_t) linkStatisticsFrame;
+            crsfRouter.makeLinkStatisticsPacket(&linkStatisticsFrame.h);
             // the linkStats 'originates' from the OTA connector so we don't send it back there.
-            crsfRouter.deliverMessage(&otaConnector, (crsf_header_t *)linkStatisticsFrame);
+            crsfRouter.deliverMessage(&otaConnector, &linkStatisticsFrame.h);
             SendLinkStatstoFCintervalLastSent = now;
             if (SendLinkStatstoFCForcedSends)
                 --SendLinkStatstoFCForcedSends;

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1406,12 +1406,11 @@ static void checkSendLinkStatsToHandset(uint32_t now)
       }
     }
 
-    uint8_t linkStatisticsFrame[CRSF_FRAME_NOT_COUNTED_BYTES + CRSF_FRAME_SIZE(sizeof(crsfLinkStatistics_t))];
-
-    crsfRouter.makeLinkStatisticsPacket(linkStatisticsFrame);
+    CRSF_MK_FRAME_T(crsfLinkStatistics_t) linkStatisticsFrame;
+    crsfRouter.makeLinkStatisticsPacket(&linkStatisticsFrame.h);
     // the linkStats originates from the OTA connector so we don't send it back there.
-    crsfRouter.deliverMessage(&otaConnector, (crsf_header_t *)linkStatisticsFrame);
-    sendCRSFTelemetryToBackpack(linkStatisticsFrame);
+    crsfRouter.deliverMessage(&otaConnector, &linkStatisticsFrame.h);
+    sendCRSFTelemetryToBackpack((uint8_t *)&linkStatisticsFrame);
     LinkStatsLastReported_Ms = now;
   }
 }


### PR DESCRIPTION
Changes transmitter linkstats reporting to add a variable grace period (0 to 3s) when reporting an internal "disconnected" state. Purpose is to reduce the frequency of the "Telemetry Lost" EdgeTX callout. This does not change internal behavior, only the external reporting is affected.

"_I'd much rather be happy than right any day_" -- Slartibartfast
Hitchhiker's Guide to the Galaxy

## Details

In 4.0, #3367 modified the behavior of reporting when our internal state goes from "connected" to "disconnected" to where it is immediately reported, instead of lazily letting EdgeTX timeout. Turns out, users don't like knowing this and this has caused a **perceived** degradation in link quality due to knowing how often we're in the disconnected state.

### Disconnected reporting behavior

* 3.x - On disconnect, stop sending LinkStats packets to the handset. Handset reports "telemetry lost" due to timeout, Handset-side 750ms - 1000ms grace period to allow a reconnect before reporting to user.
* 4.0 - On disconnect, immediately report to the handset disconnect status via LinkStats LQ of 0. Handset reports "telemetry lost" due to 0 LQ. No grace period before reporting to user.
* This PR - On disconnect, keep reporting LinkStats to the handset as normal. If the connection is recovered during our internal grace period, no "telemetry lost" report will be generated to the user. If our grace period expires without a reconnect, immediately report to the handset via LinkStats LQ of 0. Handset reports "telemetry lost" immediately.

### What does 'disconnected' mean?

The internal ExpressLRS state and behavior is determined by the presence of telemetry. Disconnected state affects dynamic power, sync packet interval, etc but **not** the sending of RC channel data which always continue regardless of connected state. ExpressLRS internally goes to disconnected after missing 5 telemetry packets back to back, with a minimum duration of 512ms. This can happen quite frequently in a many-transmitter environment due to interference.

### Grace period duration

Up for discussion! The grace period is linearly scaled depending on the last LQ received from the model. At 50% LQ or below there is no grace period, scaling up to 3 seconds at 100% LQ. I feel like 2 or 3 seconds is around where we want to be here, I erred on the side of "this callout isn't all that useful".

| Uplink LQ | Duration | 
|--|--|
| 50% | 0ms |
| 75% | 1500ms |
| 100% | 3000ms |

## Refactor

I took the time to refactor the `uint8_t []` used for sending linkstats to use a `CRSF_MK_FRAME_T(crsfLinkStatistics_t)` and then use common functions to generate the CRC.