### PR TITLE
Ignoring libraries before the LDF does it's stupidity!

### DIFF
--- a/src/lib/BUTTON/devButton.cpp
+++ b/src/lib/BUTTON/devButton.cpp
@@ -4,7 +4,6 @@
 #include "button.h"
 #include "config.h"
 #include "helpers.h"
-#include "handset.h"
 
 static Button button1;
 static Button button2;

--- a/src/lib/PWM/waveform_8266.cpp
+++ b/src/lib/PWM/waveform_8266.cpp
@@ -89,9 +89,6 @@ static WVFState wvfState;
 // Interrupt on/off control
 static void timer1Interrupt();
 
-extern "C" IRAM_ATTR int __wrap_stopWaveform(uint8_t pin) { return true; }
-extern "C" IRAM_ATTR bool __wrap__stopPWM(uint8_t pin) { return true; }
-
 static constexpr uint32_t WATCHDOG_TIMEOUT_US = 50000;
 static constexpr uint32_t WATCHDOG_TIMEOUT_CYCLES = microsecondsToClockCycles(WATCHDOG_TIMEOUT_US);
 

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -35,8 +35,8 @@
 #include "options.h"
 #include "helpers.h"
 #include "devButton.h"
-#include "devAnalogVbat.h"
 #if defined(TARGET_RX)
+#include "devAnalogVbat.h"
 #include "VbatCalibration.h"
 #endif
 #if defined(TARGET_RX) && defined(PLATFORM_ESP32)

--- a/src/python/lib_exclusions.py
+++ b/src/python/lib_exclusions.py
@@ -1,0 +1,54 @@
+"""PlatformIO pre-script that adds target-aware `lib_ignore` entries.
+
+PlatformIO's default LDF does not evaluate preprocessor branches, so it
+discovers target-incompatible libraries behind inactive `#if`s. `chain+` or
+`deep+` follows those branches but breaks external-library dependency
+resolution. Keep the default mode and explicitly exclude incompatible
+libraries here.
+
+`lib_ignore` is read by PlatformIO's Library Dependency Finder, so mutate the
+project config rather than `env["LIB_IGNORE"]`. Entries are exact library
+names from PlatformIO's dependency graph and may identify project, global, or
+`lib_deps` libraries.
+
+Set "*" for every MCU of a TX/RX target type; its entries are combined with
+that target type's MCU-specific entries. An ignored library is not selected or
+built; its target must not include headers or symbols it provides.
+"""
+
+LIBRARY_EXCLUSIONS = {
+    # target type -> "*" (all target MCUs) or MCU -> library names
+    "TX": {
+        "*": ("AnalogVbat","Baro","GYRO","MSPVTX","rx-crsf","ServoOutput","VTXSPI"),
+        "esp32c3": ("GFX Library for Arduino","U8g2","GSENSOR","SCREEN","THERMAL"),
+        "esp8285": ("GSENSOR","SCREEN","THERMAL"),
+    },
+    "RX": {
+        "*": ("ADC","Backpack","BLE","GSENSOR","Handset","POWER_DETECT","SCREEN","tx-crsf","VTX"),
+        "esp8285": ("MSPVTX","VTXSPI"),
+    }
+}
+
+
+def get_target_type(target_name):
+    target_parts = target_name.upper().split("_")
+    return next((target for target in ("RX", "TX") if target in target_parts), None)
+
+
+def get_excluded_libraries(target_type, mcu):
+    target_exclusions = LIBRARY_EXCLUSIONS.get(target_type, {})
+    return target_exclusions.get("*", ()) + target_exclusions.get(mcu, ())
+
+Import("env")
+
+target_type = get_target_type(env["PIOENV"])
+excluded_libraries = ()
+if target_type:
+    mcu = env.BoardConfig().get("build.mcu", "").lower()
+    excluded_libraries = get_excluded_libraries(target_type, mcu)
+
+if excluded_libraries:
+    config = env.GetProjectConfig()
+    ignored_libraries = config.get("env:" + env["PIOENV"], "lib_ignore", [])
+    config.set("env:" + env["PIOENV"], "lib_ignore", list(dict.fromkeys(ignored_libraries + list(excluded_libraries))))
+    print("Ignoring libraries for %s/%s: %s" % (target_type, mcu, ", ".join(excluded_libraries)))

