### PR TITLE
Implement third serial interface (Serial2)

### DIFF
--- a/src/include/common.h
+++ b/src/include/common.h
@@ -205,6 +205,8 @@ enum eServoOutputMode : uint8_t
     somPwm,         // 13: true PWM mode (NOT SUPPORTED)
     somSerial1RX,   // 14: secondary Serial RX
     somSerial1TX,   // 15: secondary Serial TX
+    somSerial2RX,   // 16: ternary Serial RX
+    somSerial2TX,   // 17: ternary Serial TX
 };
 
 enum eServoOutputFailsafeMode : uint8_t
@@ -245,6 +247,22 @@ enum eSerial1Protocol : uint8_t
     PROTOCOL_SERIAL1_GPS
 };
 #endif
+
+enum eSerial2Protocol : uint8_t
+{
+    PROTOCOL_SERIAL2_OFF,
+    PROTOCOL_SERIAL2_CRSF,
+    PROTOCOL_SERIAL2_INVERTED_CRSF,
+    PROTOCOL_SERIAL2_SBUS,
+    PROTOCOL_SERIAL2_INVERTED_SBUS,
+	PROTOCOL_SERIAL2_SUMD,
+    PROTOCOL_SERIAL2_DJI_RS_PRO,
+    PROTOCOL_SERIAL2_HOTT_TLM,
+    PROTOCOL_SERIAL2_TRAMP,
+    PROTOCOL_SERIAL2_SMARTAUDIO,
+    PROTOCOL_SERIAL2_MSP_DISPLAYPORT,
+    PROTOCOL_SERIAL2_GPS,
+};
 
 enum eFailsafeMode : uint8_t
 {

--- a/src/include/hardware.h
+++ b/src/include/hardware.h
@@ -8,7 +8,9 @@ typedef enum {
     HARDWARE_serial_tx,
     HARDWARE_serial1_rx,
     HARDWARE_serial1_tx,
-
+    HARDWARE_serial2_rx,
+    HARDWARE_serial2_tx,
+    
     // Radio
     HARDWARE_radio_busy,
     HARDWARE_radio_busy_2,

--- a/src/include/target/Unified_ESP_RX.h
+++ b/src/include/target/Unified_ESP_RX.h
@@ -3,6 +3,8 @@
 #define GPIO_PIN_RCSIGNAL_TX hardware_pin(HARDWARE_serial_tx)
 #define GPIO_PIN_SERIAL1_RX hardware_pin(HARDWARE_serial1_rx)
 #define GPIO_PIN_SERIAL1_TX hardware_pin(HARDWARE_serial1_tx)
+#define GPIO_PIN_SERIAL2_RX hardware_pin(HARDWARE_serial2_rx)
+#define GPIO_PIN_SERIAL2_TX hardware_pin(HARDWARE_serial2_tx)
 
 // Radio
 #define GPIO_PIN_BUSY hardware_pin(HARDWARE_radio_busy)

--- a/src/lib/CONFIG/config.cpp
+++ b/src/lib/CONFIG/config.cpp
@@ -1406,6 +1406,14 @@ void RxConfig::SetSerial1Protocol(eSerial1Protocol serialProtocol)
         m_modified = EVENT_CONFIG_SERIAL_CHANGE;
     }
 }
+void RxConfig::SetSerial2Protocol(eSerial2Protocol serialProtocol)
+{
+    if (m_config.serial2Protocol != serialProtocol)
+    {
+        m_config.serial2Protocol = serialProtocol;
+        m_modified = EVENT_CONFIG_SERIAL_CHANGE;
+    }
+}
 #endif
 
 void RxConfig::SetTeamraceChannel(uint8_t teamraceChannel)

--- a/src/lib/CONFIG/config.h
+++ b/src/lib/CONFIG/config.h
@@ -230,11 +230,11 @@ typedef union {
         uint32_t failsafe:11,    // us output during failsafe +476 (e.g. 1024 here would be 1500us)
                  inputChannel:4, // 0-based input channel
                  inverted:1,     // invert channel output
-                 mode:4,         // Output mode (eServoOutputMode)
+                 mode:5,         // Output mode (eServoOutputMode)
                  stretched:1,    // expand the channel input to 500us - 2500us
                  narrow:1,       // Narrow output mode (half pulse width)
                  failsafeMode:2, // failsafe output mode (eServoOutputFailsafeMode)
-                 unused:8;       // FUTURE: When someone complains "everyone" uses inverted polarity PWM or something :/
+                 unused:7;       // FUTURE: When someone complains "everyone" uses inverted polarity PWM or something :/
     } val;
     uint32_t raw;
 } rx_config_pwm_t;
