### PR TITLE
Add GPS Time (0x03), MAVLink parsing for GPS Time, Temp

### DIFF
--- a/src/include/crsf_protocol.h
+++ b/src/include/crsf_protocol.h
@@ -54,6 +54,7 @@
 typedef enum : uint8_t
 {
     CRSF_FRAMETYPE_GPS = 0x02,
+    CRSF_FRAMETYPE_GPS_TIME = 0x03,
     CRSF_FRAMETYPE_VARIO = 0x07,
     CRSF_FRAMETYPE_BATTERY_SENSOR = 0x08,
     CRSF_FRAMETYPE_BARO_ALTITUDE = 0x09,
@@ -336,6 +337,18 @@ typedef struct crsf_sensor_vario_s
 {
     int16_t verticalspd;  // Vertical speed in cm/s, BigEndian
 } PACKED crsf_sensor_vario_t;
+
+// CRSF_FRAMETYPE_GPS_TIME
+typedef struct crsf_sensor_gps_time_s
+{
+    int16_t year;
+    uint8_t month;
+    uint8_t day;
+    uint8_t hour;
+    uint8_t minute;
+    uint8_t second;
+    uint16_t millisecond;
+} PACKED crsf_sensor_gps_time_t;
 
 // CRSF_FRAMETYPE_GPS
 typedef struct crsf_sensor_gps_s

--- a/src/lib/MAVLink/MAVLink.cpp
+++ b/src/lib/MAVLink/MAVLink.cpp
@@ -267,8 +267,7 @@ void convert_mavlink_to_crsf_telem(crsf_addr_e destination, uint8_t *CRSFinBuffe
                 }
                 time_t time_unix = (time_t)(system_time.time_unix_usec / 1000000);
                 struct tm *time_info = gmtime(&time_unix);
-                CRSF_MK_FRAME_T(crsf_sensor_gps_time_t)
-                crsftime = {0};
+                CRSF_MK_FRAME_T(crsf_sensor_gps_time_t) crsftime{};
                 crsftime.p.year = htobe16(time_info->tm_year + 1900);
                 crsftime.p.month = time_info->tm_mon + 1;
                 crsftime.p.day = time_info->tm_mday;
@@ -276,7 +275,7 @@ void convert_mavlink_to_crsf_telem(crsf_addr_e destination, uint8_t *CRSFinBuffe
                 crsftime.p.minute = time_info->tm_min;
                 crsftime.p.second = time_info->tm_sec;
                 crsftime.p.millisecond = 0; // intentionally not populated, avoids 64-bit maths
-                crsfRouter.SetHeaderAndCrc((crsf_header_t *)&crsftime, CRSF_FRAMETYPE_GPS_TIME, CRSF_FRAME_SIZE(sizeof(crsf_sensor_gps_time_t)));
+                crsfRouter.SetHeaderAndCrc(&crsftime.h, CRSF_FRAMETYPE_GPS_TIME, CRSF_FRAME_SIZE(sizeof(crsf_sensor_gps_time_t)));
                 crsfRouter.deliverMessageTo(destination, &crsftime.h);
                 break;
             }
@@ -284,12 +283,11 @@ void convert_mavlink_to_crsf_telem(crsf_addr_e destination, uint8_t *CRSFinBuffe
                 mavlink_scaled_pressure_t scaled_pressure;
                 mavlink_msg_scaled_pressure_decode(&msg, &scaled_pressure);
                 // CRSF temp is variable-length: crsf_sensor_temp_t reserves 20 samples but we send only one
-                CRSF_MK_FRAME_T(crsf_sensor_temp_t)
-                crsftemp = {0};
+                CRSF_MK_FRAME_T(crsf_sensor_temp_t) crsftemp{};
                 crsftemp.p.source_id = 1; // 1 = Ambient (per CRSF temp source_id convention)
                 crsftemp.p.temperature[0] = htobe16(scaled_pressure.temperature / 10); // cdegC -> ddegC
                 constexpr size_t payloadLen = sizeof(crsftemp.p.source_id) + sizeof(crsftemp.p.temperature[0]);
-                crsfRouter.SetHeaderAndCrc((crsf_header_t *)&crsftemp, CRSF_FRAMETYPE_TEMP, CRSF_FRAME_SIZE(payloadLen));
+                crsfRouter.SetHeaderAndCrc(&crsftemp.h, CRSF_FRAMETYPE_TEMP, CRSF_FRAME_SIZE(payloadLen));
                 crsfRouter.deliverMessageTo(destination, &crsftemp.h);
                 break;
             }

--- a/src/lib/MAVLink/MAVLink.cpp
+++ b/src/lib/MAVLink/MAVLink.cpp
@@ -258,6 +258,41 @@ void convert_mavlink_to_crsf_telem(crsf_addr_e destination, uint8_t *CRSFinBuffe
                                                );
                 break;
             }
