### PR TITLE
Make Unified configuration non-interactive-safe

### DIFF
--- a/src/python/UnifiedConfiguration.py
+++ b/src/python/UnifiedConfiguration.py
@@ -1,10 +1,16 @@
 #!/usr/bin/python
 
 import argparse
+import os
 import re
 import json
 import struct
 import sys
+
+# Environment variable that selects the hardware configuration non-interactively,
+# e.g. ELRS_UNIFIED_CONFIG=radiomaster.tx_dual.nomad. Used when no board_config
+# project option is set, so an automated build/upload never needs a TTY.
+ENV_UNIFIED_CONFIG = "ELRS_UNIFIED_CONFIG"
 
 from external import jmespath
 from firmware import TXType
@@ -171,7 +177,16 @@ def interactiveProductSelect(targets: dict, target_name: str) -> dict:
         print(f'default) {default_prod}')
         print('Choose a configuration to load into the firmware file')
 
-        choice = input()
+        try:
+            choice = input()
+        except EOFError:
+            # No usable stdin (automated build, redirected pipe, some IDE shells).
+            # Leave the firmware bare rather than aborting the build; it can be
+            # configured later via the web UI or binary_configurator.py.
+            print(f'No interactive terminal available; leaving the firmware "bare".')
+            print(f'Set the {ENV_UNIFIED_CONFIG} environment variable or the '
+                  f'"board_config" option to configure non-interactively.')
+            return None
         if choice == '':
             choice = default_prod
         if choice == '0':
@@ -194,8 +209,12 @@ def doConfiguration(file, defines, config, target_name, device_name, rx_as_tx):
         targets = json.load(f)
 
     if config is not None:
+        requested = config
         config ='.'.join(map(lambda s: f'"{s}"', config.split('.')))
         config = jmespath.search(config, targets)
+        if config is None:
+            print(f'Warning: configuration "{requested}" was not found in '
+                  f'targets.json; leaving the firmware "bare".')
     elif not sys.stdin.isatty():
         print('Not running in an interactive shell, leaving the firmware "bare".\n')
         print('The current compile options (user defines) have been included.')
@@ -217,6 +236,10 @@ def appendConfiguration(source, target, env):
     target_name = env.get('PIOENV', '')
     device_name = env.get('DEVICE_NAME', None)
     config = env.GetProjectOption('board_config', None)
+    # Fall back to the environment variable so a configuration can be selected
+    # without a TTY, e.g. ELRS_UNIFIED_CONFIG=radiomaster.tx_dual.nomad pio run -t upload
+    if config is None:
+        config = os.environ.get(ENV_UNIFIED_CONFIG) or None
     if 'Unified_' not in target_name and config is None:
         return
 

--- a/src/python/binary_configurator.py
+++ b/src/python/binary_configurator.py
@@ -136,7 +136,12 @@ def ask_for_firmware(args):
                 products.append(k)
                 print(f"{i}) {k['product_name']}")
             print('Choose a configuration to flash')
-            choice = input()
+            try:
+                choice = input()
+            except EOFError:
+                print('No interactive terminal available. Specify the target on the '
+                      'command line, e.g. --target radiomaster.tx_dual.nomad')
+                exit(1)
             if choice != "":
                 config = products[int(choice)-1]
                 for v in targets:


### PR DESCRIPTION
### Description

The Unified firmware configuration step runs after the build. It calls `input()`
to ask which hardware configuration to load. An automated build has no terminal,
so `input()` raises `EOFError` and the whole build stops. This happens even
though the code tries to detect a non-interactive shell first — some shells
(CI, redirected pipes, some IDE terminals) report a tty but still return EOF on
read.

This change makes the configuration step safe without a terminal.

### Changes

- `interactiveProductSelect()` catches `EOFError` from `input()`. It then leaves
  the firmware bare and prints how to configure it, instead of stopping the
  build.
- `appendConfiguration()` reads a new `ELRS_UNIFIED_CONFIG` environment variable
  when the `board_config` option is not set. This selects the hardware
  configuration without a terminal. Example:
  `ELRS_UNIFIED_CONFIG=radiomaster.tx_dual.nomad pio run -t upload`
- `doConfiguration()` prints a warning when the requested configuration is not
  in `targets.json`. Before, a wrong name left the firmware bare with no message.
- `binary_configurator.py` prints a clear message and exits when it has no
  terminal and no `--target` argument, instead of raising `EOFError`.

### Why

There was no way to build a configured Unified target without a terminal. The
`board_config` project option needs an edit to `platformio.ini`. The environment
variable gives a simple, scriptable way to pick the target for one build or
upload. The `EOFError` guard also stops automated builds from failing when they
leave the firmware bare on purpose.

### Compatibility

- Interactive builds do not change. The prompt still works the same way.
- `board_config` still works and still takes priority over the environment
  variable.
- The environment variable uses the same target path as `--target` and
  `board_config` (for example `radiomaster.tx_dual.nomad`).

### Tests

- Unit test against the real `hardware/targets.json`: a valid path applies the
  layout; a forced `EOFError` leaves the firmware bare without a crash; a wrong
  path prints the warning and leaves it bare.
- End-to-end `pio run` with `ELRS_UNIFIED_CONFIG` set: the build finishes and
  the firmware has the selected product configuration.
