### PR TITLE
Add BLE option to backpack telemetry menu

### DIFF
--- a/src/lib/tx-crsf/TXModuleParameters.cpp
+++ b/src/lib/tx-crsf/TXModuleParameters.cpp
@@ -304,7 +304,7 @@ static selectionParameter luaHeadTrackingStartChannel = {
 static selectionParameter luaBackpackTelemetry = {
     {"Telemetry", CRSF_TEXT_SELECTION},
     0, // value
-    "Off;ESPNOW;WiFi",
+    "Off;ESPNOW;WiFi;BLE",
     STR_EMPTYSPACE};
 
 static stringParameter luaBackpackVersion = {


### PR DESCRIPTION
Companion to ExpressLRS/Backpack#222, which adds BLE CRSF telemetry forwarding to the ESP32C3 TX backpack.

This PR adds the corresponding menu value (3) so users can select Bluetooth from the radio's Backpack → Telemetry menu. The value position matches BACKPACK_TELEM_MODE_BLUETOOTH = 3 in the Backpack's lib/config/config.h, so no coordination is needed beyond merging both.

Suggested merge order: Backpack PR #222 first, then this one — so no user can pick a menu option their backpack firmware doesn't understand yet.