### PR TITLE
[4.0 Back Port] Separate FIFO locations for TX & RX on SX1280

### DIFF
--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -10,9 +10,6 @@ SX1280Driver *SX1280Driver::instance = NULL;
 
 RFAMP_hal RFAMP;
 
-constexpr uint8_t SX1280_TX_BUFFER_BASE = 0x00;
-constexpr uint8_t SX1280_RX_BUFFER_BASE = 0x80;
-
 //DEBUG_SX1280_OTA_TIMING
 
 /* Steps for startup
@@ -540,7 +537,7 @@ void ICACHE_RAM_ATTR SX1280Driver::RXnb()
 bool ICACHE_RAM_ATTR SX1280Driver::GetRxBufferAddr(SX12XX_Radio_Number_t radioNumber, uint8_t *rxBufferAddr)
 {
     WORD_ALIGNED_ATTR uint8_t status[2] = {0};
-    uint8_t const chipStatus = hal.ReadCommand(SX1280_RADIO_GET_RXBUFFERSTATUS, status, 2, radioNumber);
+    const auto chipStatus = hal.ReadCommand(SX1280_RADIO_GET_RXBUFFERSTATUS, status, 2, radioNumber);
 
     *rxBufferAddr = status[1];
 

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -10,6 +10,9 @@ SX1280Driver *SX1280Driver::instance = NULL;
 
 RFAMP_hal RFAMP;
 
+constexpr uint8_t SX1280_TX_BUFFER_BASE = 0x00;
+constexpr uint8_t SX1280_RX_BUFFER_BASE = 0x80;
+
 //DEBUG_SX1280_OTA_TIMING
 
 /* Steps for startup
@@ -176,6 +179,7 @@ void SX1280Driver::Config(uint8_t bw, uint8_t sf, uint8_t cr, uint32_t regfreq,
     uint16_t dio1Mask = SX1280_IRQ_TX_DONE | SX1280_IRQ_RX_DONE;
     uint16_t irqMask  = SX1280_IRQ_TX_DONE | SX1280_IRQ_RX_DONE | SX1280_IRQ_SYNCWORD_VALID | SX1280_IRQ_SYNCWORD_ERROR | SX1280_IRQ_CRC_ERROR;
     SetDioIrqParams(irqMask, dio1Mask);
+    SetFIFOaddr(SX1280_TX_BUFFER_BASE, SX1280_RX_BUFFER_BASE);
 }
 
 /***
@@ -489,12 +493,12 @@ void ICACHE_RAM_ATTR SX1280Driver::TXnb(uint8_t * data, bool sendGeminiBuffer, u
     RFAMP.TXenable(radioNumber); // do first to allow PA stablise
     if (sendGeminiBuffer)
     {
-        hal.WriteBuffer(0x00, data, PayloadLength, SX12XX_Radio_1);
-        hal.WriteBuffer(0x00, dataGemini, PayloadLength, SX12XX_Radio_2);
+        hal.WriteBuffer(SX1280_TX_BUFFER_BASE, data, PayloadLength, SX12XX_Radio_1);
+        hal.WriteBuffer(SX1280_TX_BUFFER_BASE, dataGemini, PayloadLength, SX12XX_Radio_2);
     }
     else
     {
-        hal.WriteBuffer(0x00, data, PayloadLength, radioNumber);
+        hal.WriteBuffer(SX1280_TX_BUFFER_BASE, data, PayloadLength, radioNumber);
     }
 
     instance->SetMode(SX1280_MODE_TX, radioNumber);

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -520,7 +520,11 @@ bool ICACHE_RAM_ATTR SX1280Driver::RXnbISR(uint16_t irqStatus, SX12XX_Radio_Numb
     }
     if (fail == SX12XX_RX_OK)
     {
-        uint8_t const FIFOaddr = GetRxBufferAddr(radioNumber);
+        uint8_t FIFOaddr = 0;
+        if (!GetRxBufferAddr(radioNumber, &FIFOaddr))
+        {
+            return false;
+        }
         hal.ReadBuffer(FIFOaddr, RXdataBuffer, PayloadLength, radioNumber);
     }
 
@@ -533,18 +537,14 @@ void ICACHE_RAM_ATTR SX1280Driver::RXnb()
     SetMode(SX1280_MODE_RX_CONT, SX12XX_Radio_All);
 }
 
-uint8_t ICACHE_RAM_ATTR SX1280Driver::GetRxBufferAddr(SX12XX_Radio_Number_t radioNumber)
+bool ICACHE_RAM_ATTR SX1280Driver::GetRxBufferAddr(SX12XX_Radio_Number_t radioNumber, uint8_t *rxBufferAddr)
 {
     WORD_ALIGNED_ATTR uint8_t status[2] = {0};
-    hal.ReadCommand(SX1280_RADIO_GET_RXBUFFERSTATUS, status, 2, radioNumber);
-    return status[1];
-}
+    uint8_t const chipStatus = hal.ReadCommand(SX1280_RADIO_GET_RXBUFFERSTATUS, status, 2, radioNumber);
 
-void ICACHE_RAM_ATTR SX1280Driver::GetStatus(SX12XX_Radio_Number_t radioNumber)
-{
-    uint8_t status = 0;
-    hal.ReadCommand(SX1280_RADIO_GET_STATUS, (uint8_t *)&status, 1, radioNumber);
-    DBGLN("Status: %x, %x, %x", (0b11100000 & status) >> 5, (0b00011100 & status) >> 2, 0b00000001 & status);
+    *rxBufferAddr = status[1];
+
+    return chipStatus == (SX1280_STATUS_CIRCUIT_MODE_RX | SX1280_STATUS_COMMAND_DATA_AVAILABLE);
 }
 
 bool ICACHE_RAM_ATTR SX1280Driver::GetFrequencyErrorbool(SX12XX_Radio_Number_t radioNumber)
@@ -592,9 +592,12 @@ void ICACHE_RAM_ATTR SX1280Driver::CheckForSecondPacket()
             }
             if (second_rx_fail == SX12XX_RX_OK)
             {
-                uint8_t const FIFOaddr = GetRxBufferAddr(radio[secondRadioIdx]);
-                hal.ReadBuffer (FIFOaddr, RXdataBufferSecond, PayloadLength, radio[secondRadioIdx]);
-                hasSecondRadioGotData = true;
+                uint8_t FIFOaddr = 0;
+                if (GetRxBufferAddr(radio[secondRadioIdx], &FIFOaddr))
+                {
+                    hal.ReadBuffer(FIFOaddr, RXdataBufferSecond, PayloadLength, radio[secondRadioIdx]);
+                    hasSecondRadioGotData = true;
+                }
             }
         }
     }

--- a/src/lib/SX1280Driver/SX1280.h
+++ b/src/lib/SX1280Driver/SX1280.h
@@ -46,7 +46,9 @@ public:
 private:
     // constant used for no power change pending
     // must not be a valid power register value
-    static const uint8_t PWRPENDING_NONE = 0x7f;
+    static constexpr uint8_t PWRPENDING_NONE = 0x7f;
+    static constexpr uint8_t SX1280_TX_BUFFER_BASE = 0x00;
+    static constexpr uint8_t SX1280_RX_BUFFER_BASE = 0x80;
 
     SX1280_RadioOperatingModes_t currOpmode;
     uint8_t packet_mode;

--- a/src/lib/SX1280Driver/SX1280.h
+++ b/src/lib/SX1280Driver/SX1280.h
@@ -38,9 +38,7 @@ public:
     uint16_t GetIrqStatus(SX12XX_Radio_Number_t radioNumber);
     void ClearIrqStatus(uint16_t irqMask, SX12XX_Radio_Number_t radioNumber);
 
-    void GetStatus(SX12XX_Radio_Number_t radioNumber);
-
-    uint8_t GetRxBufferAddr(SX12XX_Radio_Number_t radioNumber);
+    bool GetRxBufferAddr(SX12XX_Radio_Number_t radioNumber, uint8_t *rxBufferAddr);
     int8_t GetRssiInst(SX12XX_Radio_Number_t radioNumber);
     void GetLastPacketStats();
     void CheckForSecondPacket();

--- a/src/lib/SX1280Driver/SX1280_Regs.h
+++ b/src/lib/SX1280Driver/SX1280_Regs.h
@@ -23,6 +23,24 @@ typedef enum
     SX1280_RF_CAD,         //!< The radio is doing channel activity detection
 } SX1280_RadioStates_t;
 
+typedef enum
+{
+    SX1280_STATUS_CIRCUIT_MODE_STDBY_RC = 0x02 << 5,
+    SX1280_STATUS_CIRCUIT_MODE_STDBY_XOSC = 0x03 << 5,
+    SX1280_STATUS_CIRCUIT_MODE_FS = 0x04 << 5,
+    SX1280_STATUS_CIRCUIT_MODE_RX = 0x05 << 5,
+    SX1280_STATUS_CIRCUIT_MODE_TX = 0x06 << 5,
+
+    SX1280_STATUS_COMMAND_PROCESSING_SUCCESS = 0x01 << 2,
+    SX1280_STATUS_COMMAND_DATA_AVAILABLE = 0x02 << 2,
+    SX1280_STATUS_COMMAND_TIMEOUT = 0x03 << 2,
+    SX1280_STATUS_COMMAND_PROCESSING_ERROR = 0x04 << 2,
+    SX1280_STATUS_COMMAND_EXECUTE_FAILED = 0x05 << 2,
+    SX1280_STATUS_COMMAND_TX_DONE = 0x06 << 2,
+
+    SX1280_STATUS_MASK = 0xFC,
+} SX1280_RadioStatus_t;
+
 /*!
  * \brief Represents the operating mode the radio is actually running
  */

