### PR TITLE
Gate FC-bound uplink data by Model Match

### DIFF
--- a/src/lib/MSP/data_ul_model_match.h
+++ b/src/lib/MSP/data_ul_model_match.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cstdint>
+
+#include "msptypes.h"
+
+/**
+ * Receiver-local WiFi control remains available to a bound receiver on a
+ * model mismatch. Every other completed uplink payload can reach the flight
+ * controller and therefore requires a matching model.
+ */
+constexpr bool shouldProcessDataUlPayload(uint8_t payloadType, bool modelMatched)
+{
+    return modelMatched || payloadType == MSP_ELRS_SET_RX_WIFI_MODE;
+}

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -11,6 +11,7 @@
 #include "PFD.h"
 #include "dynpower.h"
 #include "freqTable.h"
+#include "data_ul_model_match.h"
 #include "msp.h"
 #include "msptypes.h"
 #include "options.h"
@@ -1231,6 +1232,12 @@ void ICACHE_RAM_ATTR TXdoneISR()
  **/
 void DataUlReceiveComplete()
 {
+    if (!shouldProcessDataUlPayload(DataUlBuffer[0], connectionHasModelMatch))
+    {
+        DataUlReceiver.Unlock();
+        return;
+    }
+
     switch (DataUlBuffer[0])
     {
     case MSP_ELRS_SET_RX_WIFI_MODE: //0x0E

--- a/src/test/test_msp/msp_tests.cpp
+++ b/src/test/test_msp/msp_tests.cpp
@@ -1,7 +1,10 @@
 #include <cstdint>
 #include <iostream>
 #include <unity.h>
+#include "crsf_protocol.h"
+#include "data_ul_model_match.h"
 #include "msp.h"
+#include "msptypes.h"
 #include "common.h"
 #include "mock_serial.h"
 
@@ -105,6 +108,16 @@ void test_msp_send(void)
     TEST_ASSERT_EQUAL(224, (uint8_t)buf[9]);     // crc
 }
 
+void test_data_ul_model_match_policy(void)
+{
+    TEST_ASSERT_TRUE(shouldProcessDataUlPayload(MSP_ELRS_SET_RX_WIFI_MODE, false));
+    TEST_ASSERT_FALSE(shouldProcessDataUlPayload(MSP_ELRS_MAVLINK_TLM, false));
+    TEST_ASSERT_FALSE(shouldProcessDataUlPayload(CRSF_ADDRESS_FLIGHT_CONTROLLER, false));
+
+    TEST_ASSERT_TRUE(shouldProcessDataUlPayload(MSP_ELRS_MAVLINK_TLM, true));
+    TEST_ASSERT_TRUE(shouldProcessDataUlPayload(CRSF_ADDRESS_FLIGHT_CONTROLLER, true));
+}
+
 extern void test_encapsulated_msp_send(void);
 extern void test_encapsulated_msp_send_not_too_long(void);
 extern void test_encapsulated_msp_send_too_long(void);
@@ -118,6 +131,7 @@ int main(int argc, char **argv)
     UNITY_BEGIN();
     RUN_TEST(test_msp_receive);
     RUN_TEST(test_msp_send);
+    RUN_TEST(test_data_ul_model_match_policy);
 
     RUN_TEST(test_encapsulated_msp_send);
     RUN_TEST(test_encapsulated_msp_send_not_too_long);


### PR DESCRIPTION
## What changed

- Keep accepting and acknowledging completed uplink transfers when Model Match rejects RC control, so the transmitter's stubborn sender is not left retrying the same payload.
- Drop completed CRSF/MSP and raw MAVLink payloads before they are forwarded to the flight controller when the receiver does not match the selected model.
- Continue allowing the receiver-local WiFi update command on a mismatch, and leave binding traffic unchanged.
- Add unit coverage for the payload-routing policy on both matching and mismatching models.

## Why

With two bound models using different Model IDs, RC control is correctly gated but uplink data could still reach the other model's flight controller. That makes MSP writes—and raw MAVLink when configured—cross the Model Match boundary even though control channels do not.

The gate is applied after a complete payload has been assembled. This preserves the existing uplink acknowledgement flow while preventing only the unsafe FC-bound side effect.

Fixes #3668

## Validation

- `PLATFORMIO_BUILD_FLAGS="-DRegulatory_Domain_ISM_2400" pio test -e native` — 12 suites, 95/95 tests passed.
- `PLATFORMIO_BUILD_FLAGS="-DRegulatory_Domain_ISM_2400" pio run -e Unified_ESP8285_2400_RX_via_UART` — ESP8285 receiver firmware built successfully.
- `clang-format --dry-run --Werror src/lib/MSP/data_ul_model_match.h` — passed for the new policy header. (The existing touched source/test files are not clean under whole-file clang-format, so they were not reformatted wholesale.)

## AI assistance

AI-assisted repository analysis and test planning were used. I reviewed the final diff and ran the validations above locally.
