### PR TITLE
Hide VTXAdmin lua fields if disabled

### DIFF
--- a/src/lib/SCREEN/display.cpp
+++ b/src/lib/SCREEN/display.cpp
@@ -162,7 +162,7 @@ static const char *smartfan_string[] = {
 };
 
 static const char *band_string[] = {
-    "OFF",
+    "Disabled",
     "A",
     "B",
     "E",

--- a/src/lib/tx-crsf/TXModuleEndpoint.h
+++ b/src/lib/tx-crsf/TXModuleEndpoint.h
@@ -28,7 +28,7 @@ public:
     void handleMessage(const crsf_header_t *message) override;
     void RcPacketToChannelsData(const crsf_header_t *message);
 
-    void updateFolderNames();
+    void updateFolderNamesAndVisibility();
     void registerParameters() override;
     void updateParameters() override;
 

--- a/src/lib/tx-crsf/TXModuleEndpoint.h
+++ b/src/lib/tx-crsf/TXModuleEndpoint.h
@@ -60,6 +60,7 @@ private:
     void handleSimpleSendCmd(propertiesCommon *item, uint8_t arg);
     void updateTlmBandwidth();
     void updateBackpackOpts();
+    void updateVtxAdminOpts();
 };
 
 extern TXModuleEndpoint crsfTransmitter;

--- a/src/lib/tx-crsf/TXModuleParameters.cpp
+++ b/src/lib/tx-crsf/TXModuleParameters.cpp
@@ -449,27 +449,15 @@ void TXModuleEndpoint::updateTlmBandwidth()
 
 void TXModuleEndpoint::updateBackpackOpts()
 {
-  if (config.GetBackpackDisable())
-  {
-    // If backpack is disabled, set all the Backpack select options to "Disabled"
-    LUA_FIELD_HIDE(luaDvrAux);
-    LUA_FIELD_HIDE(luaDvrStartDelay);
-    LUA_FIELD_HIDE(luaDvrStopDelay);
-    LUA_FIELD_HIDE(luaHeadTrackingEnableChannel);
-    LUA_FIELD_HIDE(luaHeadTrackingStartChannel);
-    LUA_FIELD_HIDE(luaBackpackTelemetry);
-    LUA_FIELD_HIDE(luaBackpackVersion);
-  }
-  else
-  {
-    LUA_FIELD_SHOW(luaDvrAux);
-    LUA_FIELD_SHOW(luaDvrStartDelay);
-    LUA_FIELD_SHOW(luaDvrStopDelay);
-    LUA_FIELD_SHOW(luaHeadTrackingEnableChannel);
-    LUA_FIELD_SHOW(luaHeadTrackingStartChannel);
-    LUA_FIELD_SHOW(luaBackpackTelemetry);
-    LUA_FIELD_SHOW(luaBackpackVersion);
-  }
+  const bool isBackpackEnabled = config.GetBackpackDisable() == false;
+
+  LUA_FIELD_VISIBLE(luaDvrAux, isBackpackEnabled);
+  LUA_FIELD_VISIBLE(luaDvrStartDelay, isBackpackEnabled);
+  LUA_FIELD_VISIBLE(luaDvrStopDelay, isBackpackEnabled);
+  LUA_FIELD_VISIBLE(luaHeadTrackingEnableChannel, isBackpackEnabled);
+  LUA_FIELD_VISIBLE(luaHeadTrackingStartChannel, isBackpackEnabled);
+  LUA_FIELD_VISIBLE(luaBackpackTelemetry, isBackpackEnabled);
+  LUA_FIELD_VISIBLE(luaBackpackVersion, isBackpackEnabled);
 }
 
 void TXModuleEndpoint::updateVtxAdminOpts()

--- a/src/lib/tx-crsf/TXModuleParameters.cpp
+++ b/src/lib/tx-crsf/TXModuleParameters.cpp
@@ -541,7 +541,11 @@ void TXModuleEndpoint::handleSimpleSendCmd(propertiesCommon *item, uint8_t arg)
     }
     else if ((void *)item == (void *)&luaVtxSend)
     {
-      VtxTriggerSend();
+      // If VtxAdmin enabled then send, otherwise show brief "Not enabled" message
+      if (config.GetVtxBand() != 0)
+        VtxTriggerSend();
+      else
+        msg = "Not enabled";
     }
     else if ((void *)item == (void *)&luaRxWebUpdate)
     {

--- a/src/lib/tx-crsf/TXModuleParameters.cpp
+++ b/src/lib/tx-crsf/TXModuleParameters.cpp
@@ -229,9 +229,9 @@ static folderParameter luaVtxFolder = {
 };
 
 static selectionParameter luaVtxBand = {
-    {"Band", CRSF_TEXT_SELECTION},
+    {"Band/Enable", CRSF_TEXT_SELECTION},
     0, // value
-    "Off;A;B;E;F;R;L",
+    "Disabled;A;B;E;F;R;L",
     STR_EMPTYSPACE
 };
 
@@ -470,6 +470,17 @@ void TXModuleEndpoint::updateBackpackOpts()
     LUA_FIELD_SHOW(luaBackpackTelemetry);
     LUA_FIELD_SHOW(luaBackpackVersion);
   }
+}
+
+void TXModuleEndpoint::updateVtxAdminOpts()
+{
+  const bool isVtxAdminEnabled = config.GetVtxBand() != 0;
+
+  LUA_FIELD_VISIBLE(luaVtxChannel, isVtxAdminEnabled);
+  LUA_FIELD_VISIBLE(luaVtxPwr, isVtxAdminEnabled);
+  LUA_FIELD_VISIBLE(luaVtxPit, isVtxAdminEnabled);
+  // Can't toggle a COMMAND type, the lua will not refresh commands
+  //LUA_FIELD_VISIBLE(luaVtxSend, isVtxAdminEnabled);
 }
 
 static void setBleJoystickMode()
