### PR TITLE
Do not switch RX rate if RX cant do rate from SYNC packet

### DIFF
--- a/src/include/common.h
+++ b/src/include/common.h
@@ -305,7 +305,8 @@ uint8_t get_elrs_HandsetRate_max(uint8_t rateIndex, uint32_t minInterval);
 
 uint8_t TLMratioEnumToValue(expresslrs_tlm_ratio_e const enumval);
 uint8_t TLMBurstMaxForRateRatio(uint16_t const rateHz, uint8_t const ratioDiv);
-uint8_t enumRatetoIndex(expresslrs_RFrates_e const eRate);
+bool enumRatetoIndex(expresslrs_RFrates_e const eRate, uint8_t &idx);
+uint8_t enumRatetoIndexSafe(expresslrs_RFrates_e const eRate);
 
 extern uint8_t UID[UID_LEN];
 extern bool connectionHasModelMatch;

--- a/src/lib/CONFIG/config.cpp
+++ b/src/lib/CONFIG/config.cpp
@@ -249,7 +249,7 @@ void TxConfig::Load()
 
             // validate the currently selected rate is supported by the hardware and choose an appropriate default if not
             if (!isSupportedRFRate(m_config.model_config[i].rate)) {
-                m_config.model_config[i].rate = enumRatetoIndex(POWER_OUTPUT_VALUES_COUNT == 0 ? RATE_LORA_2G4_250HZ : RATE_LORA_900_200HZ);
+                m_config.model_config[i].rate = enumRatetoIndexSafe(POWER_OUTPUT_VALUES_COUNT == 0 ? RATE_LORA_2G4_250HZ : RATE_LORA_900_200HZ);
                 nvs_set_u32(handle, model, Model_to_U32(&m_config.model_config[i]));
             }
         }
@@ -745,11 +745,11 @@ TxConfig::SetDefaults(bool commit)
     {
         SetModelId(i);
         #if defined(RADIO_SX127X)
-            SetRate(enumRatetoIndex(RATE_LORA_900_200HZ));
+            SetRate(enumRatetoIndexSafe(RATE_LORA_900_200HZ));
         #elif defined(RADIO_LR1121)
-            SetRate(enumRatetoIndex(POWER_OUTPUT_VALUES_COUNT == 0 ? RATE_LORA_2G4_250HZ : RATE_LORA_900_200HZ));
+            SetRate(enumRatetoIndexSafe(POWER_OUTPUT_VALUES_COUNT == 0 ? RATE_LORA_2G4_250HZ : RATE_LORA_900_200HZ));
         #elif defined(RADIO_SX128X)
-            SetRate(enumRatetoIndex(RATE_LORA_2G4_250HZ));
+            SetRate(enumRatetoIndexSafe(RATE_LORA_2G4_250HZ));
         #endif
         SetPower(POWERMGNT::getDefaultPower());
 #if defined(PLATFORM_ESP32)

--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -138,17 +138,38 @@ uint8_t get_elrs_HandsetRate_max(uint8_t rateIndex, uint32_t minInterval)
     return rateIndex;
 }
 
