### PR TITLE
Add configurable Ramp-Up aggressiveness preset for Dynamic Power.

### DIFF
--- a/src/lib/CONFIG/config.cpp
+++ b/src/lib/CONFIG/config.cpp
@@ -214,6 +214,10 @@ void TxConfig::Load()
     if (nvs_get_u8(handle, "fanthresh", &value8) == ESP_OK)
         m_config.powerFanThreshold = value8;
 
+    // dynamic power ramp-up aggressiveness (v9)
+    if (nvs_get_u8(handle, "rampup", &value8) == ESP_OK)
+        m_config.dynamicPowerRampup = value8;
+
     // Both of these were added to config v5 without incrementing the version
     if (nvs_get_u32(handle, "fan", &value) == ESP_OK)
         m_config.fanMode = value;
@@ -276,8 +280,9 @@ void TxConfig::Load()
                 nvs_set_u32(handle, model, Model_to_U32(newModel));
             }
 
-            if (version == TX_CONFIG_VERSION)
+            if (version >= 8)
             {
+                // model_config_t layout is unchanged between v8 and v9 (TX_CONFIG_VERSION)
                 U32_to_Model(value, &m_config.model_config[i]);
             }
 
@@ -335,6 +340,12 @@ void TxConfig::Load()
     if (version == 7)
     {
         UpgradeEepromV7ToV8();
+        version = 8;
+    }
+
+    if (version == 8)
+    {
+        UpgradeEepromV8ToV9();
     }
 }
 
@@ -420,6 +431,43 @@ void TxConfig::UpgradeEepromV7ToV8()
     m_config.version = 8U | TX_CONFIG_MAGIC;
     Commit();
 }
+
+void TxConfig::UpgradeEepromV8ToV9()
+{
+    v8_tx_config_t v8Config;
+    m_eeprom->Get(0, v8Config);
+
+    // Manual field copying since a new field (dynamicPowerRampup) was inserted
+    #define LAZY(member) m_config.member = v8Config.member
+    LAZY(vtxBand);
+    LAZY(vtxChannel);
+    LAZY(vtxPower);
+    LAZY(vtxPitmode);
+    LAZY(powerFanThreshold);
+    LAZY(fanMode);
+    LAZY(motionMode);
+    LAZY(dvrStopDelay);
+    LAZY(backpackDisable);
+    LAZY(backpackTlmMode);
+    LAZY(dvrStartDelay);
+    LAZY(dvrAux);
+    #undef LAZY
+    memcpy(m_config.buttonColors, v8Config.buttonColors, sizeof(m_config.buttonColors));
+
+    // model_config_t layout is unchanged between v8 and v9
+    for (unsigned i=0; i<CONFIG_TX_MODEL_CNT; i++)
+    {
+        m_config.model_config[i] = v8Config.model_config[i];
+    }
+
+    // dynamicPowerRampup is new in v9 and defaults to 0 (Normal) via SetDefaults(false)
+
+    m_modified = ALL_CHANGED;
+
+    // Full Commit now
+    m_config.version = 9U | TX_CONFIG_MAGIC;
+    Commit();
+}
 #endif
 
 uint32_t
@@ -467,6 +515,7 @@ TxConfig::Commit()
         nvs_set_u8(handle, "dvraux", m_config.dvrAux);
         nvs_set_u8(handle, "dvrstartdelay", m_config.dvrStartDelay);
         nvs_set_u8(handle, "dvrstopdelay", m_config.dvrStopDelay);
+        nvs_set_u8(handle, "rampup", m_config.dynamicPowerRampup);
     }
     if (m_modified & EVENT_CONFIG_BUTTON_CHANGED)
     {
@@ -632,6 +681,16 @@ TxConfig::SetPowerFanThreshold(uint8_t powerFanThreshold)
     {
         m_config.powerFanThreshold = powerFanThreshold;
         m_modified |= EVENT_CONFIG_FAN_CHANGED;
+    }
+}
+
+void
+TxConfig::SetDynamicPowerRampup(uint8_t dynamicPowerRampup)
+{
+    if (m_config.dynamicPowerRampup != dynamicPowerRampup)
+    {
+        m_config.dynamicPowerRampup = dynamicPowerRampup;
+        m_modified |= EVENT_CONFIG_MAIN_CHANGED;
     }
 }
 

