### PR TITLE
BLE gamepad fix for unity

### DIFF
--- a/src/targets/esp32-tx.ini
+++ b/src/targets/esp32-tx.ini
@@ -3,8 +3,8 @@ extends = env_common_esp32
 monitor_speed = 460800
 lib_deps =
 	${env_common_esp32.lib_deps}
-	h2zero/NimBLE-Arduino @ 2.3.6
-	lemmingdev/ESP32-BLE-Gamepad @ 0.7.4
+	h2zero/NimBLE-Arduino @ 2.5.1
+	lemmingdev/ESP32-BLE-Gamepad @ 0.7.5
 	olikraus/U8g2 @ 2.36.12
 	moononournation/GFX Library for Arduino @ 1.6.0
 build_src_filter = ${common_env_data.build_src_filter} -<rx_*.cpp> -<rx-*/>


### PR DESCRIPTION
Finally a new release of the `ESP32-BLE-Gamepad` library, which has my fix for the slider groups so they work correctly on unity.
And also an update to the underlying `NimBLE-Arduino` library as well.

Fixes #3559 and fixes #3604