### PR TITLE
Fix: Antenna Mode Switch not working properly

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -619,7 +619,8 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
       transmittingRadio = SX12XX_Radio_2;
       break;
     case TX_RADIO_MODE_SWITCH:
-      transmittingRadio = OtaNonce%2 == 0 ? SX12XX_Radio_1 : SX12XX_Radio_2;
+      static boolean toggle = false;
+      transmittingRadio = (toggle ^= true) ? SX12XX_Radio_1 : SX12XX_Radio_2;
       break;
     default:
       break;


### PR DESCRIPTION
Problem: Setting Antenna Mode to Switch is expected to send packets on alternating antennas. The logic to toggle between the antennas uses `OtaNonce`. But OtaNonce is not only incremented on packets sent but also if tlm is expected. With tlm ratio 1:2 selected this leads to `OtaNonce%2 == 0` always returning false and selecting Antenna 2. Other tlm ratios do toggle the Antennas but in a irregular pattern favoring Antenna 2.

Solution: Change the toggling logic.