### PR TITLE
Add wind and rangefinder to MAVLink passthrough telemetry

### DIFF
--- a/src/lib/MAVLink/MAVLink.cpp
+++ b/src/lib/MAVLink/MAVLink.cpp
@@ -1,7 +1,11 @@
 #include "MAVLink.h"
 
 #include "CRSFRouter.h"
-#include "common/mavlink.h"
+// Use the ardupilotmega dialect (superset of common) so ArduPilot-specific
+// messages such as RPM (#226) are known to the frame parser. The per-message
+// CRC_EXTRA table is dialect-specific: a common-only build rejects RPM frames
+// as bad-CRC even though the struct would decode fine.
+#include "ardupilotmega/mavlink.h"
 
 #include "ardupilot_custom_telemetry.h"
 #include "ardupilot_protocol.h"
@@ -109,7 +113,14 @@ void convert_mavlink_to_crsf_telem(crsf_addr_e destination, uint8_t *CRSFinBuffe
             case MAVLINK_MSG_ID_BATTERY_STATUS: {
                 mavlink_battery_status_t battery_status;
                 mavlink_msg_battery_status_decode(&msg, &battery_status);
-                if (battery_status.id != 0) {
+                // Yaapu supports two batteries: BATT_1 (0x5003) and BATT_2 (0x5008).
+                if (battery_status.id > 1) {
+                    break;
+                }
+                if (battery_status.id == 1) {
+                    // Second battery: passthrough only (native CRSF has a single battery
+                    // frame). Same bit-packing as BATT_1, per Ardupilot's calc_batt().
+                    ap_send_crsf_passthrough_single(destination, 0x5008, format_batt1(battery_status.voltages[0], battery_status.current_battery, battery_status.current_consumed));
                     break;
                 }
                 CRSF_MK_FRAME_T(crsf_sensor_battery_t)
@@ -310,6 +321,13 @@ void convert_mavlink_to_crsf_telem(crsf_addr_e destination, uint8_t *CRSFinBuffe
                 mavlink_msg_high_latency2_decode(&msg, &high_latency_data);
                 // send the waypoint message to Yaapu Telemetry Script
                 ap_send_crsf_passthrough_single(destination, 0x500D, format_waypoint(high_latency_data.target_heading, high_latency_data.target_distance, high_latency_data.wp_num));
+                break;
+            }
+            case MAVLINK_MSG_ID_RPM: {
+                mavlink_rpm_t rpm;
+                mavlink_msg_rpm_decode(&msg, &rpm);
+                // send the rpm message to Yaapu Telemetry Script
+                ap_send_crsf_passthrough_single(destination, 0x500A, format_rpm(rpm.rpm1, rpm.rpm2));
                 break;
             }
             }

--- a/src/lib/MAVLink/MAVLink.cpp
+++ b/src/lib/MAVLink/MAVLink.cpp
@@ -10,6 +10,8 @@
 #include "ardupilot_custom_telemetry.h"
 #include "ardupilot_protocol.h"
 
+#include <math.h>
+
 /*
  * Helper function to send an ardupilot specific CRSF passthrough frame
  * with a single data item appid is the function that produces the data.
@@ -94,6 +96,9 @@ void convert_mavlink_to_crsf_telem(crsf_addr_e destination, uint8_t *CRSFinBuffe
     // Store the home position for distance and bearing calculation
     static int32_t home_latitude_degE7 = 0;
     static int32_t home_longitude_degE7 = 0;
+
+    // Store the latest rangefinder distance for the attitude/rangefinder packet
+    static int32_t rangefinder_cm = 0;
 
     for (uint8_t i = 0; i < count; i++)
     {
@@ -211,7 +216,7 @@ void convert_mavlink_to_crsf_telem(crsf_addr_e destination, uint8_t *CRSFinBuffe
                 crsfRouter.deliverMessageTo(destination, &crsfatt.h);
 
                 // send the attitude message to Yaapu Telemetry Script
-                ap_send_crsf_passthrough_single(destination, 0x5006, format_attiandrng(attitude.pitch, attitude.roll));
+                ap_send_crsf_passthrough_single(destination, 0x5006, format_attiandrng(attitude.pitch, attitude.roll, rangefinder_cm));
                 break;
             }
             case MAVLINK_MSG_ID_HEARTBEAT: {
@@ -328,6 +333,20 @@ void convert_mavlink_to_crsf_telem(crsf_addr_e destination, uint8_t *CRSFinBuffe
                 mavlink_msg_rpm_decode(&msg, &rpm);
                 // send the rpm message to Yaapu Telemetry Script
                 ap_send_crsf_passthrough_single(destination, 0x500A, format_rpm(rpm.rpm1, rpm.rpm2));
+                break;
+            }
+            case MAVLINK_MSG_ID_RANGEFINDER: {
+                mavlink_rangefinder_t rangefinder;
+                mavlink_msg_rangefinder_decode(&msg, &rangefinder);
+                // stash the distance in cm for the next attitude/rangefinder packet
+                rangefinder_cm = (int32_t)lroundf(rangefinder.distance * 100);
+                break;
+            }
+            case MAVLINK_MSG_ID_WIND: {
+                mavlink_wind_t wind;
+                mavlink_msg_wind_decode(&msg, &wind);
+                // send the wind message to Yaapu Telemetry Script
+                ap_send_crsf_passthrough_single(destination, 0x500C, format_wind(wind.direction, wind.speed));
                 break;
             }
             }

--- a/src/lib/MAVLink/MAVLink.cpp
+++ b/src/lib/MAVLink/MAVLink.cpp
@@ -10,6 +10,8 @@
 #include "ardupilot_custom_telemetry.h"
 #include "ardupilot_protocol.h"
 
+#include <math.h>
+
 /*
  * Helper function to send an ardupilot specific CRSF passthrough frame
  * with a single data item appid is the function that produces the data.
@@ -94,6 +96,12 @@ void convert_mavlink_to_crsf_telem(crsf_addr_e destination, uint8_t *CRSFinBuffe
     // Store the home position for distance and bearing calculation
     static int32_t home_latitude_degE7 = 0;
     static int32_t home_longitude_degE7 = 0;
+
+    // Store the latest downward rangefinder distance for the attitude/rangefinder packet
+    static int32_t rangefinder_cm = 0;
+    // DISTANCE_SENSOR is the primary source. RANGEFINDER is the fallback for
+    // flight controllers that do not send DISTANCE_SENSOR.
+    static bool have_distance_sensor = false;
 
     for (uint8_t i = 0; i < count; i++)
     {
@@ -211,7 +219,7 @@ void convert_mavlink_to_crsf_telem(crsf_addr_e destination, uint8_t *CRSFinBuffe
                 crsfRouter.deliverMessageTo(destination, &crsfatt.h);
 
                 // send the attitude message to Yaapu Telemetry Script
-                ap_send_crsf_passthrough_single(destination, 0x5006, format_attiandrng(attitude.pitch, attitude.roll));
+                ap_send_crsf_passthrough_single(destination, 0x5006, format_attiandrng(attitude.pitch, attitude.roll, rangefinder_cm));
                 break;
             }
             case MAVLINK_MSG_ID_HEARTBEAT: {
@@ -328,6 +336,39 @@ void convert_mavlink_to_crsf_telem(crsf_addr_e destination, uint8_t *CRSFinBuffe
                 mavlink_msg_rpm_decode(&msg, &rpm);
                 // send the rpm message to Yaapu Telemetry Script
                 ap_send_crsf_passthrough_single(destination, 0x500A, format_rpm(rpm.rpm1, rpm.rpm2));
+                break;
+            }
+            case MAVLINK_MSG_ID_DISTANCE_SENSOR: {
+                mavlink_distance_sensor_t distance_sensor;
+                mavlink_msg_distance_sensor_decode(&msg, &distance_sensor);
+                // ArduPilot 4.7 and later send DISTANCE_SENSOR in place of RANGEFINDER.
+                // The vehicle sends one message for each sensor. Use only the
+                // downward sensor, because that is the sensor this field shows.
+                if (distance_sensor.orientation == MAV_SENSOR_ROTATION_PITCH_270)
+                {
+                    have_distance_sensor = true;
+                    // stash the distance in cm for the next attitude/rangefinder packet
+                    rangefinder_cm = distance_sensor.current_distance;
+                }
+                break;
+            }
+            case MAVLINK_MSG_ID_RANGEFINDER: {
+                // Fallback only. DISTANCE_SENSOR gives the orientation, so it wins.
+                if (have_distance_sensor)
+                {
+                    break;
+                }
+                mavlink_rangefinder_t rangefinder;
+                mavlink_msg_rangefinder_decode(&msg, &rangefinder);
+                // stash the distance in cm for the next attitude/rangefinder packet
+                rangefinder_cm = (int32_t)lroundf(rangefinder.distance * 100);
+                break;
+            }
+            case MAVLINK_MSG_ID_WIND: {
+                mavlink_wind_t wind;
+                mavlink_msg_wind_decode(&msg, &wind);
+                // send the wind message to Yaapu Telemetry Script
+                ap_send_crsf_passthrough_single(destination, 0x500C, format_wind(wind.direction, wind.speed));
                 break;
             }
             }

--- a/src/lib/MAVLink/ardupilot_custom_telemetry.cpp
+++ b/src/lib/MAVLink/ardupilot_custom_telemetry.cpp
@@ -433,9 +433,10 @@ uint32_t format_velandyaw(float climb_mps, float airspeed_mps, float groundspeed
 /*
  * Adapted from Ardupilot's AP_Frsky_SPort_Passthrough::calc_attiandrng()
  * This is the content of the 0x5006 Attitude and RangeFinder.
- * We don't provide Rangefinder here.
+ * rangefinder_cm is the downward rangefinder distance in cm, or 0 when there
+ * is no rangefinder.
  */
-uint32_t format_attiandrng(float pitch_rad, float roll_rad)
+uint32_t format_attiandrng(float pitch_rad, float roll_rad, int32_t rangefinder_cm)
 {
 #define ATTIANDRNG_ROLL_LIMIT       0x7FF
 #define ATTIANDRNG_PITCH_LIMIT      0x3FF
@@ -443,6 +444,8 @@ uint32_t format_attiandrng(float pitch_rad, float roll_rad)
 #define ATTIANDRNG_RNGFND_OFFSET    21
     uint32_t attiandrng = ((((uint16_t)(roll_rad * 286.0f)) + 900) & ATTIANDRNG_ROLL_LIMIT);
     attiandrng |= ((((uint16_t)(pitch_rad * 286.0f)) + 450) & ATTIANDRNG_PITCH_LIMIT)<<ATTIANDRNG_PITCH_OFFSET;
+    // rangefinder measurement in cm
+    attiandrng |= prep_number(rangefinder_cm, 3, 1)<<ATTIANDRNG_RNGFND_OFFSET;
     return attiandrng;
 }
 
@@ -499,6 +502,23 @@ uint32_t format_waypoint(uint8_t heading, uint16_t distance, uint16_t number)
     value |= prep_number(distance, 3, 2) << WP_DISTANCE_OFFSET;
     // bearing encoded in 3 degrees increments
     value |= (heading * 2 / 3) << WP_BEARING_OFFSET;
+    return value;
+}
+
+
+/*
+ * Adapted from Ardupilot's AP_Frsky_SPort_Passthrough::calc_wind()
+ * This is the content of the 0x500C wind value.
+ * Apparent wind is a Rover WindVane feature and is not available via MAVLink,
+ * so only the true wind angle and speed are sent.
+ */
+uint32_t format_wind(float direction_deg, float speed_mps)
+{
+#define WIND_SPEED_OFFSET           7
+    // true wind angle in 3 degree increments 0,360 (unsigned)
+    uint32_t value = prep_number(lroundf(direction_deg * (1.0f / 3.0f)), 2, 0);
+    // true wind speed in dm/s
+    value |= prep_number(lroundf(speed_mps * 10), 2, 1) << WIND_SPEED_OFFSET;
     return value;
 }
 

--- a/src/lib/MAVLink/ardupilot_custom_telemetry.cpp
+++ b/src/lib/MAVLink/ardupilot_custom_telemetry.cpp
@@ -19,6 +19,7 @@
 
 #include "ardupilot_custom_telemetry.h"
 #include "common/mavlink.h"
+#include <math.h>
 
 /*
  * Known Issues:
@@ -459,6 +460,20 @@ uint32_t format_param(uint8_t param_id, uint32_t param_value)
 }
 
 /*
+ * Adapted from Ardupilot's AP_Frsky_SPort_Passthrough::calc_rpm()
+ * This is the content of the 0x500A RPM value.
+ * Two signed 16-bit RPM values, each scaled by 0.1 (Yaapu multiplies back by 10).
+ * rpm1 occupies bits 0-15, rpm2 bits 16-31.
+ */
+uint32_t format_rpm(float rpm1, float rpm2)
+{
+    uint32_t value = (uint16_t)(int16_t)lroundf(rpm1 * 0.1f);
+    value |= ((uint32_t)(uint16_t)(int16_t)lroundf(rpm2 * 0.1f)) << 16;
+    return value;
+}
+
+
+/*
  * Adapted from Ardupilot's AP_Frsky_SPort_Passthrough::calc_terrain()
  * This is the content of the 0x500B terrain.
  */
@@ -471,7 +486,7 @@ uint32_t format_terrain(uint32_t altitude_terrain)
 
 /*
  * Adapted from Ardupilot's AP_Frsky_SPort_Passthrough::calc_waypoint()
- * This is the content of the 0x500B terrain.
+ * This is the content of the 0x500D waypoint.
  */
 uint32_t format_waypoint(uint8_t heading, uint16_t distance, uint16_t number)
 {

--- a/src/lib/MAVLink/ardupilot_custom_telemetry.h
+++ b/src/lib/MAVLink/ardupilot_custom_telemetry.h
@@ -84,9 +84,10 @@ uint32_t format_velandyaw(float climb_mps, float airspeed_mps, float groundspeed
 /*
  * Adapted from Ardupilot's AP_Frsky_SPort_Passthrough::calc_attiandrng()
  * This is the content of the 0x5006 Attitude and RangeFinder.
- * We don't provide Rangefinder here.
+ * rangefinder_cm is the downward rangefinder distance in cm, or 0 when there
+ * is no rangefinder.
  */
-uint32_t format_attiandrng(float pitch_rad, float roll_rad);
+uint32_t format_attiandrng(float pitch_rad, float roll_rad, int32_t rangefinder_cm);
 
 /*
  * Adapted from Ardupilot's AP_Frsky_SPort_Passthrough::calc_param()
@@ -111,4 +112,10 @@ uint32_t format_terrain(uint32_t altitude_terrain);
  * This is the content of the 0x500B terrain.
  */
 uint32_t format_waypoint(uint8_t heading, uint16_t distance, uint16_t number);
+
+/*
+ * Adapted from Ardupilot's AP_Frsky_SPort_Passthrough::calc_wind()
+ * This is the content of the 0x500C wind value.
+ */
+uint32_t format_wind(float direction_deg, float speed_mps);
 

--- a/src/lib/MAVLink/ardupilot_custom_telemetry.h
+++ b/src/lib/MAVLink/ardupilot_custom_telemetry.h
@@ -95,6 +95,12 @@ uint32_t format_attiandrng(float pitch_rad, float roll_rad);
 uint32_t format_param(uint8_t param_id, uint32_t param_value);
 
 /*
+ * Adapted from Ardupilot's AP_Frsky_SPort_Passthrough::calc_rpm()
+ * This is the content of the 0x500A RPM value.
+ */
+uint32_t format_rpm(float rpm1, float rpm2);
+
+/*
  * Adapted from Ardupilot's AP_Frsky_SPort_Passthrough::calc_terrain()
  * This is the content of the 0x500B terrain.
  */


### PR DESCRIPTION
Adds wind (`0x500C`) and fills in the rangefinder field of the attitude packet (`0x5006`), same bit layout as `calc_wind()` and `calc_attiandrng()`. Distance comes from `DISTANCE_SENSOR` (#132) filtered to `ROTATION_PITCH_270`, falling back to `RANGEFINDER` (#173) for pre-4.7, and we drop the fallback once we've seen a downward `DISTANCE_SENSOR` so a vehicle sending both doesn't flip-flop. Thanks @jlpoltrack for the 4.7 heads up.

Sits on #3720 for the ardupilotmega dialect, merge that one first. `WIND` needs an airspeed source or the wind estimator, the rangefinder needs `RNGFND*` and `SR*` > 0. Encode and decode tested on host, not on a real Yaapu display.
