### PR TITLE
Fix airport sending CRSF telemetry linkstats data!

### DIFF
--- a/src/lib/Backpack/devBackpack.cpp
+++ b/src/lib/Backpack/devBackpack.cpp
@@ -402,23 +402,25 @@ static void sendConfigToBackpack()
 
 static bool initialize()
 {
-    if (OPT_USE_TX_BACKPACK)
+    if (!OPT_USE_TX_BACKPACK || firmwareOptions.is_airport)
     {
-        if (GPIO_PIN_BACKPACK_EN != UNDEF_PIN)
-        {
-            pinMode(GPIO_PIN_BOOT0, INPUT); // setup so we can detect pin-change for passthrough mode
-            pinMode(GPIO_PIN_BACKPACK_BOOT, OUTPUT);
-            pinMode(GPIO_PIN_BACKPACK_EN, OUTPUT);
-            // Shut down the backpack via EN pin and hold it there until the first event()
-            digitalWrite(GPIO_PIN_BACKPACK_EN, LOW);   // enable low
-            digitalWrite(GPIO_PIN_BACKPACK_BOOT, LOW); // bootloader pin high
-            delay(20);
-            // Rely on event() to boot
-        }
-        // Set all channels of PTR data to "do not override" (0xffff)
-        memset(ptrChannelData, 0xff, sizeof(ptrChannelData));
+        return false;
     }
-    return OPT_USE_TX_BACKPACK;
+
+    if (GPIO_PIN_BACKPACK_EN != UNDEF_PIN)
+    {
+        pinMode(GPIO_PIN_BOOT0, INPUT); // setup so we can detect pin-change for passthrough mode
+        pinMode(GPIO_PIN_BACKPACK_BOOT, OUTPUT);
+        pinMode(GPIO_PIN_BACKPACK_EN, OUTPUT);
+        // Shut down the backpack via EN pin and hold it there until the first event()
+        digitalWrite(GPIO_PIN_BACKPACK_EN, LOW);   // enable low
+        digitalWrite(GPIO_PIN_BACKPACK_BOOT, LOW); // bootloader pin high
+        delay(20);
+        // Rely on event() to boot
+    }
+    // Set all channels of PTR data to "do not override" (0xffff)
+    memset(ptrChannelData, 0xff, sizeof(ptrChannelData));
+    return true;
 }
 
 static int start()

--- a/src/lib/VTX/devVTX.cpp
+++ b/src/lib/VTX/devVTX.cpp
@@ -104,6 +104,10 @@ static void VtxConfigToMSPOut()
 
 static bool initialize()
 {
+    if (firmwareOptions.is_airport)
+    {
+        return false;
+    }
     registerButtonFunction(ACTION_SEND_VTX, VtxTriggerSend);
     return true;
 }

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -1422,13 +1422,16 @@ void setup()
     Radio.RXdoneCallback = &RXdoneISR;
     Radio.TXdoneCallback = &TXdoneISR;
 
-    crsfTransmitter.begin();
-    crsfRouter.addConnector(&otaConnector);
-    crsfRouter.addEndpoint(&crsfTransmitter);
-    crsfRouter.addConnector(&usbConnector);
-    // When a CRSF handset is detected, it will add itself to the router
+    if (!firmwareOptions.is_airport)
+    {
+      crsfTransmitter.begin();
+      crsfRouter.addConnector(&otaConnector);
+      crsfRouter.addEndpoint(&crsfTransmitter);
+      crsfRouter.addConnector(&usbConnector);
 
-    handset->registerCallbacks(UARTconnected, firmwareOptions.is_airport ? nullptr : UARTdisconnected);
+      // When a CRSF handset is detected, it will add itself to the router
+      handset->registerCallbacks(UARTconnected, firmwareOptions.is_airport ? nullptr : UARTdisconnected);
+    }
 
     eeprom.Begin(); // Init the eeprom
     config.SetStorageProvider(&eeprom); // Pass pointer to the Config class for access to storage
@@ -1531,10 +1534,12 @@ void loop()
   CheckConfigChangePending();
   DynamicPower_Update(now);
   VtxPitmodeSwitchUpdate();
-  checkSendLinkStatsToHandset(now);
 
-  if (DataDlReceiver.HasFinishedData())
+  if (!firmwareOptions.is_airport)
   {
+    checkSendLinkStatsToHandset(now);
+    if (DataDlReceiver.HasFinishedData())
+    {
       if (CRSFinBuffer[0] == CRSF_ADDRESS_USB)
       {
         if (config.GetLinkMode() == TX_MAVLINK_MODE)
@@ -1558,6 +1563,7 @@ void loop()
         sendCRSFTelemetryToBackpack(CRSFinBuffer);
       }
       DataDlReceiver.Unlock();
+    }
   }
 
   // only send Uplink data when binding is not active


### PR DESCRIPTION
CRSF Linkstats data was making it's way into the Airport data stream on the transmitter, basically corrupting the byte stream!