-uint8_t ICACHE_RAM_ATTR enumRatetoIndex(expresslrs_RFrates_e const eRate)
-{ // convert enum_rate to index
-    expresslrs_mod_settings_s const * ModParams;
+/***
+ * @brief Find the RFrates_e in the active ModParams table, returning true and its index if found
+ * @param eRate (in) expresslrs_RFrates_e of rate to find
+ * @param idx (out) Index into ExpressLRS_AirRateConfig[] of the rate, not modified if not found
+ * @return true if rate is in the ModParams table, false if not
+ */
+bool ICACHE_RAM_ATTR enumRatetoIndex(expresslrs_RFrates_e const eRate, uint8_t &idx)
+{
     for (uint8_t i = 0; i < RATE_MAX; i++)
     {
-        ModParams = get_elrs_airRateConfig(i);
+        expresslrs_mod_settings_s const *ModParams = &ExpressLRS_AirRateConfig[i];
         if (ModParams->enum_rate == eRate)
         {
-            return i;
+            idx = i;
+            return true;
         }
     }
+
+    return false;
+}
+
+/***
+ * @brief Find the RFrates_e in the active ModParams table, always returning a valid value
+ * @param eRate (in) expresslrs_RFrates_e of rate to find
+ * @return  A valid index into the ModParams table, even if the rate was not found
+ */
+uint8_t enumRatetoIndexSafe(expresslrs_RFrates_e const eRate)
+{
+    uint8_t idx;
+    if (enumRatetoIndex(eRate, idx))
+        return idx;
+
     // If 25Hz selected and not available, return the slowest rate available
     // else return the fastest rate available (500Hz selected but not available)
     return (eRate == RATE_LORA_900_25HZ) ? RATE_MAX - 1 : 0;
@@ -227,12 +248,16 @@ bool ICACHE_RAM_ATTR isDualRadio()
 
 
 #if defined(RADIO_LR1121)
-bool isSupportedRFRate(uint8_t index)
+/***
+ * @brief Return true if the rate index passed is valid for the current RF hardware
+ * @param index Index into the ModParams table
+ */
+bool ICACHE_RAM_ATTR isSupportedRFRate(uint8_t index)
 {
     const expresslrs_mod_settings_s *const ModParams = get_elrs_airRateConfig(index);
 
     // Dual Band modes not supported for hardware with only a single LR1121
-    if (GPIO_PIN_NSS_2 == UNDEF_PIN && RadioBandMod::isBDUAL(ModParams->radio_type))
+    if (!isDualRadio() && RadioBandMod::isBDUAL(ModParams->radio_type))
     {
         return false;
     }

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1011,6 +1011,17 @@ static bool ICACHE_RAM_ATTR ProcessRfPacket_SYNC(uint32_t const now, OTA_Sync_s 
     if ((otaSync->UID5 & ~MODELMATCH_MASK) != (UID[5] & ~MODELMATCH_MASK))
         return false;
 
+    // Check the any proposed packet rate switch and verify the hardware has a valid config
+    // and hardware frontend for it. Ignore the mode switch if not valid.
+    uint8_t proposedRateIdx;
+    expresslrs_RFrates_e proposedRateEnum = (expresslrs_RFrates_e)otaSync->rfRateEnum;
+    if (!enumRatetoIndex(proposedRateEnum, proposedRateIdx)
+        || !isSupportedRFRate(proposedRateIdx))
+    {
+        DBGLN("Unsupported rate %u", proposedRateEnum);
+        return false;
+    }
+
     LastSyncPacket = now;
 #if defined(DEBUG_RX_SCOREBOARD)
     DBGW('s');
@@ -1039,7 +1050,7 @@ static bool ICACHE_RAM_ATTR ProcessRfPacket_SYNC(uint32_t const now, OTA_Sync_s 
     }
 
     // Will change the packet air rate in loop() if this changes
-    ExpressLRS_nextAirRateIndex = enumRatetoIndex((expresslrs_RFrates_e)otaSync->rfRateEnum);
+    ExpressLRS_nextAirRateIndex = proposedRateIdx;
     updateSwitchModePendingFromOta(otaSync->switchEncMode);
 
     // Update TLM ratio, should never be TLM_RATIO_STD/DISARMED, the TX calculates the correct value for the RX
@@ -1605,11 +1616,11 @@ static void cycleRfMode(unsigned long now)
     {
         RFmodeLastCycled = now;
         LastSyncPacket = now;           // reset this variable
+        // Display the current air rate to the user as an indicator something is happening
         SendLinkStatstoFCForcedSends = 2;
         SetRFLinkRate(scanIndex % RATE_MAX, false); // switch between rates
         LQCalc.reset100();
         LQCalcDVDA.reset100();
-        // Display the current air rate to the user as an indicator something is happening
         scanIndex++;
         Radio.RXnb();
         DBGLN("%u", ExpressLRS_currAirRate_Modparams->interval);
@@ -1651,7 +1662,7 @@ static void EnterBindingMode()
 
     // Start attempting to bind
     // Lock the RF rate and freq while binding
-    SetRFLinkRate(enumRatetoIndex(RATE_BINDING), true);
+    SetRFLinkRate(enumRatetoIndexSafe(RATE_BINDING), true);
 
     // If the Radio Params (including InvertIQ) parameter changed, need to restart RX to take effect
     Radio.RXnb();
@@ -1713,11 +1724,11 @@ static void updateBindingMode(unsigned long now)
         BindingRateChangeMs = now;
         if (ExpressLRS_currAirRate_Modparams->enum_rate == RATE_DUALBAND_BINDING)
         {
-            SetRFLinkRate(enumRatetoIndex(RATE_BINDING), true);
+            SetRFLinkRate(enumRatetoIndexSafe(RATE_BINDING), true);
         }
         else
         {
-            SetRFLinkRate(enumRatetoIndex(RATE_DUALBAND_BINDING), true);
+            SetRFLinkRate(enumRatetoIndexSafe(RATE_DUALBAND_BINDING), true);
         }
 
         Radio.RXnb();
@@ -2069,11 +2080,6 @@ void loop()
     if ((connectionState != disconnected) && (ExpressLRS_currAirRate_Modparams->index != ExpressLRS_nextAirRateIndex)) // forced change
     {
         DBGLN("Req air rate change %u->%u", ExpressLRS_currAirRate_Modparams->index, ExpressLRS_nextAirRateIndex);
-        if (!isSupportedRFRate(ExpressLRS_nextAirRateIndex))
-        {
-            DBGLN("Mode %u not supported, ignoring", ExpressLRS_nextAirRateIndex);
-            ExpressLRS_nextAirRateIndex = ExpressLRS_currAirRate_Modparams->index;
-        }
         LostConnection(true);
         LastSyncPacket = now;           // reset this variable to stop rf mode switching and add extra time
         RFmodeLastCycled = now;         // reset this variable to stop rf mode switching and add extra time

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1023,7 +1023,7 @@ static void EnterBindingMode()
 
   // Start attempting to bind
   // Lock the RF rate and freq while binding
-  SetRFLinkRate(enumRatetoIndex(RATE_BINDING));
+  SetRFLinkRate(enumRatetoIndexSafe(RATE_BINDING));
 
   // Start transmitting again
   hwTimer::resume();
@@ -1572,7 +1572,7 @@ void loop()
 #if defined(RADIO_LR1121)
     // Send half of the bind packets on the 2.4GHz domain
     if (BindingSendCount == BindingSpamAmount / 2) {
-      SetRFLinkRate(enumRatetoIndex(RATE_DUALBAND_BINDING));
+      SetRFLinkRate(enumRatetoIndexSafe(RATE_DUALBAND_BINDING));
       // Increment BindingSendCount so that SetRFLinkRate is only called once.
       BindingSendCount++;
     }


### PR DESCRIPTION
Changes SYNC behavior to prevent a receiver from switching to a Packet Rate it can't do. Currently it will always soft-brick the receiver, and this PR changes the behavior to just not switch at all.

This was discovered during like 4.0.0-RC4 but everything was so stable I didn't want to throw in all these changes to an interrupt function and possibly breaking something for a relatively minor fix. 

### Steps to Reproduce

1. Get an LR1121 TX and a SX1280 RX, or SX1280 TX and LR1121 TX
2. Establish a connection on a rate that is common to both, e.g. 500Hz LoRa 2G4
3. Switch the TX to a rate not supported by the RX
  * For LR1121 TX, switch to e.g. DK500
  * For SX1280 TX, switch to e.g. F500
4. The RX will disconnect but not connect at the new rate, as expected because it can not support the required modulation
5. Switch the TX back to the previous rate, the RX will not connect at this rate either, because it actually switched to a different completely unsupported rate and the RX will now need to be rebooted.

### Details

When the receiver receives a SYNC packet for a rate that isn't in its ModParams table, it instead selects index 0. For LR1121 receivers this will be SubGHz FSK K1000 Full, which SX1280 transmitters can not do. For SX1280 receivers this will be F1000 FLRC, which LR1121 transmitters can not do.

This is mitigated on single band LR1121 receivers, as there _was_ code to prevent it from switching to K1000 Full due to it not being supported (even though this wasn't the mode the transmitter requested), so it tries to bounce back to the previous rate and usually can do so. However, all the other parameters from the SYNC packet will be accepted anyway, meaning the switch mode could flip unintentionally, or the serial output mode might change as well which could also be unrecoverable.

The issue is that enumRatetoIndex() is always is expected to return a valid Index into the ModParams table, even if the rate isn't supported. They SYNC packet tries to find the unsupported rate, it instead returns index 0 which **is** valid, and the receiver is now locked itself in a room and won't come out.

### Solution

Use a different function to see if the rate is in the ModParams table first, and also verify that the rate is supported by the frontend hardware-- ignoring the entire sync packet entirely if both of these aren't true. The receiver stays at the old rate and disconnects, but the transmitter can still go back to the previous rate to reconnect.

