### PR TITLE
Stub DWARF frame registration on ESP8266

### DIFF
--- a/src/src/esp8266_stubs.cpp
+++ b/src/src/esp8266_stubs.cpp
@@ -1,0 +1,14 @@
+#if defined(PLATFORM_ESP8266)
+#include <Arduino.h>
+
+// PWM waveform generator is not used, keep its entry points out of the image
+extern "C" IRAM_ATTR int __wrap_stopWaveform(uint8_t pin) { return true; }
+extern "C" IRAM_ATTR bool __wrap__stopPWM(uint8_t pin) { return true; }
+
+// The core registers DWARF unwind frames in do_global_ctors(), which pulls
+// libgcc's unwinder (~4KB) into the image. We build without exceptions and
+// never unwind, so satisfy the symbols here instead.
+struct object;
+extern "C" void __register_frame_info(const void *, struct object *) {}
+extern "C" void *__deregister_frame_info(const void *) { return nullptr; }
+#endif

--- a/src/src/esp8266_waveform_stubs.cpp
+++ b/src/src/esp8266_waveform_stubs.cpp
@@ -1,5 +1,0 @@
-#if defined(PLATFORM_ESP8266)
-#include <Arduino.h>
-extern "C" IRAM_ATTR int __wrap_stopWaveform(uint8_t pin) { return true; }
-extern "C" IRAM_ATTR bool __wrap__stopPWM(uint8_t pin) { return true; }
-#endif


### PR DESCRIPTION
The 8266 core's `do_global_ctors()` references `__register_frame_info`, which drags ~4k of libgcc DWARF unwind code into every image. We build `-fno-exceptions` so nothing ever reads it. Empty stubs in `esp8266_stubs.cpp` satisfy the symbol first so the linker never opens the libgcc member, ~4.3k off both RX and TX.
