### PR TITLE
Remove isElrs distinction from CRSF parameter read/write

### DIFF
--- a/src/include/crsf_protocol.h
+++ b/src/include/crsf_protocol.h
@@ -148,8 +148,7 @@ typedef enum : uint8_t
 
 // These flags are or'ed with the field type above to hide the field from the normal LUA view
 #define CRSF_FIELD_HIDDEN       0x80     // marked as hidden in all LUA responses
-#define CRSF_FIELD_ELRS_HIDDEN  0x40     // marked as hidden when talking to ELRS specific LUA
-#define CRSF_FIELD_TYPE_MASK    ~(CRSF_FIELD_HIDDEN|CRSF_FIELD_ELRS_HIDDEN)
+#define CRSF_FIELD_TYPE_MASK    ~(CRSF_FIELD_HIDDEN)
 
 /**
  * Define the shape of a standard header

--- a/src/lib/CrsfProtocol/CRSFEndpoint.cpp
+++ b/src/lib/CrsfProtocol/CRSFEndpoint.cpp
@@ -178,7 +178,7 @@ uint8_t *CRSFEndpoint::folderParameterToArray(const folderParameter *parameter, 
     return childParameters;
 }
 
-uint8_t CRSFEndpoint::sendParameter(const crsf_addr_e origin, const bool isElrs, const crsf_frame_type_e frameType, const uint8_t fieldChunk, const propertiesCommon *parameter)
+uint8_t CRSFEndpoint::sendParameter(const crsf_addr_e origin, const crsf_frame_type_e frameType, const uint8_t fieldChunk, const propertiesCommon *parameter)
 {
     const uint8_t dataType = parameter->type & CRSF_FIELD_TYPE_MASK;
 
@@ -191,10 +191,6 @@ uint8_t CRSFEndpoint::sendParameter(const crsf_addr_e origin, const bool isElrs,
     chunkBuffer[3] = dataType;
     // Set the hidden flag
     chunkBuffer[3] |= parameter->type & CRSF_FIELD_HIDDEN ? 0x80 : 0;
-    if (isElrs)
-    {
-        chunkBuffer[3] |= parameter->type & CRSF_FIELD_ELRS_HIDDEN ? 0x80 : 0;
-    }
     uint8_t paramInformation[CRSF_MAX_PACKET_LEN];
 
     // Copy the name to the buffer starting at chunkBuffer[4]
@@ -257,10 +253,10 @@ uint8_t CRSFEndpoint::sendParameter(const crsf_addr_e origin, const bool isElrs,
     return chunkCnt - (fieldChunk + 1);
 }
 
-void CRSFEndpoint::pushResponseChunk(commandParameter *cmd, const bool isElrs)
+void CRSFEndpoint::pushResponseChunk(commandParameter *cmd)
 {
     DBGVLN("sending response for [%s] chunk=%u step=%u", cmd->common.name, nextStatusChunk, cmd->step);
-    if (sendParameter(requestOrigin, isElrs, CRSF_FRAMETYPE_PARAMETER_SETTINGS_ENTRY, nextStatusChunk, (propertiesCommon *)cmd) == 0)
+    if (sendParameter(requestOrigin, CRSF_FRAMETYPE_PARAMETER_SETTINGS_ENTRY, nextStatusChunk, (propertiesCommon *)cmd) == 0)
     {
         nextStatusChunk = 0;
     }
@@ -275,7 +271,7 @@ void CRSFEndpoint::sendCommandResponse(commandParameter *cmd, const commandStep_
     cmd->step = step;
     cmd->info = message;
     nextStatusChunk = 0;
-    pushResponseChunk(cmd, false);
+    pushResponseChunk(cmd);
 }
 
 void CRSFEndpoint::registerParameter(void *definition, const parameterHandlerCallback &callback, const uint8_t parent)
@@ -295,7 +291,7 @@ void CRSFEndpoint::registerParameter(void *definition, const parameterHandlerCal
     paramCallbacks[lastParameter] = callback;
 }
 
-void CRSFEndpoint::parameterUpdateReq(const crsf_addr_e origin, const bool isElrs, const uint8_t parameterType, const uint8_t parameterIndex, void *payload)
+void CRSFEndpoint::parameterUpdateReq(const crsf_addr_e origin, const uint8_t parameterType, const uint8_t parameterIndex, void *payload)
 {
     propertiesCommon *parameter = paramDefinitions[parameterIndex];
     requestOrigin = origin;
@@ -334,7 +330,7 @@ void CRSFEndpoint::parameterUpdateReq(const crsf_addr_e origin, const bool isElr
             // remaining chunks when nextStatusChunk != 0
             if (parameterArg == lcsQuery && nextStatusChunk != 0)
             {
-                pushResponseChunk((commandParameter *)parameter, isElrs);
+                pushResponseChunk((commandParameter *)parameter);
             }
             else
             {
@@ -360,7 +356,7 @@ void CRSFEndpoint::parameterUpdateReq(const crsf_addr_e origin, const bool isElr
                 field->step = lcsIdle;
                 field->info = "";
             }
-            sendParameter(origin, isElrs, CRSF_FRAMETYPE_PARAMETER_SETTINGS_ENTRY, parameterArg, &field->common);
+            sendParameter(origin, CRSF_FRAMETYPE_PARAMETER_SETTINGS_ENTRY, parameterArg, &field->common);
         }
     }
     break;

--- a/src/lib/CrsfProtocol/CRSFEndpoint.h
+++ b/src/lib/CrsfProtocol/CRSFEndpoint.h
@@ -70,7 +70,7 @@ protected:
 
     /**
      * Registers a parameter with the CRSF endpoint.
-     * 
+     *
      * @param definition Pointer to the parameter definition
      * @param callback Optional callback function to be called when the parameter is updated
      * @param parent Parent parameter index, defaults to 0 for root level parameters
@@ -85,18 +85,17 @@ protected:
 
     /**
      * Handles parameter update requests from the CRSF network.
-     * 
+     *
      * @param origin The address of the requesting device
-     * @param isElrs Boolean indicating if this is an ELRS-specific parameter
      * @param parameterType The type of parameter being updated
      * @param parameterIndex The index of the parameter to update
      * @param payload Pointer to the start of the parameter payload or chunk number for multipart parameters
      */
