### PR TITLE
Fix I2S driver grabbing GPIO0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install platformio
         pip install wheel
+        pio pkg install --global --tool "framework-arduinoststm32=https://github.com/stm32duino/Arduino_Core_STM32.git#2.1.0"
 
     - name: Cache PlatformIO
       uses: actions/cache@v4

--- a/src/lib/LED/esp32rgb.cpp
+++ b/src/lib/LED/esp32rgb.cpp
@@ -56,6 +56,7 @@ void ESP32S3LedDriver::Begin()
     };
 
     i2s_pin_config_t pin_config = {
+        .mck_io_num = -1,
         .bck_io_num = -1,
         .ws_io_num = -1,
         .data_out_num = gpio_pin,

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -167,6 +167,8 @@ upload_resetmethod = nodemcu
 # ------------------------- COMMON STM32 DEFINITIONS -----------------
 [env_common_stm32]
 platform = ststm32@15.1.0
+platform_packages =
+	framework-arduinoststm32@https://github.com/stm32duino/Arduino_Core_STM32.git#2.1.0
 board = bluepill_f103c8
 build_flags =
 	-D PLATFORM_STM32=1


### PR DESCRIPTION
This fixes an issue where devices that use GPIO0 (i.e. ANT_CTRL) would have the pin stolen by the I2S driver which would set the pin to INPUT mode! 
This also fixed ESP32C3 dual LR1121 devices that use GPIO0 as NSS for the first radio, which caused them to intermittently (on startup) show the "radio not detected" led sequence.