### PR TITLE
Fix PPM input not reconnecting

### DIFF
--- a/src/lib/Handset/PPMHandset.cpp
+++ b/src/lib/Handset/PPMHandset.cpp
@@ -24,11 +24,6 @@ void PPMHandset::Begin()
     rmt_get_ringbuf_handle(PPM_RMT_CHANNEL, &rb);
     rmt_rx_start(PPM_RMT_CHANNEL, true);
     lastPPM = 0;
-
-    if (connected)
-    {
-        connected();
-    }
 }
 
 void PPMHandset::End()
@@ -62,8 +57,12 @@ void PPMHandset::handleInput()
                                        CRSF_CHANNEL_VALUE_STD_MIN, CRSF_CHANNEL_VALUE_STD_MAX);
         }
         numChannels = channelCount;
-        vRingbufferReturnItem(rb, static_cast<void *>(items));
+        vRingbufferReturnItem(rb, items);
         lastPPM = now;
+        if (connected && connectionState == noCrossfire)
+        {
+            connected();
+        }
 
         PerformChannelOverrides(localChannelData, numChannels);
 
@@ -75,7 +74,7 @@ void PPMHandset::handleInput()
     {
         DBGLN("PPM signal lost, disarming");
         isArmed = false;
-        if (disconnected)
+        if (disconnected && connectionState != noCrossfire)
         {
             disconnected();
         }

--- a/src/lib/Handset/PPMHandset.cpp
+++ b/src/lib/Handset/PPMHandset.cpp
@@ -42,7 +42,7 @@ void PPMHandset::handleInput()
     {
         length /= 4; // one RMT = 4 Bytes
         int channelCount = 0;
-        for (int i = 0; i < length; i++)
+        for (int i = 0; i < length && i < CRSF_NUM_CHANNELS; i++)
         {
             const auto item = items[i];
             // Stop if there is a 0 duration


### PR DESCRIPTION
Also fixed a buffer overrun issue when I was pulling and reconnecting the signal cable. It would cause noise on the line which would evaluate to more pulses which would overrun the channel buffer!

fixes #3518 