@@ -244,7 +244,7 @@ typedef struct __attribute__((packed)) {
     uint8_t     uid[UID_LEN];
     uint8_t     unused_padding;
     uint8_t     serial1Protocol:4,  // secondary serial protocol
-                serial1Protocol_unused:4;
+                serial2Protocol:4;  // ternary serial protocol
     uint32_t    flash_discriminator;
     struct __attribute__((packed)) {
         uint16_t    scale;          // FUTURE: Override compiled vbat scale
@@ -297,6 +297,7 @@ public:
     eSerialProtocol GetSerialProtocol() const { return (eSerialProtocol)m_config.serialProtocol; }
 #if defined(PLATFORM_ESP32)
     eSerial1Protocol GetSerial1Protocol() const { return (eSerial1Protocol)m_config.serial1Protocol; }
+    eSerial2Protocol GetSerial2Protocol() const { return (eSerial2Protocol)m_config.serial2Protocol; }
 #endif
     uint8_t GetTeamraceChannel() const { return m_config.teamraceChannel; }
     uint8_t GetTeamracePosition() const { return m_config.teamracePosition; }
@@ -322,7 +323,9 @@ public:
     void SetSerialProtocol(eSerialProtocol serialProtocol);
 #if defined(PLATFORM_ESP32)
     void SetSerial1Protocol(eSerial1Protocol serial1Protocol);
+    void SetSerial2Protocol(eSerial2Protocol serial2Protocol);
 #endif
+    
     void SetTeamraceChannel(uint8_t teamraceChannel);
     void SetTeamracePosition(uint8_t teamracePosition);
     void SetFailsafeMode(eFailsafeMode failsafeMode);

--- a/src/lib/OPTIONS/hardware.cpp
+++ b/src/lib/OPTIONS/hardware.cpp
@@ -23,6 +23,8 @@ static const struct {
     {HARDWARE_serial_tx, "serial_tx", INT},
     {HARDWARE_serial1_rx, "serial1_rx", INT},
     {HARDWARE_serial1_tx, "serial1_tx", INT},
+    {HARDWARE_serial2_rx, "serial2_rx", INT},
+    {HARDWARE_serial2_tx, "serial2_tx", INT},
     {HARDWARE_radio_busy, "radio_busy", INT},
     {HARDWARE_radio_busy_2, "radio_busy_2", INT},
     {HARDWARE_radio_dio0, "radio_dio0", INT},

--- a/src/lib/rx-crsf/RXParameters.cpp
+++ b/src/lib/rx-crsf/RXParameters.cpp
@@ -11,10 +11,12 @@
 #include "logging.h"
 
 #define RX_HAS_SERIAL1 (GPIO_PIN_SERIAL1_TX != UNDEF_PIN || OPT_HAS_SERVO_OUTPUT)
+#define RX_HAS_SERIAL2 (GPIO_PIN_SERIAL2_TX != UNDEF_PIN || OPT_HAS_SERVO_OUTPUT)
 
 extern void reconfigureSerial();
 #if defined(PLATFORM_ESP32)
 extern void reconfigureSerial1();
+extern void reconfigureSerial2();
 #endif
 extern bool BindingModeRequest;
 
@@ -30,7 +32,7 @@ char strPowerLevels[] = "10;25;50;100;250;500;1000;2000;MatchTX ";
 char strPowerLevels[] = "10;25;50;100;250;500;1000;2000;MatchTX ";
 #endif
 static char modelString[] = "000";
-static char pwmModes[] = "50Hz;60Hz;100Hz;160Hz;333Hz;400Hz;10kHzDuty;On/Off;DShot;DShot 3D;Serial RX;Serial TX;I2C SCL;I2C SDA;Serial2 RX;Serial2 TX";
+static char pwmModes[] = "50Hz;60Hz;100Hz;160Hz;333Hz;400Hz;10kHzDuty;On/Off;DShot;DShot 3D;Serial RX;Serial TX;I2C SCL;I2C SDA;Serial2 RX;Serial2 TX; Serial3 RX; Serial3 TX";
 
 static selectionParameter luaSerialProtocol = {
     {"Protocol", CRSF_TEXT_SELECTION},
@@ -44,6 +46,13 @@ static selectionParameter luaSerial1Protocol = {
     {"Protocol2", CRSF_TEXT_SELECTION},
     0, // value
     "Off;CRSF;Inverted CRSF;SBUS;Inverted SBUS;SUMD;DJI RS Pro;HoTT Telemetry;Tramp;SmartAudio;DisplayPort;GPS",
+    STR_EMPTYSPACE
+};
+
+static selectionParameter luaSerial2Protocol = {
+    {"Protocol3", CRSF_TEXT_SELECTION},
+    0, // value
+    "Off;CRSF;Inverted CRSF;SBUS;Inverted SBUS;SUMD;DJI RS Pro;HoTT Telemetry;Tramp;SmartAudio;DisplayPort;GPS;ESCape32",
     STR_EMPTYSPACE
 };
 #endif
@@ -213,6 +222,8 @@ void RXEndpoint::luaparamMappingChannelOut(propertiesCommon *item, uint8_t arg)
 #if defined(PLATFORM_ESP32)
     bool serial1rxAssigned = false;
     bool serial1txAssigned = false;
+    bool serial2rxAssigned = false;
+    bool serial2txAssigned = false;
 #endif
 
     const char *no1Option    = ";";
@@ -227,8 +238,11 @@ void RXEndpoint::luaparamMappingChannelOut(propertiesCommon *item, uint8_t arg)
     const char *serial1_TX   = ";;Serial2 TX";
     const char *serial1_BOTH = ";Serial2 RX;Serial2 TX";
     const char *dshot        = ";DShot;DShot 3D";
+    const char *serial2_RX   = ";Serial3 RX;";
+    const char *serial2_TX   = ";;Serial3 TX";
+    const char *serial2_BOTH = ";Serial3 RX;Serial3 TX";
 #endif
-
+    
     const char *pModeString;
 
 
@@ -252,6 +266,11 @@ void RXEndpoint::luaparamMappingChannelOut(propertiesCommon *item, uint8_t arg)
 
       if (mode == somSerial1TX)
         serial1txAssigned = true;
+      if (mode == somSerial2RX)
+        serial2rxAssigned = true;
+
+      if (mode == somSerial2TX)
+        serial2txAssigned = true;
 #endif
     }
 
@@ -367,7 +386,6 @@ void RXEndpoint::luaparamMappingChannelOut(propertiesCommon *item, uint8_t arg)
         {
             pModeString = serial1_TX;
         }
-
         else if (!serial1rxAssigned && !serial1txAssigned)
         {
             pModeString = serial1_BOTH;
@@ -382,8 +400,51 @@ void RXEndpoint::luaparamMappingChannelOut(propertiesCommon *item, uint8_t arg)
         pModeString = no2Options;
     }
     strcat(pwmModes, pModeString);
-#endif
 
+    // ternary Serial pins (2 options)
+    // ;[SERIAL3 RX] ;[SERIAL3_TX]
+    if (!OPT_PWM_OUT_ONLY && (GPIO_PIN_SERIAL2_RX != UNDEF_PIN || GPIO_PIN_SERIAL2_TX != UNDEF_PIN))
+    {
+        // If the target defines Serial2 RX/TX then those pins MUST be used
+        if (GPIO_PIN_PWM_OUTPUTS[arg-1] == GPIO_PIN_SERIAL2_RX)
+        {
+            pModeString = serial2_RX;
+        }
+        else if (GPIO_PIN_PWM_OUTPUTS[arg-1] == GPIO_PIN_SERIAL2_TX)
+        {
+            pModeString = serial2_TX;
+        }
+        else
+        {
+            pModeString = no2Options;
+        }
+    }
+    else if (!OPT_PWM_OUT_ONLY)
+    {   // otherwise allow any pin to be either RX or TX but only once
+        if (serial2txAssigned && !serial2rxAssigned)
+        {
+            pModeString = serial2_RX;
+        }
+        else if (serial2rxAssigned && !serial2txAssigned)
+        {
+            pModeString = serial2_TX;
+        }
+        else if (!serial2rxAssigned && !serial2txAssigned)
+        {
+            pModeString = serial2_BOTH;
+        }
+        else
+        {
+            pModeString = no2Options;
+        }
+    }
+    else
+    {
+        pModeString = no2Options;
+    }
+    strcat(pwmModes, pModeString);
+#endif
+    
     // trim off trailing semicolons (assumes pwmModes has at least 1 non-semicolon)
     for (auto lastPos = strlen(pwmModes)-1; pwmModes[lastPos] == ';'; lastPos--)
     {
@@ -535,8 +596,19 @@ void RXEndpoint::registerParameters()
       }
     });
   }
