### PR TITLE
Prefer vendored esptool over a system-installed esptool

### DIFF
--- a/src/python/binary_flash.py
+++ b/src/python/binary_flash.py
@@ -13,7 +13,7 @@ from firmware import DeviceType, FirmwareOptions, MCUType
 
 import sys
 from os.path import dirname
-sys.path.append(dirname(__file__) + '/external/esptool')
+sys.path.insert(0, dirname(__file__) + '/external/esptool')
 
 from external.esptool import esptool
 sys.path.append(dirname(__file__) + "/external")


### PR DESCRIPTION
Prepend src/python/external/esptool to sys.path instead of appending it, so the bundled esptool's internal absolute imports resolve to the vendored copy even when an incompatible esptool exists in site-packages (e.g. Fedora's esptool package, which lacks esptool.cmds.make_image).

Fixes https://github.com/ExpressLRS/ExpressLRS/issues/3705