### PR TITLE
Preserve more accuracy of CRSF channel values

### DIFF
--- a/src/include/crsf_protocol.h
+++ b/src/include/crsf_protocol.h
@@ -18,7 +18,7 @@
 
 #define CRSF_CHANNEL_VALUE_EXT_MIN      0       // 880us  -121.1% (with E.Limits on)
 #define CRSF_CHANNEL_VALUE_STD_MIN      172     // 988us  -100% (actual CRSF min is 0 with E.Limits on)
-#define CRSF_CHANNEL_VALUE_1000         191     // 1000us
+#define CRSF_CHANNEL_VALUE_1000         192     // 1000us (192=1000.5, 191=999.87)
 #define CRSF_CHANNEL_VALUE_MID          992     // 1500us center
 #define CRSF_CHANNEL_VALUE_2000         1792    // 2000us
 #define CRSF_CHANNEL_VALUE_STD_MAX      1811    // 2012us +100% (actual CRSF max is 1984 with E.Limits on)
@@ -446,12 +446,15 @@ static inline uint16_t ICACHE_RAM_ATTR N_to_CRSF(uint16_t val, uint16_t max)
 // Convert CRSF to 0-(cnt-1), constrained between 1000us and 2000us
 static inline uint16_t ICACHE_RAM_ATTR CRSF_to_N(uint16_t val, uint16_t cnt)
 {
-    // The span is increased by one to prevent the max val from returning cnt
+    // Both endpoints are returned explicitly, so the span does not need to be
+    // biased to keep the max val from returning cnt. Using the true span also
+    // keeps CRSF_CHANNEL_VALUE_MID exactly on the cnt/2 boundary, since it sits
+    // exactly halfway between CRSF_CHANNEL_VALUE_1000 and CRSF_CHANNEL_VALUE_2000
     if (val <= CRSF_CHANNEL_VALUE_1000)
         return 0;
     if (val >= CRSF_CHANNEL_VALUE_2000)
         return cnt - 1;
-    return (val - CRSF_CHANNEL_VALUE_1000) * cnt / (CRSF_CHANNEL_VALUE_2000 - CRSF_CHANNEL_VALUE_1000 + 1);
+    return (val - CRSF_CHANNEL_VALUE_1000) * cnt / (CRSF_CHANNEL_VALUE_2000 - CRSF_CHANNEL_VALUE_1000);
 }
 
 static inline uint8_t ICACHE_RAM_ATTR CRSF_to_SWITCH3b(uint16_t ch)

--- a/src/lib/OTA/OTA.cpp
+++ b/src/lib/OTA/OTA.cpp
@@ -72,16 +72,79 @@ static uint32_t packetCnt;
 /******** Decimate 11bit to 10bit functions ********/
 typedef uint32_t (*Decimate11to10_fn)(uint32_t ch11bit);
 
-static uint32_t ICACHE_RAM_ATTR Decimate11to10_Limit(uint32_t ch11bit)
+// static uint32_t ICACHE_RAM_ATTR Decimate11to10_Limit(uint32_t ch11bit)
+// {
+//     // Limit 10-bit result to the range CRSF_CHANNEL_VALUE_STD_MIN/MAX
+//     return CRSF_to_UINT10(constrain(ch11bit, CRSF_CHANNEL_VALUE_STD_MIN, CRSF_CHANNEL_VALUE_STD_MAX));
+// }
+// static uint32_t ICACHE_RAM_ATTR Decimate11to10_Div2(uint32_t ch11bit)
+// {
+//     // Simple divide-by-2 to discard the bit
+//     return ch11bit >> 1;
+// }
+
+static uint32_t ICACHE_RAM_ATTR Decimate11to10_nlimit(uint32_t ch11bit)
 {
-    // Limit 10-bit result to the range CRSF_CHANNEL_VALUE_STD_MIN/MAX
-    return CRSF_to_UINT10(constrain(ch11bit, CRSF_CHANNEL_VALUE_STD_MIN, CRSF_CHANNEL_VALUE_STD_MAX));
+    // Non-linear piecewise map with don't-care endpoints (R=OTA_DECIMATE_R_NLIMIT)
+    // Inner region [691, 1293]: 1:1 mapping (603 values)
+    // Lower outer [172, 691): 520 values -> 311 levels [1, 311)
+    // Upper outer [1293, 1811]: 519 values -> 311 levels [712, 1022]
+    // Don't care: [0, 172) -> 0, (1811, 1984] -> 1023
+    constexpr uint32_t R = OTA_DECIMATE_R_NLIMIT;
+    constexpr uint32_t center = CRSF_CHANNEL_VALUE_MID;
+    constexpr uint32_t limit_lo = CRSF_CHANNEL_VALUE_STD_MIN;
+    constexpr uint32_t limit_hi = CRSF_CHANNEL_VALUE_STD_MAX;
+    constexpr uint32_t inner_size = 2 * R + 1; // 603
+    constexpr uint32_t half_outer_input = center - R - limit_lo; // 520
+    constexpr uint32_t outer_levels = 1023 - inner_size - 1; // 419
+    constexpr uint32_t half_outer_output = outer_levels / 2; // 209
+    constexpr uint32_t inner_offset = half_outer_output + 1; // 210
+
+    if (ch11bit < limit_lo)
+    {
+        return 0;
+    }
+    if (ch11bit > limit_hi)
+    {
+        return 1023;
+    }
+    if (ch11bit < center - R)
+    {
+        uint32_t offset = ch11bit - limit_lo;
+        return 1 + (offset * (half_outer_output - 1) + half_outer_input / 2) / half_outer_input;
+    }
+    if (ch11bit > center + R)
+    {
+        uint32_t offset = ch11bit - (center + R);
+        return inner_offset + inner_size + (offset * (half_outer_output - 1) + half_outer_input / 2) / half_outer_input;
+    }
+    return inner_offset + (ch11bit - (center - R));
 }
 
