### PR TITLE
Wait for all channels to have data before marking channel data available

### DIFF
--- a/src/lib/OTA/OTA.cpp
+++ b/src/lib/OTA/OTA.cpp
@@ -296,6 +296,7 @@ static void ICACHE_RAM_ATTR GenerateChannelData12ch(OTA_Packet_s * const otaPktP
 
 // Current ChannelData unpacker function being used by RX
 UnpackChannelData_t OtaUnpackChannelData;
+static bool OtaChannelDataComplete;
 
 #if defined(DEBUG_RCVR_LINKSTATS)
 // Sequential PacketID from the TX
@@ -465,6 +466,50 @@ bool ICACHE_RAM_ATTR UnpackChannelData8ch(OTA_Packet_s const * const otaPktPtr, 
     // Restore the uplink_TX_Power range 0-7 -> 1-8
     linkStats.uplink_TX_Power = constrain(ota8->rc.uplinkPower + 1, 1, 8);
     return ota8->rc.stubbornAck;
+}
+
+void OtaResetChannelDataComplete()
+{
+    OtaChannelDataComplete = false;
+}
+
+bool ICACHE_RAM_ATTR OtaIsChannelDataComplete(uint32_t const *channelData)
+{
+#if defined(DEBUG_RCVR_LINKSTATS)
+    (void)channelData;
+    OtaChannelDataComplete = true;
+    return true;
+#else
+    if (!OtaChannelDataComplete) {
+        uint8_t lastRequiredChannel = 11;
+        if (OtaIsFullRes)
+        {
+            switch (OtaSwitchModeCurrent)
+            {
+                case smWideOr8ch:
+                    lastRequiredChannel = 7;
+                    break;
+                case sm12ch:
+                    lastRequiredChannel = 11;
+                    break;
+                case smHybridOr16ch:
+                    lastRequiredChannel = 15;
+                    break;
+            }
+        }
+
+        for (uint8_t ch = 0; ch <= lastRequiredChannel; ++ch)
+        {
+            if (channelData[ch] == CRSF_CHANNEL_VALUE_UNSET)
+            {
+                return false;
+            }
+        }
+
+        OtaChannelDataComplete = true;
+    }
+    return OtaChannelDataComplete;
+#endif
 }
 #endif
 

--- a/src/lib/OTA/OTA.h
+++ b/src/lib/OTA/OTA.h
@@ -201,6 +201,8 @@ void OtaSetFullResNextChannelSet(bool next);
 #if defined(TARGET_RX) || defined(UNIT_TEST)
 typedef bool (*UnpackChannelData_t)(OTA_Packet_s const * const otaPktPtr, uint32_t *channelData);
 extern UnpackChannelData_t OtaUnpackChannelData;
+void OtaResetChannelDataComplete();
+bool OtaIsChannelDataComplete(uint32_t const *channelData);
 #endif
 
 void OtaPackAirportData(OTA_Packet_s * const otaPktPtr, FIFO<AP_MAX_BUF_LEN> *inputBuffer);

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -806,6 +806,7 @@ void LostConnection(bool resumeRx)
     LPF_Offset.init(0);
     LPF_OffsetDx.init(0);
     alreadyTLMresp = false;
+    OtaResetChannelDataComplete();
 
     if (!InBindingMode)
     {
@@ -828,6 +829,8 @@ void ICACHE_RAM_ATTR TentativeConnection(unsigned long now)
     PFDloop.reset();
     setConnectionState(tentative);
     connectionHasModelMatch = false;
+    ChannelDataReset();
+    OtaResetChannelDataComplete();
     RXtimerState = tim_disconnected;
     DBGLN("tentative conn");
     PfdPrevRawOffset = 0;
@@ -880,8 +883,10 @@ static void ICACHE_RAM_ATTR ProcessRfPacket_RC(OTA_Packet_s const * const otaPkt
     bool telemetryConfirmValue = OtaUnpackChannelData(otaPktPtr, ChannelData);
     DataDlSender.ConfirmCurrentPayload(telemetryConfirmValue);
 
+    bool const channelDataComplete = OtaIsChannelDataComplete(ChannelData);
+
     // No channels packets to the FC or PWM pins if no model match
-    if (connectionHasModelMatch)
+    if (connectionHasModelMatch && channelDataComplete)
     {
         if (ExpressLRS_currAirRate_Modparams->numOfSends == 1)
         {
@@ -1908,6 +1913,8 @@ static void updateSwitchMode()
         return;
 
     OtaUpdateSerializers((OtaSwitchMode_e)(SwitchModePending - 1), ExpressLRS_currAirRate_Modparams->PayloadLength);
+    ChannelDataReset();
+    OtaResetChannelDataComplete();
     SwitchModePending = 0;
 }
 

--- a/src/test/test_ota/test_switches.cpp
+++ b/src/test/test_ota/test_switches.cpp
@@ -30,6 +30,12 @@ CRSFEndpoint *crsfEndpoint = new MockEndpoint();
 
 uint32_t ChannelData[CRSF_NUM_CHANNELS];      // Current state of channels, CRSF format
 
+static void resetTestChannelData()
+{
+    for (auto &ch : ChannelData)
+        ch = CRSF_CHANNEL_VALUE_UNSET;
+}
+
 void test_crsf_endpoints()
 {
     // Validate 988us and 2012us convert to approprate CRSF values. Spoiler: They don't
@@ -254,6 +260,65 @@ void test_decodingHybrid8_all()
     // // Switch 7 is 16 pos
     // for (uint8_t val=0; val<16; ++val)
     //     test_decodingHybrid8(7, val);
+}
+
+void test_channelDataComplete_hybrid8()
+{
+    OtaUpdateSerializers(smHybridOr16ch, OTA4_PACKET_SIZE);
+    resetTestChannelData();
+    OtaResetChannelDataComplete();
+
+    for (int i = 0; i < 12; ++i)
+        ChannelData[i] = CRSF_CHANNEL_VALUE_MID;
+    for (int i = 12; i < CRSF_NUM_CHANNELS; ++i)
+        ChannelData[i] = CRSF_CHANNEL_VALUE_UNSET;
+
+    TEST_ASSERT_TRUE(OtaIsChannelDataComplete(ChannelData));
+}
+
+void test_channelDataComplete_wide8ch()
+{
+    OtaUpdateSerializers(smWideOr8ch, OTA8_PACKET_SIZE);
+    resetTestChannelData();
+    OtaResetChannelDataComplete();
+
+    for (int i = 0; i < 8; ++i)
+        ChannelData[i] = CRSF_CHANNEL_VALUE_MID;
+
+    TEST_ASSERT_TRUE(OtaIsChannelDataComplete(ChannelData));
+
+    resetTestChannelData();
+    OtaResetChannelDataComplete();
+    for (int i = 0; i < 7; ++i)
+        ChannelData[i] = CRSF_CHANNEL_VALUE_MID;
+
+    TEST_ASSERT_FALSE(OtaIsChannelDataComplete(ChannelData));
+}
+
+void test_channelDataComplete_12ch()
+{
+    OtaUpdateSerializers(sm12ch, OTA8_PACKET_SIZE);
+    resetTestChannelData();
+    OtaResetChannelDataComplete();
+
+    for (int i = 0; i < 12; ++i)
+        ChannelData[i] = CRSF_CHANNEL_VALUE_MID;
+
+    TEST_ASSERT_TRUE(OtaIsChannelDataComplete(ChannelData));
+}
+
+void test_channelDataComplete_16ch()
+{
+    OtaUpdateSerializers(smHybridOr16ch, OTA8_PACKET_SIZE);
+    resetTestChannelData();
+    OtaResetChannelDataComplete();
+
+    for (int i = 0; i < 15; ++i)
+        ChannelData[i] = CRSF_CHANNEL_VALUE_MID;
+    TEST_ASSERT_FALSE(OtaIsChannelDataComplete(ChannelData));
+
+    ChannelData[15] = CRSF_CHANNEL_VALUE_MID;
+    TEST_ASSERT_TRUE(OtaIsChannelDataComplete(ChannelData));
 }
 
 /* Check the HybridWide encoding of a packet for OTA tx
@@ -647,6 +712,10 @@ int main(int argc, char **argv)
     RUN_TEST(test_encodingHybrid8_3);
     RUN_TEST(test_encodingHybrid8_7);
     RUN_TEST(test_decodingHybrid8_all);
+    RUN_TEST(test_channelDataComplete_hybrid8);
+    RUN_TEST(test_channelDataComplete_wide8ch);
+    RUN_TEST(test_channelDataComplete_12ch);
+    RUN_TEST(test_channelDataComplete_16ch);
 
     RUN_TEST(test_encodingHybridWide_low);
     RUN_TEST(test_decodingHybridWide_AUX1);


### PR DESCRIPTION
# Problem
When an RX first starts receiving packets it will populate the channels that are in the packet, the problem here is that a packet does not contain _all_ the channels. So what we see is that the channels that are not in the packet get random data (actually all 1's) which end up being sent to the flight controller.

See #3633 

# Solution
Before marking the flag that trigger new data available, ensure that none of the channels that the packet rate supports has an "unset" value.