### PR TITLE
Hide Switch & TLM screens when in MAVLink mode

### DIFF
--- a/src/lib/SCREEN/menu.cpp
+++ b/src/lib/SCREEN/menu.cpp
@@ -570,10 +570,10 @@ fsm_state_event_t const wifi_menu_events[] = {MENU_EVENTS(wifi_menu_fsm)};
 
 fsm_state_entry_t const main_menu_fsm[] = {
     {STATE_PACKET, nullptr, displayMenuScreen, 20000, value_menu_events, ARRAY_SIZE(value_menu_events)},
+    {STATE_TELEMETRY, [](){return !firmwareOptions.is_airport && config.GetLinkMode() != TX_MAVLINK_MODE;}, displayMenuScreen, 20000, value_menu_events, ARRAY_SIZE(value_menu_events)},
     {STATE_SWITCH, [](){return !firmwareOptions.is_airport && config.GetLinkMode() != TX_MAVLINK_MODE;}, displayMenuScreen, 20000, value_menu_events, ARRAY_SIZE(value_menu_events)},
     {STATE_ANTENNA, [](){return isDualRadio();}, displayMenuScreen, 20000, value_menu_events, ARRAY_SIZE(value_menu_events)},
     {STATE_POWER, nullptr, displayMenuScreen, 20000, power_menu_events, ARRAY_SIZE(power_menu_events)},
-    {STATE_TELEMETRY, [](){return !firmwareOptions.is_airport && config.GetLinkMode() != TX_MAVLINK_MODE;}, displayMenuScreen, 20000, value_menu_events, ARRAY_SIZE(value_menu_events)},
     {STATE_POWERSAVE, [](){return OPT_HAS_GSENSOR && !firmwareOptions.is_airport;}, displayMenuScreen, 20000, value_menu_events, ARRAY_SIZE(value_menu_events)},
     {STATE_SMARTFAN, [](){return OPT_HAS_THERMAL;}, displayMenuScreen, 20000, value_menu_events, ARRAY_SIZE(value_menu_events)},
     {STATE_JOYSTICK, nullptr, displayMenuScreen, 20000, ble_menu_events, ARRAY_SIZE(ble_menu_events)},


### PR DESCRIPTION
On modules with a display we should not allow the user to change these settings!
This bug fix disabled (hides) these screens when in MAVLink mode.