### PR TITLE
added warning dlg when setting blank SSID

### DIFF
--- a/src/html/src/pages/wifi-panel.js
+++ b/src/html/src/pages/wifi-panel.js
@@ -1,7 +1,7 @@
 import {html, LitElement} from "lit"
 import {customElement, query, state} from "lit/decorators.js"
 import {elrsState} from "../utils/state.js"
-import {postWithFeedback} from "../utils/feedback.js"
+import {errorAlert, postWithFeedback} from "../utils/feedback.js"
 import {autocomplete} from "../utils/autocomplete.js"
 
 @customElement('wifi-panel')
@@ -109,6 +109,10 @@ class WifiPanel extends LitElement {
     _setupNetwork(event) {
         event.preventDefault()
         const self = this
+        if ((this.selectedValue === '0' || this.selectedValue === '1') && !this.network.value.trim()) {
+            errorAlert('WiFi SSID Required', 'Please enter a WiFi SSID.')
+            return
+        }
         switch (this.selectedValue) {
             case '0':
                 postWithFeedback('Set Home Network', 'An error occurred setting the home network', '/sethome?save', function () {


### PR DESCRIPTION
I simply want to prevent somebody from accidentally setting a blank SSID

realistically, what happened was... I wasn't paying attention, dismissed the "discard" dialog with the cancel button, clicked "save" to make the dialog go away... then the receiver basically became a brick lol