### PR TITLE
Keep the MAVLink CRC_EXTRA table in flash

### DIFF
--- a/src/include/mavlink_msg_entry.h
+++ b/src/include/mavlink_msg_entry.h
@@ -1,0 +1,21 @@
+#pragma once
+
+/**
+ * Replacement for the c_library_v2 message entry lookup.
+ *
+ * The default mavlink_get_msg_entry() keeps the CRC_EXTRA / length table as a
+ * plain const inside a static inline helper, which on ESP8266 puts ~2.6KB in
+ * DRAM (and one copy per translation unit that includes the helpers). Our
+ * version keeps a single copy in flash (PROGMEM) and reads it with pgm
+ * accessors.
+ *
+ * Include this header before "common/mavlink.h" in every file that includes
+ * the MAVLink headers, otherwise that file silently gets the default table.
+ */
+
+#include <stdint.h>
+#include "mavlink_types.h"
+
+#define MAVLINK_GET_MSG_ENTRY
+
+const mavlink_msg_entry_t *mavlink_get_msg_entry(uint32_t msgid);

--- a/src/lib/MAVLink/MAVLink.cpp
+++ b/src/lib/MAVLink/MAVLink.cpp
@@ -1,6 +1,7 @@
 #include "MAVLink.h"
 
 #include "CRSFRouter.h"
+#include "mavlink_msg_entry.h"
 #include "common/mavlink.h"
 
 #include "ardupilot_custom_telemetry.h"

--- a/src/lib/MAVLink/ardupilot_custom_telemetry.cpp
+++ b/src/lib/MAVLink/ardupilot_custom_telemetry.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "ardupilot_custom_telemetry.h"
+#include "mavlink_msg_entry.h"
 #include "common/mavlink.h"
 
 /*

--- a/src/src/mavlink_msg_entry.cpp
+++ b/src/src/mavlink_msg_entry.cpp
@@ -1,0 +1,51 @@
+#include <Arduino.h>
+
+#include "helpers.h"
+#include "mavlink_msg_entry.h"
+
+#define MAVLINK_COMM_NUM_BUFFERS 1
+#include "common/mavlink.h"
+
+// The table the dialect header hands us, sorted by msgid, but in flash.
+static const mavlink_msg_entry_t mavlink_message_crcs[] PROGMEM = MAVLINK_MESSAGE_CRCS;
+
+/**
+ * Same bisection as the stock helper, but the probes read msgid (a 32-bit,
+ * 4-byte aligned field, so a single word load from flash) and the matching
+ * entry is copied out for the caller.
+ *
+ * The parser calls this once per received frame from the main loop, so a
+ * single static scratch entry is enough: nothing on either target parses
+ * MAVLink from interrupt context.
+ */
+const mavlink_msg_entry_t *mavlink_get_msg_entry(uint32_t msgid)
+{
+    static mavlink_msg_entry_t entry;
+
+    uint32_t low = 0;
+    uint32_t high = ARRAY_SIZE(mavlink_message_crcs) - 1;
+    while (low < high)
+    {
+        const uint32_t mid = (low + 1 + high) / 2;
+        const uint32_t midId = pgm_read_dword(&mavlink_message_crcs[mid].msgid);
+        if (msgid < midId)
+        {
+            high = mid - 1;
+            continue;
+        }
+        if (msgid > midId)
+        {
+            low = mid;
+            continue;
+        }
+        low = mid;
+        break;
+    }
+    if (pgm_read_dword(&mavlink_message_crcs[low].msgid) != msgid)
+    {
+        // msgid is not in the table
+        return NULL;
+    }
+    memcpy_P(&entry, &mavlink_message_crcs[low], sizeof(entry));
+    return &entry;
+}

--- a/src/src/rx-serial/SerialMavlink.cpp
+++ b/src/src/rx-serial/SerialMavlink.cpp
@@ -9,6 +9,7 @@
 #define MAVLINK_RC_PACKET_INTERVAL 10
 
 #define MAVLINK_COMM_NUM_BUFFERS 1
+#include "mavlink_msg_entry.h"
 #include "common/mavlink.h"
 
 #define MAV_FTP_OPCODE_OPENFILERO 4


### PR DESCRIPTION
Converting the MAVLink CRC_EXTRA table to flash, using the c_library_v2 `MAVLINK_GET_MSG_ENTRY` hook so we're not patching upstream. It's referenced per-message, not per-byte, so it's on the hottish path but not super hot: 8 probes a lookup, ~1us warm in icache, ~10us if every one misses, against a couple hundred frames a second in the main loop. This _should_ be a no-risk change for ~2.6k of RAM at ~60 bytes of flash.
