### PR TITLE
Add 2400 Upper Bands to avoid WiFi Channel 1 used by Backpack

### DIFF
--- a/src/lib/FHSS/FHSS.cpp
+++ b/src/lib/FHSS/FHSS.cpp
@@ -30,12 +30,19 @@ const fhss_config_t domains[] = {
 #if defined(RADIO_LR1121)
 const fhss_config_t domainsDualBand[] = {
     {
-    #if defined(Regulatory_Domain_EU_CE_2400)
+    #if defined(Regulatory_Domain_EU_CE_2400) || defined(Regulatory_Domain_EU_CE_2400_Upper)
         "CE_LBT",
     #else
         "ISM2G4",
     #endif
-    FREQ_HZ_TO_REG_VAL(2400400000), FREQ_HZ_TO_REG_VAL(2479400000), 80, 2440000000}
+    FREQ_HZ_TO_REG_VAL(2400400000), FREQ_HZ_TO_REG_VAL(2479400000), 80, 2440000000},
+    {
+    #if defined(Regulatory_Domain_EU_CE_2400) || defined(Regulatory_Domain_EU_CE_2400_Upper)
+        "CE_LBT",
+    #else
+        "ISM2G4",
+    #endif
+    FREQ_HZ_TO_REG_VAL(2424400000), FREQ_HZ_TO_REG_VAL(2479400000), 56, 2452000000},
 };
 #endif
 
@@ -44,12 +51,19 @@ const fhss_config_t domainsDualBand[] = {
 
 const fhss_config_t domains[] = {
     {
-    #if defined(Regulatory_Domain_EU_CE_2400)
+    #if defined(Regulatory_Domain_EU_CE_2400) || defined(Regulatory_Domain_EU_CE_2400_Upper)
         "CE_LBT",
     #elif defined(Regulatory_Domain_ISM_2400)
         "ISM2G4",
     #endif
-    FREQ_HZ_TO_REG_VAL(2400400000), FREQ_HZ_TO_REG_VAL(2479400000), 80, 2440000000}
+    FREQ_HZ_TO_REG_VAL(2400400000), FREQ_HZ_TO_REG_VAL(2479400000), 80, 2440000000},
+    {
+    #if defined(Regulatory_Domain_EU_CE_2400) || defined(Regulatory_Domain_EU_CE_2400_Upper)
+        "CE_LBT",
+    #elif defined(Regulatory_Domain_ISM_2400)
+        "ISM2G4",
+    #endif
+    FREQ_HZ_TO_REG_VAL(2424400000), FREQ_HZ_TO_REG_VAL(2479400000), 56, 2452000000},
 };
 #endif
 

--- a/src/python/build_flags.py
+++ b/src/python/build_flags.py
@@ -149,7 +149,9 @@ if '-DRADIO_SX127X=1' in build_flags or '-DRADIO_LR1121=1' in build_flags:
     # disallow setting 2400s for 900
     if '-DRADIO_SX127X=1' in build_flags and \
             (fnmatch.filter(build_flags, '*-DRegulatory_Domain_ISM_2400') or
-             fnmatch.filter(build_flags, '*-DRegulatory_Domain_EU_CE_2400')):
+             fnmatch.filter(build_flags, '*-DRegulatory_Domain_ISM_2400_Upper*') or
+             fnmatch.filter(build_flags, '*-DRegulatory_Domain_EU_CE_2400') or
+             fnmatch.filter(build_flags, '*-DRegulatory_Domain_EU_CE_2400_Upper*')):
         print_error('Regulatory_Domain 2400 not compatible with RADIO_SX127X/RADIO_LR1121')
 
     # require a domain be set for 900
@@ -173,9 +175,15 @@ if '-DRADIO_SX127X=1' in build_flags or '-DRADIO_LR1121=1' in build_flags:
     if fnmatch.filter(build_flags, '*-DRegulatory_Domain_US_433_WIDE'):
         json_flags['domain'] = 7
 else:
-    json_flags['domain'] = 0
+    # 2.4GHz radio (SX128X) - domain index selects into the domains[] array in FHSS.cpp
+    if fnmatch.filter(build_flags, '*-DRegulatory_Domain_ISM_2400_Upper*') or \
+            fnmatch.filter(build_flags, '*-DRegulatory_Domain_EU_CE_2400_Upper*'):
+        json_flags['domain'] = 1
+    else:
+        json_flags['domain'] = 0
 
-# Remove ISM_2400 domain flag if not unit test, it is defined per target config
+# Remove ISM_2400 domain flags if not unit test, they are defined per target config.
+# EU_CE variants are NOT removed here as they must reach the compiler for #if defined() checks in FHSS.cpp
 if fnmatch.filter(build_flags, '*Regulatory_Domain_ISM_2400*') and \
         target_name != "NATIVE":
     build_flags = [f for f in build_flags if "Regulatory_Domain_ISM_2400" not in f]

--- a/src/user_defines.txt
+++ b/src/user_defines.txt
@@ -26,7 +26,9 @@
 #-DRegulatory_Domain_US_433_WIDE
 #-DRegulatory_Domain_FCC_915
 #-DRegulatory_Domain_ISM_2400
+#-DRegulatory_Domain_ISM_2400_Upper
 #-DRegulatory_Domain_EU_CE_2400
+#-DRegulatory_Domain_EU_CE_2400_Upper
 
 ### PERFORMANCE OPTIONS: ###
 


### PR DESCRIPTION
Backpack operates on WiFi Channel 1 (2401-2423 MHz) so allow an option to allow the main RF link to avoid these frequencies.