### PR TITLE
fix(tx): correct Gemini downlink span buffer assembly when Radio_2 is primary

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -192,8 +192,8 @@ void ICACHE_RAM_ATTR ProcessOtaDataDl(uint8_t pi1, uint8_t pi2, uint8_t *data1, 
       }
       else
       {
-          packageIndexRadio2 = pi1;
-          memcpy(&geminiSpanBuffer[dataLen], data1, dataLen);
+          packageIndexRadio2 = pi2;
+          memcpy(&geminiSpanBuffer[dataLen], data2, dataLen);
       }
 
       if (Radio.GetProcessingPacketRadio() == SX12XX_Radio_1 && Radio.hasSecondRadioGotData)
@@ -203,8 +203,8 @@ void ICACHE_RAM_ATTR ProcessOtaDataDl(uint8_t pi1, uint8_t pi2, uint8_t *data1, 
       }
       else if (Radio.GetProcessingPacketRadio() == SX12XX_Radio_2 && Radio.hasSecondRadioGotData)
       {
-          packageIndexRadio1 = pi2;
-          memcpy(geminiSpanBuffer, data2, dataLen);
+          packageIndexRadio1 = pi1;
+          memcpy(geminiSpanBuffer, data1, dataLen);
       }
 
       if (packageIndexRadio1 == packageIndexRadio2 && packageIndexRadio1 != 0xFF)


### PR DESCRIPTION
## Description

In Gemini mode, `ProcessOtaDataDl` builds a span buffer from both radios' telemetry halves. The Radio_2 path had two copy-paste mistakes that caused the wrong parameter set (`pi1`/`data1`) to be used where `pi2`/`data2` was intended, and vice versa in the `hasSecondRadioGotData` complementary path.

## Failure modes

**Asymmetric reception (Radio_1 drop):** When only Radio_2 receives the telemetry packet, the `else` branch stored `pi1` as the Radio_2 package index and copied `data1` (stale Radio_1 buffer) into the second half of the span buffer. The freshly received Radio_2 data was never used.

**Concurrent reception, Radio_2 ISR first:** Both radios receive successfully but Radio_2 triggers `GetProcessingPacketRadio` first. The two branches ran in sequence and wrote the halves cross-swapped — Radio_2's second-half payload ended up in the first-half slot and vice versa. The assembled frame passed the package-index equality check (`pi1 == pi2`) but delivered a structurally corrupt packet that the downstream CRSF parser drops.

## Change

```diff
-          packageIndexRadio2 = pi1;
-          memcpy(&geminiSpanBuffer[dataLen], data1, dataLen);
+          packageIndexRadio2 = pi2;
+          memcpy(&geminiSpanBuffer[dataLen], data2, dataLen);
```

```diff
-          packageIndexRadio1 = pi2;
-          memcpy(geminiSpanBuffer, data2, dataLen);
+          packageIndexRadio1 = pi1;
+          memcpy(geminiSpanBuffer, data1, dataLen);
```