### PR TITLE
Remove the left-over power calibration code from pre 3.0

### DIFF
--- a/src/lib/POWERMGNT/POWERMGNT.cpp
+++ b/src/lib/POWERMGNT/POWERMGNT.cpp
@@ -80,8 +80,6 @@ int8_t POWERMGNT::CurrentSX1280Power = 0;
 
 extern bool isUsingPrimaryFreqBand();
 
-static int8_t powerCaliValues[PWR_COUNT] = {0};
-
 #if defined(PLATFORM_ESP32)
 nvs_handle POWERMGNT::handle = 0;
 #endif
@@ -151,73 +149,9 @@ uint8_t POWERMGNT::getPowerIndBm()
     }
 }
 
-void POWERMGNT::SetPowerCaliValues(int8_t *values, size_t size)
-{
-    bool isUpdate = false;
-    for(size_t i=0 ; i<size ; i++)
-    {
-        if(powerCaliValues[i] != values[i])
-        {
-            powerCaliValues[i] = values[i];
-            isUpdate = true;
-        }
-    }
-#if defined(PLATFORM_ESP32)
-    if (isUpdate)
-    {
-        nvs_set_blob(handle, "powercali", &powerCaliValues, sizeof(powerCaliValues));
-    }
-    nvs_commit(handle);
-#else
-    UNUSED(isUpdate);
-#endif
-}
-
-void POWERMGNT::GetPowerCaliValues(int8_t *values, size_t size)
-{
-    for(size_t i=0 ; i<size ; i++)
-    {
-        *(values + i) = powerCaliValues[i];
-    }
-}
-
-void POWERMGNT::LoadCalibration()
-{
-#if defined(PLATFORM_ESP32)
-    // Initialize NVS
-    esp_err_t err = nvs_flash_init();
-    if (err == ESP_ERR_NVS_NO_FREE_PAGES || err == ESP_ERR_NVS_NEW_VERSION_FOUND)
-    {
-        ESP_ERROR_CHECK(nvs_flash_erase());
-        err = nvs_flash_init();
-    }
-    ESP_ERROR_CHECK( err );
-    ESP_ERROR_CHECK(nvs_open("PWRCALI", NVS_READWRITE, &handle));
-
-    uint32_t version;
-    if(nvs_get_u32(handle, "calversion", &version) != ESP_ERR_NVS_NOT_FOUND
-        && version == (uint32_t)(CALIBRATION_VERSION | CALIBRATION_MAGIC))
-    {
-        size_t size = sizeof(powerCaliValues);
-        nvs_get_blob(handle, "powercali", &powerCaliValues, &size);
-    }
-    else
-    {
-        nvs_set_blob(handle, "powercali", &powerCaliValues, sizeof(powerCaliValues));
-        nvs_set_u32(handle, "calversion", CALIBRATION_VERSION | CALIBRATION_MAGIC);
-        nvs_commit(handle);
-    }
-#else
-    memset(powerCaliValues, 0, sizeof(powerCaliValues));
-#endif
-}
-
-
 void POWERMGNT::init()
 {
     PowerLevelContainer::CurrentPower = PWR_COUNT;
-
-    LoadCalibration();
     setDefaultPower();
 }
 
@@ -269,7 +203,7 @@ void POWERMGNT::setPower(PowerLevels_e Power)
     }
     else if (POWER_OUTPUT_VALUES != nullptr)
     {
-        CurrentSX1280Power = SAFE_GET_POWER_VALUE(POWER_OUTPUT_VALUES, powerIdx) + powerCaliValues[Power];
+        CurrentSX1280Power = SAFE_GET_POWER_VALUE(POWER_OUTPUT_VALUES, powerIdx);
         Radio.SetOutputPower(CurrentSX1280Power);
     }
 

--- a/src/lib/POWERMGNT/POWERMGNT.h
+++ b/src/lib/POWERMGNT/POWERMGNT.h
@@ -143,9 +143,6 @@ public:
      * device
      */
     static void init();
-
-    static void SetPowerCaliValues(int8_t *values, size_t size);
-    static void GetPowerCaliValues(int8_t *values, size_t size);
 };
 
 

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -963,36 +963,6 @@ static void CheckReadyToSend()
   }
 }
 
-void OnPowerGetCalibration(mspPacket_t *packet)
-{
-  uint8_t index = packet->readByte();
-  UNUSED(index);
-  int8_t values[PWR_COUNT] = {0};
-  POWERMGNT::GetPowerCaliValues(values, PWR_COUNT);
-  DBGLN("power get calibration value %d",  values[index]);
-}
-
-void OnPowerSetCalibration(mspPacket_t *packet)
-{
-  uint8_t index = packet->readByte();
-  int8_t value = packet->readByte();
-
-  if((index < 0) || (index >= PWR_COUNT))
-  {
-    DBGLN("calibration error index %d out of range", index);
-    return;
-  }
-  hwTimer::stop();
-  delay(20);
-
-  int8_t values[PWR_COUNT] = {0};
-  POWERMGNT::GetPowerCaliValues(values, PWR_COUNT);
-  values[index] = value;
-  POWERMGNT::SetPowerCaliValues(values, PWR_COUNT);
-  DBGLN("power calibration done %d, %d", index, value);
-  hwTimer::resume();
-}
-
 void SendUIDOverMSP()
 {
   MSPDataPackage[0] = MSP_ELRS_BIND;
@@ -1057,25 +1027,7 @@ void ProcessMSPPacket(uint32_t now, mspPacket_t *packet)
 {
 #if defined(PLATFORM_ESP32)
   // Inspect packet for ELRS specific opcodes
-  if (packet->function == MSP_ELRS_FUNC)
-  {
-    uint8_t opcode = packet->readByte();
-
-    CHECK_PACKET_PARSING();
-
-    switch (opcode)
-    {
-    case MSP_ELRS_POWER_CALI_GET:
-      OnPowerGetCalibration(packet);
-      break;
-    case MSP_ELRS_POWER_CALI_SET:
-      OnPowerSetCalibration(packet);
-      break;
-    default:
-      break;
-    }
-  }
-  else if (packet->function == MSP_SET_VTX_CONFIG)
+  if (packet->function == MSP_SET_VTX_CONFIG)
   {
     if (packet->payload[0] < 48) // Standard 48 channel VTx table size e.g. A, B, E, F, R, L
     {


### PR DESCRIPTION
Since version 3.0 all the hardware settings are configurable from hardware page/JSON file.
We can remove this vestigial piece of code that was never really used.