### PR TITLE
Fix dynamic power headroom underflow when config power lowered while armed

### DIFF
--- a/src/src/dynpower.cpp
+++ b/src/src/dynpower.cpp
@@ -114,7 +114,9 @@ void DynamicPower_Update(uint32_t now)
   }
 
   // How much available power is left for incremental increases
-  uint8_t powerHeadroom = (uint8_t)config.GetPower() - (uint8_t)POWERMGNT::currPower();
+  uint8_t configPower = (uint8_t)config.GetPower();
+  uint8_t currPower = (uint8_t)POWERMGNT::currPower();
+  uint8_t powerHeadroom = (configPower > currPower) ? configPower - currPower : 0;
 
   if (lastTlmMissed)
   {


### PR DESCRIPTION
## Problem

  When a user lowers their configured max power via Lua script while armed with dynamic power enabled, `POWERMGNT::currPower()` can exceed `config.GetPower()`. The unsigned subtraction on line 117 of `dynpower.cpp`:
```cpp
  uint8_t powerHeadroom = (uint8_t)config.GetPower() - (uint8_t)POWERMGNT::currPower();
```
wraps to ~255 (`uint8_t` underflow), causing the `powerHeadroom > 0` guards to pass. This allows `incPower()` to ramp transmit power up to hardware maximum, exceeding the user's configured limit.

On FCC 915MHz and ISM 2400 (non-EU) builds, there is no compile-time cap, so power can reach the hardware maximum. EU CE 2400 builds have a `getMaxPower()` cap at 100mW which partially mitigates the issue.

## Fix

Guard the subtraction so `powerHeadroom` is 0 when `currPower >= configPower`:

```cpp
  uint8_t configPower = (uint8_t)config.GetPower();
  uint8_t currPower = (uint8_t)POWERMGNT::currPower();
  uint8_t powerHeadroom = (configPower > currPower) ? configPower - currPower : 0;
```

## How to reproduce
  1. Set dynamic power enabled, configure max power to e.g. 250mW
  2. Arm and fly — dynamic power raises output to 250mW
  3. While still armed, lower configured max power to 25mW via Lua
  4. Observe: power ramps to hardware max instead of staying at or below 25mW