### PR TITLE
[3.x] Fix radios with PDET blasting output power

### DIFF
--- a/src/lib/ADC/devADC.cpp
+++ b/src/lib/ADC/devADC.cpp
@@ -20,6 +20,12 @@ static int start()
         return DURATION_IMMEDIATELY;
     }
 #endif
+#if defined(GPIO_PIN_PA_PDET)
+    if (GPIO_PIN_PA_PDET != UNDEF_PIN)
+    {
+        return DURATION_IMMEDIATELY;
+    }
+#endif
     return DURATION_NEVER;
 }
 


### PR DESCRIPTION
Fixes a bug in #3112 (Jan 23, 2025 / ExpressLRS 3.5.4 onward) that never sampled PDET power output from the ADC on radios without joysticks e.g. TX16S. The ADC device was missing the check for PDET to see if it should be enabled, so the transmit output power was increased to maximum every time.

Found this while testing that the CW webui button worked in #3606 and was like wait, why is 10mW 20mW... and 100mW 200mW?! 😬 250mW ended up around 320mW so probably not the most destructive case for the PA.

Separate PR for master is needed. Should I go against 4.x-maint or just go to master?