### PR TITLE
Do not display parens in lua subfolder titles

### DIFF
--- a/src/lua/elrs.lua
+++ b/src/lua/elrs.lua
@@ -10,7 +10,6 @@ local EXITVER = "-- EXIT (Lua r18) --"
 local deviceId = 0xEE
 local handsetId = 0xEA
 local deviceName = nil
-local currentFolderName = nil
 local lineIndex = 1
 local pageOffset = 0
 local edit = nil
@@ -27,6 +26,7 @@ local elrsFlagsInfo = ""
 local fields_count = 0
 local devicesRefreshTimeout = 50
 local currentFolderId = nil
+local currentFolderName = nil
 local commandRunningIndicator = 1
 local expectChunksRemain = -1
 local deviceIsELRS_TX = nil
@@ -310,7 +310,7 @@ end
 
 local function fieldFolderOpen(field)
   currentFolderId = field.id
-  currentFolderName = field.name
+  currentFolderName = string.match(field.name, "^(.-)%s*%(.*%)$") or field.name
 
   local backFld = fields[#fields]
   backFld.name = "----BACK----"


### PR DESCRIPTION
This resolves the issue of lua subfolder titles, that are displayed on the top line of the lua, not updating when the value in it changes. This is resolved by removing the dynamic part of the folder name (everything in parens) in the same way the LVGL lua does it.

I did not update the r number since this is just cosmetic and we haven't had an actual main release with it yet, but I can be forced if it is that important.

### Details

* Go into the dynamic power subfolder, the title will be `TX Power (100mW Dyn)` or whatever is set
* Change power to e.g. 50mW
* Title stays the same with the incorrect power level on the current lua. Will display just `TX Power` all the time on this PR.

Thanks @mha1 for reporting and @jurgelenas for already fixing this in the future lua.