--- a/src/lib/CONFIG/config.h
+++ b/src/lib/CONFIG/config.h
@@ -16,7 +16,7 @@
 #define TX_CONFIG_MAGIC     (0b01U << 30)
 #define RX_CONFIG_MAGIC     (0b10U << 30)
 
-#define TX_CONFIG_VERSION   8U
+#define TX_CONFIG_VERSION   9U
 #define RX_CONFIG_VERSION   11U
 
 class BindphraseConfigurable
@@ -110,7 +110,8 @@ typedef struct {
     uint8_t         vtxChannel; // 0=Ch1 -> 7=Ch8
     uint8_t         vtxPower;   // 0=Do not set, else power number
     uint8_t         vtxPitmode; // Off/On/AUX1^/AUX1v/etc
-    uint8_t         powerFanThreshold:4; // Power level to enable fan if present
+    uint8_t         powerFanThreshold:4, // Power level to enable fan if present
+                    dynamicPowerRampup:2; // Dynamic Power raise-up aggressiveness: 0=Normal, 1=Aggressive, 2=Very Aggressive
     model_config_t  model_config[CONFIG_TX_MODEL_CNT];
     uint8_t         fanMode;            // some value used by thermal?
     uint8_t         motionMode:2,       // bool, but space for 2 more modes
@@ -148,6 +149,7 @@ public:
     uint8_t  GetVtxPower() const { return m_config.vtxPower; }
     uint8_t  GetVtxPitmode() const { return m_config.vtxPitmode; }
     uint8_t GetPowerFanThreshold() const { return m_config.powerFanThreshold; }
+    uint8_t GetDynamicPowerRampup() const { return m_config.dynamicPowerRampup; }
     uint8_t  GetFanMode() const { return m_config.fanMode; }
     uint8_t  GetMotionMode() const { return m_config.motionMode; }
     uint8_t  GetDvrAux() const { return m_config.dvrAux; }
@@ -177,6 +179,7 @@ public:
     void SetVtxPower(uint8_t vtxPower);
     void SetVtxPitmode(uint8_t vtxPitmode);
     void SetPowerFanThreshold(uint8_t powerFanThreshold);
+    void SetDynamicPowerRampup(uint8_t dynamicPowerRampup);
     void SetFanMode(uint8_t fanMode);
     void SetMotionMode(uint8_t motionMode);
     void SetDvrAux(uint8_t dvrAux);
@@ -197,6 +200,7 @@ private:
     void UpgradeEepromV5ToV6();
     void UpgradeEepromV6ToV7();
     void UpgradeEepromV7ToV8();
+    void UpgradeEepromV8ToV9();
 #endif
 
     tx_config_t m_config;

--- a/src/lib/CONFIG/config_legacy.h
+++ b/src/lib/CONFIG/config_legacy.h
@@ -97,6 +97,33 @@ typedef struct {
     uint8_t         dvrStopDelay:3;
 } v7_tx_config_t;
 
+// V8 (model_config_t layout is unchanged in V9; only the top-level struct gained dynamicPowerRampup)
+typedef struct {
+    uint32_t        version;
+    uint8_t         vtxBand;
+    uint8_t         vtxChannel;
+    uint8_t         vtxPower;
+    uint8_t         vtxPitmode;
+    uint8_t         powerFanThreshold:4; // Power level to enable fan if present
+    model_config_t  model_config[64];
+    uint8_t         fanMode;
+    uint8_t         motionMode:2,
+                    dvrStopDelay:3,
+                    backpackDisable:1,
+                    backpackTlmMode:2;
+    uint8_t         dvrStartDelay:3,
+                    dvrAux:5;
+    tx_button_color_t buttonColors[2];
+} v8_tx_config_t;
+
+// UpgradeEepromV7ToV8() (config.cpp) still writes the *current* m_config (tx_config_t, i.e. v9) via the generic
+// Commit(), rather than a true v8_tx_config_t snapshot like UpgradeEepromV5ToV6/V6ToV7 do for their versions.
+// That's only safe because v8_tx_config_t and tx_config_t are byte-layout identical -- dynamicPowerRampup was
+// added as extra bits inside the existing powerFanThreshold byte, not a new field, so the struct size didn't
+// change. If a future version bump changes tx_config_t's size, this assert will fail at compile time, and
+// UpgradeEepromV7ToV8 must be updated to write a real v8_tx_config_t snapshot directly instead.
+static_assert(sizeof(v8_tx_config_t) == sizeof(tx_config_t), "v8_tx_config_t must stay byte-layout-compatible with tx_config_t -- see comment above");
+
 /***
  * RX config
  ***/

--- a/src/lib/tx-crsf/TXModuleParameters.cpp
+++ b/src/lib/tx-crsf/TXModuleParameters.cpp
@@ -124,6 +124,13 @@ static selectionParameter luaFanThreshold = {
     STR_EMPTYSPACE // units embedded so it won't display "NevermW"
 };
 
+static selectionParameter luaDynamicPowerRampup = {
+    {"Ramp-Up", CRSF_TEXT_SELECTION},
+    0, // value
+    "Normal;Aggressive;Very Aggressive",
+    STR_EMPTYSPACE
+};
+
 #if defined(Regulatory_Domain_EU_CE_2400)
 static stringParameter luaCELimit = {
 #if defined(RADIO_LR1121)
@@ -879,6 +886,9 @@ void TXModuleEndpoint::registerParameters()
     registerParameter(&luaDynamicPower, [this](propertiesCommon *item, uint8_t arg) {
       SetDynamicPower(arg);
     }, luaPowerFolder.common.id);
+    registerParameter(&luaDynamicPowerRampup, [](propertiesCommon *item, uint8_t arg) {
+      config.SetDynamicPowerRampup(arg);
+    }, luaPowerFolder.common.id);
   }
   if (GPIO_PIN_FAN_EN != UNDEF_PIN || GPIO_PIN_FAN_PWM != UNDEF_PIN) {
     registerParameter(&luaFanThreshold, [](propertiesCommon *item, uint8_t arg){
@@ -1018,6 +1028,7 @@ void TXModuleEndpoint::updateParameters()
 
   uint8_t dynamic = config.GetDynamicPower() ? config.GetBoostChannel() + 1 : 0;
   setTextSelectionValue(&luaDynamicPower, dynamic);
+  setTextSelectionValue(&luaDynamicPowerRampup, config.GetDynamicPowerRampup());
 
   setTextSelectionValue(&luaVtxBand, config.GetVtxBand());
   setUint8Value(&luaVtxChannel, config.GetVtxChannel() + 1);

--- a/src/src/dynpower.cpp
+++ b/src/src/dynpower.cpp
@@ -17,7 +17,6 @@
 #define DYNPOWER_LQ_BOOST_THRESH_DIFF 20  // If LQ is dropped suddenly for this amount (relative), immediately boost to the max power configured.
 #define DYNPOWER_LQ_BOOST_THRESH_MIN  50  // If LQ is below this value (absolute), immediately boost to the max power configured.
 #define DYNPOWER_LQ_MOVING_AVG_K      8   // Number of previous values for calculating moving average. Best with power of 2.
-#define DYNPOWER_LQ_THRESH_UP         85  // Below this LQ, the RSSI/SNR code will increase the power if RSSI/SNR did nothing
 
 // RSSI-based increment defines
 #define DYNPOWER_RSSI_CNT 5               // Number of RSSI readings to average (straight average) to make an RSSI-based adjustment
@@ -25,8 +24,27 @@
 #define DYNPOWER_RSSI_THRESH_DN 21        // RSSI > (Sensitivity+Dn) >- lower power
 
 // SNR-based increment defines
-#define DYNPOWER_LQ_THRESH_DN 95          // Min LQ for lowering power using SNR-based power lowering
 constexpr int8_t SNR1dB = SNR_SCALE(1.0); // SNR 1dB scaled
+
+// Ramp-up aggressiveness, selected via config.GetDynamicPowerRampup() (Lua "Ramp-Up": 0=Normal, 1=Aggressive, 2=Very Aggressive)
+// Raising and lowering are adjusted together: raise thresholds move to trigger *sooner* (at better signal) while the
+// matching lower thresholds move to require *more* margin before backing off, so the raise/lower gap does not shrink
+// as aggressiveness increases (for RSSI and the pre-statistics SNR default it is provably constant; for the
+// statistics-derived SNR threshold and the bounded 0-100% LQ gate it shrinks much less than if only the raise side moved).
+// A runtime cap is still kept on every raise threshold as defense-in-depth in case these arrays are ever edited independently.
+#define DYNPOWER_RAMPUP_LEVEL_MAX 2
+static constexpr uint8_t DYNPOWER_RAMPUP_LQ_THRESH_UP[]     = {85, 90, 93};                     // Raise: below this LQ, raise power if RSSI/SNR did nothing this period. Step (+5,+3) is not perfectly linear like the rest -- 93 was chosen over the "linear" 95 to keep a 5-point gap against the Very Aggressive DN threshold (98) instead of narrowing to 3, which was firing too often on ordinary link noise
+static constexpr uint8_t DYNPOWER_RAMPUP_LQ_THRESH_DN[]     = {95, 97, 98};                     // Lower: lq_avg must be at least this to permit any RSSI/SNR-based lowering. Steps (+2,+1) are not perfectly linear like the rest -- 98 was chosen over the "linear" 99 to avoid requiring near-perfect LQ before Very Aggressive ever permits lowering
+static constexpr int8_t  DYNPOWER_RAMPUP_RSSI_BONUS[]       = {0, 4, 8};                        // Added to BOTH the RSSI raise and RSSI lower thresholds (dBm) -- gap stays fixed at 6dB
+static constexpr int8_t  DYNPOWER_RAMPUP_SNR_BONUS_SCALED[] = {0, SNR_SCALE(1), SNR_SCALE(2)};  // Added to BOTH the pre-statistics SNR raise and lower thresholds -- gap stays fixed at the per-rate compiled value
+static constexpr int32_t DYNPOWER_RAMPUP_SNR_SIGMA_UP_NUM[] = {13, 10, 7};                      // Raise: /4 sigma-multiple subtracted from the SNR mean (13/4=3.25sigma .. 7/4=1.75sigma)
+static constexpr int32_t DYNPOWER_RAMPUP_SNR_SIGMA_DN_NUM[] = {2, 5, 8};                        // Lower: /4 sigma-multiple added to the SNR mean (2/4=0.5sigma .. 8/4=2.0sigma). UP_NUM+DN_NUM==15 at every level, so the total up-to-down span stays a constant 3.75sigma
+// Missed-telemetry raise delay is scaled by NUM/DEN of the debounced (2x nominal telemetry period) delay, in linear
+// steps of 0.5 periods to match the linear shape of every other ramp-up parameter above:
+// Normal=2.0x (full debounce, waits for a 2nd miss), Aggressive=1.5x (reacts partway into the 2nd period),
+// Very Aggressive=1.0x (reacts on the 1st miss, every time -- no debounce). No lower-side counterpart exists for this mechanism.
+static constexpr uint8_t DYNPOWER_RAMPUP_TLM_NUM[] = {1, 3, 1};
+static constexpr uint8_t DYNPOWER_RAMPUP_TLM_DEN[] = {1, 4, 2};
 
 template<uint8_t K, uint8_t SHIFT>
 class MovingAvg
@@ -103,6 +121,8 @@ void DynamicPower_Update(uint32_t now)
   // The rest of the codes should be executeded only if dynamic power config is enabled
   //
 
+  const uint8_t rampup = std::min(config.GetDynamicPowerRampup(), (uint8_t)DYNPOWER_RAMPUP_LEVEL_MAX);
+
   // =============  DYNAMIC_POWER_BOOST: Switch-triggered power boost up ==============
   // Or if telemetry is lost while armed (done up here because dynpower_updated is only updated on telemetry)
   uint8_t boostChannel = config.GetBoostChannel();
@@ -126,7 +146,7 @@ void DynamicPower_Update(uint32_t now)
     if (isArmed && (powerHeadroom > 0))
     {
       uint32_t linkstatsInterval = ExpressLRS_currTlmDenom * ExpressLRS_currAirRate_Modparams->interval / (1000U / 2U);
-      linkstatsInterval = std::max(linkstatsInterval, (uint32_t)512U);
+      linkstatsInterval = std::max(linkstatsInterval, (uint32_t)512U) * DYNPOWER_RAMPUP_TLM_NUM[rampup] / DYNPOWER_RAMPUP_TLM_DEN[rampup];
       if ((now - dynpower_last_linkstats_millis) > (linkstatsInterval + 2U))
       {
         DBGLN("+power (tlm)");
@@ -172,15 +192,18 @@ void DynamicPower_Update(uint32_t now)
 
     if (dynpower_mean_rssi.getCount() >= DYNPOWER_RSSI_CNT)
     {
-      int8_t rssi_inc_threshold = expected_RXsensitivity + DYNPOWER_RSSI_THRESH_UP;
-      int8_t rssi_dec_threshold = expected_RXsensitivity + DYNPOWER_RSSI_THRESH_DN;
+      int8_t rssi_dec_threshold = expected_RXsensitivity + DYNPOWER_RSSI_THRESH_DN + DYNPOWER_RAMPUP_RSSI_BONUS[rampup];
+      // Cap the raise threshold at least 1dB below the lower threshold; a no-op given the shared bonus above, kept as defense-in-depth
+      int8_t rssi_inc_threshold = static_cast<int8_t>(std::min(
+          (int16_t)(expected_RXsensitivity + DYNPOWER_RSSI_THRESH_UP + DYNPOWER_RAMPUP_RSSI_BONUS[rampup]),
+          (int16_t)(rssi_dec_threshold - 1)));
       int8_t avg_rssi = dynpower_mean_rssi.mean(); // resets it too
       if ((avg_rssi < rssi_inc_threshold) && (powerHeadroom > 0))
       {
         DBGLN("+power (rssi)");
         POWERMGNT::incPower();
       }
-      else if (avg_rssi > rssi_dec_threshold && lq_avg >= DYNPOWER_LQ_THRESH_DN)
+      else if (avg_rssi > rssi_dec_threshold && lq_avg >= DYNPOWER_RAMPUP_LQ_THRESH_DN[rampup])
       {
         DBGVLN("-power (rssi)"); // Verbose because this spams when idle
         POWERMGNT::decPower();
@@ -190,8 +213,8 @@ void DynamicPower_Update(uint32_t now)
   else
   {
     // default thresholds from the config (as a fallback)
-    int8_t snr_stat_threshold_up = ExpressLRS_currAirRate_RFperfParams->DynpowerSnrThreshUp;
-    int8_t snr_stat_threshold_dn = ExpressLRS_currAirRate_RFperfParams->DynpowerSnrThreshDn;
+    int8_t snr_stat_threshold_up = ExpressLRS_currAirRate_RFperfParams->DynpowerSnrThreshUp + DYNPOWER_RAMPUP_SNR_BONUS_SCALED[rampup];
+    int8_t snr_stat_threshold_dn = ExpressLRS_currAirRate_RFperfParams->DynpowerSnrThreshDn + DYNPOWER_RAMPUP_SNR_BONUS_SCALED[rampup];
 
     // Incorporate the current value if LQ meets the desired LQ standard
     if (lq_current >= 99)
@@ -206,15 +229,16 @@ void DynamicPower_Update(uint32_t now)
       int32_t snr_stat_stdev = dynpower_stat_snr.standardDeviationRaw() >> (dynpower_stat_snr.FIXED_POINT_SHIFT - 4);
 
       // Fuzzy logic: reduce scale factor when LQ is getting low for more conservative power management
-      // Base scale factor is 13/4 (3.25), reduce it proportionally when LQ < 100
-      int32_t scale_factor_numerator = 13;
+      // Base scale factor is DYNPOWER_RAMPUP_SNR_SIGMA_UP_NUM/4 sigma below the mean, reduce it proportionally when LQ < 100
+      // (this LQ-based fuzz only applies to the raise side, same as before ramp-up presets existed)
+      int32_t scale_factor_numerator = DYNPOWER_RAMPUP_SNR_SIGMA_UP_NUM[rampup];
       if (lq_current < 100) {
         // scale factor will be 1 (=-0.25 sd for power up threshold) when LQ is 85
         scale_factor_numerator = std::max((int32_t)(scale_factor_numerator - ((100 - lq_current) * (scale_factor_numerator - 1)) / 15), (int32_t)1);
       }
 
-      int8_t snr_thre_up_scaled = static_cast<int8_t>((snr_stat_mean - (snr_stat_stdev * scale_factor_numerator) / 4) / 16);  // Dynamic scale based on LQ
-      int8_t snr_thre_dn_scaled = static_cast<int8_t>((snr_stat_mean + (snr_stat_stdev / 2)) / 16);                           // fixed +0.5sd
+      int8_t snr_thre_up_scaled = static_cast<int8_t>((snr_stat_mean - (snr_stat_stdev * scale_factor_numerator) / 4) / 16);            // Dynamic scale based on LQ
+      int8_t snr_thre_dn_scaled = static_cast<int8_t>((snr_stat_mean + (snr_stat_stdev * DYNPOWER_RAMPUP_SNR_SIGMA_DN_NUM[rampup]) / 4) / 16); // 0.5sd .. 2.0sd, growing with aggressiveness so lowering requires more margin above the mean
       int8_t snr_thre_up_limit = snr_thre_dn_scaled - SNR1dB;                                                                 // 1dB min threshold separation
 
       snr_stat_threshold_up = std::min(snr_thre_up_scaled, snr_thre_up_limit);
@@ -226,7 +250,7 @@ void DynamicPower_Update(uint32_t now)
     // =============  SNR-based power increment ==============
     // Decrease the power if SNR above threshold and LQ is good
     // Increase the power for each (X) SNR below the threshold
-    if (snrScaled >= snr_stat_threshold_dn && lq_avg >= DYNPOWER_LQ_THRESH_DN)
+    if (snrScaled >= snr_stat_threshold_dn && lq_avg >= DYNPOWER_RAMPUP_LQ_THRESH_DN[rampup])
     {
       if(POWERMGNT::currPower() > MinPower) // prevent spamming when idle
       {
@@ -236,7 +260,9 @@ void DynamicPower_Update(uint32_t now)
     }
 
     // use RSSI_DN threshold to make sure the signal is still in good range but with some distance for SNR to exhibit a fair distribution
-    bool isSignalBad = (rssi <= (expected_RXsensitivity + DYNPOWER_RSSI_THRESH_DN)) || (lq_avg <= 95);
+    // (ramped like the rest of this branch, so a stronger RSSI/LQ doesn't silently block the more aggressive presets'
+    // SNR-based raise from ever firing -- e.g. strong RSSI + good LQ but degraded SNR from 2.4GHz interference)
+    bool isSignalBad = (rssi <= (expected_RXsensitivity + DYNPOWER_RSSI_THRESH_DN + DYNPOWER_RAMPUP_RSSI_BONUS[rampup])) || (lq_avg <= DYNPOWER_RAMPUP_LQ_THRESH_DN[rampup]);
 
     while ((snrScaled <= snr_stat_threshold_up) && (powerHeadroom > 0) && isSignalBad)
     {
@@ -249,7 +275,9 @@ void DynamicPower_Update(uint32_t now)
   } // ^^ if SNR-based
 
   // If instant LQ is low, but the SNR/RSSI did nothing, inc power by one step
-  if ((powerHeadroom > 0) && (startPowerLevel == POWERMGNT::currPower()) && (lq_current <= DYNPOWER_LQ_THRESH_UP))
+  // Cap at least 1% below the (also ramp-adjusted) lowering-permission threshold; a no-op given the values chosen above, kept as defense-in-depth
+  uint8_t lqThreshUp = std::min(DYNPOWER_RAMPUP_LQ_THRESH_UP[rampup], (uint8_t)(DYNPOWER_RAMPUP_LQ_THRESH_DN[rampup] - 1));
+  if ((powerHeadroom > 0) && (startPowerLevel == POWERMGNT::currPower()) && (lq_current <= lqThreshUp))
   {
     DBGLN("+power (lq)");
     POWERMGNT::incPower();


### PR DESCRIPTION
With the current default thresholds, Dynamic Power's raise/lower behavior reflects years of empirical flight-test tuning, but as far as I can tell there's no built-in bias toward "raise sooner" for pilots who'd rather trade some efficiency for margin. Right now that only exists as an all-or-nothing choice — accept the default balance, or don't use Dynamic Power at all and pick a fixed power manually, which is its own non-trivial decision to get right, and differs per flight environment.

This PR adds a Lua-selectable Default/Aggressive preset that scales Dynamic Power's raise thresholds (RSSI, SNR, LQ, missed-telemetry) down and its lower thresholds up in tandem, so more aggressive presets reach for power sooner and relinquish it more reluctantly, with a fixed hysteresis gap on every parameter to prevent oscillation. Bumps TX_CONFIG_VERSION to 9 with EEPROM (ESP8266) and NVS (ESP32) upgrade paths.

Related documentation PR: https://github.com/ExpressLRS/Docs/pull/542