--- a/src/python/lib_exclusions.py
+++ b/src/python/lib_exclusions.py
@@ -19,7 +19,7 @@ built; its target must not include headers or symbols it provides.
 LIBRARY_EXCLUSIONS = {
     # target type -> "*" (all target MCUs) or MCU -> library names
     "TX": {
-        "*": ("AnalogVbat","Baro","GYRO","MSPVTX","rx-crsf","ServoOutput","VTXSPI"),
+        "*": ("AnalogVbat","Baro","GYRO","MSPVTX","PWM","rx-crsf","ServoOutput","VTXSPI"),
         "esp32c3": ("GFX Library for Arduino","U8g2","GSENSOR","SCREEN","THERMAL"),
         "esp8285": ("GSENSOR","SCREEN","THERMAL"),
     },

--- a/src/src/esp8266_waveform_stubs.cpp
+++ b/src/src/esp8266_waveform_stubs.cpp
@@ -1,0 +1,5 @@
+#if defined(PLATFORM_ESP8266)
+#include <Arduino.h>
+extern "C" IRAM_ATTR int __wrap_stopWaveform(uint8_t pin) { return true; }
+extern "C" IRAM_ATTR bool __wrap__stopPWM(uint8_t pin) { return true; }
+#endif

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -16,12 +16,14 @@
 #include "devButton.h"
 #include "devVTX.h"
 #if defined(PLATFORM_ESP32)
-#include "devScreen.h"
 #include "devBLE.h"
+#include "devBackpack.h"
+#if !defined(PLATFORM_ESP32_C3)
+#include "devScreen.h"
 #include "devGsensor.h"
 #include "devThermal.h"
 #include "devPDET.h"
-#include "devBackpack.h"
+#endif
 #else
 // Fake functions for 8285
 void checkBackpackUpdate() {}
@@ -106,8 +108,8 @@ device_affinity_t ui_devices[] = {
   {&WIFI_device, 0},
   {&Button_device, 0},
 #if defined(PLATFORM_ESP32)
-  {&Backpack_device, 0},
   {&BLE_device, 0},
+  {&Backpack_device, 0},
 #if !defined(PLATFORM_ESP32_C3)
   {&Screen_device, 0},
   {&Gsensor_device, 0},

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -4,6 +4,7 @@
 framework = arduino
 extra_scripts =
 	pre:python/build_flags.py
+	pre:python/lib_exclusions.py
 	python/build_env_setup.py
 monitor_dtr = 0
 monitor_rts = 0
@@ -73,7 +74,6 @@ build_flags =
 	-D PIO_FRAMEWORK_ARDUINO_MMU_CACHE16_IRAM48
 	-D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH
 	-I ${PROJECTSRC_DIR}/hal
-	-Wl,--wrap=stopWaveform -Wl,--wrap=_stopPWM
 build_src_filter = ${common_env_data.build_src_filter} -<ESP32*.*>
 extra_scripts =
 	${env.extra_scripts}

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -53,7 +53,6 @@ build_flags =
 	-D BEARSSL_SSL_BASIC
 	-D CONFIG_DISABLE_HAL_LOCKS=1
 	-I ${PROJECTSRC_DIR}/hal
-build_src_filter = ${common_env_data.build_src_filter} -<ESP8266*.*>
 lib_deps =
 	esp32async/AsyncTCP @ 3.4.8
 	esp32async/ESPAsyncWebServer @ 3.8.1
@@ -75,7 +74,6 @@ build_flags =
 	-D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH
 	-Wl,--wrap=stopWaveform -Wl,--wrap=_stopPWM
 	-I ${PROJECTSRC_DIR}/hal
-build_src_filter = ${common_env_data.build_src_filter} -<ESP32*.*>
 extra_scripts =
 	${env.extra_scripts}
 	pre:python/copy_html.py

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -73,6 +73,7 @@ build_flags =
 	-D VTABLES_IN_FLASH=1
 	-D PIO_FRAMEWORK_ARDUINO_MMU_CACHE16_IRAM48
 	-D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH
+	-Wl,--wrap=stopWaveform -Wl,--wrap=_stopPWM
 	-I ${PROJECTSRC_DIR}/hal
 build_src_filter = ${common_env_data.build_src_filter} -<ESP32*.*>
 extra_scripts =

--- a/src/targets/esp32-rx.ini
+++ b/src/targets/esp32-rx.ini
@@ -5,7 +5,7 @@ build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_rx}
 	-include target/Unified_ESP_RX.h
-build_src_filter = ${env_common_esp32.build_src_filter} -<tx_*.cpp> -<tx-*/>
+build_src_filter = ${common_env_data.build_src_filter} -<tx_*.cpp> -<tx-*/>
 
 [env:Unified_ESP32_2400_RX_via_UART]
 extends = env_common_esp32rx, radio_SX128X

--- a/src/targets/esp32-tx.ini
+++ b/src/targets/esp32-tx.ini
@@ -7,7 +7,7 @@ lib_deps =
 	lemmingdev/ESP32-BLE-Gamepad @ 0.7.4
 	olikraus/U8g2 @ 2.36.12
 	moononournation/GFX Library for Arduino @ 1.6.0
-build_src_filter = ${env_common_esp32.build_src_filter} -<rx_*.cpp> -<rx-*/>
+build_src_filter = ${common_env_data.build_src_filter} -<rx_*.cpp> -<rx-*/>
 build_flags =
 	${env_common_esp32.build_flags}
 	${common_env_data.build_flags_tx}

--- a/src/targets/esp32c3-tx.ini
+++ b/src/targets/esp32c3-tx.ini
@@ -2,7 +2,6 @@
 extends = env_common_esp32tx
 board = esp32-c3-devkitm-1
 board_build.f_cpu = 160000000L
-lib_ignore = Backpack GSENSOR SCREEN Thermal VTX VTXSPI
 build_flags =
 	${env_common_esp32tx.build_flags}
 	-D PLATFORM_ESP32_C3=1

--- a/src/targets/esp8285-rx.ini
+++ b/src/targets/esp8285-rx.ini
@@ -4,6 +4,7 @@ monitor_speed = 420000
 build_flags =
 	${env_common_esp82xx.build_flags}
 	${common_env_data.build_flags_rx}
+	-Wl,--wrap=stopWaveform -Wl,--wrap=_stopPWM
 	-include target/Unified_ESP_RX.h
 build_src_filter =
 	${env_common_esp82xx.build_src_filter} -<tx_*.cpp> -<tx-*/>

--- a/src/targets/esp8285-rx.ini
+++ b/src/targets/esp8285-rx.ini
@@ -4,7 +4,6 @@ monitor_speed = 420000
 build_flags =
 	${env_common_esp82xx.build_flags}
 	${common_env_data.build_flags_rx}
-	-Wl,--wrap=stopWaveform -Wl,--wrap=_stopPWM
 	-include target/Unified_ESP_RX.h
 build_src_filter =
 	${env_common_esp82xx.build_src_filter} -<tx_*.cpp> -<tx-*/>

--- a/src/targets/esp8285-rx.ini
+++ b/src/targets/esp8285-rx.ini
@@ -6,7 +6,7 @@ build_flags =
 	${common_env_data.build_flags_rx}
 	-include target/Unified_ESP_RX.h
 build_src_filter =
-	${env_common_esp82xx.build_src_filter} -<tx_*.cpp> -<tx-*/>
+	${common_env_data.build_src_filter} -<tx_*.cpp> -<tx-*/>
 
 [env:Unified_ESP8285_2400_RX_via_UART]
 extends = env_common_8285rx, radio_SX128X

--- a/src/targets/esp8285-tx.ini
+++ b/src/targets/esp8285-tx.ini
@@ -6,7 +6,7 @@ build_flags =
 	${common_env_data.build_flags_tx}
 	-include target/Unified_ESP8285_TX.h
 build_src_filter =
-	${env_common_esp82xx.build_src_filter} -<rx_*.cpp> -<rx-*/>
+	${common_env_data.build_src_filter} -<rx_*.cpp> -<rx-*/>
 
 [env:Unified_ESP8285_2400_TX_via_UART]
 extends = env_common_8285tx, radio_SX128X


### PR DESCRIPTION
# Problem
While working on the gyro code, starting on a web UI for configuration, I came across an issue where the TX build would also build the GYRO library.

Whilst this doesn't sound like too much of an issue, it's actually really painful as you'd have to sprinkle `#if defined(TARGET_RX)` all over the code just to stop it building and being included, which is frankly _shite!_

The real issue is that the PIO LDF scanner in it's `chain` or `deep` mode does not respect define guards when looking for libraries to exclude from building. Just use `chain+` or `deep+`, I hear you say. Well... that's just broken in a very different way. It causes the `ArduinoJson` library to be excluded from the build, thereby causing the whole build to fail spectacularly.

# Solution
Simply add a "pre build" script than excludes certain libraries from the list to be considered for building when LDF kicks in.

Since we're doing this, we can do better! The script includes configuration so that different libraries can be excluded based on the target type (`TX` or `RX`) or the MCU (`esp32`, `esp32s3`, `esp32c3`, `esp8285`).