### PR TITLE
Refresh warning flags before selecting status message

### DIFF
--- a/src/lib/tx-crsf/TXModuleParameters.cpp
+++ b/src/lib/tx-crsf/TXModuleParameters.cpp
@@ -372,6 +372,10 @@ void TXModuleEndpoint::sendELRSstatus(const crsf_addr_e origin)
     "Baud rate too low",  //critical warning2, changing packet rate and baud rate too low
     ""   //critical warning1, reserved for future use
   };
+  setWarningFlag(LUA_FLAG_MODEL_MATCH, connectionState == connected && connectionHasModelMatch == false);
+  setWarningFlag(LUA_FLAG_CONNECTED, connectionState == connected);
+  setWarningFlag(LUA_FLAG_ISARMED, handset->IsArmed());
+
   auto warningInfo = "";
 
   for (int i = 7; i >= 0; i--)
@@ -385,10 +389,6 @@ void TXModuleEndpoint::sendELRSstatus(const crsf_addr_e origin)
   const uint8_t payloadSize = sizeof(elrsStatusParameter) + strlen(warningInfo) + 1;
   uint8_t buffer[sizeof(crsf_ext_header_t) + payloadSize + 1];
   const auto params = (elrsStatusParameter *)&buffer[sizeof(crsf_ext_header_t)];
-
-  setWarningFlag(LUA_FLAG_MODEL_MATCH, connectionState == connected && connectionHasModelMatch == false);
-  setWarningFlag(LUA_FLAG_CONNECTED, connectionState == connected);
-  setWarningFlag(LUA_FLAG_ISARMED, handset->IsArmed());
 
   params->pktsBad = CRSFHandset::BadPktsCountResult;
   params->pktsGood = htobe16(CRSFHandset::GoodPktsCountResult);


### PR DESCRIPTION
sendELRSstatus() picked the warning text from luaWarningFlags before the CONNECTED/MODEL_MATCH/ISARMED bits were refreshed, but wrote params->flags after. A status frame could therefore carry a newly set flag with a stale (empty or lower-priority) message, and the matching text only went out with the next frame. Refresh the flags first so flags, message, and payload size derive from one snapshot.