+  if (RX_HAS_SERIAL2)
+  {
+    registerParameter(&luaSerial2Protocol, [](propertiesCommon* item, uint8_t arg){
+    config.SetSerial2Protocol((eSerial2Protocol)arg);
+    if (config.IsModified()) {
+      deferExecutionMillis(100, [](){
+        reconfigureSerial2();
+      });
+    }
+    });
+  }
 #endif
-
+  
   registerParameter(&luaSBUSFailsafeMode, [](propertiesCommon* item, uint8_t arg){
     config.SetFailsafeMode((eFailsafeMode)arg);
   });
@@ -624,8 +696,12 @@ void RXEndpoint::updateParameters()
   {
     setTextSelectionValue(&luaSerial1Protocol, config.GetSerial1Protocol());
   }
+  if (RX_HAS_SERIAL2)
+  {
+    setTextSelectionValue(&luaSerial2Protocol, config.GetSerial2Protocol());
+  }
 #endif
-
+  
   setTextSelectionValue(&luaSBUSFailsafeMode, config.GetFailsafeMode());
 
   if (GPIO_PIN_ANT_CTRL != UNDEF_PIN)

--- a/src/src/rx-serial/devSerialIO.cpp
+++ b/src/src/rx-serial/devSerialIO.cpp
@@ -13,6 +13,7 @@
 extern SerialIO *serialIO;
 #if defined(PLATFORM_ESP32)
 extern SerialIO *serial1IO;
