### PR TITLE
Fix S3 USB connection for CRSF/MAVLink telemetry

### DIFF
--- a/src/lib/Backpack/devBackpack.cpp
+++ b/src/lib/Backpack/devBackpack.cpp
@@ -139,29 +139,33 @@ void checkBackpackUpdate()
         {
             startPassthrough(false);
         }
-#if defined(PLATFORM_ESP32_S3)
-        // Start passthrough mode if an Espressif resync packet is detected on the USB port
-        static const uint8_t resync[] = {
-            0xc0,0x00,0x08,0x24,0x00,0x00,0x00,0x00,0x00,0x07,0x07,0x12,0x20,0x55,0x55,0x55,0x55,
-            0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55, 0x55,0x55,
-            0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0xc0
-        };
-        static int resync_pos = 0;
-        while(USBSerial.available())
-        {
-            const int byte = USBSerial.read();
-            if (byte == resync[resync_pos])
-            {
-                resync_pos++;
-                if (resync_pos == sizeof(resync)) startPassthrough(true);
-            }
-            else
-            {
-                resync_pos = 0;
-            }
-        }
-#endif
     }
+}
+
+void feedUSB(const uint8_t *buf, const uint16_t size)
+{
+#if defined(PLATFORM_ESP32_S3)
+    // Start passthrough mode if an Espressif resync packet is detected on the USB port
+    static const uint8_t resync[] = {
+        0xc0,0x00,0x08,0x24,0x00,0x00,0x00,0x00,0x00,0x07,0x07,0x12,0x20,0x55,0x55,0x55,0x55,
+        0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55, 0x55,0x55,
+        0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0xc0
+    };
+    static int resync_pos = 0;
+    for (int pos = 0 ; pos < size ; pos++)
+    {
+        const u_int8_t byte = buf[pos];
+        if (byte == resync[resync_pos])
+        {
+            resync_pos++;
+            if (resync_pos == sizeof(resync)) startPassthrough(true);
+        }
+        else
+        {
+            resync_pos = 0;
+        }
+    }
+#endif
 }
 
 static void BackpackWiFiToMSPOut(const uint16_t command)

--- a/src/lib/Backpack/devBackpack.h
+++ b/src/lib/Backpack/devBackpack.h
@@ -19,6 +19,14 @@ void processPanTiltRollPacket(uint32_t now, const mspPacket_t *packet);
 void checkBackpackUpdate();
 
 /**
+ * @brief Feed USB bytes through to see if the device should start in passthrough update mode
+ *
+ * If a backpack update has been requested then all devices are stopped and the UARTs
+ * are configured for passthrough flashing.
+ */
+void feedUSB(const uint8_t *buf, uint16_t size);
+
+/**
  * @brief send CRSF telemetry packet to the backpack.
  *
  * The CRSF packet is wrapped in an MSP packet of type `MSP_ELRS_BACKPACK_CRSF_TLM`

--- a/src/lib/tx-crsf/TXUSBConnector.cpp
+++ b/src/lib/tx-crsf/TXUSBConnector.cpp
@@ -10,7 +10,21 @@ void TXUSBConnector::forwardMessage(const crsf_header_t *message)
 {
     if (TxUSB != BackpackOrLogStrm && config.GetLinkMode() != TX_MAVLINK_MODE)
     {
-        const uint8_t length = message->frame_size + CRSF_FRAME_NOT_COUNTED_BYTES;
+        const size_t length = message->frame_size + CRSF_FRAME_NOT_COUNTED_BYTES;
         TxUSB->write((uint8_t *)message, length);
     }
+}
+
+uint8_t TXUSBConnector::GetMaxPacketBytes() const
+{
+#if defined(PLATFORM_ESP32_S3)
+#if ESP_ARDUINO_VERSION <= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
+    // Arduino < 3.0.0 & S3 has real issues sending 64 bytes!
+    return CRSF_MAX_PACKET_LEN >= 64 ? 63 : CRSF_MAX_PACKET_LEN;
+#else
+    return CRSF_MAX_PACKET_LEN;
+#endif
+#else
+    return CRSF_MAX_PACKET_LEN;
+#endif
 }

--- a/src/lib/tx-crsf/TXUSBConnector.h
+++ b/src/lib/tx-crsf/TXUSBConnector.h
@@ -6,6 +6,7 @@ class TXUSBConnector final : public CRSFConnector
 {
 public:
     void forwardMessage(const crsf_header_t *message) override;
+    uint8_t GetMaxPacketBytes() const override;
 };
 
 #endif //TX_USB_CONNECTOR_H

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -25,6 +25,7 @@
 #else
 // Fake functions for 8285
 void checkBackpackUpdate() {}
+void feedUSB(const uint8_t *, const uint16_t) {}
 void sendCRSFTelemetryToBackpack(uint8_t *) {}
 void sendMAVLinkTelemetryToBackpack(uint8_t *) {}
 #endif
@@ -1136,7 +1137,8 @@ static void HandleUARTin()
     if (size > 0)
     {
       uint8_t buf[size];
-      TxUSB->readBytes(buf, size);
+      size = TxUSB->readBytes(buf, size);
+      if (connectionState != connected) feedUSB(buf, size);
       apInputBuffer.lock();
       apInputBuffer.pushBytes(buf, size);
       apInputBuffer.unlock();
@@ -1151,7 +1153,8 @@ static void HandleUARTin()
   if (size > 0)
   {
     uint8_t buf[size];
-    TxUSB->readBytes(buf, size);
+    size = TxUSB->readBytes(buf, size);
+    if (connectionState > MODE_STATES) feedUSB(buf, size);
 
     // If the data is MAVLink, then auto change LinkMode and start the radio link
     // since the user might be operating the module as a standalone unit without a handset.


### PR DESCRIPTION
# Problem
S3 devices that use the native USB device (CDC) could not read MAVLink/CRSF data correctly from USBSerial device.
The issue is that we also read the USBSerial device in the backpack and try to detect an ESP resync packet for passthrough flashing of the backpack. So data was being read and discarded in that detection code when it could be MAVLink or CRSF packet data.

# Solution
Once the data is read in the main loop, pass it to the backpack as well to see if it can detect a resync packet. This means the passthrough update detection is not doing it's own read of the USB and everything is read in the main loop.

# Safety
Also as part of this, we also only allow going to passthrough update mode iff
- we are not connected in airport mode; or
- we are not connected to a radio handset in CRSF or MAVLink mode