### PR TITLE
Fix FHSS sequence truncation when an LR1121 receiver binds on 2.4GHz

### DIFF
--- a/src/lib/FHSS/FHSS.cpp
+++ b/src/lib/FHSS/FHSS.cpp
@@ -90,28 +90,27 @@ char version_domain[VERSION_DOMAIN_MAXLEN] {};
 
 void FHSSrandomiseFHSSsequence(const uint32_t seed)
 {
+    // the hop pointer indexes sequences that are about to be replaced
+    FHSSptr = 0;
+
     FHSSconfig = &domains[firmwareOptions.domain];
     sync_channel = FHSSconfig->freq_count / 2;
     freq_spread = (FHSSconfig->freq_stop - FHSSconfig->freq_start) * FREQ_SPREAD_SCALE / (FHSSconfig->freq_count - 1);
-    primaryBandCount = (FHSS_SEQUENCE_LEN / FHSSconfig->freq_count) * FHSSconfig->freq_count;
 
     DBGLN("Primary Domain %s, %u channels, sync=%u",
         FHSSconfig->domain, FHSSconfig->freq_count, sync_channel);
 
-    FHSSrandomiseFHSSsequenceBuild(seed, FHSSconfig->freq_count, sync_channel, FHSSsequence);
+    primaryBandCount = FHSSrandomiseFHSSsequenceBuild(seed, FHSSconfig->freq_count, sync_channel, FHSSsequence);
 
 #if defined(RADIO_LR1121)
     FHSSconfigDualBand = &domainsDualBand[0];
     sync_channel_DualBand = FHSSconfigDualBand->freq_count / 2;
     freq_spread_DualBand = (FHSSconfigDualBand->freq_stop - FHSSconfigDualBand->freq_start) * FREQ_SPREAD_SCALE / (FHSSconfigDualBand->freq_count - 1);
-    secondaryBandCount = (FHSS_SEQUENCE_LEN / FHSSconfigDualBand->freq_count) * FHSSconfigDualBand->freq_count;
 
     DBGLN("Dual Domain %s, %u channels, sync=%u",
         FHSSconfigDualBand->domain, FHSSconfigDualBand->freq_count, sync_channel_DualBand);
 
-    FHSSusePrimaryFreqBand = false;
-    FHSSrandomiseFHSSsequenceBuild(seed, FHSSconfigDualBand->freq_count, sync_channel_DualBand, FHSSsequence_DualBand);
-    FHSSusePrimaryFreqBand = true;
+    secondaryBandCount = FHSSrandomiseFHSSsequenceBuild(seed, FHSSconfigDualBand->freq_count, sync_channel_DualBand, FHSSsequence_DualBand);
 #endif
 
     // add frequency and regulatory domain to the string used by the Lua script
@@ -131,14 +130,14 @@ Approach:
   another random entry, excluding the sync channel.
 
 */
-void FHSSrandomiseFHSSsequenceBuild(const uint32_t seed, uint32_t freqCount, uint_fast8_t syncChannel, uint8_t *inSequence)
+uint16_t FHSSrandomiseFHSSsequenceBuild(const uint32_t seed, uint32_t freqCount, uint_fast8_t syncChannel, uint8_t *inSequence)
 {
-    // reset the pointer (otherwise the tests fail)
-    FHSSptr = 0;
+    const uint16_t sequenceCount = (FHSS_SEQUENCE_LEN / freqCount) * freqCount;
+
     rngSeed(seed);
 
     // initialize the sequence array
-    for (uint16_t i = 0; i < FHSSgetSequenceCount(); i++)
+    for (uint16_t i = 0; i < sequenceCount; i++)
     {
         if (i % freqCount == 0) {
             inSequence[i] = syncChannel;
@@ -149,7 +148,7 @@ void FHSSrandomiseFHSSsequenceBuild(const uint32_t seed, uint32_t freqCount, uin
         }
     }
 
-    for (uint16_t i = 0; i < FHSSgetSequenceCount(); i++)
+    for (uint16_t i = 0; i < sequenceCount; i++)
     {
         // if it's not the sync channel
         if (i % freqCount != 0)
@@ -164,14 +163,7 @@ void FHSSrandomiseFHSSsequenceBuild(const uint32_t seed, uint32_t freqCount, uin
         }
     }
 
-    // output FHSS sequence
-    // for (uint16_t i=0; i < FHSSgetSequenceCount(); i++)
-    // {
-    //     DBG("%u ",inSequence[i]);
-    //     if (i % 10 == 9)
-    //         DBGCR;
-    // }
-    // DBGCR;
+    return sequenceCount;
 }
 
 /**

--- a/src/lib/FHSS/FHSS.cpp
+++ b/src/lib/FHSS/FHSS.cpp
@@ -163,6 +163,15 @@ uint16_t FHSSrandomiseFHSSsequenceBuild(const uint32_t seed, uint32_t freqCount,
         }
     }
 
+    // output FHSS sequence
+    // for (uint16_t i=0; i < sequenceCount; i++)
+    // {
+    //     DBG("%u ",inSequence[i]);
+    //     if (i % 10 == 9)
+    //         DBGCR;
+    // }
+    // DBGCR;
+
     return sequenceCount;
 }
 

--- a/src/lib/FHSS/FHSS.h
+++ b/src/lib/FHSS/FHSS.h
@@ -55,7 +55,9 @@ extern char version_domain[];
 
 // create and randomise an FHSS sequence
 void FHSSrandomiseFHSSsequence(uint32_t seed);
-void FHSSrandomiseFHSSsequenceBuild(uint32_t seed, uint32_t freqCount, uint_fast8_t sync_channel, uint8_t *sequence);
+// build one band's sequence from freqCount alone and return the number of
+// entries written, always a whole multiple of freqCount
+uint16_t FHSSrandomiseFHSSsequenceBuild(uint32_t seed, uint32_t freqCount, uint_fast8_t sync_channel, uint8_t *sequence);
 
 // add domain info for Lua
 void addDomainInfo(char *version_domain, uint8_t maxlen);
@@ -83,7 +85,8 @@ static inline uint32_t FHSSgetChannelCount(void)
     }
 }
 
-// get the number of entries in the FHSS sequence
+// how far the shared hop index may advance in the current mode. This is not any
+// one band's table length, so never size a sequence build from it
 static inline uint16_t FHSSgetSequenceCount()
 {
     if (FHSSuseDualBand) // Use the smaller of the 2 bands as not to go beyond the max index for each sequence.

--- a/src/test/test_fhss/test_fhss.cpp
+++ b/src/test/test_fhss/test_fhss.cpp
@@ -1,4 +1,6 @@
 #include <cstdint>
+#include <cstdio>
+#include <cstring>
 #include <SX1280_Regs.h>
 #include <FHSS.h>
 #include <unity.h>
@@ -84,8 +86,60 @@ void test_fhss_reg_same(void)
     }
 }
 
+// the channel counts the shipped domains use
+static constexpr uint32_t FREQ_COUNTS[] = {3, 4, 8, 13, 20, 40, 80};
+// the count a receiver binding on 2.4GHz leaves selected
+static constexpr uint16_t OTHER_BAND_COUNT = 240;
+static constexpr uint8_t POISON = 0xEE;
+static constexpr uint32_t SEED = 0x05060708L;
+
+// A sequence is a function of freqCount alone, so a build must produce the same
+// entries whichever band the caller happens to have selected. On a dual band
+// receiver that is whichever binding rate was up when the bind landed.
+void test_fhss_build_ignores_band_selection(void)
+{
+    uint8_t reference[FHSS_SEQUENCE_LEN];
+    uint8_t sequence[FHSS_SEQUENCE_LEN];
+
+    for (uint32_t freqCount : FREQ_COUNTS)
+    {
+        char msg[32];
+        snprintf(msg, sizeof(msg), "freqCount=%u", (unsigned)freqCount);
+
+        memset(reference, POISON, sizeof(reference));
+        memset(sequence, POISON, sizeof(sequence));
+
+        const uint16_t wholeBlocks = FHSSrandomiseFHSSsequenceBuild(SEED, freqCount, freqCount / 2, reference);
+
+        // the state the build used to take its length from
+        secondaryBandCount = OTHER_BAND_COUNT;
+        FHSSusePrimaryFreqBand = false;
+
+        TEST_ASSERT_EQUAL_UINT16_MESSAGE(wholeBlocks,
+            FHSSrandomiseFHSSsequenceBuild(SEED, freqCount, freqCount / 2, sequence), msg);
+        TEST_ASSERT_FALSE_MESSAGE(FHSSusePrimaryFreqBand, msg);
+        // comparing the whole buffer catches a short build in the poison it
+        // leaves behind, and a long one where the reference is still poison
+        TEST_ASSERT_EQUAL_MEMORY_MESSAGE(reference, sequence, FHSS_SEQUENCE_LEN, msg);
+
+        // every block holds each channel exactly once
+        for (uint16_t block = 0; block < wholeBlocks; block += freqCount)
+        {
+            std::set<uint8_t> channels(sequence + block, sequence + block + freqCount);
+            TEST_ASSERT_EQUAL_UINT32_MESSAGE(freqCount, channels.size(), msg);
+            TEST_ASSERT_LESS_THAN_MESSAGE(freqCount, *channels.rbegin(), msg);
+        }
+    }
+}
+
 // Unity setup/teardown
-void setUp() {}
+void setUp()
+{
+    FHSSusePrimaryFreqBand = true;
+    FHSSuseDualBand = false;
+    primaryBandCount = 0;
+    secondaryBandCount = 0;
+}
 void tearDown() {}
 
 int main(int argc, char **argv)
@@ -96,6 +150,7 @@ int main(int argc, char **argv)
     RUN_TEST(test_fhss_unique);
     RUN_TEST(test_fhss_same);
     RUN_TEST(test_fhss_reg_same);
+    RUN_TEST(test_fhss_build_ignores_band_selection);
     UNITY_END();
 
     return 0;


### PR DESCRIPTION
On an LR1121 receiver, a bind that completes while the 2.4GHz binding rate is up builds the sub-GHz hop sequence to the wrong length. The receiver flies on a sequence the transmitter does not share, losing about 10 of its 247 hops on EU868 while the link still reports connected, until the next power cycle.

`FHSSrandomiseFHSSsequenceBuild()` takes its loop bound from `FHSSgetSequenceCount()`, which answers for whichever band is currently selected, so a sequence's length depends on state unrelated to the sequence being built. This derives the length from `freqCount` inside the builder and returns it, which also retires the `FHSSusePrimaryFreqBand` flipping around the secondary build.

It is an edge case, but it gives no diagnostic and lasts the whole flight.

### Details

While binding, an LR1121 receiver alternates every 125ms between the two binding rates, and `SetRFLinkRate()` sets `FHSSusePrimaryFreqBand` from whichever it picked. `ExitBindingMode()` rebuilds immediately, before anything resets that flag, so a bind landing on the 2.4GHz side builds the primary sequence to `secondaryBandCount` (240) instead of its own 247. On EU868 that leaves entries 240 to 246 holding the pre-bind sequence, with 234 to 239 shuffled against them.

Despite the name, `RATE_DUALBAND_BINDING` is `RATE_LORA_2G4_50HZ`, a plain 2.4GHz rate, so `FHSSuseDualBand` stays false and no dual band mode is involved.

Changing rate afterwards does not repair it: only `setup()` and `ExitBindingMode()` rebuild, so the corrected flag just points the receiver back at the damaged array. What it flies on decides the damage. A sub-GHz rate reads the whole bad tail; an X band rate caps the count at `min(247, 240)` so only the shuffled entries bite; a 2.4GHz only rate reads `FHSSsequence_DualBand`, which is always built correctly.

EU868, IN866, AU433, EU433 and US433 are affected. AU915, FCC915 and US433W already come out at 240.

Landing on the 2.4GHz half is uncommon. The transmitter sends the first half of its bind burst on sub-GHz (`BindingSpamAmount` in `tx_main.cpp`), and the receiver's 125ms toggle means it is listening there for part of that window, so an ordinary bind completes on sub-GHz. It takes that half being missed, or the receiver entering binding mode late in the burst.

The same read also let the build walk off the end of the 256 byte array whenever the count it was handed exceeded the block aligned length. Loop bodies are untouched, so the emitted sequence is bit identical wherever the old bound was already right; the commented-out debug loop went too, since its bound was the call being removed.

### Regressions

`FHSSrandomiseFHSSsequenceBuild()` returns `uint16_t` instead of `void`. Both callers are in `FHSS.cpp` and can ignore it. It also stops forcing `FHSSusePrimaryFreqBand` true after an LR1121 rebuild, so the flag now keeps whatever the caller selected; nothing relied on that, since `LostConnection()` re-cycles rates straight after the bind path.

### Tests

`test_fhss_build_ignores_band_selection` sweeps channel counts, building each sequence with the primary band selected and then rebuilding it with the secondary selected, into the buffer a receiver would already be hopping on. The two must match, every block must still hold each channel exactly once, and the build must leave the band selection alone. It sweeps rather than fixing a domain because the host build is 2.4GHz only, so the affected counts have no table to come from.

