### PR TITLE
Add CRSF GPS Date/Time from Serial connected GPS

### DIFF
--- a/src/src/rx-serial/SerialGPS.cpp
+++ b/src/src/rx-serial/SerialGPS.cpp
@@ -50,7 +50,7 @@ int32_t parseDecimalToScaled(const char* str, int32_t scale) {
  * @brief Parse NMEA Decimal Degrees Minutes value and return Decimal Degrees * 1e7.
  * @param field Points to beginning of DDMM[M] string, must not be blank!
  */
-int32_t nmeaDdmToDd(const char *field)
+static int32_t nmeaDdmToDd(const char *field)
 {
     // Latitude is DDMM.MMMMM, Longitude is DDDMM.MMMM
     // Start by getting the part before the decimal, and divide by 100 to remove the MM part
@@ -63,6 +63,18 @@ int32_t nmeaDdmToDd(const char *field)
     int32_t minutesPart = parseDecimalToScaled(minutes - 2, 10000000) / 60;
 
     return degrees * 10000000 + minutesPart;
+}
+
+static void nmeaUTCtoTime(GpsData *data, const char *field)
+{
+    uint32_t time_ms = parseDecimalToScaled(field, 1000);
+    data->millisecond = time_ms % 1000;
+    time_ms /= 1000;
+    data->second = time_ms % 100;
+    time_ms /= 100;
+    data->minute = time_ms % 100;
+    time_ms /= 100;
+    data->hour = time_ms % 100;
 }
 
 bool SerialGPS::isValidChecksum(char *sentence, uint8_t size)
@@ -115,6 +127,9 @@ void SerialGPS::fieldParseGGA(SerialGPS *ctx, uint8_t fieldIdx, char *field)
 
     switch (fieldIdx)
     {
+        case 1:
+            nmeaUTCtoTime(&ctx->gpsData, field);
+            break;
         case 2:
             ctx->gpsData.lat = (blank) ? 0 : nmeaDdmToDd(field);
             break;
@@ -154,6 +169,27 @@ void SerialGPS::fieldParseVTG(SerialGPS *ctx, uint8_t fieldIdx, char *field)
     }
 }
 