-    void parameterUpdateReq(crsf_addr_e origin, bool isElrs, uint8_t parameterType, uint8_t parameterIndex, void *payload);
+    void parameterUpdateReq(crsf_addr_e origin, uint8_t parameterType, uint8_t parameterIndex, void *payload);
 
     /**
      * Sends a command response back to the CRSF network.
-     * 
+     *
      * @param cmd Pointer to the command parameter structure
      * @param step The current step in the command execution
      * @param message Response message to send
@@ -200,8 +199,8 @@ private:
     static uint8_t *stringParameterToArray(const stringParameter *parameter, uint8_t *next);
     uint8_t *folderParameterToArray(const folderParameter *parameter, uint8_t *next) const;
 
-    uint8_t sendParameter(crsf_addr_e origin, bool isElrs, crsf_frame_type_e frameType, uint8_t fieldChunk, const propertiesCommon *parameter);
-    void pushResponseChunk(commandParameter *cmd, bool isElrs);
+    uint8_t sendParameter(crsf_addr_e origin, crsf_frame_type_e frameType, uint8_t fieldChunk, const propertiesCommon *parameter);
+    void pushResponseChunk(commandParameter *cmd);
 };
 
 #endif //CRSF_ENDPOINT_H

--- a/src/lib/rx-crsf/RXEndpoint.cpp
+++ b/src/lib/rx-crsf/RXEndpoint.cpp
@@ -79,7 +79,6 @@ void RXEndpoint::handleMessage(const crsf_header_t *message)
     {
         parameterUpdateReq(
             extMessage->orig_addr,
-            false,
             extMessage->type,
             extMessage->payload[0],  // parameter index
             extMessage->payload + 1  // start of parameter payload

--- a/src/lib/tx-crsf/TXModuleEndpoint.cpp
+++ b/src/lib/tx-crsf/TXModuleEndpoint.cpp
@@ -71,24 +71,20 @@ void TXModuleEndpoint::handleMessage(const crsf_header_t *message)
         || packetType == CRSF_FRAMETYPE_PARAMETER_READ
         || packetType == CRSF_FRAMETYPE_PARAMETER_WRITE)
     {
-        // dodgy hack because 'our' LUA script uses a different origin and we need to reply to the radio!
-        bool isElrsCalling = extMessage->orig_addr == CRSF_ADDRESS_ELRS_LUA;
-        crsf_addr_e requestOrigin = isElrsCalling ? CRSF_ADDRESS_RADIO_TRANSMITTER : extMessage->orig_addr;
-
         if (packetType == CRSF_FRAMETYPE_PARAMETER_WRITE)
         {
             if (extMessage->payload[0] == 0)
             {
                 // special case for elrs linkstat request
                 DBGVLN("ELRS status request");
-                sendELRSstatus(requestOrigin);
+                sendELRSstatus(extMessage->orig_addr);
             }
             else if (extMessage->payload[0] == 0x2E)
             {
                 supressCriticalErrors();
             }
         }
-        parameterUpdateReq(requestOrigin, isElrsCalling, packetType, extMessage->payload[0], extMessage->payload + 1);
+        parameterUpdateReq(extMessage->orig_addr, packetType, extMessage->payload[0], extMessage->payload + 1);
     }
 }
 

--- a/src/lib/tx-crsf/TXModuleEndpoint.h
+++ b/src/lib/tx-crsf/TXModuleEndpoint.h
@@ -50,7 +50,6 @@ protected:
     void sendELRSstatus(crsf_addr_e origin);
 
 private:
-    char luaBadGoodString[10] {};
     uint8_t luaWarningFlags = 0b00000000; //8 flag, 1 bit for each flag. set the bit to 1 to show specific warning. 3 MSB is for critical flag
 
     void handleWifiBle(propertiesCommon *item, uint8_t arg);

--- a/src/lib/tx-crsf/TXModuleParameters.cpp
+++ b/src/lib/tx-crsf/TXModuleParameters.cpp
@@ -171,11 +171,6 @@ static commandParameter luaBind = {
     STR_EMPTYSPACE
 };
 
-static stringParameter luaInfo = {
-    {"Bad/Good", (crsf_value_type_e)(CRSF_INFO | CRSF_FIELD_ELRS_HIDDEN)},
-    STR_EMPTYSPACE
-};
-
 static stringParameter luaELRSversion = {
     {version_domain, CRSF_INFO},
     commit
@@ -337,9 +332,6 @@ void TXModuleEndpoint::supressCriticalErrors()
 void TXModuleEndpoint::devicePingCalled()
 {
     supressCriticalErrors();
-    utoa(CRSFHandset::BadPktsCountResult, luaBadGoodString, 10);
-    strcat(luaBadGoodString, "/");
-    utoa(CRSFHandset::GoodPktsCountResult, luaBadGoodString + strlen(luaBadGoodString), 10);
 }
 
 void TXModuleEndpoint::setWarningFlag(const warningFlags flag, const bool value)
@@ -784,8 +776,6 @@ static void recalculatePacketRateOptions(int minInterval)
 
 void TXModuleEndpoint::registerParameters()
 {
-  setStringValue(&luaInfo, luaBadGoodString);
-
   auto wifiBleCallback = [&](propertiesCommon *item, const uint8_t arg) { handleWifiBle(item, arg); };
   auto sendCallback = [&](propertiesCommon *item, const uint8_t arg) { handleSimpleSendCmd(item, arg); };
 
@@ -983,7 +973,6 @@ void TXModuleEndpoint::registerParameters()
     registerParameter(&luaBind, sendCallback);
   }
 
-  registerParameter(&luaInfo);
   registerParameter(&luaELRSversion);
 }
 

--- a/src/lua/elrs.lua
+++ b/src/lua/elrs.lua
@@ -391,7 +391,6 @@ local function changeDeviceId(devId) --change to selected device ID
   deviceName = device.name
   fields_count = device.fldcnt
   deviceIsELRS_TX = device.isElrs and devId == 0xEE or nil -- ELRS and ID is TX module
-  -- handsetId = deviceIsELRS_TX and 0xEF or 0xEA -- Address ELRS_LUA vs RADIO_TRANSMITTER for pre 4.1.0 TX firmwares
 
   allocateFields()
   reloadAllField()

--- a/src/lua/elrs.lua
+++ b/src/lua/elrs.lua
@@ -6,9 +6,9 @@
 ---- # License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html               #
 ---- #                                                                       #
 ---- #########################################################################
-local EXITVER = "-- EXIT (Lua r17) --"
+local EXITVER = "-- EXIT (Lua r18) --"
 local deviceId = 0xEE
-local handsetId = 0xEF
+local handsetId = 0xEA
 local deviceName = nil
 local currentFolderName = nil
 local lineIndex = 1
@@ -391,7 +391,7 @@ local function changeDeviceId(devId) --change to selected device ID
   deviceName = device.name
   fields_count = device.fldcnt
   deviceIsELRS_TX = device.isElrs and devId == 0xEE or nil -- ELRS and ID is TX module
-  handsetId = deviceIsELRS_TX and 0xEF or 0xEA -- Address ELRS_LUA vs RADIO_TRANSMITTER
+  -- handsetId = deviceIsELRS_TX and 0xEF or 0xEA -- Address ELRS_LUA vs RADIO_TRANSMITTER for pre 4.1.0 TX firmwares
 
   allocateFields()
   reloadAllField()

--- a/src/test/test_crsf/test_crsf.cpp
+++ b/src/test/test_crsf/test_crsf.cpp
@@ -28,7 +28,7 @@ public:
         uint8_t payload[4] = {0};
         for (size_t i = 0; i < valueSize; ++i)
             payload[i] = static_cast<uint8_t>((value >> ((valueSize - 1 - i) * 8)) & 0xFF);
-        parameterUpdateReq(destAddr, false, paramId, paramIndex, payload);
+        parameterUpdateReq(destAddr, paramId, paramIndex, payload);
     }
 } crsfEndpoint;
 


### PR DESCRIPTION
Removes the special `CRSF_ADDRESS_ELRS_LUA` from our code, and the always-hidden-for-ELRS "Bad/Good" parameter listed in the lua.

### Details

The lua uses the made-up address `CRSF_ADDRESS_ELRS_LUA` to indicate that our own lua is sending the request for `PARAMETER_INFO`, and thus lets the TX module that very complex special handling should be done.

What special handling? To use a non-standard CRSF flag to override the HIDDEN flag of the "Bad/Good" parameter to be always hidden in our Lua, and therefore shown in the standard TBS lua.

Removing this field means we can remove the non-standard address, all the code associated with tracking this non-standard flag, the code for updating the string nobody sees, and the lua list will load 1/30th faster!

### Regressions

* Users who only use TBS-standard lua scripts will no longer see the "Bad/Good" field in the parameter list. If they want to know this, they'll have to use our own lua which has a separate mechanism for querying this value.
* Users who update their lua using the version from this PR, but not the TX module firmware built on this PR will now see a new Bad/Good parameter that will not update in their list. The counts on the header still update, but this static value will be there. To clarify:
  * Newest lua running against older (pre-4.1.0) firmware: Will see "bad/good" in list
  * Older lua running against any firmware (2.x.x or 3.x.x or 4.0.x or 4.1.x): No difference from previous behavior

### What to Test

There is no visible difference when using the r17 lua or this one (r18) when a module is flashed with this PR. The only difference is in the TBS lua, which will show a bad/good normally but will not on this PR.  Our lua should be the only thing that ever used this value, so any other lua script that tunnels through ExpressLRS should still work fine (I tested bf.lua and rotorflight). I do not think there is any need to be to thorough with testing other lua utilities.

So for testing I guess just test that our existing lua (<r18)  still loads and works against this PR, EdgeTX still displays the module name in its "About" modules page. You can also verify that when running the r18 lua against any order code (4.0 or 3.x or 2.x) that you now see a bad/good parameter, but I don't think that's worth testing since it is a known result.