### PR TITLE
PWM ISR watchdog

### DIFF
--- a/src/lib/PWM/PWM.h
+++ b/src/lib/PWM/PWM.h
@@ -37,6 +37,14 @@ public:
      * @param microseconds the high time in microseconds
      */
     void setMicroseconds(pwm_channel_t channel, uint16_t microseconds);
+
+    /**
+     * @brief Service the watchdog timer to prevent an unintended runaway if there are no channel updates.
+     *
+     * Call this method periodically within the required watchdog timeout window to
+     * indicate that the system is still running correctly.
+     */
+    void feedWatchdog();
 };
 
 extern PWMController PWM;

--- a/src/lib/PWM/PWM_ESP32.cpp
+++ b/src/lib/PWM/PWM_ESP32.cpp
@@ -281,4 +281,8 @@ void PWMController::setMicroseconds(pwm_channel_t channel, uint16_t microseconds
 #endif
 }
 
+void PWMController::feedWatchdog()
+{
+}
+
 #endif

--- a/src/lib/PWM/PWM_ESP8266.cpp
+++ b/src/lib/PWM/PWM_ESP8266.cpp
@@ -52,4 +52,9 @@ void PWMController::setMicroseconds(pwm_channel_t channel, uint16_t microseconds
     startWaveform8266(pin, microseconds, refreshInterval[channel] - microseconds);
 }
 
+void PWMController::feedWatchdog()
+{
+    feedWaveform8266();
+}
+
 #endif

--- a/src/lib/PWM/waveform_8266.cpp
+++ b/src/lib/PWM/waveform_8266.cpp
@@ -212,12 +212,13 @@ static inline IRAM_ATTR uint32_t earliest(uint32_t a, uint32_t b) {
     return (da < db) ? a : b;
 }
 
