### PR TITLE
Use 1-based antenna naming on the receiver

### DIFF
--- a/src/lib/CONFIG/config.cpp
+++ b/src/lib/CONFIG/config.cpp
@@ -1201,7 +1201,7 @@ RxConfig::SetPower(uint8_t power)
 void
 RxConfig::SetAntennaMode(uint8_t antennaMode)
 {
-    //0 and 1 is use for gpio_antenna_select
+    // 0=Antenna 1, 1=Antenna 2 are used for gpio_antenna_select
     // 2 is diversity
     if (m_config.antennaMode != antennaMode)
     {

--- a/src/lib/CONFIG/config.h
+++ b/src/lib/CONFIG/config.h
@@ -240,7 +240,7 @@ typedef struct __attribute__((packed)) {
     } vbat;
     uint8_t     bindStorage:2,     // rx_config_bindstorage_t
                 power:4,
-                antennaMode:2;      // 0=0, 1=1, 2=Diversity
+                antennaMode:2;      // 0=Antenna 1, 1=Antenna 2, 2=Diversity
     uint8_t     powerOnCounter:2,
                 forceTlmOff:1,
                 rateInitialIdx:5;   // Rate to start rateCycling at on boot

--- a/src/lib/SCREEN/OLED/oleddisplay.cpp
+++ b/src/lib/SCREEN/OLED/oleddisplay.cpp
@@ -394,7 +394,7 @@ void OLEDDisplay::displayLinkstats()
         u8g2->setCursor(LINKSTATS_COL_THIRD, LINKSTATS_ROW_FOURTH);
         u8g2->print((int8_t)linkStats.downlink_SNR);
         u8g2->setCursor(LINKSTATS_COL_SECOND, LINKSTATS_ROW_FIFTH);
-        u8g2->print(linkStats.active_antenna);
+        u8g2->print(linkStats.active_antenna + 1);
     }
 
     u8g2->sendBuffer();

--- a/src/lib/SCREEN/TFT/tftdisplay.cpp
+++ b/src/lib/SCREEN/TFT/tftdisplay.cpp
@@ -424,7 +424,7 @@ void TFTDisplay::displayLinkstats()
     gfx->setCursor(LINKSTATS_COL_SECOND, LINKSTATS_ROW_FOURTH);
     gfx->print(linkStats.uplink_SNR);
     gfx->setCursor(LINKSTATS_COL_SECOND, LINKSTATS_ROW_FIFTH);
-    gfx->print(linkStats.active_antenna);
+    gfx->print(linkStats.active_antenna + 1);
 
     // Downlink Linkstats
     gfx->setCursor(LINKSTATS_COL_THIRD, LINKSTATS_ROW_FIRST);

--- a/src/lib/rx-crsf/RXParameters.cpp
+++ b/src/lib/rx-crsf/RXParameters.cpp
@@ -84,9 +84,9 @@ static selectionParameter luaTlmPower = {
 };
 
 static selectionParameter luaAntennaMode = {
-    {"Ant. Mode", CRSF_TEXT_SELECTION},
+    {"Antenna Mode", CRSF_TEXT_SELECTION},
     0, // value
-    "Antenna A;Antenna B;Diversity",
+    "Antenna 1;Antenna 2;Diversity",
     STR_EMPTYSPACE
 };
 


### PR DESCRIPTION
The receiver was the only surface naming antennas with letters: its Lua parameter read "Ant. Mode" with "Antenna A;Antenna B;Diversity", while the TX parameter, the TX OLED menu, the CRSF link-statistics spec and the handset's 1RSS/2RSS sensors are all 1-based.

Rename the parameter to "Antenna Mode" to match the TX and its options to "Antenna 1;Antenna 2;Diversity", and print the active antenna as 1 or 2 on the link-stats screens so it reads against the RSSI 1 / RSSI 2 rows above it.