### PR TITLE
Only process/forward MAVLink messages which pass frame check

### DIFF
--- a/src/lib/MAVLink/MAVLink.cpp
+++ b/src/lib/MAVLink/MAVLink.cpp
@@ -95,7 +95,7 @@ void convert_mavlink_to_crsf_telem(crsf_addr_e destination, uint8_t *CRSFinBuffe
     {
         mavlink_message_t msg;
         mavlink_status_t status;
-        bool have_message = mavlink_frame_char(MAVLINK_COMM_0, CRSFinBuffer[CRSF_FRAME_NOT_COUNTED_BYTES + i], &msg, &status);
+        bool have_message = mavlink_frame_char(MAVLINK_COMM_0, CRSFinBuffer[CRSF_FRAME_NOT_COUNTED_BYTES + i], &msg, &status) == MAVLINK_FRAMING_OK;
         // convert mavlink messages to CRSF messages
         if (have_message)
         {

--- a/src/src/rx-serial/SerialMavlink.cpp
+++ b/src/src/rx-serial/SerialMavlink.cpp
@@ -127,7 +127,7 @@ void SerialMavlink::sendQueuedData(uint32_t maxBytesToSend)
         mavlink_status_t status;
 
         // Try parse a mavlink message
-        if (mavlink_frame_char(MAVLINK_COMM_0, c, &msg, &status))
+        if (mavlink_frame_char(MAVLINK_COMM_0, c, &msg, &status) == MAVLINK_FRAMING_OK)
         {
             // Message decoded successfully
 


### PR DESCRIPTION
Adds a check to incoming and forwarded MAVLink messages to verify they pass CRC and framing requirements before using them.

### Details

`mavlink_frame_char()` returns non-zero any time there is a **possible message**, including those with bad CRCs or framing characters. Our code takes both of these cases as "good message received" indicators and parse them or forward them to external systems. I _believe_ this can cause output spam to Ardupilot and blow out their receive buffer with garbage until the stream coming OTA resyncs to a valid packet. A user reported this and I suggested this change, after which they tried to PR it and then ghosted me. 👻

We previously (4.0 RC) ran into this problem with force-switching to MAVLink mode on virtually any USB serial input due to how loosely the underlying parser would return that these were MAVLink messages* ("But I said they were  _invalid_ messages!!").

I think it is the right thing to do to verify the CRC/Framing before acting on them, like we do with CRSF.