+extern SerialIO *serial2IO;
 #endif
 
 enum teamraceOutputInhibitState_e {
@@ -34,6 +35,7 @@ typedef struct devserial_ctx_s {
 static devserial_ctx_t serial0;
 #if defined(PLATFORM_ESP32)
 static devserial_ctx_t serial1;
+static devserial_ctx_t serial2;
 #endif
 
 void ICACHE_RAM_ATTR crsfRCFrameAvailable()
@@ -41,7 +43,8 @@ void ICACHE_RAM_ATTR crsfRCFrameAvailable()
     serial0.frameAvailable = true;
 #if defined(PLATFORM_ESP32)
     serial1.frameAvailable = true;
-#endif
+    serial2.frameAvailable = true;
+#endif    
 }
 
 void ICACHE_RAM_ATTR crsfRCFrameMissed()
@@ -49,7 +52,8 @@ void ICACHE_RAM_ATTR crsfRCFrameMissed()
     serial0.frameMissed = true;
 #if defined(PLATFORM_ESP32)
     serial1.frameMissed = true;
-#endif
+    serial2.frameMissed = true;
+#endif    
 }
 
 static int start()
@@ -59,8 +63,9 @@ static int start()
 #if defined(PLATFORM_ESP32)
     serial1.io = &serial1IO;
     serial1.lastConnectionState = disconnected;
+    serial2.io = &serial2IO;
+    serial2.lastConnectionState = disconnected;
 #endif
-
     return DURATION_IMMEDIATELY;
 }
 
@@ -89,6 +94,10 @@ static int event0()
 static int event1()
 {
     return event(&serial1);
+}
+static int event2()
+{
+    return event(&serial2);
 }
 #endif
 
@@ -263,7 +272,17 @@ void sendImmediateRC()
 
         (*(serial1.io))->sendRCFrame(sendChannels, missed, ChannelData);
     }
-#endif
+    if (*(serial2.io) != nullptr && (*(serial2.io))->sendImmediateRC() && connectionState != serialUpdate)
+    {
+        const bool missed = serial2.frameMissed;
+        serial2.frameMissed = false;
+
+        // Verify the new channel data should be sent on
+        const bool sendChannels = confirmFrameAvailable(&serial2);
+
+        (*(serial2.io))->sendRCFrame(sendChannels, missed, ChannelData);
+    }
+#endif    
 }
 
 void handleSerialIO()
@@ -280,7 +299,12 @@ void handleSerialIO()
         (*(serial1.io))->processSerialInput();
         (*(serial1.io))->sendQueuedData((*(serial1.io))->getMaxSerialWriteSize());
     }
