### PR TITLE
Fix five-way button ADC calibration for ESP32

### DIFF
--- a/src/lib/ADC/devADC.cpp
+++ b/src/lib/ADC/devADC.cpp
@@ -49,7 +49,11 @@ static int timeout()
 #if defined(GPIO_PIN_JOYSTICK)
     if (GPIO_PIN_JOYSTICK != UNDEF_PIN)
     {
+#if defined(PLATFORM_ESP32)
+        analogReadings[ADC_JOYSTICK] = analogReadMilliVolts(GPIO_PIN_JOYSTICK);
+#else
         analogReadings[ADC_JOYSTICK] = analogRead(GPIO_PIN_JOYSTICK);
+#endif
     }
 #endif
 #if defined(GPIO_PIN_PA_PDET)

--- a/src/lib/SCREEN/FiveWayButton/FiveWayButton.cpp
+++ b/src/lib/SCREEN/FiveWayButton/FiveWayButton.cpp
@@ -10,6 +10,11 @@ uint16_t FiveWayButton::joyAdcValues[] = {0};
  * The goal is to avoid collisions between joystick positions while still maintaining
  * the widest tolerance for the analog value.
  *
+ * On ESP32, JOY_ADC_VALUES (raw counts) are converted to millivolt values
+ * (Vref=3300mV, 12-bit ADC) to match the calibrated mV readings from
+ * analogReadMilliVolts() used in devADC. This corrects for chip-to-chip
+ * reference voltage variation.
+ *
  * Example: {10,50,800,1000,300,1600}
  * If we just choose the minimum difference for this array the value would
  * be 40/2 = 20.
@@ -23,6 +28,17 @@ uint16_t FiveWayButton::joyAdcValues[] = {0};
 void FiveWayButton::calcFuzzValues()
 {
     memcpy(FiveWayButton::joyAdcValues, JOY_ADC_VALUES, sizeof(FiveWayButton::joyAdcValues));
+
+#if defined(PLATFORM_ESP32)
+    // Convert JOY_ADC_VALUES from raw counts to millivolt values to match
+    // the calibrated mV readings from analogReadMilliVolts() used in devADC.
+    // This corrects for chip-to-chip reference voltage variation.
+    for (unsigned int i = 0; i < N_JOY_ADC_VALUES; i++)
+    {
+        joyAdcValues[i] = (uint32_t)joyAdcValues[i] * 3300 / 4096;
+    }
+#endif
+
     for (unsigned int i = 0; i < N_JOY_ADC_VALUES; i++)
     {
         uint16_t closestDist = 0xffff;


### PR DESCRIPTION
在使用5维按键时遇到按键失灵，主要是右键与上键。以下有原理图：
<img width="1419" height="705" alt="image" src="https://github.com/user-attachments/assets/f9f0cfac-83c9-4db8-a7ca-d26224262907" />
<img width="849" height="645" alt="a30197da086f715730a7a02ce224bee3" src="https://github.com/user-attachments/assets/10538fb4-a976-4ced-b786-500a354a83d4" />
<img width="905" height="642" alt="3e86dde4cae4d300a2f17c543a22372c" src="https://github.com/user-attachments/assets/751b4e7b-d988-468b-9e3b-07798b3fa7db" />
<img width="873" height="786" alt="d76b1e3a7bc9a422f33dc47877f63072" src="https://github.com/user-attachments/assets/bacf2d67-c570-4991-a5a6-571a6fd8c96e" />
<img width="1593" height="1713" alt="image" src="https://github.com/user-attachments/assets/6c43bb47-f286-4da8-9b71-c744da5894d8" />

有读取efuse中的校准数据对比，出现这个按键失灵的原因有以下：
1，各按键之间的电压取值过近，实际使用"joystick_values": [3276,0,2072,2730,1377,4095]。
2，MCU内部硬件制造差异（±6%），电阻分压网络误差（1%左右）。
3，ExpressLRS软件默认使用 50%半距离作为模糊区间且未校准ADC。
基于以上信息，校准ADC更容易修复且影响最小，对硬件设计将放宽要求。

若官方开发人员有更好的修复方法就关闭此PR，非常感谢！