### PR TITLE
Add RPM and second battery to MAVLink passthrough telemetry

### DIFF
--- a/src/lib/MAVLink/MAVLink.cpp
+++ b/src/lib/MAVLink/MAVLink.cpp
@@ -1,7 +1,11 @@
 #include "MAVLink.h"
 
 #include "CRSFRouter.h"
-#include "common/mavlink.h"
+// Use the ardupilotmega dialect (superset of common) so ArduPilot-specific
+// messages such as RPM (#226) are known to the frame parser. The per-message
+// CRC_EXTRA table is dialect-specific: a common-only build rejects RPM frames
+// as bad-CRC even though the struct would decode fine.
+#include "ardupilotmega/mavlink.h"
 
 #include "ardupilot_custom_telemetry.h"
 #include "ardupilot_protocol.h"
@@ -109,7 +113,14 @@ void convert_mavlink_to_crsf_telem(crsf_addr_e destination, uint8_t *CRSFinBuffe
             case MAVLINK_MSG_ID_BATTERY_STATUS: {
                 mavlink_battery_status_t battery_status;
                 mavlink_msg_battery_status_decode(&msg, &battery_status);
-                if (battery_status.id != 0) {
+                // Yaapu supports two batteries: BATT_1 (0x5003) and BATT_2 (0x5008).
+                if (battery_status.id > 1) {
+                    break;
+                }
+                if (battery_status.id == 1) {
+                    // Second battery: passthrough only (native CRSF has a single battery
+                    // frame). Same bit-packing as BATT_1, per Ardupilot's calc_batt().
+                    ap_send_crsf_passthrough_single(destination, 0x5008, format_batt1(battery_status.voltages[0], battery_status.current_battery, battery_status.current_consumed));
                     break;
                 }
                 CRSF_MK_FRAME_T(crsf_sensor_battery_t)
@@ -310,6 +321,13 @@ void convert_mavlink_to_crsf_telem(crsf_addr_e destination, uint8_t *CRSFinBuffe
                 mavlink_msg_high_latency2_decode(&msg, &high_latency_data);
                 // send the waypoint message to Yaapu Telemetry Script
                 ap_send_crsf_passthrough_single(destination, 0x500D, format_waypoint(high_latency_data.target_heading, high_latency_data.target_distance, high_latency_data.wp_num));
+                break;
+            }
+            case MAVLINK_MSG_ID_RPM: {
+                mavlink_rpm_t rpm;
+                mavlink_msg_rpm_decode(&msg, &rpm);
+                // send the rpm message to Yaapu Telemetry Script
+                ap_send_crsf_passthrough_single(destination, 0x500A, format_rpm(rpm.rpm1, rpm.rpm2));
                 break;
             }
             }

--- a/src/lib/MAVLink/ardupilot_custom_telemetry.cpp
+++ b/src/lib/MAVLink/ardupilot_custom_telemetry.cpp
@@ -19,6 +19,7 @@
 
 #include "ardupilot_custom_telemetry.h"
 #include "common/mavlink.h"
+#include <math.h>
 
 /*
  * Known Issues:
@@ -459,6 +460,20 @@ uint32_t format_param(uint8_t param_id, uint32_t param_value)
 }
 
 /*
+ * Adapted from Ardupilot's AP_Frsky_SPort_Passthrough::calc_rpm()
+ * This is the content of the 0x500A RPM value.
+ * Two signed 16-bit RPM values, each scaled by 0.1 (Yaapu multiplies back by 10).
+ * rpm1 occupies bits 0-15, rpm2 bits 16-31.
+ */
+uint32_t format_rpm(float rpm1, float rpm2)
+{
+    uint32_t value = (uint16_t)(int16_t)lroundf(rpm1 * 0.1f);
+    value |= ((uint32_t)(uint16_t)(int16_t)lroundf(rpm2 * 0.1f)) << 16;
+    return value;
+}
+
+
+/*
  * Adapted from Ardupilot's AP_Frsky_SPort_Passthrough::calc_terrain()
  * This is the content of the 0x500B terrain.
  */
@@ -471,7 +486,7 @@ uint32_t format_terrain(uint32_t altitude_terrain)
 
 /*
  * Adapted from Ardupilot's AP_Frsky_SPort_Passthrough::calc_waypoint()
- * This is the content of the 0x500B terrain.
+ * This is the content of the 0x500D waypoint.
  */
 uint32_t format_waypoint(uint8_t heading, uint16_t distance, uint16_t number)
 {

--- a/src/lib/MAVLink/ardupilot_custom_telemetry.h
+++ b/src/lib/MAVLink/ardupilot_custom_telemetry.h
@@ -95,6 +95,12 @@ uint32_t format_attiandrng(float pitch_rad, float roll_rad);
 uint32_t format_param(uint8_t param_id, uint32_t param_value);
 
 /*
+ * Adapted from Ardupilot's AP_Frsky_SPort_Passthrough::calc_rpm()
+ * This is the content of the 0x500A RPM value.
+ */
+uint32_t format_rpm(float rpm1, float rpm2);
+
+/*
  * Adapted from Ardupilot's AP_Frsky_SPort_Passthrough::calc_terrain()
  * This is the content of the 0x500B terrain.
  */


### PR DESCRIPTION
Adds RPM (`0x500A`) and second battery (`0x5008`) to the Yaapu passthrough, same bit layout as ArduPilot so the script reads them as-is. `RPM` is ardupilotmega, so `MAVLink.cpp` moves off the common dialect: CRC_EXTRA is per-dialect and a common-only build CRC-rejects every RPM frame before it decodes. TX only, ~1.2k of flash, no ESP32 RAM change.

Needs `RPM_TYPE` and `SR*_EXTRA3` > 0 on the FC or there's nothing to convert. Encode tested on host against ArduPilot's output, not tested against a real Yaapu display.