+void SerialGPS::fieldParseRMC(SerialGPS *ctx, uint8_t fieldIdx, char *field)
+{
+    const bool blank = (field[0] == '\0');
+    if (blank) return;
+
+    switch (fieldIdx) {
+        case 1: // Time: HHMMSS.ss
+            nmeaUTCtoTime(&ctx->gpsData, field);
+            break;
+        case 9: // Date: DDMMYY
+            uint32_t date = atoi(field);
+            ctx->gpsData.year = 2000 + date % 100;
+            date /= 100;
+            ctx->gpsData.month = date % 100;
+            date /= 100;
+            ctx->gpsData.day = date % 100;
+            ctx->gpsData.hasDateTime = true;
+            break;
+    }
+}
+
 void SerialGPS::processSentence(char *sentence, uint8_t size)
 {
     if (sentence[3] == 'G' && sentence[4] == 'G' && sentence[5] == 'A') {
@@ -165,12 +201,16 @@ void SerialGPS::processSentence(char *sentence, uint8_t size)
         // VTG usually comes before GGA, only generate one telemetry frame with both combined
         //sendTelemetryFrame();
     }
+    else if (sentence[3] == 'R' && sentence[4] == 'M' && sentence[5] == 'C') {
+        splitSentenceFields(sentence, size, &fieldParseRMC);
+    }
+    // Maybe we need to think about ZDA as well so we can adjust UTC to local time!
 }
 
 void SerialGPS::processBytes(uint8_t *bytes, uint16_t size)
 {
     for (uint16_t i = 0; i < size; i++) {
-        char c = bytes[i];
+        const char c = bytes[i];
         if (nmeaBufferIndex < sizeof(nmeaBuffer)) {
             nmeaBuffer[nmeaBufferIndex++] = c;
         }
@@ -185,13 +225,27 @@ void SerialGPS::processBytes(uint8_t *bytes, uint16_t size)
 
 void SerialGPS::sendTelemetryFrame()
 {
-    CRSF_MK_FRAME_T(crsf_sensor_gps_t) crsfgps = { 0 };
+    CRSF_MK_FRAME_T(crsf_sensor_gps_t) crsfgps{};
     crsfgps.p.latitude = htobe32(gpsData.lat);
     crsfgps.p.longitude = htobe32(gpsData.lon);
     crsfgps.p.altitude = htobe16((int16_t)(gpsData.alt / 100 + 1000));
     crsfgps.p.groundspeed = htobe16((uint16_t)(gpsData.speed / 10));
     crsfgps.p.satellites_in_use = gpsData.satellites;
     crsfgps.p.gps_heading = htobe16(gpsData.heading);
-    crsfRouter.SetHeaderAndCrc((crsf_header_t *)&crsfgps, CRSF_FRAMETYPE_GPS, CRSF_FRAME_SIZE(sizeof(crsf_sensor_gps_t)));
+    crsfRouter.SetHeaderAndCrc(&crsfgps.h, CRSF_FRAMETYPE_GPS, CRSF_FRAME_SIZE(sizeof(crsf_sensor_gps_t)));
     crsfRouter.deliverMessageTo(CRSF_ADDRESS_RADIO_TRANSMITTER, &crsfgps.h);
+
+    if (gpsData.hasDateTime)
+    {
+        CRSF_MK_FRAME_T(crsf_sensor_gps_time_t) crsftime{};
+        crsftime.p.year = htobe16(gpsData.year);
+        crsftime.p.month = gpsData.month;
+        crsftime.p.day = gpsData.day;
+        crsftime.p.hour = gpsData.hour;
+        crsftime.p.minute = gpsData.minute;
+        crsftime.p.second = gpsData.second;
+        crsftime.p.millisecond = htobe16(gpsData.millisecond);
+        crsfRouter.SetHeaderAndCrc(&crsftime.h, CRSF_FRAMETYPE_GPS_TIME, CRSF_FRAME_SIZE(sizeof(crsf_sensor_gps_time_t)));
+        crsfRouter.deliverMessageTo(CRSF_ADDRESS_RADIO_TRANSMITTER, &crsftime.h);
+    }
 }

--- a/src/src/rx-serial/SerialGPS.cpp
+++ b/src/src/rx-serial/SerialGPS.cpp
@@ -7,10 +7,12 @@ void SerialGPS::sendQueuedData(uint32_t maxBytesToSend)
 {
 }
 
-// Parses a decimal string with optional decimal point and returns the value scaled by the given factor as an integer
-// Ex: "0.442" with scale 100 returns 44
-// Ex: "123.456" with scale 1000 returns 123456
-int32_t parseDecimalToScaled(const char* str, int32_t scale) {
+/***
+* @brief Parses a decimal string with optional decimal point and returns the value scaled by the given factor as an integer
+*   Ex: "0.442" with scale 100 returns 44
+*   Ex: "123.456" with scale 1000 returns 123456
+*/
+static int32_t parseDecimalToScaled(const char* str, int32_t scale) {
     char *end;
     int32_t whole = strtol(str, &end, 10);
     int32_t result = whole * scale;
@@ -65,18 +67,6 @@ static int32_t nmeaDdmToDd(const char *field)
     return degrees * 10000000 + minutesPart;
 }
 
-static void nmeaUTCtoTime(GpsData *data, const char *field)
-{
-    uint32_t time_ms = parseDecimalToScaled(field, 1000);
-    data->millisecond = time_ms % 1000;
-    time_ms /= 1000;
-    data->second = time_ms % 100;
-    time_ms /= 100;
-    data->minute = time_ms % 100;
-    time_ms /= 100;
-    data->hour = time_ms % 100;
-}
-
 bool SerialGPS::isValidChecksum(char *sentence, uint8_t size)
 {
     // Could also check for the \r\n but we know it at least has the \n to get here
@@ -127,9 +117,6 @@ void SerialGPS::fieldParseGGA(SerialGPS *ctx, uint8_t fieldIdx, char *field)
 
     switch (fieldIdx)
     {
-        case 1:
-            nmeaUTCtoTime(&ctx->gpsData, field);
-            break;
         case 2:
             ctx->gpsData.lat = (blank) ? 0 : nmeaDdmToDd(field);
             break;
@@ -176,17 +163,27 @@ void SerialGPS::fieldParseRMC(SerialGPS *ctx, uint8_t fieldIdx, char *field)
 
     switch (fieldIdx) {
         case 1: // Time: HHMMSS.ss
-            nmeaUTCtoTime(&ctx->gpsData, field);
+        {
+            uint32_t time_ms = parseDecimalToScaled(field, 1000);
+            ctx->gpsData.millisecond = time_ms % 1000;
+            time_ms /= 1000;
+            ctx->gpsData.second = time_ms % 100;
+            time_ms /= 100;
+            ctx->gpsData.minute = time_ms % 100;
+            time_ms /= 100;
+            ctx->gpsData.hour = time_ms % 100;
             break;
+        }
         case 9: // Date: DDMMYY
+        {
             uint32_t date = atoi(field);
             ctx->gpsData.year = 2000 + date % 100;
             date /= 100;
             ctx->gpsData.month = date % 100;
             date /= 100;
             ctx->gpsData.day = date % 100;
-            ctx->gpsData.hasDateTime = true;
             break;
+        }
     }
 }
 
@@ -203,6 +200,7 @@ void SerialGPS::processSentence(char *sentence, uint8_t size)
     }
     else if (sentence[3] == 'R' && sentence[4] == 'M' && sentence[5] == 'C') {
         splitSentenceFields(sentence, size, &fieldParseRMC);
+        sendGpsTimeTelemetryFrame();
     }
     // Maybe we need to think about ZDA as well so we can adjust UTC to local time!
 }
@@ -223,6 +221,26 @@ void SerialGPS::processBytes(uint8_t *bytes, uint16_t size)
     }
 }
 
