### PR TITLE
Gate SBUS failsafe in Lua

### DIFF
--- a/src/lib/rx-crsf/RXParameters.cpp
+++ b/src/lib/rx-crsf/RXParameters.cpp
@@ -600,6 +600,21 @@ void RXEndpoint::updateParameters()
 #endif
 
   setTextSelectionValue(&luaSBUSFailsafeMode, config.GetFailsafeMode());
+  bool sbusFailsafeApplies =
+    config.GetSerialProtocol() == PROTOCOL_SBUS ||
+    config.GetSerialProtocol() == PROTOCOL_INVERTED_SBUS ||
+    config.GetSerialProtocol() == PROTOCOL_DJI_RS_PRO;
+#if defined(PLATFORM_ESP32)
+  if (RX_HAS_SERIAL1)
+  {
+    eSerial1Protocol s1 = config.GetSerial1Protocol();
+    sbusFailsafeApplies = sbusFailsafeApplies ||
+      s1 == PROTOCOL_SERIAL1_SBUS ||
+      s1 == PROTOCOL_SERIAL1_INVERTED_SBUS ||
+      s1 == PROTOCOL_SERIAL1_DJI_RS_PRO;
+  }
+#endif
+  LUA_FIELD_VISIBLE(luaSBUSFailsafeMode, sbusFailsafeApplies)
 
   if (GPIO_PIN_ANT_CTRL != UNDEF_PIN)
   {

--- a/src/lib/rx-crsf/RXParameters.cpp
+++ b/src/lib/rx-crsf/RXParameters.cpp
@@ -607,11 +607,10 @@ void RXEndpoint::updateParameters()
 #if defined(PLATFORM_ESP32)
   if (RX_HAS_SERIAL1)
   {
-    eSerial1Protocol s1 = config.GetSerial1Protocol();
     sbusFailsafeApplies = sbusFailsafeApplies ||
-      s1 == PROTOCOL_SERIAL1_SBUS ||
-      s1 == PROTOCOL_SERIAL1_INVERTED_SBUS ||
-      s1 == PROTOCOL_SERIAL1_DJI_RS_PRO;
+      config.GetSerial1Protocol() == PROTOCOL_SERIAL1_SBUS ||
+      config.GetSerial1Protocol() == PROTOCOL_SERIAL1_INVERTED_SBUS ||
+      config.GetSerial1Protocol() == PROTOCOL_SERIAL1_DJI_RS_PRO;
   }
 #endif
   LUA_FIELD_VISIBLE(luaSBUSFailsafeMode, sbusFailsafeApplies)


### PR DESCRIPTION
Currently the SBUS failsafe option shows even when using a non-SBUS protocol, so this change hides it for all non-SBUS protocols.

Before:

<img width="370" height="85" alt="image" src="https://github.com/user-attachments/assets/8248e5db-bdf3-49dc-8e61-877189c246c4" />

After:

<img width="384" height="87" alt="image" src="https://github.com/user-attachments/assets/cc041d80-a39c-46b6-a3c6-02756e5e3eab" />