-#endif
+    if (*(serial2.io) != nullptr)
+    {
+        (*(serial2.io))->processSerialInput();
+        (*(serial2.io))->sendQueuedData((*(serial2.io))->getMaxSerialWriteSize());
+    }
+#endif    
 }
 
 static int timeout0()
@@ -292,6 +316,10 @@ static int timeout0()
 static int timeout1()
 {
   return timeout(&serial1);
+}
+static int timeout2()
+{
+  return timeout(&serial2);
 }
 #endif
 
@@ -309,6 +337,13 @@ device_t Serial1_device = {
     .start = start,
     .event = event1,
     .timeout = timeout1,
+    .subscribe = EVENT_CONNECTION_CHANGED | EVENT_CONFIG_MODEL_CHANGED
+};
+device_t Serial2_device = {
+    .initialize = nullptr,
+    .start = start,
+    .event = event2,
+    .timeout = timeout2,
     .subscribe = EVENT_CONNECTION_CHANGED | EVENT_CONFIG_MODEL_CHANGED
 };
 #endif

--- a/src/src/rx-serial/devSerialIO.h
+++ b/src/src/rx-serial/devSerialIO.h
@@ -5,6 +5,7 @@
 extern device_t Serial0_device;
 #if defined(PLATFORM_ESP32)
 extern device_t Serial1_device;
+extern device_t Serial2_device;
 #endif
 extern void sendImmediateRC();
 extern void handleSerialIO();

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -78,7 +78,8 @@ device_affinity_t ui_devices[] = {
 #if defined(PLATFORM_ESP32)
   {&Serial1_device, 1},
   {&SerialUpdate_device, 1},
-#endif
+  {&Serial2_device, 1},
+#endif    
   {&LED_device, 0},
   {&RXLUA_device, 0},
   {&RGB_device, 0},
@@ -124,9 +125,14 @@ uint32_t serialBaud;
     const Stream *serial1_protocol_tx = &(SERIAL1_PROTOCOL_TX);
 
     SerialIO *serial1IO = nullptr;
+    
+    SerialIO *serial2IO = nullptr;
+    #define SERIAL2_PROTOCOL_TX Serial2
+    #define SERIAL2_PROTOCOL_RX Serial2
 #endif
 
 SerialIO *serialIO = nullptr;
+
 
 #define SERIAL_PROTOCOL_RX Serial
 #define SERIAL1_PROTOCOL_RX Serial1
@@ -1490,9 +1496,107 @@ void reconfigureSerial1()
     serial1Shutdown();
     setupSerial1();
 }