-static uint32_t ICACHE_RAM_ATTR Decimate11to10_Div2(uint32_t ch11bit)
+static uint32_t ICACHE_RAM_ATTR Decimate11to10_nmap(uint32_t ch11bit)
 {
-    // Simple divide-by-2 to discard the bit
-    return ch11bit >> 1;
+    // Non-linear piecewise map (R=OTA_DECIMATE_R_NMAP)
+    // Inner region [802, 1182]: 1:1 mapping (381 values)
+    // Lower outer [0, 802): 802 values -> 322 levels [0, 322)
+    // Upper outer [1182, 1984]: 803 values -> 322 levels [702, 1023]
+    constexpr uint32_t R = OTA_DECIMATE_R_NMAP;
+    constexpr uint32_t center = CRSF_CHANNEL_VALUE_MID;
+    constexpr uint32_t inner_size = 2 * R + 1; // 381
+    constexpr uint32_t half_outer_input = center - R; // 802
+    constexpr uint32_t outer_levels = 1023 - inner_size + 1; // 643
+    constexpr uint32_t half_outer_output = outer_levels / 2; // 321
+    constexpr uint32_t inner_offset = half_outer_output; // 321
+
+    if (ch11bit < center - R)
+    {
+        return (ch11bit * half_outer_output + half_outer_input / 2) / half_outer_input;
+    }
+    if (ch11bit > center + R)
+    {
+        uint32_t offset = ch11bit - (center + R);
+        return inner_offset + inner_size + (offset * half_outer_output + half_outer_input / 2) / half_outer_input;
+    }
+    return inner_offset + (ch11bit - (center - R));
 }
 
 /***
@@ -122,9 +185,9 @@ static void ICACHE_RAM_ATTR PackChannelDataHybridCommon(OTA_Packet4_s * const ot
     // Incremental packet counter for verification on the RX side, 32 bits shoved into CH1-CH4
     ota4->dbg_linkstats.packetNum = packetCnt++;
 #else
-    // CRSF input is 11bit and OTA will carry only 10bit. Discard the Extended Limits (E.Limits)
-    // range and use the full 10bits to carry only 998us - 2012us
-    PackUInt11ToChannels4x10(&channelData[0], &ota4->rc.ch, &Decimate11to10_Limit);
+    // CRSF input is 11bit and OTA will carry only 10bit. Use non-linear nlimit encoding
+    // for higher accuracy in the center range with don't-care endpoints
+    PackUInt11ToChannels4x10(&channelData[0], &ota4->rc.ch, &Decimate11to10_nlimit);
 
     // send armed status to receiver
     #if defined(UNIT_TEST)
@@ -267,8 +330,8 @@ static void ICACHE_RAM_ATTR GenerateChannelData8ch12ch(OTA_Packet8_s * const ota
         chSrcLow = 0;
         chSrcHigh = isHighAux ? 8 : 4;
     }
-    PackUInt11ToChannels4x10(&channelData[chSrcLow], &ota8->rc.chLow, &Decimate11to10_Div2);
-    PackUInt11ToChannels4x10(&channelData[chSrcHigh], &ota8->rc.chHigh, &Decimate11to10_Div2);
+    PackUInt11ToChannels4x10(&channelData[chSrcLow], &ota8->rc.chLow, &Decimate11to10_nmap);
+    PackUInt11ToChannels4x10(&channelData[chSrcHigh], &ota8->rc.chHigh, &Decimate11to10_nmap);
 #endif
 }
 
@@ -303,14 +366,83 @@ static bool OtaChannelDataComplete;
 uint32_t debugRcvrLinkstatsPacketId;
 #else
 
-static void UnpackChannels4x10ToUInt11(OTA_Channels_4x10 const * const srcChannels4x10, uint32_t * const dest)
+/******** Expand 10bit to 11bit functions ********/
+
+typedef uint32_t (*Expand10to11_fn)(uint32_t ch10bit);
+
+// static uint32_t ICACHE_RAM_ATTR Expand10to11_limit(uint32_t ch10bit)
+// {
+//     // Wraps the standard UINT10_to_CRSF for testing
+//     return UINT10_to_CRSF(ch10bit);
+// }
+// static uint32_t ICACHE_RAM_ATTR Expand10to11_div2(uint32_t ch10bit)
+// {
+//     // Wraps the standard << 1 for testing
+//     return ch10bit << 1;
+// }
+
+static uint32_t ICACHE_RAM_ATTR Expand10to11_nlimit(uint32_t ch10bit)
+{
+    // Reverse of Decimate11to10_nlimit (R=OTA_DECIMATE_R_NLIMIT)
+    // Don't care: [0] -> 172, [1023] -> 1811
+    // Lower outer [1, 210): 311 levels -> 520 values [172, 691)
+    // Inner [210, 813]: 603 values [691, 1293]
+    // Upper outer [814, 1022]: 311 levels -> 519 values [1293, 1811]
+    constexpr uint32_t R = OTA_DECIMATE_R_NLIMIT;
+    constexpr uint32_t center = CRSF_CHANNEL_VALUE_MID;
+    constexpr uint32_t limit_lo = CRSF_CHANNEL_VALUE_STD_MIN;
+    constexpr uint32_t limit_hi = CRSF_CHANNEL_VALUE_STD_MAX;
+    constexpr uint32_t inner_size = 2 * R + 1; // 603
+    constexpr uint32_t half_outer_input = center - R - limit_lo; // 520
+    constexpr uint32_t outer_levels = 1023 - inner_size - 1; // 419
+    constexpr uint32_t half_outer_output = outer_levels / 2; // 209
+    constexpr uint32_t inner_offset = half_outer_output + 1; // 210
+
+    if (ch10bit < inner_offset)
+    {
+        uint32_t offset = ch10bit - 1;
+        return limit_lo + (offset * half_outer_input + (half_outer_output - 1) / 2) / (half_outer_output - 1);
+    }
+    if (ch10bit >= inner_offset + inner_size)
+    {
+        uint32_t offset = ch10bit - (inner_offset + inner_size);
+        return (center + R) + (offset * half_outer_input + (half_outer_output - 1) / 2) / (half_outer_output - 1);
+    }
+    return (center - R) + (ch10bit - inner_offset);
+}
+
+static uint32_t ICACHE_RAM_ATTR Expand10to11_nmap(uint32_t ch10bit)
+{
+    // Reverse of Decimate11to10_nmap (R=OTA_DECIMATE_R_NMAP)
+    // Lower outer [0, 321): 322 levels -> 802 values [0, 802)
+    // Inner [321, 702]: 381 values [802, 1182]
+    // Upper outer [702, 1023]: 342 levels -> 803 values [1182, 1984]
+    constexpr uint32_t R = OTA_DECIMATE_R_NMAP;
+    constexpr uint32_t center = CRSF_CHANNEL_VALUE_MID;
+    constexpr uint32_t inner_size = 2 * R + 1; // 381
+    constexpr uint32_t half_outer_input = center - R; // 802
+    constexpr uint32_t outer_levels = 1023 - inner_size + 1; // 643
+    constexpr uint32_t half_outer_output = outer_levels / 2; // 321
+    constexpr uint32_t inner_offset = half_outer_output; // 321
+
+    if (ch10bit < inner_offset)
+    {
+        return (ch10bit * half_outer_input + half_outer_output / 2) / half_outer_output;
+    }
+    if (ch10bit >= inner_offset + inner_size)
+    {
+        uint32_t offset = ch10bit - (inner_offset + inner_size);
+        return (center + R) + (offset * half_outer_input + half_outer_output / 2) / half_outer_output;
+    }
+    return (center - R) + (ch10bit - inner_offset);
+}
+
+static void UnpackChannels4x10ToUInt11(OTA_Channels_4x10 const * const srcChannels4x10, uint32_t * const dest, Expand10to11_fn expand)
 {
     uint8_t const * const payload = (uint8_t const * const)srcChannels4x10;
     constexpr unsigned numOfChannels = 4;
     constexpr unsigned srcBits = 10;
-    constexpr unsigned dstBits = 11;
     constexpr unsigned inputChannelMask = (1 << srcBits) - 1;
-    constexpr unsigned precisionShift = dstBits - srcBits;
 
     // code from BetaFlight rx/crsf.cpp / bitpacker_unpack
     uint8_t bitsMerged = 0;
@@ -325,7 +457,7 @@ static void UnpackChannels4x10ToUInt11(OTA_Channels_4x10 const * const srcChanne
             bitsMerged += 8;
         }
         //printf("rv=%x(%x) bm=%u\n", readValue, (readValue & channelMask), bitsMerged);
-        dest[n] = (readValue & inputChannelMask) << precisionShift;
+        dest[n] = expand(readValue & inputChannelMask);
         readValue >>= srcBits;
         bitsMerged -= srcBits;
     }
