### PR TITLE
Remove the EEPROM usage on ESP32 TX modules

### DIFF
--- a/src/lib/CONFIG/config.cpp
+++ b/src/lib/CONFIG/config.cpp
@@ -172,9 +172,6 @@ TxConfig::TxConfig() :
 #if defined(PLATFORM_ESP32)
 void TxConfig::Load()
 {
-#if defined(PLATFORM_ESP8266)
-    m_eeprom.Begin();
-#endif
     m_modified = 0;
 
     // Initialize NVS

--- a/src/lib/CONFIG/config.cpp
+++ b/src/lib/CONFIG/config.cpp
@@ -172,6 +172,9 @@ TxConfig::TxConfig() :
 #if defined(PLATFORM_ESP32)
 void TxConfig::Load()
 {
+#if defined(PLATFORM_ESP8266)
+    m_eeprom.Begin();
+#endif
     m_modified = 0;
 
     // Initialize NVS
@@ -299,7 +302,7 @@ void TxConfig::Load()
 void TxConfig::Load()
 {
     m_modified = 0;
-    m_eeprom->Get(0, m_config);
+    m_eeprom.Get(0, m_config);
 
     uint32_t version = 0;
     if ((m_config.version & CONFIG_MAGIC_MASK) == TX_CONFIG_MAGIC)
@@ -344,15 +347,15 @@ void TxConfig::UpgradeEepromV5ToV6()
     v6_tx_config_t v6Config = { 0 }; // default the new fields to 0
 
     // Populate the prev version struct from eeprom
-    m_eeprom->Get(0, v5Config);
+    m_eeprom.Get(0, v5Config);
 
     // Copy prev values to current config struct
     // This only workse because v5 and v6 are the same up to the new fields
     // which have already been set to 0
     memcpy(&v6Config, &v5Config, sizeof(v5Config));
     v6Config.version = 6U | TX_CONFIG_MAGIC;
-    m_eeprom->Put(0, v6Config);
-    m_eeprom->Commit();
+    m_eeprom.Put(0, v6Config);
+    m_eeprom.Commit();
 }
 
 void TxConfig::UpgradeEepromV6ToV7()
@@ -361,7 +364,7 @@ void TxConfig::UpgradeEepromV6ToV7()
     v7_tx_config_t v7Config = { 0 }; // default the new fields to 0
 
     // Populate the prev version struct from eeprom
-    m_eeprom->Get(0, v6Config);
+    m_eeprom.Get(0, v6Config);
 
     // Manual field copying as some fields have moved
     #define LAZY(member) v7Config.member = v6Config.member
@@ -386,14 +389,14 @@ void TxConfig::UpgradeEepromV6ToV7()
 
     // Full Commit now
     m_config.version = 7U | TX_CONFIG_MAGIC;
-    m_eeprom->Put(0, v7Config);
-    m_eeprom->Commit();
+    m_eeprom.Put(0, v7Config);
+    m_eeprom.Commit();
 }
 
 void TxConfig::UpgradeEepromV7ToV8()
 {
     v7_tx_config_t v7Config;
-    m_eeprom->Get(0, v7Config);
+    m_eeprom.Get(0, v7Config);
 
     // Manual field copying as some fields were removed
     #define LAZY(member) m_config.member = v7Config.member
@@ -480,8 +483,8 @@ TxConfig::Commit()
     nvs_commit(handle);
 #else
     // Write the struct to eeprom
-    m_eeprom->Put(0, m_config);
-    m_eeprom->Commit();
+    m_eeprom.Put(0, m_config);
+    m_eeprom.Commit();
 #endif
     uint32_t changes = m_modified;
     m_modified = 0;
@@ -632,15 +635,6 @@ TxConfig::SetPowerFanThreshold(uint8_t powerFanThreshold)
     {
         m_config.powerFanThreshold = powerFanThreshold;
         m_modified |= EVENT_CONFIG_FAN_CHANGED;
-    }
-}
-
-void
-TxConfig::SetStorageProvider(ELRS_EEPROM *eeprom)
-{
-    if (eeprom)
-    {
-        m_eeprom = eeprom;
     }
 }
 

--- a/src/lib/CONFIG/config.h
+++ b/src/lib/CONFIG/config.h
@@ -171,7 +171,6 @@ public:
     void SetLinkMode(uint8_t linkMode);
     void SetModelMatch(bool modelMatch);
     void SetDefaults(bool commit);
-    void SetStorageProvider(ELRS_EEPROM *eeprom);
     void SetVtxBand(uint8_t vtxBand);
     void SetVtxChannel(uint8_t vtxChannel);
     void SetVtxPower(uint8_t vtxPower);
@@ -193,19 +192,18 @@ public:
     bool SetModelId(uint8_t modelId);
 
 private:
-#if !defined(PLATFORM_ESP32)
-    void UpgradeEepromV5ToV6();
-    void UpgradeEepromV6ToV7();
-    void UpgradeEepromV7ToV8();
-#endif
 
     tx_config_t m_config;
-    ELRS_EEPROM *m_eeprom;
     uint32_t     m_modified;
     model_config_t *m_model;
     uint8_t     m_modelId;
 #if defined(PLATFORM_ESP32)
     nvs_handle  handle;
+#else
+    ELRS_EEPROM m_eeprom;
+    void UpgradeEepromV5ToV6();
+    void UpgradeEepromV6ToV7();
+    void UpgradeEepromV7ToV8();
 #endif
 };
 

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -42,7 +42,6 @@ void sendMAVLinkTelemetryToBackpack(uint8_t *) {}
 
 /// define some libs to use ///
 MSP msp;
-ELRS_EEPROM eeprom;
 TxConfig config;
 Stream *TxUSB;
 
@@ -1430,8 +1429,6 @@ void setup()
 
     handset->registerCallbacks(UARTconnected, firmwareOptions.is_airport ? nullptr : UARTdisconnected);
 
-    eeprom.Begin(); // Init the eeprom
-    config.SetStorageProvider(&eeprom); // Pass pointer to the Config class for access to storage
     config.Load(); // Load the stored values from eeprom
 
     Radio.currFreq = FHSSgetInitialFreq(); //set frequency first or an error will occur!!!


### PR DESCRIPTION
It has not been used for a _very_ long time, so we may as well save some a little flash space, ~600 bytes.