### PR TITLE
Update devBLE.cpp -disable hat on BLE HID device

### DIFF
--- a/src/lib/BLE/devBLE.cpp
+++ b/src/lib/BLE/devBLE.cpp
@@ -58,6 +58,7 @@ void BluetoothJoystickBegin()
     gamepadConfig.setControllerType(CONTROLLER_TYPE_JOYSTICK); // CONTROLLER_TYPE_JOYSTICK, CONTROLLER_TYPE_GAMEPAD (DEFAULT), CONTROLLER_TYPE_MULTI_AXIS
     gamepadConfig.setWhichAxes(true, true, true, true, true, true, true, true);	// Enable all axes
     gamepadConfig.setButtonCount(8);
+    gamepadConfig.setHatSwitchCount(0);
 
     bleGamepad = new BleGamepad("ELRS Joystick", "ELRS", 100);
     bleGamepad->setTXPowerLevel(9);


### PR DESCRIPTION
Disables the hat device in ESP32-BLE-Gamepad. 

Unity Input System is known to be problematic / crash when detecting generic HID devices especially when a generic HID device includes a hat... ELRS is not currently using the hat anyway.