@@ -339,16 +471,8 @@ static void ICACHE_RAM_ATTR UnpackChannelDataHybridCommon(OTA_Packet4_s const * 
 #if defined(DEBUG_RCVR_LINKSTATS)
     debugRcvrLinkstatsPacketId = ota4->dbg_linkstats.packetNum;
 #else
-    // The analog channels, encoded as 10bit where 0 = 998us and 1023 = 2012us
-    uint32_t rawChannelData[4];
-    UnpackChannels4x10ToUInt11(&ota4->rc.ch, rawChannelData);
-    // The unpacker simply does a << 1 to convert 10 to 11bit, but Hybrid/Wide modes
-    // only pack a subset of the full range CRSF data, so properly expand it
-    // This is ~80 bytes less code than passing an 10-to-11 expander fn to the unpacker
-    for (unsigned ch=0; ch<4; ++ch)
-    {
-        channelData[ch] = UINT10_to_CRSF(rawChannelData[ch] >> 1);
-    }
+    // The analog channels, encoded as 10bit with nlimit non-linear encoding (CRSF STD range)
+    UnpackChannels4x10ToUInt11(&ota4->rc.ch, channelData, &Expand10to11_nlimit);
     channelData[4] = BIT_to_CRSF(isArmed);
     // Copy the armed flag into CH14/AUX10 for consistency with fullres
     channelData[13] = channelData[4];
@@ -458,10 +582,10 @@ bool ICACHE_RAM_ATTR UnpackChannelData8ch(OTA_Packet_s const * const otaPktPtr, 
         channelData[13] = BIT_to_CRSF(isArmed);
     }
 
-    // Analog channels packed 10bit covering the entire CRSF extended range (i.e. not just 988-2012)
+    // Analog channels packed 10bit with nmap non-linear encoding (full CRSF EXT range)
     // ** Different than the 10bit encoding in Hybrid/Wide mode **
-    UnpackChannels4x10ToUInt11(&ota8->rc.chLow, &channelData[chDstLow]);
-    UnpackChannels4x10ToUInt11(&ota8->rc.chHigh, &channelData[chDstHigh]);
+    UnpackChannels4x10ToUInt11(&ota8->rc.chLow, &channelData[chDstLow], &Expand10to11_nmap);
+    UnpackChannels4x10ToUInt11(&ota8->rc.chHigh, &channelData[chDstHigh], &Expand10to11_nmap);
 #endif
     // Restore the uplink_TX_Power range 0-7 -> 1-8
     linkStats.uplink_TX_Power = constrain(ota8->rc.uplinkPower + 1, 1, 8);

--- a/src/lib/OTA/OTA.cpp
+++ b/src/lib/OTA/OTA.cpp
@@ -83,68 +83,49 @@ typedef uint32_t (*Decimate11to10_fn)(uint32_t ch11bit);
 //     return ch11bit >> 1;
 // }
 
-static uint32_t ICACHE_RAM_ATTR Decimate11to10_nlimit(uint32_t ch11bit)
+static __attribute__((noinline)) uint32_t ICACHE_RAM_ATTR Decimate11to10_n(uint32_t ch11bit, uint32_t R, uint32_t lo, bool clamp)
 {
-    // Non-linear piecewise map with don't-care endpoints (R=OTA_DECIMATE_R_NLIMIT)
-    // Inner region [691, 1293]: 1:1 mapping (603 values)
-    // Lower outer [172, 691): 520 values -> 311 levels [1, 311)
-    // Upper outer [1293, 1811]: 519 values -> 311 levels [712, 1022]
-    // Don't care: [0, 172) -> 0, (1811, 1984] -> 1023
-    constexpr uint32_t R = OTA_DECIMATE_R_NLIMIT;
     constexpr uint32_t center = CRSF_CHANNEL_VALUE_MID;
-    constexpr uint32_t limit_lo = CRSF_CHANNEL_VALUE_STD_MIN;
-    constexpr uint32_t limit_hi = CRSF_CHANNEL_VALUE_STD_MAX;
-    constexpr uint32_t inner_size = 2 * R + 1; // 603
-    constexpr uint32_t half_outer_input = center - R - limit_lo; // 520
-    constexpr uint32_t outer_levels = 1023 - inner_size - 1; // 419
-    constexpr uint32_t half_outer_output = outer_levels / 2; // 209
-    constexpr uint32_t inner_offset = half_outer_output + 1; // 210
+    const uint32_t in_span = center - R - lo;
+    const uint32_t mult = 511 - R;
+    const uint32_t inner_offset = mult;
+    const uint32_t base_hi = inner_offset + (2 * R + 1);
 
-    if (ch11bit < limit_lo)
+    if (clamp)
     {
-        return 0;
-    }
-    if (ch11bit > limit_hi)
-    {
-        return 1023;
+        if (ch11bit < lo)
+        {
+            return 0;
+        }
+        // upper bound mirrors the lower one: center + R + in_span - 1
+        if (ch11bit > center + R + in_span - 1)
+        {
+            return 1023;
+        }
     }
     if (ch11bit < center - R)
     {
-        uint32_t offset = ch11bit - limit_lo;
-        return 1 + (offset * (half_outer_output - 1) + half_outer_input / 2) / half_outer_input;
+        uint32_t offset = ch11bit - lo;
+        return (offset * mult + in_span / 2) / in_span;
     }
     if (ch11bit > center + R)
     {
         uint32_t offset = ch11bit - (center + R);
-        return inner_offset + inner_size + (offset * (half_outer_output - 1) + half_outer_input / 2) / half_outer_input;
+        return base_hi + (offset * mult + in_span / 2) / in_span;
     }
     return inner_offset + (ch11bit - (center - R));
 }
 
+// nlimit: CRSF standard range, clamps out-of-range inputs to the extreme codes
+static uint32_t ICACHE_RAM_ATTR Decimate11to10_nlimit(uint32_t ch11bit)
+{
+    return Decimate11to10_n(ch11bit, OTA_DECIMATE_R_NLIMIT, CRSF_CHANNEL_VALUE_STD_MIN, true);
+}
+
+// nmap: full CRSF range, no clamp needed
 static uint32_t ICACHE_RAM_ATTR Decimate11to10_nmap(uint32_t ch11bit)
 {
-    // Non-linear piecewise map (R=OTA_DECIMATE_R_NMAP)
-    // Inner region [802, 1182]: 1:1 mapping (381 values)
-    // Lower outer [0, 802): 802 values -> 322 levels [0, 322)
-    // Upper outer [1182, 1984]: 803 values -> 322 levels [702, 1023]
-    constexpr uint32_t R = OTA_DECIMATE_R_NMAP;
-    constexpr uint32_t center = CRSF_CHANNEL_VALUE_MID;
-    constexpr uint32_t inner_size = 2 * R + 1; // 381
-    constexpr uint32_t half_outer_input = center - R; // 802
-    constexpr uint32_t outer_levels = 1023 - inner_size + 1; // 643
-    constexpr uint32_t half_outer_output = outer_levels / 2; // 321
-    constexpr uint32_t inner_offset = half_outer_output; // 321
-
-    if (ch11bit < center - R)
-    {
-        return (ch11bit * half_outer_output + half_outer_input / 2) / half_outer_input;
-    }
-    if (ch11bit > center + R)
-    {
-        uint32_t offset = ch11bit - (center + R);
-        return inner_offset + inner_size + (offset * half_outer_output + half_outer_input / 2) / half_outer_input;
-    }
-    return inner_offset + (ch11bit - (center - R));
+    return Decimate11to10_n(ch11bit, OTA_DECIMATE_R_NMAP, CRSF_CHANNEL_VALUE_EXT_MIN, false);
 }
 
 /***
@@ -381,60 +362,36 @@ typedef uint32_t (*Expand10to11_fn)(uint32_t ch10bit);
 //     return ch10bit << 1;
 // }
 
-static uint32_t ICACHE_RAM_ATTR Expand10to11_nlimit(uint32_t ch10bit)
+static __attribute__((noinline)) uint32_t ICACHE_RAM_ATTR Expand10to11_n(uint32_t ch10bit, uint32_t R, uint32_t lo)
 {
-    // Reverse of Decimate11to10_nlimit (R=OTA_DECIMATE_R_NLIMIT)
-    // Don't care: [0] -> 172, [1023] -> 1811
-    // Lower outer [1, 210): 311 levels -> 520 values [172, 691)
-    // Inner [210, 813]: 603 values [691, 1293]
-    // Upper outer [814, 1022]: 311 levels -> 519 values [1293, 1811]
-    constexpr uint32_t R = OTA_DECIMATE_R_NLIMIT;
     constexpr uint32_t center = CRSF_CHANNEL_VALUE_MID;
-    constexpr uint32_t limit_lo = CRSF_CHANNEL_VALUE_STD_MIN;
-    constexpr uint32_t limit_hi = CRSF_CHANNEL_VALUE_STD_MAX;
-    constexpr uint32_t inner_size = 2 * R + 1; // 603
-    constexpr uint32_t half_outer_input = center - R - limit_lo; // 520
-    constexpr uint32_t outer_levels = 1023 - inner_size - 1; // 419
-    constexpr uint32_t half_outer_output = outer_levels / 2; // 209
-    constexpr uint32_t inner_offset = half_outer_output + 1; // 210
+    const uint32_t in_span = center - R - lo;
+    const uint32_t mult = 511 - R;
+    const uint32_t inner_offset = mult;
+    const uint32_t base_hi = inner_offset + (2 * R + 1);
 
     if (ch10bit < inner_offset)
     {
-        uint32_t offset = ch10bit - 1;
-        return limit_lo + (offset * half_outer_input + (half_outer_output - 1) / 2) / (half_outer_output - 1);
+        return lo + (ch10bit * in_span + mult / 2) / mult;
     }
-    if (ch10bit >= inner_offset + inner_size)
+    if (ch10bit >= base_hi)
     {
-        uint32_t offset = ch10bit - (inner_offset + inner_size);
-        return (center + R) + (offset * half_outer_input + (half_outer_output - 1) / 2) / (half_outer_output - 1);
+        uint32_t offset = ch10bit - base_hi;
+        return (center + R) + (offset * in_span + mult / 2) / mult;
     }
     return (center - R) + (ch10bit - inner_offset);
 }
 
+// nlimit: reverse of Decimate11to10_nlimit
+static uint32_t ICACHE_RAM_ATTR Expand10to11_nlimit(uint32_t ch10bit)
+{
+    return Expand10to11_n(ch10bit, OTA_DECIMATE_R_NLIMIT, CRSF_CHANNEL_VALUE_STD_MIN);
+}
+
+// nmap: reverse of Decimate11to10_nmap
 static uint32_t ICACHE_RAM_ATTR Expand10to11_nmap(uint32_t ch10bit)
 {
-    // Reverse of Decimate11to10_nmap (R=OTA_DECIMATE_R_NMAP)
-    // Lower outer [0, 321): 322 levels -> 802 values [0, 802)
-    // Inner [321, 702]: 381 values [802, 1182]
-    // Upper outer [702, 1023]: 342 levels -> 803 values [1182, 1984]
-    constexpr uint32_t R = OTA_DECIMATE_R_NMAP;
-    constexpr uint32_t center = CRSF_CHANNEL_VALUE_MID;
-    constexpr uint32_t inner_size = 2 * R + 1; // 381
-    constexpr uint32_t half_outer_input = center - R; // 802
-    constexpr uint32_t outer_levels = 1023 - inner_size + 1; // 643
-    constexpr uint32_t half_outer_output = outer_levels / 2; // 321
-    constexpr uint32_t inner_offset = half_outer_output; // 321
-
-    if (ch10bit < inner_offset)
-    {
-        return (ch10bit * half_outer_input + half_outer_output / 2) / half_outer_output;
-    }
-    if (ch10bit >= inner_offset + inner_size)
-    {
-        uint32_t offset = ch10bit - (inner_offset + inner_size);
-        return (center + R) + (offset * half_outer_input + half_outer_output / 2) / half_outer_output;
-    }
-    return (center - R) + (ch10bit - inner_offset);
+    return Expand10to11_n(ch10bit, OTA_DECIMATE_R_NMAP, CRSF_CHANNEL_VALUE_EXT_MIN);
 }
 
 static void UnpackChannels4x10ToUInt11(OTA_Channels_4x10 const * const srcChannels4x10, uint32_t * const dest, Expand10to11_fn expand)

--- a/src/lib/OTA/OTA.cpp
+++ b/src/lib/OTA/OTA.cpp
@@ -116,10 +116,10 @@ static __attribute__((noinline)) uint32_t ICACHE_RAM_ATTR Decimate11to10_n(uint3
     return inner_offset + (ch11bit - (center - R));
 }
 
-// nlimit: CRSF standard range, clamps out-of-range inputs to the extreme codes
+// nlimit: 1000-2000us range, clamps out-of-range inputs to the extreme codes
 static uint32_t ICACHE_RAM_ATTR Decimate11to10_nlimit(uint32_t ch11bit)
 {
-    return Decimate11to10_n(ch11bit, OTA_DECIMATE_R_NLIMIT, CRSF_CHANNEL_VALUE_STD_MIN, true);
+    return Decimate11to10_n(ch11bit, OTA_DECIMATE_R_NLIMIT, CRSF_CHANNEL_VALUE_1000, true);
 }
 
 // nmap: full CRSF range, no clamp needed
@@ -385,7 +385,7 @@ static __attribute__((noinline)) uint32_t ICACHE_RAM_ATTR Expand10to11_n(uint32_
 // nlimit: reverse of Decimate11to10_nlimit
 static uint32_t ICACHE_RAM_ATTR Expand10to11_nlimit(uint32_t ch10bit)
 {
-    return Expand10to11_n(ch10bit, OTA_DECIMATE_R_NLIMIT, CRSF_CHANNEL_VALUE_STD_MIN);
+    return Expand10to11_n(ch10bit, OTA_DECIMATE_R_NLIMIT, CRSF_CHANNEL_VALUE_1000);
 }
 
 // nmap: reverse of Decimate11to10_nmap
@@ -428,7 +428,7 @@ static void ICACHE_RAM_ATTR UnpackChannelDataHybridCommon(OTA_Packet4_s const * 
 #if defined(DEBUG_RCVR_LINKSTATS)
     debugRcvrLinkstatsPacketId = ota4->dbg_linkstats.packetNum;
 #else
-    // The analog channels, encoded as 10bit with nlimit non-linear encoding (CRSF STD range)
+    // The analog channels, encoded as 10bit with nlimit non-linear encoding (1000-2000us range)
     UnpackChannels4x10ToUInt11(&ota4->rc.ch, channelData, &Expand10to11_nlimit);
     channelData[4] = BIT_to_CRSF(isArmed);
     // Copy the armed flag into CH14/AUX10 for consistency with fullres

--- a/src/lib/OTA/OTA.h
+++ b/src/lib/OTA/OTA.h
@@ -167,6 +167,10 @@ typedef struct {
 
 enum OtaSwitchMode_e { smWideOr8ch = 0, smHybridOr16ch = 1, sm12ch = 2 };
 
+// Radius used for center-preserving Decimate/Expand functions (CRSF units)
+constexpr uint32_t OTA_DECIMATE_R_NLIMIT = 301;
+constexpr uint32_t OTA_DECIMATE_R_NMAP = 190;
+
 extern uint8_t UID[UID_LEN];
 extern elrsLinkStatistics_t linkStats;
 extern bool isArmed;

--- a/src/lib/OTA/OTA.h
+++ b/src/lib/OTA/OTA.h
@@ -168,7 +168,7 @@ typedef struct {
 enum OtaSwitchMode_e { smWideOr8ch = 0, smHybridOr16ch = 1, sm12ch = 2 };
 
 // Radius used for center-preserving Decimate/Expand functions (CRSF units)
-constexpr uint32_t OTA_DECIMATE_R_NLIMIT = 301;
+constexpr uint32_t OTA_DECIMATE_R_NLIMIT = 366;
 constexpr uint32_t OTA_DECIMATE_R_NMAP = 190;
 
 extern uint8_t UID[UID_LEN];

--- a/src/test/test_ota/test_switches.cpp
+++ b/src/test/test_ota/test_switches.cpp
@@ -157,7 +157,7 @@ void test_encodingHybrid8(bool highResChannel)
     TEST_ASSERT_EQUAL(header, TXdataBuffer[0]);
 
     // bytes 1 through 5 are 10 bit packed analog channels using nlimit encoding
-    uint8_t expected[5] = { 0x31, 0x44, 0x7d, 0x06, 0xe2 };
+    uint8_t expected[5] = { 0x30, 0x44, 0x7d, 0x06, 0xe2 };
     TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, &TXdataBuffer[1], 5);
 
     // byte 6 is the switch encoding
@@ -235,7 +235,7 @@ void test_decodingHybrid8(uint8_t forceSwitch, uint8_t switchval)
     OtaUnpackChannelData(otaPktPtr, ChannelData);
 
     // compare the unpacked results with the input data (nlimit may have ±1 quantization error)
-    uint16_t expectedDecoded[4] = {292, 1383, 427, 1520};
+    uint16_t expectedDecoded[4] = {291, 1382, 427, 1518};
     for (unsigned ch=0; ch<4; ++ch)
     {
         TEST_ASSERT_EQUAL(expectedDecoded[ch], ChannelData[ch]);
@@ -363,7 +363,7 @@ void test_encodingHybridWide(uint8_t nonce)
     TEST_ASSERT_EQUAL(header, TXdataBuffer[0]);
 
     // bytes 1 through 5 are 10 bit packed analog channels using nlimit encoding
-    uint8_t expected[5] = { 0x31, 0x44, 0x7d, 0x06, 0xe2 };
+    uint8_t expected[5] = { 0x30, 0x44, 0x7d, 0x06, 0xe2 };
     TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, &TXdataBuffer[1], 5);
 
     // byte 6 is the switches encoded
@@ -437,7 +437,7 @@ void test_decodingHybridWide(uint8_t nonce, uint8_t forceSwitch, uint16_t forceV
     bool telemResult = OtaUnpackChannelData(otaPktPtr, ChannelData);
 
     // compare the unpacked results with the input data (nlimit may have ±1 quantization error)
-    uint16_t expectedDecoded[4] = {292, 1383, 427, 1520};
+    uint16_t expectedDecoded[4] = {291, 1382, 427, 1518};
     for (unsigned ch=0; ch<4; ++ch)
     {
         TEST_ASSERT_EQUAL(expectedDecoded[ch], ChannelData[ch]);

--- a/src/test/test_ota/test_switches.cpp
+++ b/src/test/test_ota/test_switches.cpp
@@ -156,8 +156,8 @@ void test_encodingHybrid8(bool highResChannel)
     uint8_t header = PACKET_TYPE_RCDATA;
     TEST_ASSERT_EQUAL(header, TXdataBuffer[0]);
 
-    // bytes 1 through 5 are 10 bit packed analog channels representing 998-2012 (CRSF_CHANNEL_VALUE_STD_MIN-CRSF_CHANNEL_VALUE_STD_MAX)
-    uint8_t expected[5] = { 0x4a, 0xd0, 0xfb, 0x49, 0xd2 };
+    // bytes 1 through 5 are 10 bit packed analog channels using nlimit encoding
+    uint8_t expected[5] = { 0x31, 0x44, 0x7d, 0x06, 0xe2 };
     TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, &TXdataBuffer[1], 5);
 
     // byte 6 is the switch encoding
@@ -234,11 +234,12 @@ void test_decodingHybrid8(uint8_t forceSwitch, uint8_t switchval)
     // run the decoder, results in crsf->PackedRCdataOut
     OtaUnpackChannelData(otaPktPtr, ChannelData);
 
-    // compare the unpacked results with the input data
-    TEST_ASSERT_EQUAL(ChannelsIn[0], ChannelData[0]);
-    TEST_ASSERT_EQUAL(ChannelsIn[1], ChannelData[1]);
-    TEST_ASSERT_EQUAL(ChannelsIn[2], ChannelData[2]);
-    TEST_ASSERT_EQUAL(ChannelsIn[3], ChannelData[3]);
+    // compare the unpacked results with the input data (nlimit may have ±1 quantization error)
+    uint16_t expectedDecoded[4] = {292, 1383, 427, 1520};
+    for (unsigned ch=0; ch<4; ++ch)
+    {
+        TEST_ASSERT_EQUAL(expectedDecoded[ch], ChannelData[ch]);
+    }
 
     TEST_ASSERT_EQUAL(ChannelsIn[4+0], ChannelData[4]); // Switch 0 is sent on every packet
     if (forceSwitch == 7)
@@ -361,8 +362,8 @@ void test_encodingHybridWide(uint8_t nonce)
     uint8_t header = PACKET_TYPE_RCDATA;
     TEST_ASSERT_EQUAL(header, TXdataBuffer[0]);
 
-    // bytes 1 through 5 are 10 bit packed analog channels representing 998-2012 (CRSF_CHANNEL_VALUE_STD_MIN-CRSF_CHANNEL_VALUE_STD_MAX)
-    uint8_t expected[5] = { 0x4a, 0xd0, 0xfb, 0x49, 0xd2 };
+    // bytes 1 through 5 are 10 bit packed analog channels using nlimit encoding
+    uint8_t expected[5] = { 0x31, 0x44, 0x7d, 0x06, 0xe2 };
     TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, &TXdataBuffer[1], 5);
 
     // byte 6 is the switches encoded
@@ -435,11 +436,12 @@ void test_decodingHybridWide(uint8_t nonce, uint8_t forceSwitch, uint16_t forceV
     // run the decoder, results in crsf->PackedRCdataOut
     bool telemResult = OtaUnpackChannelData(otaPktPtr, ChannelData);
 
-    // compare the unpacked results with the input data
-    TEST_ASSERT_EQUAL(ChannelsIn[0], ChannelData[0]);
-    TEST_ASSERT_EQUAL(ChannelsIn[1], ChannelData[1]);
-    TEST_ASSERT_EQUAL(ChannelsIn[2], ChannelData[2]);
-    TEST_ASSERT_EQUAL(ChannelsIn[3], ChannelData[3]);
+    // compare the unpacked results with the input data (nlimit may have ±1 quantization error)
+    uint16_t expectedDecoded[4] = {292, 1383, 427, 1520};
+    for (unsigned ch=0; ch<4; ++ch)
+    {
+        TEST_ASSERT_EQUAL(expectedDecoded[ch], ChannelData[ch]);
+    }
 
     // Switch 0 is sent on every packet
     TEST_ASSERT_EQUAL(ChannelData[4], ChannelData[4]);
@@ -521,20 +523,11 @@ void test_encodingFullres8ch()
     OtaUpdateSerializers(smWideOr8ch, OTA8_PACKET_SIZE);
     OtaPackChannelData(otaPktPtr, ChannelData, false);
 
-    // Low 4ch (CH1-CH4)
-    uint8_t expected[5];
-    expected[0] = ((ChannelsIn[0] >> 1) >> 0);
-    expected[1] = ((ChannelsIn[0] >> 1) >> 8) | ((ChannelsIn[1] >> 1) << 2);
-    expected[2] = ((ChannelsIn[1] >> 1) >> 6) | ((ChannelsIn[2] >> 1) << 4);
-    expected[3] = ((ChannelsIn[2] >> 1) >> 4) | ((ChannelsIn[3] >> 1) << 6);
-    expected[4] = ((ChannelsIn[3] >> 1) >> 2);
+    // Low 4ch (CH1-CH4) - nmap encoded
+    uint8_t expected[5] = {0x74, 0x38, 0xbc, 0x4a, 0xd1};
     TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, &TXdataBuffer[offsetof(OTA_Packet8_s, rc.chLow)], 5);
-    // High 4ch (CH5-CH8)
-    expected[0] = ((ChannelsIn[4] >> 1) >> 0);
-    expected[1] = ((ChannelsIn[4] >> 1) >> 8) | ((ChannelsIn[5] >> 1) << 2);
-    expected[2] = ((ChannelsIn[5] >> 1) >> 6) | ((ChannelsIn[6] >> 1) << 4);
-    expected[3] = ((ChannelsIn[6] >> 1) >> 4) | ((ChannelsIn[7] >> 1) << 6);
-    expected[4] = ((ChannelsIn[7] >> 1) >> 2);
+    // High 4ch (CH5-CH8) - nmap encoded
+    expected[0] = 0xd3; expected[1] = 0xb4; expected[2] = 0xad; expected[3] = 0x10; expected[4] = 0xe9;
     TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, &TXdataBuffer[offsetof(OTA_Packet8_s, rc.chHigh)], 5);
 
     // Check the header bits
@@ -562,38 +555,21 @@ void test_encodingFullres16ch()
     // ** PACKET ONE **
     memset(TXdataBuffer, 0, sizeof(TXdataBuffer)); // "destChannels4x10 must be zeroed"
     OtaPackChannelData(otaPktPtr, ChannelData, false);
-    // Low 4ch (CH1-CH4)
-    uint8_t expected[5];
-    expected[0] = ((ChannelsIn[0] >> 1) >> 0);
-    expected[1] = ((ChannelsIn[0] >> 1) >> 8) | ((ChannelsIn[1] >> 1) << 2);
-    expected[2] = ((ChannelsIn[1] >> 1) >> 6) | ((ChannelsIn[2] >> 1) << 4);
-    expected[3] = ((ChannelsIn[2] >> 1) >> 4) | ((ChannelsIn[3] >> 1) << 6);
-    expected[4] = ((ChannelsIn[3] >> 1) >> 2);
+    // Low 4ch (CH1-CH4) - nmap encoded
+    uint8_t expected[5] = {0x74, 0x38, 0xbc, 0x4a, 0xd1};
     TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, &TXdataBuffer[offsetof(OTA_Packet8_s, rc.chLow)], 5);
-    // High 4ch, includes AUX1 (CH5-CH8)
-    expected[0] = ((ChannelsIn[4] >> 1) >> 0);
-    expected[1] = ((ChannelsIn[4] >> 1) >> 8) | ((ChannelsIn[5] >> 1) << 2);
-    expected[2] = ((ChannelsIn[5] >> 1) >> 6) | ((ChannelsIn[6] >> 1) << 4);
-    expected[3] = ((ChannelsIn[6] >> 1) >> 4) | ((ChannelsIn[7] >> 1) << 6);
-    expected[4] = ((ChannelsIn[7] >> 1) >> 2);
+    // High 4ch, includes AUX1 (CH5-CH8) - nmap encoded
+    expected[0] = 0xd3; expected[1] = 0xb4; expected[2] = 0xad; expected[3] = 0x10; expected[4] = 0xe9;
     TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, &TXdataBuffer[offsetof(OTA_Packet8_s, rc.chHigh)], 5);
 
     // ** PACKET TWO **
     memset(TXdataBuffer, 0, sizeof(TXdataBuffer)); // "destChannels4x10 must be zeroed"
     OtaPackChannelData(otaPktPtr, ChannelData, false);
-    // Low 4ch (CH9-CH12)
-    expected[0] = ((ChannelsIn[8] >> 1) >> 0);
-    expected[1] = ((ChannelsIn[8] >> 1) >> 8) | ((ChannelsIn[9] >> 1) << 2);
-    expected[2] = ((ChannelsIn[9] >> 1) >> 6) | ((ChannelsIn[10] >> 1) << 4);
-    expected[3] = ((ChannelsIn[10] >> 1) >> 4) | ((ChannelsIn[11] >> 1) << 6);
-    expected[4] = ((ChannelsIn[11] >> 1) >> 2);
+    // Low 4ch (CH9-CH12) - nmap encoded
+    expected[0] = 0x34; expected[1] = 0x39; expected[2] = 0x8f; expected[3] = 0x1a; expected[4] = 0x01;
     TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, &TXdataBuffer[offsetof(OTA_Packet8_s, rc.chLow)], 5);
-    // High 4ch (CH13-CH16)
-    expected[0] = ((ChannelsIn[12] >> 1) >> 0);
-    expected[1] = ((ChannelsIn[12] >> 1) >> 8) | ((ChannelsIn[13] >> 1) << 2);
-    expected[2] = ((ChannelsIn[13] >> 1) >> 6) | ((ChannelsIn[14] >> 1) << 4);
-    expected[3] = ((ChannelsIn[14] >> 1) >> 4) | ((ChannelsIn[15] >> 1) << 6);
-    expected[4] = ((ChannelsIn[15] >> 1) >> 2);
+    // High 4ch (CH13-CH16) - nmap encoded
+    expected[0] = 0x0e; expected[1] = 0x54; expected[2] = 0xaa; expected[3] = 0x04; expected[4] = 0xb9;
     TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, &TXdataBuffer[offsetof(OTA_Packet8_s, rc.chHigh)], 5);
 }
 
@@ -614,38 +590,21 @@ void test_encodingFullres12ch()
     // ** PACKET ONE **
     memset(TXdataBuffer, 0, sizeof(TXdataBuffer)); // "destChannels4x10 must be zeroed"
     OtaPackChannelData(otaPktPtr, ChannelData, false);
-    // Low 4ch (CH1-CH4)
-    uint8_t expected[5];
-    expected[0] = ((ChannelsIn[0] >> 1) >> 0);
-    expected[1] = ((ChannelsIn[0] >> 1) >> 8) | ((ChannelsIn[1] >> 1) << 2);
-    expected[2] = ((ChannelsIn[1] >> 1) >> 6) | ((ChannelsIn[2] >> 1) << 4);
-    expected[3] = ((ChannelsIn[2] >> 1) >> 4) | ((ChannelsIn[3] >> 1) << 6);
-    expected[4] = ((ChannelsIn[3] >> 1) >> 2);
+    // Low 4ch (CH1-CH4) - nmap encoded
+    uint8_t expected[5] = {0x74, 0x38, 0xbc, 0x4a, 0xd1};
     TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, &TXdataBuffer[offsetof(OTA_Packet8_s, rc.chLow)], 5);
-    // High 4ch (CH5-CH8)
-    expected[0] = ((ChannelsIn[4] >> 1) >> 0);
-    expected[1] = ((ChannelsIn[4] >> 1) >> 8) | ((ChannelsIn[5] >> 1) << 2);
-    expected[2] = ((ChannelsIn[5] >> 1) >> 6) | ((ChannelsIn[6] >> 1) << 4);
-    expected[3] = ((ChannelsIn[6] >> 1) >> 4) | ((ChannelsIn[7] >> 1) << 6);
-    expected[4] = ((ChannelsIn[7] >> 1) >> 2);
+    // High 4ch (CH5-CH8) - nmap encoded
+    expected[0] = 0xd3; expected[1] = 0xb4; expected[2] = 0xad; expected[3] = 0x10; expected[4] = 0xe9;
     TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, &TXdataBuffer[offsetof(OTA_Packet8_s, rc.chHigh)], 5);
 
     // ** PACKET TWO **
     memset(TXdataBuffer, 0, sizeof(TXdataBuffer)); // "destChannels4x10 must be zeroed"
     OtaPackChannelData(otaPktPtr, ChannelData, false);
-    // Low 4ch (CH1-CH4)
-    expected[0] = ((ChannelsIn[0] >> 1) >> 0);
-    expected[1] = ((ChannelsIn[0] >> 1) >> 8) | ((ChannelsIn[1] >> 1) << 2);
-    expected[2] = ((ChannelsIn[1] >> 1) >> 6) | ((ChannelsIn[2] >> 1) << 4);
-    expected[3] = ((ChannelsIn[2] >> 1) >> 4) | ((ChannelsIn[3] >> 1) << 6);
-    expected[4] = ((ChannelsIn[3] >> 1) >> 2);
+    // Low 4ch (CH1-CH4) - nmap encoded
+    expected[0] = 0x74; expected[1] = 0x38; expected[2] = 0xbc; expected[3] = 0x4a; expected[4] = 0xd1;
     TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, &TXdataBuffer[offsetof(OTA_Packet8_s, rc.chLow)], 5);
-    // Other high 4ch (CH9-CH12)
-    expected[0] = ((ChannelsIn[8] >> 1) >> 0);
-    expected[1] = ((ChannelsIn[8] >> 1) >> 8) | ((ChannelsIn[9] >> 1) << 2);
-    expected[2] = ((ChannelsIn[9] >> 1) >> 6) | ((ChannelsIn[10] >> 1) << 4);
-    expected[3] = ((ChannelsIn[10] >> 1) >> 4) | ((ChannelsIn[11] >> 1) << 6);
-    expected[4] = ((ChannelsIn[11] >> 1) >> 2);
+    // Other high 4ch (CH9-CH12) - nmap encoded
+    expected[0] = 0x34; expected[1] = 0x39; expected[2] = 0x8f; expected[3] = 0x1a; expected[4] = 0x01;
     TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, &TXdataBuffer[offsetof(OTA_Packet8_s, rc.chHigh)], 5);
 }
 
@@ -667,18 +626,22 @@ void test_decodingFullres16chLow()
     memset(TXdataBuffer, 0, sizeof(TXdataBuffer)); // "destChannels4x10 must be zeroed"
     OtaPackChannelData(otaPktPtr, ChannelData, false);
     OtaUnpackChannelData(otaPktPtr, ChannelData);
+    // nmap decode expected values (may have ±1 quantization error vs original)
+    uint16_t expectedDecoded1[8] = {290, 1382, 427, 1519, 527, 1619, 665, 1757};
     for (unsigned ch=0; ch<8; ++ch)
     {
-        TEST_ASSERT_EQUAL(ChannelsIn[ch] & 0b11111111110, ChannelData[ch]);
+        TEST_ASSERT_EQUAL(expectedDecoded1[ch], ChannelData[ch]);
     }
 
     // ** PACKET TWO **
     memset(TXdataBuffer, 0, sizeof(TXdataBuffer)); // "destChannels4x10 must be zeroed"
     OtaPackChannelData(otaPktPtr, ChannelData, false);
     OtaUnpackChannelData(otaPktPtr, ChannelData);
-    for (unsigned ch=9; ch<16; ++ch)
+    // nmap decode expected values for CH9-CH15
+    uint16_t expectedDecoded2[7] = {1862, 905, 10, 35, 1142, 185, 1277};
+    for (unsigned i=0; i<7; ++i)
     {
-        TEST_ASSERT_EQUAL(ChannelsIn[ch] & 0b11111111110, ChannelData[ch]);
+        TEST_ASSERT_EQUAL(expectedDecoded2[i], ChannelData[9+i]);
     }
 }
 
@@ -694,6 +657,48 @@ void test_decodingHybridWide_AUXX_low()
     constexpr int N_SWITCHES = 8;
     for (int i=0; i<N_SWITCHES; ++i)
         test_decodingHybridWide(i, 0, CRSF_CHANNEL_VALUE_1000);
+}
+
+void test_n_quantization_common(size_t ota_packet_size, uint32_t R, uint32_t crsf_low, uint32_t crsf_high)
+{
+    uint8_t TXdataBuffer[ota_packet_size]{};
+    OTA_Packet_s * const otaPktPtr = (OTA_Packet_s *)TXdataBuffer;
+
+    OtaUpdateSerializers(smWideOr8ch, ota_packet_size);
+
+    constexpr uint32_t center = CRSF_CHANNEL_VALUE_MID;
+    uint32_t inner_lo = center - R;
+    uint32_t inner_hi = center + R;
+
+    for (uint32_t val = crsf_low; val <= crsf_high; ++val)
+    {
+        memset(ChannelData, 0, sizeof(ChannelData));
+        ChannelData[0] = val;
+        memset(TXdataBuffer, 0, sizeof(TXdataBuffer));
+
+        OtaPackChannelData(otaPktPtr, ChannelData, false);
+        OtaUnpackChannelData(otaPktPtr, ChannelData);
+
+        if (val >= inner_lo && val <= inner_hi)
+        {
+            TEST_ASSERT_EQUAL_MESSAGE(val, ChannelData[0], "inner region should decode exactly");
+        }
+        else
+        {
+            int diff = ChannelData[0] > val ? (int)ChannelData[0] - val : (int)val - ChannelData[0];
+            TEST_ASSERT_LESS_THAN_MESSAGE(2, diff, "outer region should be within +/-1");
+        }
+    }
+}
+
+void test_nlimit_quantization()
+{
+    test_n_quantization_common(OTA4_PACKET_SIZE, OTA_DECIMATE_R_NLIMIT, CRSF_CHANNEL_VALUE_STD_MIN, CRSF_CHANNEL_VALUE_STD_MAX);
+}
+
+void test_nmap_quantization()
+{
+    test_n_quantization_common(OTA8_PACKET_SIZE, OTA_DECIMATE_R_NMAP, CRSF_CHANNEL_VALUE_EXT_MIN, CRSF_CHANNEL_VALUE_EXT_MAX);
 }
 
 // Unity setup/teardown
@@ -726,6 +731,9 @@ int main(int argc, char **argv)
     RUN_TEST(test_encodingFullres16ch);
     RUN_TEST(test_encodingFullres12ch);
     RUN_TEST(test_decodingFullres16chLow);
+
+    RUN_TEST(test_nlimit_quantization);
+    RUN_TEST(test_nmap_quantization);
 
     UNITY_END();
 

--- a/src/test/test_ota/test_switches.cpp
+++ b/src/test/test_ota/test_switches.cpp
@@ -54,7 +54,7 @@ void test_crsf_endpoints()
 
     // Validate important values are still the same value when mapped and umapped from their 10-bit representations
     TEST_ASSERT_EQUAL(CRSF_CHANNEL_VALUE_STD_MIN,  Crsf_to_Uint10_to_Crsf(CRSF_CHANNEL_VALUE_STD_MIN));
-    TEST_ASSERT_EQUAL(CRSF_CHANNEL_VALUE_1000, Crsf_to_Uint10_to_Crsf(CRSF_CHANNEL_VALUE_1000));
+    TEST_ASSERT_EQUAL(CRSF_CHANNEL_VALUE_1000-1, Crsf_to_Uint10_to_Crsf(CRSF_CHANNEL_VALUE_1000)); // NOTE: 192 is not one of the 1024 values the linear 10-bit map preserves, it comes back as 191
     TEST_ASSERT_EQUAL(CRSF_CHANNEL_VALUE_MID,  Crsf_to_Uint10_to_Crsf(CRSF_CHANNEL_VALUE_MID));
     TEST_ASSERT_EQUAL(CRSF_CHANNEL_VALUE_2000, Crsf_to_Uint10_to_Crsf(CRSF_CHANNEL_VALUE_2000));
     TEST_ASSERT_EQUAL(CRSF_CHANNEL_VALUE_STD_MAX,  Crsf_to_Uint10_to_Crsf(CRSF_CHANNEL_VALUE_STD_MAX));
@@ -96,7 +96,7 @@ void test_nToCrsf()
 
     // 7-bit
     TEST_ASSERT_EQUAL(CRSF_CHANNEL_VALUE_1000, N_to_CRSF(0, 127));
-    TEST_ASSERT_EQUAL(997, N_to_CRSF(0b1000000, 127));
+    TEST_ASSERT_EQUAL(998, N_to_CRSF(0b1000000, 127));
     TEST_ASSERT_EQUAL(CRSF_CHANNEL_VALUE_2000, N_to_CRSF(0b1111111, 127));
 }
 
@@ -157,7 +157,7 @@ void test_encodingHybrid8(bool highResChannel)
     TEST_ASSERT_EQUAL(header, TXdataBuffer[0]);
 
     // bytes 1 through 5 are 10 bit packed analog channels using nlimit encoding
-    uint8_t expected[5] = { 0x30, 0x44, 0x7d, 0x06, 0xe2 };
+    uint8_t expected[5] = { 0x21, 0xd8, 0xfd, 0x04, 0xe9 };
     TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, &TXdataBuffer[1], 5);
 
     // byte 6 is the switch encoding
@@ -235,7 +235,7 @@ void test_decodingHybrid8(uint8_t forceSwitch, uint8_t switchval)
     OtaUnpackChannelData(otaPktPtr, ChannelData);
 
     // compare the unpacked results with the input data (nlimit may have ±1 quantization error)
-    uint16_t expectedDecoded[4] = {291, 1382, 427, 1518};
+    uint16_t expectedDecoded[4] = {291, 1382, 428, 1520};
     for (unsigned ch=0; ch<4; ++ch)
     {
         TEST_ASSERT_EQUAL(expectedDecoded[ch], ChannelData[ch]);
@@ -363,7 +363,7 @@ void test_encodingHybridWide(uint8_t nonce)
     TEST_ASSERT_EQUAL(header, TXdataBuffer[0]);
 
     // bytes 1 through 5 are 10 bit packed analog channels using nlimit encoding
-    uint8_t expected[5] = { 0x30, 0x44, 0x7d, 0x06, 0xe2 };
+    uint8_t expected[5] = { 0x21, 0xd8, 0xfd, 0x04, 0xe9 };
     TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, &TXdataBuffer[1], 5);
 
     // byte 6 is the switches encoded
@@ -437,7 +437,7 @@ void test_decodingHybridWide(uint8_t nonce, uint8_t forceSwitch, uint16_t forceV
     bool telemResult = OtaUnpackChannelData(otaPktPtr, ChannelData);
 
     // compare the unpacked results with the input data (nlimit may have ±1 quantization error)
-    uint16_t expectedDecoded[4] = {291, 1382, 427, 1518};
+    uint16_t expectedDecoded[4] = {291, 1382, 428, 1520};
     for (unsigned ch=0; ch<4; ++ch)
     {
         TEST_ASSERT_EQUAL(expectedDecoded[ch], ChannelData[ch]);
@@ -693,7 +693,40 @@ void test_n_quantization_common(size_t ota_packet_size, uint32_t R, uint32_t crs
 
 void test_nlimit_quantization()
 {
-    test_n_quantization_common(OTA4_PACKET_SIZE, OTA_DECIMATE_R_NLIMIT, CRSF_CHANNEL_VALUE_STD_MIN, CRSF_CHANNEL_VALUE_STD_MAX);
+    // nlimit only carries the 1000-2000us range, anything outside is clamped
+    test_n_quantization_common(OTA4_PACKET_SIZE, OTA_DECIMATE_R_NLIMIT, CRSF_CHANNEL_VALUE_1000, CRSF_CHANNEL_VALUE_2000);
+}
+
+void test_nlimit_clamping()
+{
+    uint8_t TXdataBuffer[OTA4_PACKET_SIZE]{};
+    OTA_Packet_s * const otaPktPtr = (OTA_Packet_s *)TXdataBuffer;
+
+    OtaUpdateSerializers(smWideOr8ch, OTA4_PACKET_SIZE);
+
+    // Values below CRSF_CHANNEL_VALUE_1000 clamp to the low code, above
+    // CRSF_CHANNEL_VALUE_2000 clamp to the high code
+    constexpr struct { uint32_t in; uint32_t out; } CASES[] = {
+        { CRSF_CHANNEL_VALUE_STD_MIN, CRSF_CHANNEL_VALUE_1000 },
+        { CRSF_CHANNEL_VALUE_1000 - 1, CRSF_CHANNEL_VALUE_1000 },
+        { CRSF_CHANNEL_VALUE_1000, CRSF_CHANNEL_VALUE_1000 },
+        { CRSF_CHANNEL_VALUE_MID, CRSF_CHANNEL_VALUE_MID },
+        { CRSF_CHANNEL_VALUE_2000, CRSF_CHANNEL_VALUE_2000 },
+        { CRSF_CHANNEL_VALUE_2000 + 1, CRSF_CHANNEL_VALUE_2000 },
+        { CRSF_CHANNEL_VALUE_STD_MAX, CRSF_CHANNEL_VALUE_2000 },
+    };
+
+    for (auto const &c : CASES)
+    {
+        memset(ChannelData, 0, sizeof(ChannelData));
+        ChannelData[0] = c.in;
+        memset(TXdataBuffer, 0, sizeof(TXdataBuffer));
+
+        OtaPackChannelData(otaPktPtr, ChannelData, false);
+        OtaUnpackChannelData(otaPktPtr, ChannelData);
+
+        TEST_ASSERT_EQUAL(c.out, ChannelData[0]);
+    }
 }
 
 void test_nmap_quantization()
@@ -733,6 +766,7 @@ int main(int argc, char **argv)
     RUN_TEST(test_decodingFullres16chLow);
 
     RUN_TEST(test_nlimit_quantization);
+    RUN_TEST(test_nlimit_clamping);
     RUN_TEST(test_nmap_quantization);
 
     UNITY_END();


### PR DESCRIPTION
## OTA 5.0

Replaces the channel decimate/expand functions with new center-prioritizing versions which preserve more of the original CRSF input values than the current implementation. This provides full 11-bit precision in the center region of the stick (or CRSF's version of 11 bits anyway)

**TLDR**: Std mode increases our CRSF output coverage from 25% to 38.53%. Fullres modes increase from 25.03% to 26.56%

### Details

Our current 11 to 10 bit decimators produce a lot close-but-not-quite values. These images show a green dot where the 2 channels produce exactly the same value as the input CRSF value, and a yellow dot is where at least one of the values output is off by 1 from the original
<img width="770" height="396" alt="image" src="https://github.com/user-attachments/assets/f2d5838d-fddd-4492-b433-a5be70e9bbdf" />

Fullres does a pretty good job given how large a range it has to cover but Std mode has a lot of rounding error. This PR experiments with a better distribution of where the more accurate values are, and attempting to reduce the rounding errors of Std res. (The shrinking of the images causes a real loss of information here but the yellow areas still have many green dots in them, they are just less concentrated than before to create the completely solid center regions)
<img width="1680" height="838" alt="elrs-n-quant" src="https://github.com/user-attachments/assets/79180e86-3789-41b8-9383-0eed012046fe" />

In table form it is easier to read

| Method | Exact | Exact% | Within1 | Within1% | MoreThan1 | MoreThan1% | Don't Care |
| --- | --- | --- | --- | --- | --- | --- | --- |
| div2 | 986,049 | 25.03% | 2,954,176 | 74.97% | 0 | 0.00% | 0 |
| limit | 672,400 | 25.00% | 2,017,200 | 75.00% | 0 | 0.00% | 1,250,625 |
| nmap R=190 | 1,046,529 | 26.56% | 2,893,696 | 73.44% | 0 | 0.00% | 0 |
| nlimit R=301 | 1,036,324 | 38.53% | 1,653,276 | 61.47% | 0 | 0.00% | 1,250,625 |
| nlimit R=366 / 192 |  | 63.9% |  | 36.1% | 0 | 0.00% | 1,380,225 |

* Std mode (nlimit) R=301 maps full precision in 1310us-1686us range
* Std mode (nlimit) R=366 maps full precision in 1272us-1729us range
* Fullres mode (nmap) R=190 maps full precision in 1381us-1619us range

I've updated my [ExpressLRS Precision Loser](https://heatermeter.com/elrs/edgetx-convert.html) demo with the new encoding methods to see how mixer outputs compare to receiver outputs.

### 192

We use a CRSF value of 191 to represent 1000us. This works out to be 999.87us so it is as close as CRSF gets, but if we up that to 192 (1000.5us) then that makes the range 1000-2000 consist of 1601 values which means there's 1 mid value, and 800 on each side, which makes my calculation in this symmetric meaning 1 coded value isn't wasted. Betaflight also decodes this value as 1000us (according to the webui but internally they use float).

### Drawbacks

While the accuracy in the center is perfect, the accuracy of the outside portion is worse. The current `limit` method we use has an RMS error of 0.619 CRSF which is spread somewhat uniformly across the range, roughly 1 output for every 1.6 inputs.The nlimit has an RMS error of 0.600853, but the center has error of 0 and the outer bits have RMS error of 0.8165 with roughly 1 output value for every 3 inputs. Those combine to an nlimit total of 1 output for every 1.565 input.

### Worth It?

Maybe? It is ~250 bytes more code to fix a value that is off by 1 out of 1984 possible values. However, having an exact 11-bit 1:1 mapping of the inner ~45% of Std res isn't shabby. 5.0 is a long way away though so I just thought I'd put this up as the only positive result I've had after dozens of hours of quantization and lossy encoding experimentation.

### AI Disclosure

An LLM was used to generate the python script used to test different encoding strategies, along with generating the images and statistics about coverage. It also updated the tests to make them pass although I'm not pleased with some of its changes. I wrote the new tests though because I was concerned the clanker was gaslighting me about the results.