+            case MAVLINK_MSG_ID_SYSTEM_TIME: {
+                mavlink_system_time_t system_time;
+                mavlink_msg_system_time_decode(&msg, &system_time);
+                // SYSTEM_TIME.time_unix_usec is non-zero only when AP::rtc() has a valid time source
+                if (system_time.time_unix_usec == 0) {
+                    break;
+                }
+                time_t time_unix = (time_t)(system_time.time_unix_usec / 1000000);
+                struct tm *time_info = gmtime(&time_unix);
+                CRSF_MK_FRAME_T(crsf_sensor_gps_time_t)
+                crsftime = {0};
+                crsftime.p.year = htobe16(time_info->tm_year + 1900);
+                crsftime.p.month = time_info->tm_mon + 1;
+                crsftime.p.day = time_info->tm_mday;
+                crsftime.p.hour = time_info->tm_hour;
+                crsftime.p.minute = time_info->tm_min;
+                crsftime.p.second = time_info->tm_sec;
+                crsftime.p.millisecond = 0; // intentionally not populated, avoids 64-bit maths
+                crsfRouter.SetHeaderAndCrc((crsf_header_t *)&crsftime, CRSF_FRAMETYPE_GPS_TIME, CRSF_FRAME_SIZE(sizeof(crsf_sensor_gps_time_t)));
+                crsfRouter.deliverMessageTo(destination, &crsftime.h);
+                break;
+            }
+            case MAVLINK_MSG_ID_SCALED_PRESSURE: {
+                mavlink_scaled_pressure_t scaled_pressure;
+                mavlink_msg_scaled_pressure_decode(&msg, &scaled_pressure);
+                // CRSF temp is variable-length: crsf_sensor_temp_t reserves 20 samples but we send only one
+                CRSF_MK_FRAME_T(crsf_sensor_temp_t)
+                crsftemp = {0};
+                crsftemp.p.source_id = 1; // 1 = Ambient (per CRSF temp source_id convention)
+                crsftemp.p.temperature[0] = htobe16(scaled_pressure.temperature / 10); // cdegC -> ddegC
+                constexpr size_t payloadLen = sizeof(crsftemp.p.source_id) + sizeof(crsftemp.p.temperature[0]);
+                crsfRouter.SetHeaderAndCrc((crsf_header_t *)&crsftemp, CRSF_FRAMETYPE_TEMP, CRSF_FRAME_SIZE(payloadLen));
+                crsfRouter.deliverMessageTo(destination, &crsftemp.h);
+                break;
+            }
             case MAVLINK_MSG_ID_HOME_POSITION: {
                 mavlink_home_position_t home_pos;
                 mavlink_msg_home_position_decode(&msg, &home_pos);


### PR DESCRIPTION
- Add GPS Time message to CRSF Protocol
- Add MAVLink Parsing of System Time to populate GPS Time
- Add MAVLink Parsing of Scaled Pressure to send Temp

EdgeTx support for GPS Time (shows up as Date sensor) added via: https://github.com/EdgeTX/edgetx/pull/7317 allows for automatic RTC adjust.

Screenshot, refer to lines 31, 32:
<img width="320" height="240" alt="screen-2026-05-06-082841" src="https://github.com/user-attachments/assets/4cd845a6-e779-4b6a-bbb0-72eacb0246c0" />
