### PR TITLE
Build MAVLink without packet signing

### DIFF
--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -11,7 +11,7 @@ monitor_rts = 0
 
 [common_env_data]
 build_src_filter = +<*> -<.git/> -<svn/> -<example/> -<examples/> -<test/> -<tests/> -<*.py> -<*test*.*>
-build_flags = -Wall -Iinclude
+build_flags = -Wall -Iinclude -DMAVLINK_NO_SIGN_PACKET -DMAVLINK_NO_SIGNATURE_CHECK
 build_flags_tx = -DTARGET_TX=1 ${common_env_data.build_flags}
 build_flags_rx = -DTARGET_RX=1 ${common_env_data.build_flags}
 mavlink_lib_dep = https://github.com/mavlink/c_library_v2.git#e54a8d2e8cf7985e689ad1c8c8f37dc0800ea87b


### PR DESCRIPTION
Nothing ever sets `status->signing`, but every MAVLink build carries the sign and check paths plus the SHA-256 round constants that come with them. `MAVLINK_NO_SIGN_PACKET` and `MAVLINK_NO_SIGNATURE_CHECK` in common.ini takes ~1.8k of flash off the 8285 RX.

Signed frames still parse and still forward with the signature intact, the parser consumes the trailer either way and `mavlink_msg_to_send_buffer` sizes it off `MAVLINK_IFLAG_SIGNED` without caring about the defines. All we give up is creating a signature and validating one, neither of which we do today.
