### PR TITLE
Fix AirPort transparent serial on ESP8266 (dedicate UART0)

### DIFF
--- a/src/lib/Handset/devHandset.cpp
+++ b/src/lib/Handset/devHandset.cpp
@@ -7,6 +7,7 @@
 #include "devHandset.h"
 
 #include "CRSFEndpoint.h"
+#include "options.h"
 
 #if defined(PLATFORM_ESP32)
 #include "AutoDetect.h"
@@ -29,6 +30,13 @@ static bool initialize()
 
 static int start()
 {
+#if defined(PLATFORM_ESP8266)
+    // AirPort dedicates UART0 to the transparent serial (see setupSerial in
+    // tx_main.cpp). The CRSF handset would reconfigure/steal UART0, so it must
+    // not start in AirPort mode.
+    if (firmwareOptions.is_airport)
+        return DURATION_NEVER;
+#endif
     handset->Begin();
 #if defined(DEBUG_TX_FREERUN)
     handset->forceConnection();

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1294,6 +1294,20 @@ static void setupSerial()
     TxUSB = new HardwareSerial(1);
     ((HardwareSerial *)TxUSB)->begin(firmwareOptions.uart_baud, SERIAL_8N1, U0RXD_GPIO_NUM, U0TXD_GPIO_NUM);
   }
+#elif defined(PLATFORM_ESP8266)
+  // ESP8266 has a single hardware UART (UART0). In AirPort mode there is no
+  // CRSF handset (devHandset skips it), so dedicate UART0 to the transparent
+  // AirPort serial. Leaving TxUSB as a NullStream here is why AirPort passes
+  // zero bytes on an ESP8266 TX target.
+  if (firmwareOptions.is_airport)
+  {
+    Serial.begin(firmwareOptions.uart_baud);
+    TxUSB = &Serial;
+  }
+  else
+  {
+    TxUSB = new NullStream();
+  }
 #else
   TxUSB = new NullStream();
 #endif


### PR DESCRIPTION
## Problem

On ESP8266 TX targets, **AirPort (transparent serial) passes zero bytes in either direction** even with a solid RF bind. The host MCU wired to the module's UART reads literally nothing — not corrupted data, *nothing*.

I hit this with a pair of Happymodel **ES900** modules (SX1276 + ESP8285, 868 MHz **EU_868**, fw **4.1.0**), one flashed `--rx-as-tx=internal` as the transmit end, each driven by its own ESP32 over UART, AirPort enabled on both ends, bound (solid LED both ends).

The identical hardware, wiring and bind carry **1000+ native-CRSF frames flawlessly** (LQ 100%, RSSI −22 dBm) the moment AirPort is turned off — which isolates the failure to the **AirPort path on ESP8266**, not wiring, pins, solder, RF, bind, or baud.

## Root cause

In `setupSerial()` (`src/src/tx_main.cpp`), every non-ESP32 platform falls into:

```cpp
#else
  TxUSB = new NullStream();
#endif
```

So on ESP8266 `TxUSB` is **always** a `NullStream`. AirPort's transparent-serial I/O flows through `TxUSB` (`HandleUARTout()` / the AirPort read path), so on ESP8266 every byte is silently sunk into the null stream in both directions — hence the exact-zero result.

The ESP8266 has a single hardware UART (UART0, GPIO 1/3), normally claimed by the CRSF handset. In AirPort mode there is no handset, but nothing hands UART0 to the transparent serial either, so it stays a `NullStream`.

## Fix

Two small, guarded changes (ESP8266 + AirPort only):

**1. `src/src/tx_main.cpp` — give AirPort a real UART on ESP8266**

```cpp
#elif defined(PLATFORM_ESP8266)
  // ESP8266 has a single hardware UART (UART0). In AirPort mode there is no
  // CRSF handset (devHandset skips it), so dedicate UART0 to the transparent
  // AirPort serial. Leaving TxUSB as a NullStream here is why AirPort passes
  // zero bytes on an ESP8266 TX target.
  if (firmwareOptions.is_airport)
  {
    Serial.begin(firmwareOptions.uart_baud);
    TxUSB = &Serial;
  }
  else
  {
    TxUSB = new NullStream();
  }
```

**2. `src/lib/Handset/devHandset.cpp` — don't start the handset in AirPort on ESP8266**

```cpp
#if defined(PLATFORM_ESP8266)
    // AirPort dedicates UART0 to the transparent serial (see setupSerial in
    // tx_main.cpp). The CRSF handset would reconfigure/steal UART0, so it must
    // not start in AirPort mode.
    if (firmwareOptions.is_airport)
        return DURATION_NEVER;
#endif
```

(plus the `#include "options.h"` needed for `firmwareOptions` in that file.)

The non-AirPort ESP8266 path is unchanged (still `NullStream`), and ESP32 is untouched — the change is gated on both `PLATFORM_ESP8266` and `firmwareOptions.is_airport`. The baud comes from `firmwareOptions.uart_baud` (the WiFi UI "AirPort UART baud" field), so it is not hardcoded.

## Verification

With the patch, AirPort passes data **byte-perfect over the air, 100% sustained**, in both directions.

Measured throughput once working (ES900 pair, EU_868):

| TLM ratio | Downlink | Uplink | Notes |
|---|---|---|---|
| 1:2 (AirPort default) | ~384 B/s | ~224 B/s | ~600 B/s combined, ~37 ms one-way |
| 1:4 | ~608 B/s | ~200 B/s | telemetry still ~8 Hz |

The ~1000 B/s aggregate is the PHY ceiling (5 B per OTA packet × ~200 slots/s); the TLM ratio just redistributes it between the two directions.

## Ruled out (before finding the root cause)

- ESP32 host UART — hardware loopback echoes perfectly.
- Baud — tested 115200 and the documented 4800 for 868 MHz; zero bytes at both.
- Signal inversion — all TX/RX inversion combinations.
- Clean reflash of both modules to 4.1.0.
- Both directions (base→rover and rover→base) — symmetric zero.
- **Clincher:** native CRSF on the identical setup carries 1000+ frames at LQ 100%.

## Scope / notes

- Tested on ES900 (SX1276 + ESP8285), **rx-as-tx**, EU_868, 4.1.0. It should apply to any ESP8266 TX target running AirPort, but I can only confirm the ES900.
- May be related to earlier "AirPort connected but no data" reports (#2546, #2249, #2297) and the EU-domain symbol-loss thread (#2358); and touches the rx-as-tx caveat (#627).

Happy to share the full test sketches, serial logs, and WiFi-UI screenshots on request.