+
+static void serial2Shutdown()
+{
+    if(serial2IO != nullptr)
+    {
+        Serial2.end();
+        delete serial2IO;
+        serial2IO = nullptr;
+    }
+}
+
+static void setupSerial2()
+{
+    //
+    // init secondary serial and protocol
+    //
+    int8_t serial2RXpin = GPIO_PIN_SERIAL2_RX;
+
+    if (serial2RXpin == UNDEF_PIN)
+    {
+        for (uint8_t ch = 0; ch < GPIO_PIN_PWM_OUTPUTS_COUNT; ch++)
+        {
+            if (config.GetPwmChannel(ch)->val.mode == somSerial2RX)
+                serial2RXpin = GPIO_PIN_PWM_OUTPUTS[ch];
+        }
+    }
+
+    int8_t serial2TXpin = GPIO_PIN_SERIAL2_TX;
+
+    if (serial2TXpin == UNDEF_PIN)
+    {
+        for (uint8_t ch = 0; ch < GPIO_PIN_PWM_OUTPUTS_COUNT; ch++)
+        {
+            if (config.GetPwmChannel(ch)->val.mode == somSerial2TX)
+                serial2TXpin = GPIO_PIN_PWM_OUTPUTS[ch];
+        }
+    }
+
+    if ((serial2TXpin == UNDEF_PIN) || (serial2RXpin == UNDEF_PIN)) 
+    {
+        return;
+    }
+    
+    switch(config.GetSerial2Protocol())
+    {
+        case PROTOCOL_SERIAL2_OFF:
+            break;
+        case PROTOCOL_SERIAL2_CRSF:
+            Serial2.begin(firmwareOptions.uart_baud, SERIAL_8N1, serial2RXpin, serial2TXpin, false);
+            serial2IO = new SerialCRSF(SERIAL2_PROTOCOL_TX, SERIAL2_PROTOCOL_RX);
+            break;
+        case PROTOCOL_SERIAL2_INVERTED_CRSF:
+            Serial2.begin(firmwareOptions.uart_baud, SERIAL_8N1, serial2RXpin, serial2TXpin, true);
+            serial2IO = new SerialCRSF(SERIAL2_PROTOCOL_TX, SERIAL2_PROTOCOL_RX);
+            break;
+        case PROTOCOL_SERIAL2_SBUS:
+        case PROTOCOL_SERIAL2_DJI_RS_PRO:
+            Serial2.begin(100000, SERIAL_8E2, UNDEF_PIN, serial2TXpin, true);
+            serial2IO = new SerialSBUS(SERIAL2_PROTOCOL_TX, SERIAL2_PROTOCOL_RX);
+            break;
+        case PROTOCOL_SERIAL2_INVERTED_SBUS:
+            Serial2.begin(100000, SERIAL_8E2, UNDEF_PIN, serial2TXpin, false);
+            serial2IO = new SerialSBUS(SERIAL2_PROTOCOL_TX, SERIAL2_PROTOCOL_RX);
+            break;
+        case PROTOCOL_SERIAL2_SUMD:
+            Serial2.begin(115200, SERIAL_8N1, UNDEF_PIN, serial2TXpin, false);
+            serial2IO = new SerialSUMD(SERIAL2_PROTOCOL_TX, SERIAL2_PROTOCOL_RX);
+            break;
+        case PROTOCOL_SERIAL2_HOTT_TLM:
+            Serial2.begin(19200, SERIAL_8N2, serial2RXpin, serial2TXpin, false);
+            serial2IO = new SerialHoTT_TLM(SERIAL2_PROTOCOL_TX, SERIAL2_PROTOCOL_RX, serial2TXpin);
+            break;
+        case PROTOCOL_SERIAL2_TRAMP:
+            Serial2.begin(9600, SERIAL_8N1, UNDEF_PIN, serial2TXpin, false);
+            serial2IO = new SerialTramp(SERIAL2_PROTOCOL_TX, SERIAL2_PROTOCOL_RX, serial2TXpin);
+            break;
+        case PROTOCOL_SERIAL2_SMARTAUDIO:
+            Serial2.begin(4800, SERIAL_8N2, UNDEF_PIN, serial2TXpin, false);
+            serial2IO = new SerialSmartAudio(SERIAL2_PROTOCOL_TX, SERIAL2_PROTOCOL_RX, serial2TXpin);
+            break;
+        case PROTOCOL_SERIAL2_MSP_DISPLAYPORT:
+            Serial2.begin(115200, SERIAL_8N1, UNDEF_PIN, serial2TXpin, false);
+            serial2IO = new SerialDisplayport(SERIAL2_PROTOCOL_TX, SERIAL2_PROTOCOL_RX);
+            break;
+        case PROTOCOL_SERIAL2_GPS:
+            Serial2.begin(115200, SERIAL_8N1, serial2RXpin, serial2TXpin, false);
+            serial2IO = new SerialGPS(SERIAL2_PROTOCOL_TX, SERIAL2_PROTOCOL_RX);
+            break;
+    }
+}
+
+void reconfigureSerial2()
+{
+    serial2Shutdown();
+    setupSerial2();
+}
 #else
     void setupSerial1() {};
     void reconfigureSerial1() {};
+    void setupSerial2() {};
+    void reconfigureSerial2() {};
 #endif
 
 static void serialShutdown()
@@ -2030,6 +2134,7 @@ void setup()
         crsfRouter.addConnector(&otaConnector);
         setupSerial();
         setupSerial1();
+        setupSerial2();
 
         devicesRegister(ui_devices, ARRAY_SIZE(ui_devices));
         devicesInit();


### PR DESCRIPTION
This adds Serial2 to a receiver: the third UART on ESP32 platform as "Protocol3".

One can choose "Protocol3" in the main receiver menu and "Serial3 TX" / "Serial3 RX" in the outut mapping menu.

Be sure to _reboot_ the receiver after changing the settings, or make the settings in output-mapping _first_ and _then_ setup "Protocol3".

The implementation follows strictly the pattern that was used for Serial and Serial1. So, there is room for improvement, since the result is code duplication instead of proper refactoring.

This PR still lacks the support for Serial3 in the Web-UI.

If you flash this onto a receiver with a previous version, do a full _erase_ of the flash or a full reset.