### PR TITLE
Drop newlib float printf/scanf from ESP8266 images

### DIFF
--- a/src/python/build_env_setup.py
+++ b/src/python/build_env_setup.py
@@ -30,7 +30,25 @@ print("PLATFORM : '%s'" % platform)
 print("BUILD ENV: '%s'" % target_name)
 print("build version: %s\n\n" % get_version(env))
 
+def strip_float_stdio_link_flags():
+    # The espressif8266 builder forces newlib's float printf/scanf into every
+    # image with "-u _printf_float -u _scanf_float". Nothing in the firmware
+    # formats or parses floats, and the two pull in ~16KB of flash.
+    flags = env['LINKFLAGS']
+    stripped = []
+    skip = False
+    for i, flag in enumerate(flags):
+        if skip:
+            skip = False
+            continue
+        if flag == '-u' and i + 1 < len(flags) and flags[i + 1] in ('_printf_float', '_scanf_float'):
+            skip = True
+            continue
+        stripped.append(flag)
+    env.Replace(LINKFLAGS=stripped)
+
 if platform in ['espressif8266']:
+    strip_float_stdio_link_flags()
     if "_WIFI" in target_name:
         env.Replace(UPLOAD_PROTOCOL="custom")
         env.Replace(UPLOADCMD=upload_via_esp8266_backpack.on_upload)

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1891,11 +1891,20 @@ static void debugRcvrSignalStats(uint32_t now)
 #if defined(DEBUG_RCVR_SIGNAL_STATS)
     static uint32_t lastReport = 0;
 
-    // log column header:  or, both
+    // log column header:  cnt1, rssi1, snr1, snr1_max, telem1, fail1, cnt2, rssi2, snr2, snr2_max, telem2, fail2, or, both
+    // snr columns are in RADIO_SNR_SCALE units, integer math keeps float printf out of the image
     if(now - lastReport >= 1000 && connectionState == connected)
     {
         for (int i = 0 ; i < (isDualRadio()?2:1) ; i++)
         {
+            DBG("%u\t%d\t%d\t%d\t%u\t%u\t",
+                Radio.rxSignalStats[i].irq_count,
+                (Radio.rxSignalStats[i].irq_count==0) ? 0 : (int)(Radio.rxSignalStats[i].rssi_sum / Radio.rxSignalStats[i].irq_count),
+                (Radio.rxSignalStats[i].irq_count==0) ? 0 : (int)(Radio.rxSignalStats[i].snr_sum / Radio.rxSignalStats[i].irq_count),
+                (int)Radio.rxSignalStats[i].snr_max,
+                Radio.rxSignalStats[i].telem_count,
+                Radio.rxSignalStats[i].fail_count);
+
                 Radio.rxSignalStats[i].irq_count = 0;
                 Radio.rxSignalStats[i].snr_sum = 0;
                 Radio.rxSignalStats[i].rssi_sum = 0;

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1891,19 +1891,11 @@ static void debugRcvrSignalStats(uint32_t now)
 #if defined(DEBUG_RCVR_SIGNAL_STATS)
     static uint32_t lastReport = 0;
 
-    // log column header:  cnt1, rssi1, snr1, snr1_max, telem1, fail1, cnt2, rssi2, snr2, snr2_max, telem2, fail2, or, both
+    // log column header:  or, both
     if(now - lastReport >= 1000 && connectionState == connected)
     {
         for (int i = 0 ; i < (isDualRadio()?2:1) ; i++)
         {
-            DBG("%d\t%f\t%f\t%f\t%d\t%d\t",
-                Radio.rxSignalStats[i].irq_count,
-                (Radio.rxSignalStats[i].irq_count==0) ? 0 : double(Radio.rxSignalStats[i].rssi_sum)/Radio.rxSignalStats[i].irq_count,
-                (Radio.rxSignalStats[i].irq_count==0) ? 0 : double(Radio.rxSignalStats[i].snr_sum)/Radio.rxSignalStats[i].irq_count/RADIO_SNR_SCALE,
-                float(Radio.rxSignalStats[i].snr_max)/RADIO_SNR_SCALE,
-                Radio.rxSignalStats[i].telem_count,
-                Radio.rxSignalStats[i].fail_count);
-
                 Radio.rxSignalStats[i].irq_count = 0;
                 Radio.rxSignalStats[i].snr_sum = 0;
                 Radio.rxSignalStats[i].rssi_sum = 0;

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -1892,16 +1892,15 @@ static void debugRcvrSignalStats(uint32_t now)
     static uint32_t lastReport = 0;
 
     // log column header:  cnt1, rssi1, snr1, snr1_max, telem1, fail1, cnt2, rssi2, snr2, snr2_max, telem2, fail2, or, both
-    // snr columns are in RADIO_SNR_SCALE units, integer math keeps float printf out of the image
     if(now - lastReport >= 1000 && connectionState == connected)
     {
         for (int i = 0 ; i < (isDualRadio()?2:1) ; i++)
         {
-            DBG("%u\t%d\t%d\t%d\t%u\t%u\t",
+            DBG("%d\t%f\t%f\t%f\t%d\t%d\t",
                 Radio.rxSignalStats[i].irq_count,
-                (Radio.rxSignalStats[i].irq_count==0) ? 0 : (int)(Radio.rxSignalStats[i].rssi_sum / Radio.rxSignalStats[i].irq_count),
-                (Radio.rxSignalStats[i].irq_count==0) ? 0 : (int)(Radio.rxSignalStats[i].snr_sum / Radio.rxSignalStats[i].irq_count),
-                (int)Radio.rxSignalStats[i].snr_max,
+                (Radio.rxSignalStats[i].irq_count==0) ? 0 : double(Radio.rxSignalStats[i].rssi_sum)/Radio.rxSignalStats[i].irq_count,
+                (Radio.rxSignalStats[i].irq_count==0) ? 0 : double(Radio.rxSignalStats[i].snr_sum)/Radio.rxSignalStats[i].irq_count/RADIO_SNR_SCALE,
+                float(Radio.rxSignalStats[i].snr_max)/RADIO_SNR_SCALE,
                 Radio.rxSignalStats[i].telem_count,
                 Radio.rxSignalStats[i].fail_count);
 


### PR DESCRIPTION
The espressif8266 builder forces `-u _printf_float -u _scanf_float` onto every image and nothing in the tree needs it, the only `%f` goes through `debugPrintf` which does its own itoa. Stripping both from LINKFLAGS in `build_env_setup.py` is ~16.5k of flash on the 8285.

Checked with `nm` on a `DEBUG_RCVR_SIGNAL_STATS` build, no `_printf_float` or `_dtoa_r` left. newlib's reference is weak so a future `%f` through a real printf won't fail to link, it just won't format that field.
