### PR TITLE
Load proper default product with mixed case

### DIFF
--- a/src/python/UnifiedConfiguration.py
+++ b/src/python/UnifiedConfiguration.py
@@ -83,7 +83,7 @@ def getDefaultProductForTarget(target_name: str) -> tuple[str, bool]:
         return ''
 
     # remove the "_via_WIFI" etc method
-    target_wo_method = re.sub('_VIA_.*', '', target_name.upper())
+    target_wo_method = re.sub('_via_.*', '', target_name)
     try:
         with open('.pio/default_target_config.json', 'r') as f:
             data = json.load(f)


### PR DESCRIPTION
The "default product" for the interactive hardware appending step of the build was failing to find the correct default. This is due to it now saving the target in mixed case, and trying to load it in upper case. This was missed by me during my review of #3585.

Symptom: Builds always show a default of 0 when prompting for which hardware config to append at the end of the build.

I could also fix this by reverting the changes to `clearDefaultProductForTarget()` and `setDefaultProductForTarget()` but I figure this is fewer changes and keeps everything consistent with how the other PR no longer uses uppercase either.