### PR TITLE
Drop Baro and Wire from ESP8266 builds

### DIFF
--- a/src/python/lib_exclusions.py
+++ b/src/python/lib_exclusions.py
@@ -21,11 +21,11 @@ LIBRARY_EXCLUSIONS = {
     "TX": {
         "*": ("AnalogVbat","Baro","GYRO","MSPVTX","PWM","rx-crsf","ServoOutput","VTXSPI"),
         "esp32c3": ("GFX Library for Arduino","U8g2","GSENSOR","SCREEN","THERMAL"),
-        "esp8285": ("GSENSOR","SCREEN","THERMAL"),
+        "esp8285": ("GSENSOR","SCREEN","THERMAL","Wire"),
     },
     "RX": {
         "*": ("ADC","Backpack","BLE","GSENSOR","Handset","POWER_DETECT","SCREEN","tx-crsf","VTX"),
-        "esp8285": ("MSPVTX","VTXSPI"),
+        "esp8285": ("Baro","MSPVTX","VTXSPI","Wire"),
     }
 }
 

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -29,7 +29,9 @@
 #include "rx-serial/SerialGPS.h"
 
 #include "devAnalogVbat.h"
+#if !defined(PLATFORM_ESP8266)
 #include "devBaro.h"
+#endif
 #include "devButton.h"
 #include "devLED.h"
 #include "devRXLUA.h"
@@ -86,7 +88,9 @@ device_affinity_t ui_devices[] = {
   {&Button_device, 0},
   {&AnalogVbat_device, 0},
   {&ServoOut_device, 1},
+#if !defined(PLATFORM_ESP8266)
   {&Baro_device, 0}, // must come after AnalogVbat_device to slow updates
+#endif
 #if defined(PLATFORM_ESP32) && !defined(PLATFORM_ESP32_C3)
   {&VTxSPI_device, 0},
   {&MSPVTx_device, 0}, // dependency on VTxSPI_device

--- a/src/src/rxtx_common.cpp
+++ b/src/src/rxtx_common.cpp
@@ -4,7 +4,9 @@
 #include "logging.h"
 
 #include <functional>
+#if !defined(PLATFORM_ESP8266)
 #include <Wire.h>
+#endif
 
 static const int maxDeferredFunctions = 3;
 
@@ -23,6 +25,7 @@ static deferred_t deferred[maxDeferredFunctions] = {
 boolean i2c_enabled = false;
 static unsigned long rebootTime_Ms = 0;
 
+#if !defined(PLATFORM_ESP8266)
 static void setupWire()
 {
     int gpio_scl = GPIO_PIN_SCL;
@@ -61,10 +64,13 @@ static void setupWire()
         i2c_enabled = true;
     }
 }
+#endif
 
 void setupTargetCommon()
 {
+#if !defined(PLATFORM_ESP8266)
     setupWire();
+#endif
 }
 
 void deferExecutionMicros(unsigned long us, std::function<void()> f)


### PR DESCRIPTION
No 8285 layout defines `i2c_scl` / `i2c_sda`, I checked all 85, but every 8285 RX still links the baro device, all three sensor drivers, `Wire` and the core's bit-bang I2C in IRAM. Excluding them is ~6.9k of flash plus ~650B of IRAM and ~580B of DRAM on the RX.

Users running 8285 can set pins in hardware.json to expose I2C still, but it's rare enough we might consider removing this feature anyway if the savings are worth it.