+void SerialGPS::sendGpsTimeTelemetryFrame()
+{
+    // Don't send if there hasn't been an update to the year field
+    if (gpsData.year == 0)
+        return;
+
+    CRSF_MK_FRAME_T(crsf_sensor_gps_time_t) crsftime{};
+    crsftime.p.year = htobe16(gpsData.year);
+    crsftime.p.month = gpsData.month;
+    crsftime.p.day = gpsData.day;
+    crsftime.p.hour = gpsData.hour;
+    crsftime.p.minute = gpsData.minute;
+    crsftime.p.second = gpsData.second;
+    crsftime.p.millisecond = htobe16(gpsData.millisecond);
+    crsfRouter.SetHeaderAndCrc(&crsftime.h, CRSF_FRAMETYPE_GPS_TIME, CRSF_FRAME_SIZE(sizeof(crsf_sensor_gps_time_t)));
+    crsfRouter.deliverMessageTo(CRSF_ADDRESS_RADIO_TRANSMITTER, &crsftime.h);
+
+    gpsData.year = 0;
+}
+
 void SerialGPS::sendTelemetryFrame()
 {
     CRSF_MK_FRAME_T(crsf_sensor_gps_t) crsfgps{};
@@ -234,18 +252,4 @@ void SerialGPS::sendTelemetryFrame()
     crsfgps.p.gps_heading = htobe16(gpsData.heading);
     crsfRouter.SetHeaderAndCrc(&crsfgps.h, CRSF_FRAMETYPE_GPS, CRSF_FRAME_SIZE(sizeof(crsf_sensor_gps_t)));
     crsfRouter.deliverMessageTo(CRSF_ADDRESS_RADIO_TRANSMITTER, &crsfgps.h);
-
-    if (gpsData.hasDateTime)
-    {
-        CRSF_MK_FRAME_T(crsf_sensor_gps_time_t) crsftime{};
-        crsftime.p.year = htobe16(gpsData.year);
-        crsftime.p.month = gpsData.month;
-        crsftime.p.day = gpsData.day;
-        crsftime.p.hour = gpsData.hour;
-        crsftime.p.minute = gpsData.minute;
-        crsftime.p.second = gpsData.second;
-        crsftime.p.millisecond = htobe16(gpsData.millisecond);
-        crsfRouter.SetHeaderAndCrc(&crsftime.h, CRSF_FRAMETYPE_GPS_TIME, CRSF_FRAME_SIZE(sizeof(crsf_sensor_gps_time_t)));
-        crsfRouter.deliverMessageTo(CRSF_ADDRESS_RADIO_TRANSMITTER, &crsftime.h);
-    }
 }

--- a/src/src/rx-serial/SerialGPS.h
+++ b/src/src/rx-serial/SerialGPS.h
@@ -4,19 +4,23 @@
 
 #include "device.h"
 
-typedef struct {
-    // Latitude in decimal degrees
-    uint32_t lat;
-    // Longitude in decimal degrees
-    uint32_t lon;
-    // Altitude in meters
-    uint32_t alt;
-    // Speed in km/h
-    uint32_t speed;
-    // Heading in degrees, positive. 0 is north.
-    uint16_t heading;
-    // Number of satellites
-    uint8_t satellites;
+typedef struct
+{
+    uint32_t lat;       // Latitude in decimal degrees
+    uint32_t lon;       // Longitude in decimal degrees
+    uint32_t alt;       // Altitude in meters
+    uint32_t speed;     // Speed in km/h
+    uint16_t heading;   // Heading in degrees, positive. 0 is north.
+    uint8_t satellites; // Number of satellites
+
+    uint16_t year;
+    uint8_t month;
+    uint8_t day;
+    uint8_t hour;
+    uint8_t minute;
+    uint8_t second;
+    uint16_t millisecond;
+    bool hasDateTime;
 } GpsData;
 
 class SerialGPS final : public SerialIO {
@@ -37,6 +41,7 @@ private:
 
     static void fieldParseGGA(SerialGPS *ctx, uint8_t fieldIdx, char *field);
     static void fieldParseVTG(SerialGPS *ctx, uint8_t fieldIdx, char *field);
+    static void fieldParseRMC(SerialGPS *ctx, uint8_t fieldIdx, char *field);
 
     GpsData gpsData = {0};
     // NMEA 0183 has a maximum 82 byte sentence, including the end delimiter \r\n

--- a/src/src/rx-serial/SerialGPS.h
+++ b/src/src/rx-serial/SerialGPS.h
@@ -20,7 +20,6 @@ typedef struct
     uint8_t minute;
     uint8_t second;
     uint16_t millisecond;
-    bool hasDateTime;
 } GpsData;
 
 class SerialGPS final : public SerialIO {
@@ -35,6 +34,7 @@ public:
 private:
     void processBytes(uint8_t *bytes, uint16_t size) override;
     void sendTelemetryFrame();
+    void sendGpsTimeTelemetryFrame();
     bool isValidChecksum(char *sentence, uint8_t size);
     void processSentence(char *sentence, uint8_t size);
     void splitSentenceFields(char *sentence, uint8_t size, gpsFieldParser_t callback);


### PR DESCRIPTION
1. Parse RMC GPS message which contains the date & time.
2. The time is also updated from the existing GGA message.
3. Send CRSF GPS Time message once we have seen an RMC message

This was requested as a comment on #3642 