@@ -742,6 +753,7 @@ void TXModuleEndpoint::updateFolderNames()
   // These aren't folder names, just string labels slapped in the units field generally
   updateTlmBandwidth();
   updateBackpackOpts();
+  updateVtxAdminOpts();
 }
 
 static void recalculatePacketRateOptions(int minInterval)

--- a/src/lib/tx-crsf/TXModuleParameters.cpp
+++ b/src/lib/tx-crsf/TXModuleParameters.cpp
@@ -467,6 +467,8 @@ void TXModuleEndpoint::updateVtxAdminOpts()
   LUA_FIELD_VISIBLE(luaVtxChannel, isVtxAdminEnabled);
   LUA_FIELD_VISIBLE(luaVtxPwr, isVtxAdminEnabled);
   LUA_FIELD_VISIBLE(luaVtxPit, isVtxAdminEnabled);
+  // Pit mode can only be sent as part of the power byte
+  LUA_FIELD_VISIBLE(luaVtxPit, isVtxAdminEnabled && config.GetVtxPower() != 0);
   // Can't toggle a COMMAND type, the lua will not refresh commands
   //LUA_FIELD_VISIBLE(luaVtxSend, isVtxAdminEnabled);
 }
@@ -735,14 +737,13 @@ void TXModuleEndpoint::SetDynamicPower(uint8_t idx)
 }
 
 /***
- * @brief: Update the dynamic strings used for folder names and labels
+ * @brief: Update the dynamic strings used for folder names, as well as labels and item visibility
  ***/
-void TXModuleEndpoint::updateFolderNames()
+void TXModuleEndpoint::updateFolderNamesAndVisibility()
 {
   updateFolderName_TxPower();
   updateFolderName_VtxAdmin();
 
-  // These aren't folder names, just string labels slapped in the units field generally
   updateTlmBandwidth();
   updateBackpackOpts();
   updateVtxAdminOpts();
@@ -1076,8 +1077,6 @@ void TXModuleEndpoint::updateParameters()
   setTextSelectionValue(&luaVtxBand, config.GetVtxBand());
   setUint8Value(&luaVtxChannel, config.GetVtxChannel() + 1);
   setTextSelectionValue(&luaVtxPwr, config.GetVtxPower());
-  // Pit mode can only be sent as part of the power byte
-  LUA_FIELD_VISIBLE(luaVtxPit, config.GetVtxPower() != 0);
   setTextSelectionValue(&luaVtxPit, config.GetVtxPitmode());
   if (OPT_USE_TX_BACKPACK)
   {
@@ -1090,5 +1089,5 @@ void TXModuleEndpoint::updateParameters()
     setTextSelectionValue(&luaBackpackTelemetry, config.GetBackpackDisable() ? 0 : config.GetBackpackTlmMode());
     setStringValue(&luaBackpackVersion, backpackVersion);
   }
-  updateFolderNames();
+  updateFolderNamesAndVisibility();
 }

--- a/src/lua/elrs.lua
+++ b/src/lua/elrs.lua
@@ -375,7 +375,7 @@ local function fieldBackExec(field)
     field.po = nil
     currentFolderId = nil
     currentFolderName = nil
-  else -- Executing EXIT 
+  else -- Executing EXIT
     exitscript = 1
   end
 end
@@ -675,7 +675,7 @@ local function reloadRelatedFields(field)
     local fldType = fldTest.type or 99 -- type could be nil if still loading
     if fieldId ~= field.id
       and fldTest.parent == field.parent
-      and (fldType < 11 or fldType == 12) then -- ignores FOLDER/COMMAND/devices/EXIT
+      and (fldType < 11 or fldType == 12 or fldType == 13) then -- ignores FOLDER/devices/EXIT
       fldTest.nc = true -- "no cache" the options
       loadQ[#loadQ+1] = fieldId
     end

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -796,8 +796,6 @@ static void ConfigChangeCommit()
   ChangeRadioParams();
   // Clear the commitInProgress flag so normal processing resumes
   commitInProgress = false;
-  // UpdateFolderNames is expensive so it is called directly instead of in event() which gets called a lot
-  crsfTransmitter.updateFolderNames();
   devicesTriggerEvent(changes);
 }
 


### PR DESCRIPTION
Hides the `VTX Channel`, `VTX Power`, `VTX Pit Mode` fields if VTX Admin is disabled. Also changes "Off" option to "Disabled" and the label to include the fact that `Band` is also used to enable the feature.

### Details

It has come to my attention now from a couple different people that they did not understand that setting the Band to Off in VTX Admin disabled the feature, opting to jump straight to the "Channel" field and then being confused why it never worked. Who can blame them, there's really just 1 band as far as anyone is concerned. This tries to make it clearer by hiding the Channel field until the Band is set, and updating the label to assist in that discovery.

I'd love to hide `[Send VTX]` as well, but the lua doesn't check COMMAND type fields for updates when a value changes. We could also change that, but I can see that being a major issue if most don't update their lua and suddenly Send VTX isn't there unless they exit and come back.

Instead, when you `[Send VTX]` now instead of saying `Sending...` it will say `Not enabled`. This is better than nothing?

### B&W Screens

The new "Band/Enable" label has 1 space after it before the value so this still fits. I'm open to changing this label but it has to be at most this many characters.

<img width="263" height="147" alt="image" src="https://github.com/user-attachments/assets/320138fb-3738-43f6-9efd-b8c7a3099bad" />