--- a/src/lib/SX1280Driver/SX1280_hal.cpp
+++ b/src/lib/SX1280Driver/SX1280_hal.cpp
@@ -140,7 +140,7 @@ void ICACHE_RAM_ATTR SX1280Hal::WriteCommand(SX1280_RadioCommands_t command, uin
     BusyDelay(busyDelay);
 }
 
-void ICACHE_RAM_ATTR SX1280Hal::ReadCommand(SX1280_RadioCommands_t command, uint8_t *buffer, uint8_t size, SX12XX_Radio_Number_t radioNumber)
+uint8_t ICACHE_RAM_ATTR SX1280Hal::ReadCommand(SX1280_RadioCommands_t command, uint8_t *buffer, uint8_t size, SX12XX_Radio_Number_t radioNumber)
 {
     WORD_ALIGNED_ATTR uint8_t OutBuffer[WORD_PADDED(size + 2)] = {
         (uint8_t)command,
@@ -150,17 +150,9 @@ void ICACHE_RAM_ATTR SX1280Hal::ReadCommand(SX1280_RadioCommands_t command, uint
 
     WaitOnBusy(radioNumber);
 
-    if (command == SX1280_RADIO_GET_STATUS)
-    {
-        const auto RADIO_GET_STATUS_BUF_SIZEOF = 3; // special case for command == SX1280_RADIO_GET_STATUS, fixed 3 bytes packet size
-        SPIEx.read(radioNumber, OutBuffer, RADIO_GET_STATUS_BUF_SIZEOF);
-        buffer[0] = OutBuffer[0];
-    }
-    else
-    {
-        SPIEx.read(radioNumber, OutBuffer, size + 2); // first 2 bytes returned are status!
-        memcpy(buffer, OutBuffer + 2, size);
-    }
+    SPIEx.read(radioNumber, OutBuffer, size + 2); // first 2 bytes returned are status!
+    memcpy(buffer, OutBuffer + 2, size);
+    return OutBuffer[0] & SX1280_STATUS_MASK; // Discard reserved bits
 }
 
 void ICACHE_RAM_ATTR SX1280Hal::WriteRegister(uint16_t address, uint8_t *buffer, uint8_t size, SX12XX_Radio_Number_t radioNumber)

--- a/src/lib/SX1280Driver/SX1280_hal.cpp
+++ b/src/lib/SX1280Driver/SX1280_hal.cpp
@@ -140,7 +140,7 @@ void ICACHE_RAM_ATTR SX1280Hal::WriteCommand(SX1280_RadioCommands_t command, uin
     BusyDelay(busyDelay);
 }
 
-uint8_t ICACHE_RAM_ATTR SX1280Hal::ReadCommand(SX1280_RadioCommands_t command, uint8_t *buffer, uint8_t size, SX12XX_Radio_Number_t radioNumber)
+SX1280_RadioStatus_t ICACHE_RAM_ATTR SX1280Hal::ReadCommand(SX1280_RadioCommands_t command, uint8_t *buffer, uint8_t size, SX12XX_Radio_Number_t radioNumber)
 {
     WORD_ALIGNED_ATTR uint8_t OutBuffer[WORD_PADDED(size + 2)] = {
         (uint8_t)command,
@@ -152,7 +152,7 @@ uint8_t ICACHE_RAM_ATTR SX1280Hal::ReadCommand(SX1280_RadioCommands_t command, u
 
     SPIEx.read(radioNumber, OutBuffer, size + 2); // first 2 bytes returned are status!
     memcpy(buffer, OutBuffer + 2, size);
-    return OutBuffer[0] & SX1280_STATUS_MASK; // Discard reserved bits
+    return (SX1280_RadioStatus_t)(OutBuffer[0] & SX1280_STATUS_MASK); // Discard reserved bits
 }
 
 void ICACHE_RAM_ATTR SX1280Hal::WriteRegister(uint16_t address, uint8_t *buffer, uint8_t size, SX12XX_Radio_Number_t radioNumber)

--- a/src/lib/SX1280Driver/SX1280_hal.h
+++ b/src/lib/SX1280Driver/SX1280_hal.h
@@ -43,7 +43,7 @@ public:
     void ICACHE_RAM_ATTR WriteRegister(uint16_t address, uint8_t *buffer, uint8_t size, SX12XX_Radio_Number_t radioNumber);
     void ICACHE_RAM_ATTR WriteRegister(uint16_t address, uint8_t value, SX12XX_Radio_Number_t radioNumber);
 
-    uint8_t ICACHE_RAM_ATTR ReadCommand(SX1280_RadioCommands_t opcode, uint8_t *buffer, uint8_t size, SX12XX_Radio_Number_t radioNumber);
+    SX1280_RadioStatus_t ICACHE_RAM_ATTR ReadCommand(SX1280_RadioCommands_t opcode, uint8_t *buffer, uint8_t size, SX12XX_Radio_Number_t radioNumber);
     void ICACHE_RAM_ATTR ReadRegister(uint16_t address, uint8_t *buffer, uint8_t size, SX12XX_Radio_Number_t radioNumber);
     uint8_t ICACHE_RAM_ATTR ReadRegister(uint16_t address, SX12XX_Radio_Number_t radioNumber);
 

--- a/src/lib/SX1280Driver/SX1280_hal.h
+++ b/src/lib/SX1280Driver/SX1280_hal.h
@@ -43,7 +43,7 @@ public:
     void ICACHE_RAM_ATTR WriteRegister(uint16_t address, uint8_t *buffer, uint8_t size, SX12XX_Radio_Number_t radioNumber);
     void ICACHE_RAM_ATTR WriteRegister(uint16_t address, uint8_t value, SX12XX_Radio_Number_t radioNumber);
 
-    void ICACHE_RAM_ATTR ReadCommand(SX1280_RadioCommands_t opcode, uint8_t *buffer, uint8_t size, SX12XX_Radio_Number_t radioNumber);
+    uint8_t ICACHE_RAM_ATTR ReadCommand(SX1280_RadioCommands_t opcode, uint8_t *buffer, uint8_t size, SX12XX_Radio_Number_t radioNumber);
     void ICACHE_RAM_ATTR ReadRegister(uint16_t address, uint8_t *buffer, uint8_t size, SX12XX_Radio_Number_t radioNumber);
     uint8_t ICACHE_RAM_ATTR ReadRegister(uint16_t address, SX12XX_Radio_Number_t radioNumber);
 


### PR DESCRIPTION
This PR back-ports #3620 to 4.x for a 4.0.1 release

# Problem
On SX1280 receivers, the radio driver was using the same internal packet buffer region for both transmit and receive operations. Under rare conditions this could allow a just-transmitted telemetry payload, such as an OTA LinkStats packet, to be read back through the receive path and misinterpreted as RC data. Because LinkStats and RC packets share the same OTA packet type value; when in MAVLink mode, this could appear on the flight controller as a bogus `RC_CHANNELS_OVERRIDE` frame and would cause a disarm of the craft if using channel-based arming.

# Solution
The SX1280 driver now uses separate FIFO base addresses for transmit and receive. This prevents transmitted telemetry data from being re-read through the RX path and removes the buffer aliasing condition that could cause LinkStats payloads to be decoded as RC data.

# Belt-and-braces
As an additional safeguard, the RX path also validates the radio status returned by `GET_RXBUFFERSTATUS` before reading packet data. The driver only accepts a received packet if the chip reports that it is in RX mode and that data is available for reading.