### PR TITLE
rc mavlink: add option to disable RC channels over mavlink

### DIFF
--- a/src/lib/CONFIG/config.cpp
+++ b/src/lib/CONFIG/config.cpp
@@ -1369,6 +1369,16 @@ RxConfig::SetForceTlmOff(bool forceTlmOff)
 }
 
 void
+RxConfig::SetMavlinkRCEnabled(bool enabled)
+{
+    if (GetMavlinkRCEnabled() != enabled)
+    {
+        m_config.mavlinkRcDisabled = !enabled;
+        m_modified = EVENT_CONFIG_MODEL_CHANGED;
+    }
+}
+
+void
 RxConfig::SetRateInitialIdx(uint8_t rateInitialIdx)
 {
     if (m_config.rateInitialIdx != rateInitialIdx)

--- a/src/lib/CONFIG/config.h
+++ b/src/lib/CONFIG/config.h
@@ -259,7 +259,8 @@ typedef struct __attribute__((packed)) {
     uint8_t     modelId;
     uint8_t     serialProtocol:4,
                 failsafeMode:2,
-                unused:2;
+                mavlinkRcDisabled:1,
+                unused:1;
     rx_config_pwm_t pwmChannels[PWM_MAX_CHANNELS] __attribute__((aligned(4)));
     uint8_t     teamraceChannel:4,
                 teamracePosition:3,
@@ -291,6 +292,7 @@ public:
     bool     IsModified() const { return m_modified != 0; }
     const rx_config_pwm_t *GetPwmChannel(uint8_t ch) const { return &m_config.pwmChannels[ch]; }
     bool GetForceTlmOff() const { return m_config.forceTlmOff; }
+    bool GetMavlinkRCEnabled() const { return !m_config.mavlinkRcDisabled; }
     uint8_t GetRateInitialIdx() const { return m_config.rateInitialIdx; }
     eSerialProtocol GetSerialProtocol() const { return (eSerialProtocol)m_config.serialProtocol; }
 #if defined(PLATFORM_ESP32)
@@ -315,6 +317,7 @@ public:
     void SetPwmChannel(uint8_t ch, uint16_t failsafe, uint8_t inputCh, bool inverted, uint8_t mode, uint8_t stretched);
     void SetPwmChannelRaw(uint8_t ch, uint32_t raw);
     void SetForceTlmOff(bool forceTlmOff);
+    void SetMavlinkRCEnabled(bool enabled);
     void SetRateInitialIdx(uint8_t rateInitialIdx);
     void SetSerialProtocol(eSerialProtocol serialProtocol);
 #if defined(PLATFORM_ESP32)

--- a/src/lib/rx-crsf/RXParameters.cpp
+++ b/src/lib/rx-crsf/RXParameters.cpp
@@ -78,6 +78,13 @@ static int8Parameter luaSourceSysId = {
   STR_EMPTYSPACE
 };
 
+static selectionParameter luaMavlinkRC = {
+    {"MAVLink RC", CRSF_TEXT_SELECTION},
+    1,
+    "Off;On",
+    STR_EMPTYSPACE
+};
+
 static selectionParameter luaTlmPower = {
     {"Tlm Power", CRSF_TEXT_SELECTION},
     0, // value
@@ -540,6 +547,9 @@ void RXEndpoint::registerParameters()
   registerParameter(&luaSourceSysId, [](propertiesCommon* item, uint8_t arg){
     config.SetSourceSysId((uint8_t)arg);
   });
+  registerParameter(&luaMavlinkRC, [](propertiesCommon* item, uint8_t arg){
+    config.SetMavlinkRCEnabled(arg != 0);
+  });
 
   if (GPIO_PIN_ANT_CTRL != UNDEF_PIN)
   {
@@ -654,13 +664,16 @@ void RXEndpoint::updateParameters()
   {
     setUint8Value(&luaSourceSysId, config.GetSourceSysId() == 0 ? 255 : config.GetSourceSysId());  //display Source sysID if 0 display 255 to mimic logic in SerialMavlink.cpp
     setUint8Value(&luaTargetSysId, config.GetTargetSysId() == 0 ? 1 : config.GetTargetSysId());  //display Target sysID if 0 display 1 to mimic logic in SerialMavlink.cpp
+    setTextSelectionValue(&luaMavlinkRC, config.GetMavlinkRCEnabled() ? 1 : 0);
     LUA_FIELD_SHOW(luaSourceSysId)
     LUA_FIELD_SHOW(luaTargetSysId)
+    LUA_FIELD_SHOW(luaMavlinkRC)
   }
   else
   {
     LUA_FIELD_HIDE(luaSourceSysId)
     LUA_FIELD_HIDE(luaTargetSysId)
+    LUA_FIELD_HIDE(luaMavlinkRC)
   }
 }
 #endif

--- a/src/src/rx-serial/SerialMavlink.cpp
+++ b/src/src/rx-serial/SerialMavlink.cpp
@@ -34,6 +34,10 @@ uint32_t SerialMavlink::sendRCFrame(bool frameAvailable, bool frameMissed, uint3
         return DURATION_IMMEDIATELY;
     }
 
+    if (!config.GetMavlinkRCEnabled()) {
+        return DURATION_IMMEDIATELY;
+    }
+
     const mavlink_rc_channels_override_t rc_override {
         chan1_raw: CRSF_to_US(channelData[0]),
         chan2_raw: CRSF_to_US(channelData[1]),


### PR DESCRIPTION
This adds a option to the RX to disable RC over Mavlink.

This serves the idea of using a second uart on the RX to feed SBUS to a flight controller while Mavlink stays as only telemetry.
With ArduPilot this is useful for Flight Controllers with Dual MCU (eg H7/F1), where's if there's something wrong with H7 the F1 still allows a plane to fly.
It's a really edge case.
Also allows offloading RC decoding to the F1.

The second use would be for a future eLRS as SiK Modem replacement.

Bench tested on TX15 + XR4.