-static inline IRAM_ATTR bool watchdogExpired(uint32_t now) {
+static inline IRAM_ATTR bool watchdogExpired() {
   if (!watchdogArmed) {
     return false;
   }
 
-  return static_cast<int32_t>(now - watchdogLastFeedCycle) >= static_cast<int32_t>(WATCHDOG_TIMEOUT_CYCLES);
+  uint32_t now = GetCycleCountIRQ();
+  return now - watchdogLastFeedCycle >= WATCHDOG_TIMEOUT_CYCLES;
 }
 
 static inline IRAM_ATTR void stopAllWaveformsFromWatchdog() {
@@ -264,11 +265,6 @@ static IRAM_ATTR void timer1Interrupt() {
   T1C = 0;
   T1I = 0;
   int32_t cycleDeltaNextEvent = MAXINTERVAL_CS;
-
-  if (watchdogExpired(GetCycleCountIRQ())) {
-    stopAllWaveformsFromWatchdog();
-    return;
-  }
 
   if (wvfState.waveformToEnable || wvfState.waveformToDisable) {
     // Handle enable/disable requests from main app
@@ -351,6 +347,11 @@ static IRAM_ATTR void timer1Interrupt() {
   // schedule the timer a little early to allow time to get to the pin switch code before the deadline
   T1L = (cycleDeltaNextEvent - PRESCHEDULE_CS) >> (turbo ? 1 : 0);
   T1C = (1 << TCTE); //timer1_enable(TIM_DIV1, TIM_EDGE, TIM_SINGLE)
+
+  if (watchdogExpired()) {
+    stopAllWaveformsFromWatchdog();
+    T1C = 0; // disable the timer since we're dead
+  }
 }
 
 #endif

--- a/src/lib/PWM/waveform_8266.cpp
+++ b/src/lib/PWM/waveform_8266.cpp
@@ -92,6 +92,24 @@ static void timer1Interrupt();
 extern "C" IRAM_ATTR int __wrap_stopWaveform(uint8_t pin) { return true; }
 extern "C" IRAM_ATTR bool __wrap__stopPWM(uint8_t pin) { return true; }
 
+static constexpr uint32_t WATCHDOG_TIMEOUT_US = 50000;
+static constexpr uint32_t WATCHDOG_TIMEOUT_CYCLES = microsecondsToClockCycles(WATCHDOG_TIMEOUT_US);
+
+static volatile uint32_t watchdogLastFeedCycle = 0;
+static volatile bool watchdogArmed = false;
+
+void feedWaveform8266()
+{
+  watchdogLastFeedCycle = ESP.getCycleCount();
+  watchdogArmed = true;
+  MEMBARRIER();
+}
+
+static inline void armWaveformWatchdog() {
+    watchdogLastFeedCycle = ESP.getCycleCount();
+    watchdogArmed = true;
+}
+
 static __attribute__((noinline)) void initTimer() {
   if (!wvfState.timerRunning) {
     timer1_disable();
@@ -117,6 +135,7 @@ static void disableIdleTimer() {
     timer1_disable();
     timer1_isr_init();
     wvfState.timerRunning = false;
+    watchdogArmed = false;
   }
 }
 
@@ -133,6 +152,7 @@ void startWaveform8266(uint8_t gpio, uint32_t timeHighUS, uint32_t timeLowUS) {
   MEMBARRIER();
   if (wvfState.waveformEnabled & mask) {
     wave->nextHighLowUs = (timeHighUS << 16) | timeLowUS;
+    armWaveformWatchdog();
     MEMBARRIER();
     // The waveform will be updated some time in the future on the next period for the signal
   } else { //  if (!(wvfState.waveformEnabled & mask)) {
@@ -141,6 +161,7 @@ void startWaveform8266(uint8_t gpio, uint32_t timeHighUS, uint32_t timeLowUS) {
     wave->nextHighLowUs = 0;
     wave->nextServiceCycle = ESP.getCycleCount() + microsecondsToClockCycles(1);
     wvfState.waveformToEnable |= mask;
+    armWaveformWatchdog();
     MEMBARRIER();
     initTimer();
     forceTimerInterrupt();
@@ -191,6 +212,37 @@ static inline IRAM_ATTR uint32_t earliest(uint32_t a, uint32_t b) {
     return (da < db) ? a : b;
 }
 
+static inline IRAM_ATTR bool watchdogExpired(uint32_t now) {
+  if (!watchdogArmed) {
+    return false;
+  }
+
+  return static_cast<int32_t>(now - watchdogLastFeedCycle) >= static_cast<int32_t>(WATCHDOG_TIMEOUT_CYCLES);
+}
+
+static inline IRAM_ATTR void stopAllWaveformsFromWatchdog() {
+  const uint32_t enabled = wvfState.waveformEnabled;
+  if (!enabled) {
+    watchdogArmed = false;
+    wvfState.timerRunning = false;
+    return;
+  }
+
+  GPOC = enabled & 0xffff;
+  if (enabled & (1 << 16)) {
+    GP16O = 0;
+  }
+
+  wvfState.waveformState &= ~enabled;
+  wvfState.waveformEnabled = 0;
+  wvfState.waveformToEnable = 0;
+  wvfState.waveformToDisable = 0;
+  wvfState.startPin = 0;
+  wvfState.endPin = 0;
+  watchdogArmed = false;
+  wvfState.timerRunning = false;
+}
+
 #if F_CPU == 80000000
 #define adjust(x) ((x) << (turbo ? 1 : 0))
 #else
@@ -212,6 +264,11 @@ static IRAM_ATTR void timer1Interrupt() {
   T1C = 0;
   T1I = 0;
   int32_t cycleDeltaNextEvent = MAXINTERVAL_CS;
+
+  if (watchdogExpired(GetCycleCountIRQ())) {
+    stopAllWaveformsFromWatchdog();
+    return;
+  }
 
   if (wvfState.waveformToEnable || wvfState.waveformToDisable) {
     // Handle enable/disable requests from main app

--- a/src/lib/PWM/waveform_8266.h
+++ b/src/lib/PWM/waveform_8266.h
@@ -2,6 +2,7 @@
 
 void startWaveform8266(uint8_t gpio, uint32_t timeHighUS, uint32_t timeLowUS);
 void stopWaveform8266(uint8_t gpio);
+void feedWaveform8266();
 
 #define startWaveform DO_NOT_USE
 #define startWaveformClockCycles DO_NOT_USE

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -207,6 +207,7 @@ void servoCurrentToFailsafeConfig()
 
 static void servosUpdate(unsigned long now)
 {
+    PWM.feedWatchdog();
     if (connectionState != connected || !connectionHasModelMatch || !teamraceHasModelMatch)
     {
         servosEnterFailsafe();

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -23,6 +23,7 @@ static volatile bool newChannelsAvailable;
 static uint32_t lastUpdate;
 // Absolute max failsafe time if no update is received, regardless of LQ
 static constexpr uint32_t FAILSAFE_ABS_TIMEOUT_MS = 1000U;
+static constexpr uint32_t DISCONNECTED_UPDATE_MS = 10;
 
 typedef void (*servoWrite_fn)(uint8_t ch, uint16_t us);
 
@@ -321,7 +322,8 @@ static int event()
     if (connectionState != connected)
     {
         servosEnterFailsafe();
-        return connectionState == disconnected ? DURATION_NEVER : DURATION_IMMEDIATELY;
+        // When disconnected, return a timeout to feed the ISR watchdog for the PWM signals
+        return connectionState == disconnected ? DISCONNECTED_UPDATE_MS : DURATION_IMMEDIATELY;
     }
     if (!initialized && connectionState == connected)
     {
@@ -337,7 +339,7 @@ static int event()
 #if defined(PLATFORM_ESP32)
             else if ((eServoOutputMode)chConfig->val.mode == somDShot || (eServoOutputMode)chConfig->val.mode == somDShot3D)
             {
-                dshotInstances[ch]->begin(DSHOT300, false); // Set DShot protocol and bidirectional dshot bool
+                dshotInstances[ch]->begin(DSHOT300, false); // Set DShot protocol and bidirectional DShot bool
             }
 #endif
         }
@@ -348,7 +350,8 @@ static int event()
 static int timeout()
 {
     servosUpdate(millis());
-    return DURATION_IMMEDIATELY;
+    // When disconnected, return a timeout to feed the ISR watchdog for the PWM signals
+    return connectionState == disconnected ? DISCONNECTED_UPDATE_MS : DURATION_IMMEDIATELY;
 }
 
 device_t ServoOut_device = {

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -8,6 +8,10 @@
 #include "logging.h"
 #include "rxtx_intf.h"
 
+#if defined(PLATFORM_ESP32)
+#include <driver/periph_ctrl.h>
+#endif
+
 static int8_t servoPins[PWM_MAX_CHANNELS];
 static pwm_channel_t pwmChannels[PWM_MAX_CHANNELS];
 static uint16_t pwmChannelValues[PWM_MAX_CHANNELS];
@@ -353,6 +357,22 @@ static int timeout()
     // When disconnected, return a timeout to feed the ISR watchdog for the PWM signals
     return connectionState == disconnected ? DISCONNECTED_UPDATE_MS : DURATION_IMMEDIATELY;
 }
+
+#if defined(PLATFORM_ESP32)
+// High priority constructor function to reset the hardware modules used for PWM/DShot output.
+// Restarts can leave PWM/RMT peripherals running; so reset them early in the app start process.
+__attribute__((constructor(101))) void resetEsp32PwmDevices()
+{
+    periph_module_reset(PERIPH_LEDC_MODULE);
+    periph_module_reset(PERIPH_RMT_MODULE);
+#if SOC_MCPWM_SUPPORTED
+    periph_module_reset(PERIPH_PWM0_MODULE);
+#if SOC_MCPWM_GROUPS > 1
+    periph_module_reset(PERIPH_PWM1_MODULE);
+#endif
+#endif
+}
+#endif
 
 device_t ServoOut_device = {
     .initialize = initialize,

--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -19,7 +19,8 @@ const uint8_t RMT_MAX_CHANNELS = 8;
 #endif
 
 // true when the RX has a new channels packet
-static bool newChannelsAvailable;
+static volatile bool newChannelsAvailable;
+static uint32_t lastUpdate;
 // Absolute max failsafe time if no update is received, regardless of LQ
 static constexpr uint32_t FAILSAFE_ABS_TIMEOUT_MS = 1000U;
 
@@ -143,6 +144,18 @@ static void servosFailsafe()
     }
 }
 
+static void servosEnterFailsafe()
+{
+    newChannelsAvailable = false;
+    lastUpdate = 0;
+
+    // Outputs are only allocated after the RX has reached connected once.
+    if (initialized)
+    {
+        servosFailsafe();
+    }
+}
+
 static void servoCalcAllChannels(servoWrite_fn write)
 {
     for (int ch = 0 ; ch < GPIO_PIN_PWM_OUTPUTS_COUNT ; ++ch)
@@ -194,7 +207,11 @@ void servoCurrentToFailsafeConfig()
 
 static void servosUpdate(unsigned long now)
 {
-    static uint32_t lastUpdate;
+    if (connectionState != connected || !connectionHasModelMatch || !teamraceHasModelMatch)
+    {
+        servosEnterFailsafe();
+        return;
+    }
 
     if (newChannelsAvailable)
     {
@@ -279,14 +296,9 @@ static bool initialize()
 
 static int event()
 {
-    if (connectionState == disconnected)
-    {
-        // Disconnected should come after failsafe on the RX,
-        // so it is safe to shut down when disconnected
-        return DURATION_NEVER;
-    }
     if (connectionState == wifiUpdate)
     {
+        servosEnterFailsafe();
         for (int ch = 0; ch < GPIO_PIN_PWM_OUTPUTS_COUNT; ++ch)
         {
             if (pwmChannels[ch] != -1)
@@ -304,6 +316,11 @@ static int event()
             servoPins[ch] = UNDEF_PIN;
         }
         return DURATION_NEVER;
+    }
+    if (connectionState != connected)
+    {
+        servosEnterFailsafe();
+        return connectionState == disconnected ? DURATION_NEVER : DURATION_IMMEDIATELY;
     }
     if (!initialized && connectionState == connected)
     {


### PR DESCRIPTION
# Summary

This PR should fix the runaway behaviour seen on ESP8285-based receivers using PWM/servo outputs.

Also included in this PR is an early reset of PWM modules (MCPWM, LEDC & RMT) on ESP32 devices.

# Problem

On ESP8266/ESP8285, PWM is provided by a timer ISR, PWM output generation continues inside the waveform ISR after the last pulse configuration has been written. If channel updates stop, or the servo task stops servicing outputs, the last programmed waveform can keep running indefinitely. In the worst case that leaves motors/servos holding the last command instead of cleanly entering failsafe. This has been seen when there is a semi-brownout condition on the RX; not enough for the MCU to detect a brownout, but enough for the MCU main loop to hang, and the timer interrupts still fire.

On ESP32 devices when the device reboots the ROM, and bootloader do NOT reset the modules! This means that PWM signals are running until ExpressLRS's setup function starts and clears the pins. This is also after some initialization on our side, so could be about 1 second!

# What changed

 - Added a PWMController::feedWatchdog() API.
 - Implemented a 50 ms watchdog in the ESP8266 waveform driver.
 - The watchdog is armed whenever PWM waveforms are started/updated.
 - If the watchdog expires, all active waveforms are stopped and outputs are driven low.
 - Updated devServoOutput to:
   - explicitly enter failsafe whenever the receiver is no longer fully connected/model-matched
   - keep running on a short timeout while disconnected so intentional failsafe PWM continues to service the watchdog
   - avoid leaving stale channel data pending across disconnect/failsafe transitions
   - ESP32; high-priority constructor function to reset MCPWM, LEDC & RMT devices starts at about 450ms after boot time.

# Expected result

 - Stale PWM output should no longer continue forever (or the hardware watchdog fires and reboots the RX) if channel updates stop.
 - Receiver outputs should either:
   - continue the configured failsafe output intentionally while the RX is disconnected, or
   - be shut down by the ISR watchdog if output servicing stops unexpectedly.