### PR TITLE
Add MSP DisplayPort OSD Support for DJI

### DIFF
--- a/src/html/src/pages/serial-panel.js
+++ b/src/html/src/pages/serial-panel.js
@@ -1,6 +1,6 @@
 import {html, LitElement} from "lit"
 import {customElement, state} from "lit/decorators.js"
-import {_renderOptions} from "../utils/libs.js"
+import {_renderOptions, _uintInput} from "../utils/libs.js"
 import {elrsState, saveOptionsAndConfig} from "../utils/state.js"
 import {PWM_MODE_SERIAL, PWM_MODE_SERIAL2RX, PWM_MODE_SERIAL2TX} from "./connections-panel.js"
 import {SERIAL_OPTIONS1, SERIAL_OPTIONS2} from "../utils/globals.js"
@@ -16,6 +16,11 @@ class SerialPanel extends LitElement {
     @state() accessor sbusFailsafe
     @state() accessor isAirport
     @state() accessor djiArmed
+    @state() accessor enableMspOsd
+    @state() accessor enableOsdRssi
+    @state() accessor enableOsdLq
+    @state() accessor osdChannelMonitor
+    @state() accessor osdChannelUsePercent
 
     createRenderRoot() {
         this.isAirport = elrsState.options['is-airport']
@@ -24,6 +29,11 @@ class SerialPanel extends LitElement {
         this.baudRate = elrsState.options['rcvr-uart-baud']
         this.sbusFailsafe = elrsState.config['sbus-failsafe']
         this.djiArmed = elrsState.options['dji-permanently-armed']
+        this.enableMspOsd = !!elrsState.options['enable-msp-osd']
+        this.enableOsdRssi = !!elrsState.options['enable-osd-rssi']
+        this.enableOsdLq = !!elrsState.options['enable-osd-lq']
+        this.osdChannelMonitor = elrsState.options['osd-channel-monitor'] || 0
+        this.osdChannelUsePercent = !!elrsState.options['osd-channel-use-percent']
         this._saveSerial = this._saveSerial.bind(this)
         this._setSbusFailsafe = this._setSbusFailsafe.bind(this)
         return this
@@ -89,6 +99,46 @@ class SerialPanel extends LitElement {
                                @change="${(e) => {this.djiArmed = e.target.checked}}"/>
                         <label for="dji">Permanently arm DJI air units</label>
                     </div>
+                    <div class="mui--text-title">MSP OSD Settings</div>
+                    <div class="mui-checkbox">
+                        <input id="enable-msp-osd" type='checkbox'
+                                ?checked="${this.enableMspOsd}"
+                                @change="${(e) => {this.enableMspOsd = e.target.checked}}"/>
+                        <label for="enable-msp-osd">Enable MSP DisplayPort OSD</label>
+                    </div>
+                    ${this.enableMspOsd ? html`
+                    <div class="mui-checkbox">
+                        <input id="enable-osd-rssi" type='checkbox'
+                                ?checked="${this.enableOsdRssi}"
+                                @change="${(e) => {this.enableOsdRssi = e.target.checked}}"/>
+                        <label for="enable-osd-rssi">Show RSSI dBm on OSD</label>
+                    </div>
+                    <div class="mui-checkbox">
+                        <input id="enable-osd-lq" type='checkbox'
+                                ?checked="${this.enableOsdLq}"
+                                @change="${(e) => {this.enableOsdLq = e.target.checked}}"/>
+                        <label for="enable-osd-lq">Show Link Quality (LQ) on OSD</label>
+                    </div>
+                    <div id="channel-monitor-config">
+                        <div>RC Channel Monitor</div>
+                        Set 0 to disable, or greater than 0 to specify how many channels to monitor on OSD:<br/>
+                        <div class="mui-textfield">
+                            <input id="osd-channel-monitor" min="0" max="16" type='number'
+                                   @input=${(e) => this.osdChannelMonitor = isNaN(parseInt(e.target.value)) ? 0 : parseInt(e.target.value)}
+                                   .value="${this.osdChannelMonitor}"
+                                   @keypress="${_uintInput}"/>
+                            <label for="osd-channel-monitor">Channels to Monitor (0 = Disabled)</label>
+                        </div>
+                        ${this.osdChannelMonitor > 0 ? html`
+                        <div class="mui-checkbox">
+                            <input id="osd-channel-use-percent" type='checkbox'
+                                    ?checked="${this.osdChannelUsePercent}"
+                                    @change="${(e) => {this.osdChannelUsePercent = e.target.checked}}"/>
+                            <label for="osd-channel-use-percent">Display channel values as percentage (-100% to 100%)</label>
+                        </div>
+                        ` : ''}
+                    </div>
+                    ` : ''}
                     ` : ''}
                     <button class="mui-btn mui-btn--small mui-btn--primary"
                             ?disabled="${!this.checkChanged()}"
@@ -180,7 +230,12 @@ class SerialPanel extends LitElement {
     _optionsChanged() {
         return this.isAirport !== elrsState.options['is-airport'] ||
             this.baudRate !== elrsState.options['rcvr-uart-baud'] ||
-            this.djiArmed !== elrsState.options['dji-permanently-armed']
+            this.djiArmed !== elrsState.options['dji-permanently-armed'] ||
+            this.enableMspOsd !== !!elrsState.options['enable-msp-osd'] ||
+            this.enableOsdRssi !== !!elrsState.options['enable-osd-rssi'] ||
+            this.enableOsdLq !== !!elrsState.options['enable-osd-lq'] ||
+            this.osdChannelMonitor !== (elrsState.options['osd-channel-monitor'] || 0) ||
+            this.osdChannelUsePercent !== !!elrsState.options['osd-channel-use-percent']
     }
 
     checkChanged() {
@@ -194,6 +249,11 @@ class SerialPanel extends LitElement {
                     'is-airport': this.isAirport,
                     'rcvr-uart-baud': this.baudRate,
                     'dji-permanently-armed': this.djiArmed,
+                    'enable-msp-osd': this.enableMspOsd,
+                    'enable-osd-rssi': this.enableOsdRssi,
+                    'enable-osd-lq': this.enableOsdLq,
+                    'osd-channel-monitor': this.osdChannelMonitor,
+                    'osd-channel-use-percent': this.osdChannelUsePercent,
                 },
                 config: {
                     'serial-protocol': this.isAirport ? 0 : this.serial1Protocol,

--- a/src/html/src/pages/serial-panel.js
+++ b/src/html/src/pages/serial-panel.js
@@ -107,38 +107,38 @@ class SerialPanel extends LitElement {
                         <label for="enable-msp-osd">Enable MSP DisplayPort OSD</label>
                     </div>
                     ${this.enableMspOsd ? html`
-                    <div class="mui-checkbox">
-                        <input id="enable-osd-rssi" type='checkbox'
-                                ?checked="${this.enableOsdRssi}"
-                                @change="${(e) => {this.enableOsdRssi = e.target.checked}}"/>
-                        <label for="enable-osd-rssi">Show RSSI dBm on OSD</label>
-                    </div>
-                    <div class="mui-checkbox">
-                        <input id="enable-osd-lq" type='checkbox'
-                                ?checked="${this.enableOsdLq}"
-                                @change="${(e) => {this.enableOsdLq = e.target.checked}}"/>
-                        <label for="enable-osd-lq">Show Link Quality (LQ) on OSD</label>
-                    </div>
-                    <div id="channel-monitor-config">
-                        <div>RC Channel Monitor</div>
-                        Set 0 to disable, or greater than 0 to specify how many channels to monitor on OSD:<br/>
-                        <div class="mui-textfield">
-                            <input id="osd-channel-monitor" min="0" max="16" type='number'
-                                   @input=${(e) => this.osdChannelMonitor = isNaN(parseInt(e.target.value)) ? 0 : parseInt(e.target.value)}
-                                   .value="${this.osdChannelMonitor}"
-                                   @keypress="${_uintInput}"/>
-                            <label for="osd-channel-monitor">Channels to Monitor (0 = Disabled)</label>
-                        </div>
-                        ${this.osdChannelMonitor > 0 ? html`
                         <div class="mui-checkbox">
-                            <input id="osd-channel-use-percent" type='checkbox'
-                                    ?checked="${this.osdChannelUsePercent}"
-                                    @change="${(e) => {this.osdChannelUsePercent = e.target.checked}}"/>
-                            <label for="osd-channel-use-percent">Display channel values as percentage (-100% to 100%)</label>
+                            <input id="enable-osd-rssi" type='checkbox'
+                                    ?checked="${this.enableOsdRssi}"
+                                    @change="${(e) => {this.enableOsdRssi = e.target.checked}}"/>
+                            <label for="enable-osd-rssi">Show RSSI dBm on OSD</label>
+                        </div>
+                        <div class="mui-checkbox">
+                            <input id="enable-osd-lq" type='checkbox'
+                                    ?checked="${this.enableOsdLq}"
+                                    @change="${(e) => {this.enableOsdLq = e.target.checked}}"/>
+                            <label for="enable-osd-lq">Show Link Quality (LQ) on OSD</label>
+                        </div>
+                        <div id="channel-monitor-config">
+                            <div>RC Channel Monitor</div>
+                            Set 0 to disable, or greater than 0 to specify how many channels to monitor on OSD:<br/>
+                            <div class="mui-textfield">
+                                <input id="osd-channel-monitor" min="0" max="16" type='number'
+                                    @input=${(e) => {const v = parseInt(e.target.value); this.osdChannelMonitor = isNaN(v) ? 0 : v > 16 ? 16 : v;}}
+                                    .value="${this.osdChannelMonitor}"
+                                    @keypress="${_uintInput}"/>
+                                <label for="osd-channel-monitor">Channels to Monitor (0 = Disabled)</label>
+                            </div>
+                            ${this.osdChannelMonitor > 0 ? html`
+                                <div class="mui-checkbox">
+                                    <input id="osd-channel-use-percent" type='checkbox'
+                                            ?checked="${this.osdChannelUsePercent}"
+                                            @change="${(e) => {this.osdChannelUsePercent = e.target.checked}}"/>
+                                    <label for="osd-channel-use-percent">Display channel values as percentage (-100% to 100%)</label>
+                                </div>
+                            ` : ''}
                         </div>
                         ` : ''}
-                    </div>
-                    ` : ''}
                     ` : ''}
                     <button class="mui-btn mui-btn--small mui-btn--primary"
                             ?disabled="${!this.checkChanged()}"

--- a/src/html/src/pages/serial-panel.js
+++ b/src/html/src/pages/serial-panel.js
@@ -21,6 +21,12 @@ class SerialPanel extends LitElement {
     @state() accessor enableOsdLq
     @state() accessor osdChannelMonitor
     @state() accessor osdChannelUsePercent
+    @state() accessor osdRssiRow
+    @state() accessor osdRssiCol
+    @state() accessor osdLqRow
+    @state() accessor osdLqCol
+    @state() accessor osdChannelRow
+    @state() accessor osdChannelCol
 
     createRenderRoot() {
         this.isAirport = elrsState.options['is-airport']
@@ -34,6 +40,12 @@ class SerialPanel extends LitElement {
         this.enableOsdLq = !!elrsState.options['enable-osd-lq']
         this.osdChannelMonitor = elrsState.options['osd-channel-monitor'] || 0
         this.osdChannelUsePercent = !!elrsState.options['osd-channel-use-percent']
+        this.osdRssiRow = elrsState.options['osd-rssi-row'] || 1
+        this.osdRssiCol = elrsState.options['osd-rssi-col'] || 1
+        this.osdLqRow = elrsState.options['osd-lq-row'] || 2
+        this.osdLqCol = elrsState.options['osd-lq-col'] || 1
+        this.osdChannelRow = elrsState.options['osd-channel-row'] || 5
+        this.osdChannelCol = elrsState.options['osd-channel-col'] || 1
         this._saveSerial = this._saveSerial.bind(this)
         this._setSbusFailsafe = this._setSbusFailsafe.bind(this)
         return this
@@ -113,12 +125,48 @@ class SerialPanel extends LitElement {
                                     @change="${(e) => {this.enableOsdRssi = e.target.checked}}"/>
                             <label for="enable-osd-rssi">Show RSSI dBm on OSD</label>
                         </div>
+                        ${this.enableOsdRssi ? html`
+                            <div style="display: flex; gap: 1rem; margin-left: 1.5rem;">
+                                <div class="mui-textfield">
+                                    <input id="osd-rssi-row" min="0" max="50" type='number'
+                                        @input=${(e) => {const v = parseInt(e.target.value); this.osdRssiRow = isNaN(v) ? 0 : v > 50 ? 50 : v;}}
+                                        .value="${this.osdRssiRow}"
+                                        @keypress="${_uintInput}"/>
+                                    <label for="osd-rssi-row">Row</label>
+                                </div>
+                                <div class="mui-textfield">
+                                    <input id="osd-rssi-col" min="0" max="53" type='number'
+                                        @input=${(e) => {const v = parseInt(e.target.value); this.osdRssiCol = isNaN(v) ? 0 : v > 53 ? 53 : v;}}
+                                        .value="${this.osdRssiCol}"
+                                        @keypress="${_uintInput}"/>
+                                    <label for="osd-rssi-col">Col</label>
+                                </div>
+                            </div>
+                        ` : ''}
                         <div class="mui-checkbox">
                             <input id="enable-osd-lq" type='checkbox'
                                     ?checked="${this.enableOsdLq}"
                                     @change="${(e) => {this.enableOsdLq = e.target.checked}}"/>
                             <label for="enable-osd-lq">Show Link Quality (LQ) on OSD</label>
                         </div>
+                        ${this.enableOsdLq ? html`
+                            <div style="display: flex; gap: 1rem; margin-left: 1.5rem;">
+                                <div class="mui-textfield">
+                                    <input id="osd-lq-row" min="0" max="50" type='number'
+                                        @input=${(e) => {const v = parseInt(e.target.value); this.osdLqRow = isNaN(v) ? 0 : v > 50 ? 50 : v;}}
+                                        .value="${this.osdLqRow}"
+                                        @keypress="${_uintInput}"/>
+                                    <label for="osd-lq-row">Row</label>
+                                </div>
+                                <div class="mui-textfield">
+                                    <input id="osd-lq-col" min="0" max="53" type='number'
+                                        @input=${(e) => {const v = parseInt(e.target.value); this.osdLqCol = isNaN(v) ? 0 : v > 53 ? 53 : v;}}
+                                        .value="${this.osdLqCol}"
+                                        @keypress="${_uintInput}"/>
+                                    <label for="osd-lq-col">Col</label>
+                                </div>
+                            </div>
+                        ` : ''}
                         <div id="channel-monitor-config">
                             <div>RC Channel Monitor</div>
                             Set 0 to disable, or greater than 0 to specify how many channels to monitor on OSD:<br/>
@@ -130,6 +178,22 @@ class SerialPanel extends LitElement {
                                 <label for="osd-channel-monitor">Channels to Monitor (0 = Disabled)</label>
                             </div>
                             ${this.osdChannelMonitor > 0 ? html`
+                                <div style="display: flex; gap: 1rem;">
+                                    <div class="mui-textfield">
+                                        <input id="osd-channel-row" min="0" max="50" type='number'
+                                            @input=${(e) => {const v = parseInt(e.target.value); this.osdChannelRow = isNaN(v) ? 0 : v > 50 ? 50 : v;}}
+                                            .value="${this.osdChannelRow}"
+                                            @keypress="${_uintInput}"/>
+                                        <label for="osd-channel-row">Start Row</label>
+                                    </div>
+                                    <div class="mui-textfield">
+                                        <input id="osd-channel-col" min="0" max="53" type='number'
+                                            @input=${(e) => {const v = parseInt(e.target.value); this.osdChannelCol = isNaN(v) ? 0 : v > 53 ? 53 : v;}}
+                                            .value="${this.osdChannelCol}"
+                                            @keypress="${_uintInput}"/>
+                                        <label for="osd-channel-col">Start Col</label>
+                                    </div>
+                                </div>
                                 <div class="mui-checkbox">
                                     <input id="osd-channel-use-percent" type='checkbox'
                                             ?checked="${this.osdChannelUsePercent}"
@@ -235,7 +299,13 @@ class SerialPanel extends LitElement {
             this.enableOsdRssi !== !!elrsState.options['enable-osd-rssi'] ||
             this.enableOsdLq !== !!elrsState.options['enable-osd-lq'] ||
             this.osdChannelMonitor !== (elrsState.options['osd-channel-monitor'] || 0) ||
-            this.osdChannelUsePercent !== !!elrsState.options['osd-channel-use-percent']
+            this.osdChannelUsePercent !== !!elrsState.options['osd-channel-use-percent'] ||
+            this.osdRssiRow !== (elrsState.options['osd-rssi-row'] || 1) ||
+            this.osdRssiCol !== (elrsState.options['osd-rssi-col'] || 1) ||
+            this.osdLqRow !== (elrsState.options['osd-lq-row'] || 2) ||
+            this.osdLqCol !== (elrsState.options['osd-lq-col'] || 1) ||
+            this.osdChannelRow !== (elrsState.options['osd-channel-row'] || 5) ||
+            this.osdChannelCol !== (elrsState.options['osd-channel-col'] || 1)
     }
 
     checkChanged() {
@@ -254,6 +324,12 @@ class SerialPanel extends LitElement {
                     'enable-osd-lq': this.enableOsdLq,
                     'osd-channel-monitor': this.osdChannelMonitor,
                     'osd-channel-use-percent': this.osdChannelUsePercent,
+                    'osd-rssi-row': this.osdRssiRow,
+                    'osd-rssi-col': this.osdRssiCol,
+                    'osd-lq-row': this.osdLqRow,
+                    'osd-lq-col': this.osdLqCol,
+                    'osd-channel-row': this.osdChannelRow,
+                    'osd-channel-col': this.osdChannelCol,
                 },
                 config: {
                     'serial-protocol': this.isAirport ? 0 : this.serial1Protocol,

--- a/src/lib/OPTIONS/options.cpp
+++ b/src/lib/OPTIONS/options.cpp
@@ -83,6 +83,12 @@ void saveOptions(Stream &stream, bool customised)
     doc["rcvr-uart-baud"] = firmwareOptions.uart_baud;
     doc["lock-on-first-connection"] = firmwareOptions.lock_on_first_connection;
     doc["dji-permanently-armed"] = firmwareOptions.dji_permanently_armed;
+    doc["enable-msp-osd"] = firmwareOptions.enable_msp_osd;
+    doc["enable-osd-rssi"] = firmwareOptions.enable_osd_rssi;
+    doc["enable-osd-lq"] = firmwareOptions.enable_osd_lq;
+    doc["osd-channel-monitor"] = firmwareOptions.osd_channel_monitor;
+    doc["osd-channel-use-percent"] = firmwareOptions.osd_channel_use_percent;
+
     #endif
     doc["is-airport"] = firmwareOptions.is_airport;
     doc["domain"] = firmwareOptions.domain;
@@ -199,6 +205,12 @@ static void options_LoadFromFlashOrFile(EspFlashStream &strmFlash)
     #endif
     firmwareOptions.lock_on_first_connection = doc["lock-on-first-connection"] | true;
     firmwareOptions.dji_permanently_armed = doc["dji-permanently-armed"] | false;
+    firmwareOptions.enable_msp_osd = doc["enable-msp-osd"] | false;
+    firmwareOptions.enable_osd_rssi = doc["enable-osd-rssi"] | false;
+    firmwareOptions.enable_osd_lq = doc["enable-osd-lq"] | false;
+    firmwareOptions.osd_channel_monitor = doc["osd-channel-monitor"] | 0;
+    firmwareOptions.osd_channel_use_percent = doc["osd-channel-use-percent"] | false;
+
     #endif
     firmwareOptions.domain = doc["domain"] | 0;
     firmwareOptions.flash_discriminator = doc["flash-discriminator"] | 0U;

--- a/src/lib/OPTIONS/options.cpp
+++ b/src/lib/OPTIONS/options.cpp
@@ -88,6 +88,12 @@ void saveOptions(Stream &stream, bool customised)
     doc["enable-osd-lq"] = firmwareOptions.enable_osd_lq;
     doc["osd-channel-monitor"] = firmwareOptions.osd_channel_monitor;
     doc["osd-channel-use-percent"] = firmwareOptions.osd_channel_use_percent;
+    doc["osd-rssi-row"] = firmwareOptions.osd_rssi_row;
+    doc["osd-rssi-col"] = firmwareOptions.osd_rssi_col;
+    doc["osd-lq-row"] = firmwareOptions.osd_lq_row;
+    doc["osd-lq-col"] = firmwareOptions.osd_lq_col;
+    doc["osd-channel-row"] = firmwareOptions.osd_channel_row;
+    doc["osd-channel-col"] = firmwareOptions.osd_channel_col;
 
     #endif
     doc["is-airport"] = firmwareOptions.is_airport;
@@ -210,6 +216,12 @@ static void options_LoadFromFlashOrFile(EspFlashStream &strmFlash)
     firmwareOptions.enable_osd_lq = doc["enable-osd-lq"] | false;
     firmwareOptions.osd_channel_monitor = doc["osd-channel-monitor"] | 0;
     firmwareOptions.osd_channel_use_percent = doc["osd-channel-use-percent"] | false;
+    firmwareOptions.osd_rssi_row = doc["osd-rssi-row"] | 1;
+    firmwareOptions.osd_rssi_col = doc["osd-rssi-col"] | 1;
+    firmwareOptions.osd_lq_row = doc["osd-lq-row"] | 2;
+    firmwareOptions.osd_lq_col = doc["osd-lq-col"] | 1;
+    firmwareOptions.osd_channel_row = doc["osd-channel-row"] | 5;
+    firmwareOptions.osd_channel_col = doc["osd-channel-col"] | 1;
 
     #endif
     firmwareOptions.domain = doc["domain"] | 0;

--- a/src/lib/OPTIONS/options.h
+++ b/src/lib/OPTIONS/options.h
@@ -41,6 +41,12 @@ typedef struct _options {
     bool        enable_osd_lq:1;
     uint8_t     osd_channel_monitor;
     bool        osd_channel_use_percent:1;
+    uint8_t     osd_rssi_row;
+    uint8_t     osd_rssi_col;
+    uint8_t     osd_lq_row;
+    uint8_t     osd_lq_col;
+    uint8_t     osd_channel_row;
+    uint8_t     osd_channel_col;
 #endif
 #if defined(TARGET_TX) || defined(UNIT_TEST)
     uint32_t    tlm_report_interval;

--- a/src/lib/OPTIONS/options.h
+++ b/src/lib/OPTIONS/options.h
@@ -36,6 +36,11 @@ typedef struct _options {
     bool        lock_on_first_connection:1;
     bool        dji_permanently_armed:1;
     bool        is_airport:1;
+    bool        enable_msp_osd:1;
+    bool        enable_osd_rssi:1;
+    bool        enable_osd_lq:1;
+    uint8_t     osd_channel_monitor;
+    bool        osd_channel_use_percent:1;
 #endif
 #if defined(TARGET_TX) || defined(UNIT_TEST)
     uint32_t    tlm_report_interval;

--- a/src/src/rx-serial/SerialDisplayport.cpp
+++ b/src/src/rx-serial/SerialDisplayport.cpp
@@ -97,7 +97,7 @@ void SerialDisplayport::sendMspDisplayPort(uint32_t *channelData)
     {
         int32_t rssiDBM = linkStats.active_antenna == 0 ? -linkStats.uplink_RSSI_1 : -linkStats.uplink_RSSI_2;
         snprintf(buf, sizeof(buf), "\x01 %d", rssiDBM);
-        sendDisplayPortString(1, 1, buf);
+        sendDisplayPortString(firmwareOptions.osd_rssi_row, firmwareOptions.osd_rssi_col, buf);
     }
 
     // Draw OSD ELRS Link Quality
@@ -106,7 +106,7 @@ void SerialDisplayport::sendMspDisplayPort(uint32_t *channelData)
         uint8_t rfMode = linkStats.rf_Mode;
         uint8_t linkQuality = linkStats.uplink_Link_quality;
         snprintf(buf, sizeof(buf), "\x7B %d:%d", rfMode, linkQuality);
-        sendDisplayPortString(2, 1, buf);
+        sendDisplayPortString(firmwareOptions.osd_lq_row, firmwareOptions.osd_lq_col, buf);
     }
 
     // Channel Monitor
@@ -121,7 +121,7 @@ void SerialDisplayport::sendMspDisplayPort(uint32_t *channelData)
             }
             
             snprintf(buf, sizeof(buf), "CH%d:%d", i+1, ch);
-            sendDisplayPortString(5+i, 1, buf);
+            sendDisplayPortString(firmwareOptions.osd_channel_row+i, firmwareOptions.osd_channel_col, buf);
         }
     }
     

--- a/src/src/rx-serial/SerialDisplayport.cpp
+++ b/src/src/rx-serial/SerialDisplayport.cpp
@@ -36,6 +36,99 @@ void SerialDisplayport::send(uint8_t messageID, void * payload, uint8_t size, St
     _stream->write(checksum);
 }
 
+
+// send displayport heartbeat
+void SerialDisplayport::sendDisplayPortHeartbeat()
+{
+  uint8_t payload[1] = {MSP_DP_HEARTBEAT};
+  send(MSP_DISPLAYPORT, payload, 1, _outputPort);
+}
+
+// send displayport draw screen
+void SerialDisplayport::sendDisplayPortDrawScreen()
+{
+  uint8_t payload[1] = {MSP_DP_DRAW_SCREEN};
+  send(MSP_DISPLAYPORT, payload, 1, _outputPort);
+}
+
+// send displayport clear screen
+void SerialDisplayport::sendDisplayPortClear()
+{
+  uint8_t payload[1] = {MSP_DP_CLEAR};
+  send(MSP_DISPLAYPORT, payload, 1, _outputPort);
+}
+
+// send displayport release screen
+void SerialDisplayport::sendDisplayPortReleaseScreen()
+{
+  uint8_t payload[1] = {MSP_DP_RELEASE};
+  send(MSP_DISPLAYPORT, payload, 1, _outputPort);
+}
+
+// send displayport string 
+void SerialDisplayport::sendDisplayPortString(uint8_t row, uint8_t col, char* str)
+{
+  uint8_t len = strlen(str);
+  if (len > MSP_OSD_MAX_COLUMN) len = MSP_OSD_MAX_COLUMN; 
+
+  uint8_t payload[32];
+  payload[0] = MSP_DP_WRITE_STRING;
+  payload[1] = row;
+  payload[2] = col;
+  payload[3] = 0; 
+  
+  for (uint8_t i = 0; i < len; i++) 
+  {
+    payload[4 + i] = str[i];
+  }
+  send(MSP_DISPLAYPORT, payload, 4 + len, _outputPort);
+}
+
+void SerialDisplayport::sendMspDisplayPort(uint32_t *channelData)
+{
+    char buf[MSP_OSD_MAX_COLUMN];
+    // Send heartbeat
+    sendDisplayPortHeartbeat();
+    // Clear the canvas
+    sendDisplayPortClear();
+
+    // Draw OSD ELRS RSSI dbM
+    if(firmwareOptions.enable_osd_rssi)
+    {
+        int32_t rssiDBM = linkStats.active_antenna == 0 ? -linkStats.uplink_RSSI_1 : -linkStats.uplink_RSSI_2;
+        snprintf(buf, sizeof(buf), "\x01 %d", rssiDBM);
+        sendDisplayPortString(1, 1, buf);
+    }
+
+    // Draw OSD ELRS Link Quality
+    if(firmwareOptions.enable_osd_lq)
+    {
+        uint8_t rfMode = linkStats.rf_Mode;
+        uint8_t linkQuality = linkStats.uplink_Link_quality;
+        snprintf(buf, sizeof(buf), "\x7B %d:%d", rfMode, linkQuality);
+        sendDisplayPortString(2, 1, buf);
+    }
+
+    // Channel Monitor
+    if(firmwareOptions.osd_channel_monitor > 0)
+    {
+        for (uint8_t i = 0;i<firmwareOptions.osd_channel_monitor;i++)
+        {
+            int32_t ch = CRSF_to_US(channelData[i]);
+            if (firmwareOptions.osd_channel_use_percent)
+            {
+                ch = map(channelData[i], CRSF_CHANNEL_VALUE_STD_MIN, CRSF_CHANNEL_VALUE_STD_MAX, -100, 100);
+            }
+            
+            snprintf(buf, sizeof(buf), "CH%d:%d", i+1, ch);
+            sendDisplayPortString(5+i, 1, buf);
+        }
+    }
+    
+    // Draw the screen 
+    sendDisplayPortDrawScreen();
+}
+
 uint32_t SerialDisplayport::sendRCFrame(bool frameAvailable, bool frameMissed, uint32_t *channelData)
 {
     bool armed = getArmedState();
@@ -58,6 +151,11 @@ uint32_t SerialDisplayport::sendRCFrame(bool frameAvailable, bool frameMissed, u
 
     // Send extended status MSP
     send(MSP_STATUS_EX, &status, sizeof(status), _outputPort);
+
+    if(firmwareOptions.enable_msp_osd)
+    {
+        sendMspDisplayPort(channelData);
+    }
 
     return MSP_MSG_PERIOD_MS;   // Send MSP msgs to DJI at 10Hz
 }

--- a/src/src/rx-serial/SerialDisplayport.h
+++ b/src/src/rx-serial/SerialDisplayport.h
@@ -21,6 +21,18 @@ CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
 #define MSP_STATUS          101
 #define MSP_STATUS_EX       150
 #define MSP_MSG_PERIOD_MS   100
+#define MSP_BATTERY_STATE   130
+#define MSP_DISPLAYPORT     182
+#define MSP_OSD_MAX_COLUMN  53
+
+
+// DisplayPort Sub-commands
+#define MSP_DP_HEARTBEAT       0
+#define MSP_DP_RELEASE         1
+#define MSP_DP_CLEAR           2
+#define MSP_DP_WRITE_STRING    3
+#define MSP_DP_DRAW_SCREEN     4
+#define MSP_DP_OPTIONS         5
 
 struct msp_status_t
 {
@@ -52,6 +64,12 @@ private:
     void processBytes(uint8_t *bytes, uint16_t size) override;
     void send(uint8_t messageID, void * payload, uint8_t size, Stream * _stream);
     bool getArmedState();
+    void sendDisplayPortHeartbeat();
+    void sendDisplayPortDrawScreen();
+    void sendDisplayPortClear();
+    void sendDisplayPortReleaseScreen();
+    void sendDisplayPortString(uint8_t row, uint8_t col, char* str);
+    void sendMspDisplayPort(uint32_t *channelData);
 
     uint8_t m_receivedBytes;
     uint32_t m_receivedTimestamp;


### PR DESCRIPTION
Summary
This PR adds native MSP DisplayPort OSD support to ExpressLRS receivers, allowing critical telemetry elements (RSSI, Link Quality, and RC Channel monitoring) to be rendered directly onto DJI/MSP-compatible OSDs without needing a flight controller. All OSD options can be dynamically configured directly via the ExpressLRS Web UI runtime options and serial configuration panel.

Motivation & Context
Currently, ExpressLRS receivers only support sending the MSP arming status to DJI Air Units (dji-permanently-armed) to disable DJI low power mode, but there is no native MSP DisplayPort OSD drawing support directly from the receiver.

For setups where an ExpressLRS PWM receiver is connected directly to servos without a Flight Controller (FC) (such as fixed-wing aircraft, gliders, or RC cars), users have no way to see signal quality or RC channel positions on their DJI/HD goggles.

This PR makes it easy for non-FC builds to render vital OSD elements directly from the ELRS receiver:

Easily toggle RSSI dBm and Link Quality (LQ) display elements on the OSD directly from the Web UI.
Select how many RC Channels (0 to 16) to monitor on the OSD canvas.
Choose whether channel values are displayed in raw values (CRSF_to_US) or mapped to a percentage (-100% to 100%).
(Note: Battery voltage display is not implemented yet in this PR and will be added in future work).

Tested Hardware
This feature has been tested and verified working on:
- DJI O4 Air Unit
- DJI O4 Pro Air Unit

<img width="1600" height="1050" alt="image" src="https://github.com/user-attachments/assets/620a350c-f217-45af-a1c7-ef7e503de3f9" />

<img width="1108" height="684" alt="Screenshot 2026-07-17 214049" src="https://github.com/user-attachments/assets/4eafe255-35c9-4c7e-be14-b0b5efb5d08f" />
