### PR TITLE
Replace LEAmDNS with a minimal responder on ESP8266

### DIFF
--- a/src/lib/MDNS/MiniMDNS.cpp
+++ b/src/lib/MDNS/MiniMDNS.cpp
@@ -1,0 +1,520 @@
+#include "MiniMDNS.h"
+
+#if defined(PLATFORM_ESP8266) || defined(UNIT_TEST)
+
+#include <string.h>
+#include <stdio.h>
+
+#if defined(UNIT_TEST)
+#ifndef PROGMEM
+#define PROGMEM
+#endif
+#ifndef pgm_read_byte
+#define pgm_read_byte(p) (*(const uint8_t *)(p))
+#endif
+#ifndef strlen_P
+#define strlen_P strlen
+#endif
+#ifndef memcpy_P
+#define memcpy_P memcpy
+#endif
+#ifndef PSTR
+#define PSTR(s) (s)
+#endif
+#ifndef snprintf_P
+#define snprintf_P snprintf
+#endif
+#else
+#include <Arduino.h>
+#include <ESP8266WiFi.h>
+#include <lwip/udp.h>
+#include <lwip/igmp.h>
+#include <include/UdpContext.h>
+#endif
+
+#define MDNS_PORT 5353
+#define TTL_SHORT 120
+#define TTL_LONG 4500
+#define NAME_MAX 80
+
+enum : uint16_t { T_A = 1, T_PTR = 12, T_TXT = 16, T_SRV = 33, T_ANY = 255 };
+
+// Names in wire format (length-prefixed labels); the NUL doubles as the root label
+static const char LOCAL_LABELS[] PROGMEM = "\x05" "local";
+static const char SVC_LABELS[] PROGMEM = "\x05" "_http" "\x04" "_tcp" "\x05" "local";
+static const char SD_LABELS[] PROGMEM = "\x09" "_services" "\x07" "_dns-sd" "\x04" "_udp" "\x05" "local";
+
+static inline uint8_t lower(uint8_t c)
+{
+    return (c >= 'A' && c <= 'Z') ? c + 32 : c;
+}
+
+MiniMDNS::MiniMDNS(const char *hostname, uint16_t port) : _host(hostname), _port(port)
+{
+    uint8_t mac[6];
+#if defined(UNIT_TEST)
+    memcpy(mac, "\xAA\xBB\xCC\x01\x02\x03", 6);
+#else
+    WiFi.macAddress(mac);
+#endif
+    int n = snprintf_P(_arena, ARENA, PSTR("%s_%02X%02X%02X%02X%02X%02X"), hostname, mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+    _instance = _arena;
+    _used = (n < 0 || n >= (int)ARENA) ? ARENA : n + 1;
+}
+
+MiniMDNS::~MiniMDNS()
+{
+    if (_ctx)
+    {
+        respond(R_ALL, true);
+    }
+    close();
+}
+
+void MiniMDNS::addTxt(const char *key, const char *value)
+{
+    if (_pairs < MAX_TXT && key && value)
+    {
+        _txt[2 * _pairs] = key;
+        _txt[2 * _pairs + 1] = value;
+        _pairs++;
+    }
+}
+
+const char *MiniMDNS::store(const char *s)
+{
+    size_t n = strlen(s) + 1;
+    if (_used + n > ARENA)
+    {
+        return nullptr;
+    }
+    char *p = _arena + _used;
+    memcpy(p, s, n);
+    _used += n;
+    return p;
+}
+
+/*
+ * Query side
+ */
+
+// Copies the name at pos into out in wire format, following compression
+// pointers. Returns the position after the name in the packet, 0 on error.
+uint16_t MiniMDNS::readName(uint16_t pos, uint8_t *out)
+{
+    const uint16_t len = inSize();
+    uint16_t o = 0;
+    uint16_t end = 0;
+    uint8_t jumps = 0;
+    while (true)
+    {
+        if (pos >= len)
+        {
+            return 0;
+        }
+        uint8_t l = rd(pos);
+        if (l & 0xC0)
+        {
+            if ((l & 0xC0) != 0xC0 || pos + 1 >= len || ++jumps > 4)
+            {
+                return 0;
+            }
+            uint16_t ptr = ((l & 0x3F) << 8) | rd(pos + 1);
+            if (ptr >= pos)
+            {
+                return 0;
+            }
+            if (!end)
+            {
+                end = pos + 2;
+            }
+            pos = ptr;
+            continue;
+        }
+        if (o + 1 + l >= NAME_MAX || pos + 1 + l > len)
+        {
+            return 0;
+        }
+        out[o++] = l;
+        pos++;
+        if (l == 0)
+        {
+            break;
+        }
+        while (l--)
+        {
+            out[o++] = rd(pos++);
+        }
+    }
+    return end ? end : pos;
+}
+
+// name is in wire format. dyn is an optional RAM string for the first label,
+// rest is the wire format tail in flash; its NUL doubles as the root label.
+bool MiniMDNS::nameIs(const uint8_t *name, const char *dyn, const char *rest)
+{
+    if (dyn)
+    {
+        uint8_t l = *name++;
+        if (l != strlen(dyn))
+        {
+            return false;
+        }
+        for (uint8_t i = 0; i < l; i++)
+        {
+            if (lower(name[i]) != lower(dyn[i]))
+            {
+                return false;
+            }
+        }
+        name += l;
+    }
+    size_t n = strlen_P(rest) + 1;
+    for (size_t i = 0; i < n; i++)
+    {
+        if (lower(name[i]) != lower(pgm_read_byte(rest + i)))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+void MiniMDNS::handlePacket()
+{
+    const uint16_t len = inSize();
+    if (len < 12 || (rd(2) & 0x80))
+    {
+        return; // too short, or a response
+    }
+    uint16_t questions = (rd(4) << 8) | rd(5);
+    uint16_t pos = 12;
+    uint8_t mask = 0;
+    uint8_t name[NAME_MAX];
+    while (questions--)
+    {
+        pos = readName(pos, name);
+        if (pos == 0 || pos + 4 > len)
+        {
+            break;
+        }
+        const uint16_t qtype = (rd(pos) << 8) | rd(pos + 1);
+        pos += 4;
+        const bool any = qtype == T_ANY;
+        if ((any || qtype == T_A) && nameIs(name, _host, LOCAL_LABELS))
+        {
+            mask |= R_A;
+        }
+        else if ((any || qtype == T_PTR) && nameIs(name, nullptr, SVC_LABELS))
+        {
+            mask |= R_PTR;
+        }
+        else if ((any || qtype == T_SRV || qtype == T_TXT) && nameIs(name, _instance, SVC_LABELS))
+        {
+            mask |= (qtype == T_SRV) ? R_SRV : (qtype == T_TXT) ? R_TXT : (R_SRV | R_TXT);
+        }
+        else if ((any || qtype == T_PTR) && nameIs(name, nullptr, SD_LABELS))
+        {
+            mask |= R_SD;
+        }
+    }
+    if (mask)
+    {
+        respond(mask, false);
+    }
+}
+
+/*
+ * Response side
+ */
+
+static uint8_t bitCount(uint8_t v)
+{
+    uint8_t n = 0;
+    for (; v; v >>= 1)
+    {
+        n += v & 1;
+    }
+    return n;
+}
+
+void MiniMDNS::respond(uint8_t mask, bool goodbye)
+{
+    // RFC 6763 12.1 / 12.2: a PTR answer carries SRV, TXT and A along, SRV carries A
+    uint8_t extra = 0;
+    if (mask & R_PTR)
+    {
+        extra |= R_SRV | R_TXT | R_A;
+    }
+    if (mask & R_SRV)
+    {
+        extra |= R_A;
+    }
+    extra &= ~mask;
+
+    w16(0);      // ID
+    w16(0x8400); // response, authoritative
+    w16(0);      // QDCOUNT
+    w16(bitCount(mask));
+    w16(0);      // NSCOUNT
+    w16(bitCount(extra));
+    writeRecords(mask, goodbye);
+    writeRecords(extra, goodbye);
+    flush();
+}
+
+void MiniMDNS::writeRecords(uint8_t set, bool goodbye)
+{
+    const uint32_t ttlLong = goodbye ? 0 : TTL_LONG;
+    const uint32_t ttlShort = goodbye ? 0 : TTL_SHORT;
+    if (set & R_SD)
+    {
+        wName(nullptr, SD_LABELS);
+        rrHead(T_PTR, false, ttlLong, nameLen(nullptr, SVC_LABELS));
+        wName(nullptr, SVC_LABELS);
+    }
+    if (set & R_PTR)
+    {
+        wName(nullptr, SVC_LABELS);
+        rrHead(T_PTR, false, ttlLong, nameLen(_instance, SVC_LABELS));
+        wName(_instance, SVC_LABELS);
+    }
+    if (set & R_SRV)
+    {
+        wName(_instance, SVC_LABELS);
+        rrHead(T_SRV, true, ttlShort, 6 + nameLen(_host, LOCAL_LABELS));
+        w16(0); // priority
+        w16(0); // weight
+        w16(_port);
+        wName(_host, LOCAL_LABELS);
+    }
+    if (set & R_TXT)
+    {
+        wName(_instance, SVC_LABELS);
+        rrHead(T_TXT, true, ttlLong, txtLen());
+        writeTxt();
+    }
+    if (set & R_A)
+    {
+        wName(_host, LOCAL_LABELS);
+        rrHead(T_A, true, ttlShort, 4);
+        uint32_t ip = ifIp(); // already in network byte order
+        wr(&ip, 4);
+    }
+}
+
+void MiniMDNS::rrHead(uint16_t type, bool unique, uint32_t ttl, uint16_t rdlen)
+{
+    w16(type);
+    w16(unique ? 0x8001 : 0x0001); // IN, cache flush on the records only we own
+    w32(ttl);
+    w16(rdlen);
+}
+
+uint16_t MiniMDNS::nameLen(const char *dyn, const char *rest)
+{
+    return (dyn ? 1 + strlen(dyn) : 0) + strlen_P(rest) + 1;
+}
+
+void MiniMDNS::wName(const char *dyn, const char *rest)
+{
+    if (dyn)
+    {
+        uint8_t l = strlen(dyn);
+        wr(&l, 1);
+        wr(dyn, l);
+    }
+    wP(rest, strlen_P(rest) + 1);
+}
+
+// Each TXT item is "key=value" behind a length byte, capped at 255
+uint16_t MiniMDNS::txtLen()
+{
+    uint16_t n = 0;
+    for (uint8_t i = 0; i < _pairs; i++)
+    {
+        size_t l = strlen_P(_txt[2 * i]) + 1 + strlen_P(_txt[2 * i + 1]);
+        n += 1 + (l > 255 ? 255 : l);
+    }
+    return n;
+}
+
+void MiniMDNS::writeTxt()
+{
+    for (uint8_t i = 0; i < _pairs; i++)
+    {
+        const char *key = _txt[2 * i];
+        const char *value = _txt[2 * i + 1];
+        size_t kl = strlen_P(key);
+        size_t vl = strlen_P(value);
+        size_t l = kl + 1 + vl;
+        if (l > 255)
+        {
+            vl -= l - 255;
+            l = 255;
+        }
+        uint8_t lb = l;
+        wr(&lb, 1);
+        wP(key, kl);
+        wr("=", 1);
+        wP(value, vl);
+    }
+}
+
+void MiniMDNS::w16(uint16_t v)
+{
+    uint8_t b[2] = {(uint8_t)(v >> 8), (uint8_t)v};
+    wr(b, 2);
+}
+
+void MiniMDNS::w32(uint32_t v)
+{
+    uint8_t b[4] = {(uint8_t)(v >> 24), (uint8_t)(v >> 16), (uint8_t)(v >> 8), (uint8_t)v};
+    wr(b, 4);
+}
+
+// Copy n bytes from a string that may be in flash
+void MiniMDNS::wP(const char *p, size_t n)
+{
+    char buf[32];
+    while (n)
+    {
+        size_t c = n > sizeof(buf) ? sizeof(buf) : n;
+        memcpy_P(buf, p, c);
+        wr(buf, c);
+        p += c;
+        n -= c;
+    }
+}
+
+/*
+ * Platform side
+ */
+
+#if defined(UNIT_TEST)
+
+static const uint8_t *tIn;
+static size_t tInLen;
+static uint8_t *tOut;
+static size_t tOutLen;
+static size_t tOutMax;
+
+size_t MiniMDNS::testHandle(const uint8_t *in, size_t len, uint8_t *out, size_t max)
+{
+    tIn = in;
+    tInLen = len;
+    tOut = out;
+    tOutLen = 0;
+    tOutMax = max;
+    handlePacket();
+    return tOutLen;
+}
+
+size_t MiniMDNS::testAnnounce(uint8_t *out, size_t max, bool goodbye)
+{
+    tOut = out;
+    tOutLen = 0;
+    tOutMax = max;
+    respond(R_ALL, goodbye);
+    return tOutLen;
+}
+
+uint16_t MiniMDNS::inSize() { return tInLen; }
+uint8_t MiniMDNS::rd(uint16_t pos) { return tIn[pos]; }
+void MiniMDNS::wr(const void *p, size_t n)
+{
+    if (tOutLen + n <= tOutMax)
+    {
+        memcpy(tOut + tOutLen, p, n);
+    }
+    tOutLen += n;
+}
+void MiniMDNS::flush() {}
+uint32_t MiniMDNS::ifIp() { return 10 | (1u << 24); } // 10.0.0.1 in memory order
+void MiniMDNS::open() {}
+void MiniMDNS::close() {}
+void MiniMDNS::update() {}
+
+#else
+
+static IPAddress mdnsGroup()
+{
+    return IPAddress(224, 0, 0, 251);
+}
+
+void MiniMDNS::open()
+{
+    IPAddress ifa(_ip);
+    if (igmp_joingroup(ifa, mdnsGroup()) != ERR_OK)
+    {
+        return;
+    }
+    _ctx = new UdpContext;
+    _ctx->ref();
+    _ctx->setMulticastInterface(ifa);
+    _ctx->setMulticastTTL(255);
+    if (!_ctx->listen(IPAddress(), MDNS_PORT))
+    {
+        close();
+    }
+}
+
+void MiniMDNS::close()
+{
+    if (_ctx)
+    {
+        _ctx->unref();
+        _ctx = nullptr;
+    }
+    if (_ip)
+    {
+        igmp_leavegroup(IPAddress(_ip), mdnsGroup());
+    }
+}
+
+void MiniMDNS::update()
+{
+    const uint32_t ip = (WiFi.getMode() & WIFI_AP) ? (uint32_t)WiFi.softAPIP() : (uint32_t)WiFi.localIP();
+    if (ip != _ip)
+    {
+        close();
+        _ip = ip;
+        if (ip)
+        {
+            open();
+        }
+        if (_ctx)
+        {
+            // RFC 6762 8.3: announce at least twice, a second apart
+            respond(R_ALL, false);
+            _announceAt = millis() + 1000;
+        }
+    }
+    if (!_ctx)
+    {
+        return;
+    }
+    if (_announceAt && (int32_t)(millis() - _announceAt) >= 0)
+    {
+        _announceAt = 0;
+        respond(R_ALL, false);
+    }
+    while (_ctx->next())
+    {
+        handlePacket();
+    }
+}
+
+uint16_t MiniMDNS::inSize() { return _ctx->tell() + _ctx->getSize(); }
+uint8_t MiniMDNS::rd(uint16_t pos)
+{
+    _ctx->seek(pos);
+    return _ctx->read();
+}
+void MiniMDNS::wr(const void *p, size_t n) { _ctx->append(reinterpret_cast<const char *>(p), n); }
+void MiniMDNS::flush() { _ctx->send(mdnsGroup(), MDNS_PORT); }
+uint32_t MiniMDNS::ifIp() { return _ip; }
+
+#endif
+
+#endif // PLATFORM_ESP8266 || UNIT_TEST

--- a/src/lib/MDNS/MiniMDNS.h
+++ b/src/lib/MDNS/MiniMDNS.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+
+class UdpContext;
+
+/**
+ * Minimal mDNS / DNS-SD responder for the ESP8266.
+ *
+ * One host name, one service instance, a few TXT records. It answers A, PTR,
+ * SRV and TXT queries for its own names plus the DNS-SD service enumeration,
+ * announces itself when an interface comes up and says goodbye when deleted.
+ * There is no probing, no query support, no known-answer suppression and no
+ * IPv6, which is what keeps it at a fraction of the size of LEAmDNS.
+ *
+ * Everything the responder needs lives in the object, so the static cost is
+ * the pointer that owns it and the heap is only used while WiFi is up.
+ */
+class MiniMDNS
+{
+public:
+    static constexpr uint8_t MAX_TXT = 8;
+    static constexpr size_t ARENA = 128;
+
+    // hostname is not copied and must outlive the object. The service
+    // instance name is <hostname>_<MAC> so devices can share a hostname.
+    MiniMDNS(const char *hostname, uint16_t port);
+    ~MiniMDNS();
+
+    // key and value may be in RAM or flash, neither is copied.
+    void addTxt(const char *key, const char *value);
+    // Copies s into the object; use it for a value built from a temporary.
+    const char *store(const char *s);
+    // Call from the main loop. Binds when an interface has an address,
+    // rebinds when it changes, answers queries.
+    void update();
+
+#if defined(UNIT_TEST)
+    size_t testHandle(const uint8_t *in, size_t len, uint8_t *out, size_t max);
+    size_t testAnnounce(uint8_t *out, size_t max, bool goodbye);
+    const char *instance() const { return _instance; }
+#endif
+
+private:
+    enum : uint8_t { R_A = 1, R_PTR = 2, R_SRV = 4, R_TXT = 8, R_SD = 16, R_ALL = 31 };
+
+    void open();
+    void close();
+    void handlePacket();
+    void respond(uint8_t mask, bool goodbye);
+    void writeRecords(uint8_t set, bool goodbye);
+    void rrHead(uint16_t type, bool unique, uint32_t ttl, uint16_t rdlen);
+    uint16_t readName(uint16_t pos, uint8_t *out);
+    bool nameIs(const uint8_t *name, const char *dyn, const char *rest);
+    void wName(const char *dyn, const char *rest);
+    uint16_t nameLen(const char *dyn, const char *rest);
+    uint16_t txtLen();
+    void writeTxt();
+
+    // packet I/O, one implementation per platform
+    uint16_t inSize();
+    uint8_t rd(uint16_t pos);
+    void wr(const void *p, size_t n);
+    void wP(const char *p, size_t n);
+    void w16(uint16_t v);
+    void w32(uint32_t v);
+    void flush();
+    uint32_t ifIp();
+
+    UdpContext *_ctx = nullptr;
+    const char *_host;
+    const char *_instance;
+    uint16_t _port;
+    uint32_t _ip = 0;
+    uint32_t _announceAt = 0;
+    uint8_t _pairs = 0;
+    uint8_t _used = 0;
+    const char *_txt[2 * MAX_TXT];
+    char _arena[ARENA];
+};

--- a/src/lib/WIFI/devWIFI.cpp
+++ b/src/lib/WIFI/devWIFI.cpp
@@ -16,7 +16,7 @@
 #include <soc/uart_pins.h>
 #else
 #include <ESP8266WiFi.h>
-#include <ESP8266mDNS.h>
+#include "MiniMDNS.h"
 #define wifi_mode_t WiFiMode_t
 #endif
 #include <DNSServer.h>
@@ -84,6 +84,9 @@ static bool scanComplete = false;
 
 static AsyncWebServer server(80);
 static bool servicesStarted = false;
+#if defined(PLATFORM_ESP8266)
+static MiniMDNS *mdns = nullptr;
+#endif
 static constexpr uint32_t STALE_WIFI_SCAN = 20000;
 static uint32_t lastScanTimeMS = 0;
 
@@ -1137,11 +1140,13 @@ static void startWiFi(unsigned long now)
 
 static void startMDNS()
 {
+  #if defined(PLATFORM_ESP32)
   if (!MDNS.begin(wifi_hostname))
   {
     DBGLN("Error starting mDNS");
     return;
   }
+  #endif
 
   String options = "-DAUTO_WIFI_ON_INTERVAL=" + (firmwareOptions.wifi_auto_on_interval == -1 ? "-1" : String(firmwareOptions.wifi_auto_on_interval / 1000));
 
@@ -1162,29 +1167,23 @@ static void startMDNS()
   options += " -DRCVR_UART_BAUD=" + String(firmwareOptions.uart_baud);
   #endif
 
-  String instance = String(wifi_hostname) + "_" + WiFi.macAddress();
-  instance.replace(":", "");
   #if defined(PLATFORM_ESP8266)
-    // We have to do it differently on ESP8266 as setInstanceName has the side-effect of chainging the hostname!
-    MDNS.setInstanceName(wifi_hostname);
-    MDNSResponder::hMDNSService service = MDNS.addService(instance.c_str(), "http", "tcp", 80);
-    MDNS.addServiceTxt(service, "vendor", "elrs");
-    MDNS.addServiceTxt(service, "target", (const char *)&target_name[4]);
-    MDNS.addServiceTxt(service, "device", (const char *)device_name);
-    MDNS.addServiceTxt(service, "product", (const char *)product_name);
-    MDNS.addServiceTxt(service, "version", VERSION);
-    MDNS.addServiceTxt(service, "options", options.c_str());
-    MDNS.addServiceTxt(service, "type", "rx");
-    // If the probe result fails because there is another device on the network with the same name
-    // use our unique instance name as the hostname. A better way to do this would be to use
-    // MDNSResponder::indexDomain and change wifi_hostname as well.
-    MDNS.setHostProbeResultCallback([instance](const char* p_pcDomainName, bool p_bProbeResult) {
-      if (!p_bProbeResult) {
-        WiFi.hostname(instance);
-        MDNS.setInstanceName(instance);
-      }
-    });
+    // The responder names the service instance <hostname>_<MAC> itself
+    mdns = new MiniMDNS(wifi_hostname, 80);
+    mdns->addTxt(PSTR("vendor"), PSTR("elrs"));
+    mdns->addTxt(PSTR("target"), (const char *)&target_name[4]);
+    mdns->addTxt(PSTR("device"), device_name);
+    mdns->addTxt(PSTR("product"), product_name);
+    mdns->addTxt(PSTR("version"), VERSION);
+    mdns->addTxt(PSTR("options"), mdns->store(options.c_str()));
+  #if defined(TARGET_TX)
+    mdns->addTxt(PSTR("type"), PSTR("tx"));
   #else
+    mdns->addTxt(PSTR("type"), PSTR("rx"));
+  #endif
+  #else
+    String instance = String(wifi_hostname) + "_" + WiFi.macAddress();
+    instance.replace(":", "");
     MDNS.setInstanceName(instance);
     MDNS.addService("http", "tcp", 80);
     MDNS.addServiceTxt("http", "tcp", "vendor", "elrs");
@@ -1249,6 +1248,11 @@ static void startServices()
     #if defined(PLATFORM_ESP32)
       MDNS.end();
       startMDNS();
+    #else
+      if (mdns == nullptr)
+      {
+        startMDNS();
+      }
     #endif
     return;
   }
@@ -1401,9 +1405,6 @@ static void HandleWebUpdate()
       default:
         break;
     }
-    #if defined(PLATFORM_ESP8266)
-      MDNS.notifyAPChange();
-    #endif
     changeMode = WIFI_OFF;
   }
 
@@ -1419,7 +1420,10 @@ static void HandleWebUpdate()
   {
     dnsServer.processNextRequest();
     #if defined(PLATFORM_ESP8266)
-      MDNS.update();
+      if (mdns)
+      {
+        mdns->update();
+      }
     #endif
 
     #if defined(TARGET_TX) && defined(PLATFORM_ESP32)
@@ -1446,6 +1450,10 @@ static int event()
   else if (wifiStarted)
   {
     wifiStarted = false;
+    #if defined(PLATFORM_ESP8266)
+    delete mdns;
+    mdns = nullptr;
+    #endif
     WiFi.disconnect(true);
     WiFi.mode(WIFI_OFF);
     #if defined(PLATFORM_ESP8266)

--- a/src/test/test_mdns/test_mdns.cpp
+++ b/src/test/test_mdns/test_mdns.cpp
@@ -1,0 +1,444 @@
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+#include <unity.h>
+
+#include "MiniMDNS.h"
+
+void setUp() {}
+void tearDown() {}
+
+enum : uint16_t { T_A = 1, T_PTR = 12, T_TXT = 16, T_SRV = 33, T_ANY = 255 };
+
+static uint8_t pkt[512];
+static uint8_t out[1024];
+
+static MiniMDNS *mdns;
+
+static void makeResponder()
+{
+    delete mdns;
+    mdns = new MiniMDNS("elrs_rx", 80);
+    mdns->addTxt("vendor", "elrs");
+    mdns->addTxt("type", "rx");
+    mdns->addTxt("options", mdns->store("-DAUTO_WIFI_ON_INTERVAL=60 -DRCVR_UART_BAUD=420000"));
+}
+
+/*
+ * Packet helpers
+ */
+
+static size_t putName(uint8_t *p, const char *name)
+{
+    size_t o = 0;
+    while (*name)
+    {
+        const char *dot = strchr(name, '.');
+        size_t l = dot ? (size_t)(dot - name) : strlen(name);
+        p[o++] = l;
+        memcpy(p + o, name, l);
+        o += l;
+        name += l;
+        if (*name == '.')
+        {
+            name++;
+        }
+    }
+    p[o++] = 0;
+    return o;
+}
+
+static size_t header(uint8_t *p, uint16_t questions, bool response = false)
+{
+    memset(p, 0, 12);
+    p[2] = response ? 0x80 : 0;
+    p[5] = questions;
+    return 12;
+}
+
+static size_t question(uint8_t *p, size_t o, const char *name, uint16_t type)
+{
+    o += putName(p + o, name);
+    p[o++] = type >> 8;
+    p[o++] = type;
+    p[o++] = 0;
+    p[o++] = 1;
+    return o;
+}
+
+static size_t ask(const char *name, uint16_t type)
+{
+    size_t len = question(pkt, header(pkt, 1), name, type);
+    return mdns->testHandle(pkt, len, out, sizeof(out));
+}
+
+struct RR
+{
+    std::string name;
+    uint16_t type;
+    uint16_t cls;
+    uint32_t ttl;
+    std::vector<uint8_t> rdata;
+};
+
+struct Reply
+{
+    uint16_t flags;
+    std::vector<RR> answers;
+    std::vector<RR> additionals;
+};
+
+static std::string readName(const uint8_t *p, size_t &pos)
+{
+    std::string s;
+    size_t jump = 0;
+    bool jumped = false;
+    while (true)
+    {
+        uint8_t l = p[pos];
+        if ((l & 0xC0) == 0xC0)
+        {
+            size_t ptr = ((l & 0x3F) << 8) | p[pos + 1];
+            if (!jumped)
+            {
+                jump = pos + 2;
+            }
+            jumped = true;
+            pos = ptr;
+            continue;
+        }
+        pos++;
+        if (l == 0)
+        {
+            break;
+        }
+        if (!s.empty())
+        {
+            s += '.';
+        }
+        s.append((const char *)p + pos, l);
+        pos += l;
+    }
+    if (jumped)
+    {
+        pos = jump;
+    }
+    return s;
+}
+
+static uint16_t rd16(const uint8_t *p, size_t pos)
+{
+    return (p[pos] << 8) | p[pos + 1];
+}
+
+static RR readRR(const uint8_t *p, size_t &pos)
+{
+    RR rr;
+    rr.name = readName(p, pos);
+    rr.type = rd16(p, pos);
+    rr.cls = rd16(p, pos + 2);
+    rr.ttl = ((uint32_t)rd16(p, pos + 4) << 16) | rd16(p, pos + 6);
+    uint16_t rdlen = rd16(p, pos + 8);
+    pos += 10;
+    rr.rdata.assign(p + pos, p + pos + rdlen);
+    pos += rdlen;
+    return rr;
+}
+
+static Reply parse(size_t len)
+{
+    Reply r;
+    TEST_ASSERT_GREATER_OR_EQUAL(12, len);
+    r.flags = rd16(out, 2);
+    TEST_ASSERT_EQUAL(0, rd16(out, 4)); // no questions echoed
+    TEST_ASSERT_EQUAL(0, rd16(out, 8)); // no authority records
+    uint16_t an = rd16(out, 6);
+    uint16_t ar = rd16(out, 10);
+    size_t pos = 12;
+    for (uint16_t i = 0; i < an; i++)
+    {
+        r.answers.push_back(readRR(out, pos));
+    }
+    for (uint16_t i = 0; i < ar; i++)
+    {
+        r.additionals.push_back(readRR(out, pos));
+    }
+    TEST_ASSERT_EQUAL(len, pos); // nothing left over
+    return r;
+}
+
+static const RR *find(const std::vector<RR> &rrs, uint16_t type)
+{
+    for (const RR &rr : rrs)
+    {
+        if (rr.type == type)
+        {
+            return &rr;
+        }
+    }
+    return nullptr;
+}
+
+static std::string rdataName(const RR &rr, size_t offset = 0)
+{
+    size_t pos = offset;
+    return readName(rr.rdata.data(), pos);
+}
+
+static std::vector<std::string> txtItems(const RR &rr)
+{
+    std::vector<std::string> items;
+    size_t pos = 0;
+    while (pos < rr.rdata.size())
+    {
+        uint8_t l = rr.rdata[pos++];
+        items.push_back(std::string((const char *)rr.rdata.data() + pos, l));
+        pos += l;
+    }
+    return items;
+}
+
+static const char *INSTANCE = "elrs_rx_AABBCC010203._http._tcp.local";
+
+/*
+ * Tests
+ */
+
+void test_instance_name()
+{
+    TEST_ASSERT_EQUAL_STRING("elrs_rx_AABBCC010203", mdns->instance());
+}
+
+void test_announce_has_everything()
+{
+    Reply r = parse(mdns->testAnnounce(out, sizeof(out), false));
+    TEST_ASSERT_EQUAL_HEX16(0x8400, r.flags);
+    TEST_ASSERT_EQUAL(5, r.answers.size());
+    TEST_ASSERT_EQUAL(0, r.additionals.size());
+
+    const RR *a = find(r.answers, T_A);
+    TEST_ASSERT_NOT_NULL(a);
+    TEST_ASSERT_EQUAL_STRING("elrs_rx.local", a->name.c_str());
+    TEST_ASSERT_EQUAL_HEX16(0x8001, a->cls);
+    TEST_ASSERT_EQUAL(120, a->ttl);
+    const uint8_t ip[4] = {10, 0, 0, 1};
+    TEST_ASSERT_EQUAL(4, a->rdata.size());
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(ip, a->rdata.data(), 4);
+
+    const RR *srv = find(r.answers, T_SRV);
+    TEST_ASSERT_NOT_NULL(srv);
+    TEST_ASSERT_EQUAL_STRING(INSTANCE, srv->name.c_str());
+    TEST_ASSERT_EQUAL_HEX16(0x8001, srv->cls);
+    TEST_ASSERT_EQUAL(80, rd16(srv->rdata.data(), 4));
+    TEST_ASSERT_EQUAL_STRING("elrs_rx.local", rdataName(*srv, 6).c_str());
+
+    const RR *txt = find(r.answers, T_TXT);
+    TEST_ASSERT_NOT_NULL(txt);
+    TEST_ASSERT_EQUAL_STRING(INSTANCE, txt->name.c_str());
+    TEST_ASSERT_EQUAL_HEX16(0x8001, txt->cls);
+    TEST_ASSERT_EQUAL(4500, txt->ttl);
+    std::vector<std::string> items = txtItems(*txt);
+    TEST_ASSERT_EQUAL(3, items.size());
+    TEST_ASSERT_EQUAL_STRING("vendor=elrs", items[0].c_str());
+    TEST_ASSERT_EQUAL_STRING("type=rx", items[1].c_str());
+    TEST_ASSERT_EQUAL_STRING("options=-DAUTO_WIFI_ON_INTERVAL=60 -DRCVR_UART_BAUD=420000", items[2].c_str());
+
+    // two PTRs: service enumeration and the service itself, both shared records
+    int ptrs = 0;
+    for (const RR &rr : r.answers)
+    {
+        if (rr.type != T_PTR)
+        {
+            continue;
+        }
+        ptrs++;
+        TEST_ASSERT_EQUAL_HEX16(0x0001, rr.cls);
+        if (rr.name == "_services._dns-sd._udp.local")
+        {
+            TEST_ASSERT_EQUAL_STRING("_http._tcp.local", rdataName(rr).c_str());
+        }
+        else
+        {
+            TEST_ASSERT_EQUAL_STRING("_http._tcp.local", rr.name.c_str());
+            TEST_ASSERT_EQUAL_STRING(INSTANCE, rdataName(rr).c_str());
+        }
+    }
+    TEST_ASSERT_EQUAL(2, ptrs);
+}
+
+void test_goodbye_zero_ttl()
+{
+    Reply r = parse(mdns->testAnnounce(out, sizeof(out), true));
+    TEST_ASSERT_EQUAL(5, r.answers.size());
+    for (const RR &rr : r.answers)
+    {
+        TEST_ASSERT_EQUAL(0, rr.ttl);
+    }
+}
+
+void test_service_browse()
+{
+    Reply r = parse(ask("_http._tcp.local", T_PTR));
+    TEST_ASSERT_EQUAL(1, r.answers.size());
+    TEST_ASSERT_EQUAL(T_PTR, r.answers[0].type);
+    TEST_ASSERT_EQUAL_STRING(INSTANCE, rdataName(r.answers[0]).c_str());
+    TEST_ASSERT_EQUAL(3, r.additionals.size());
+    TEST_ASSERT_NOT_NULL(find(r.additionals, T_SRV));
+    TEST_ASSERT_NOT_NULL(find(r.additionals, T_TXT));
+    TEST_ASSERT_NOT_NULL(find(r.additionals, T_A));
+}
+
+void test_host_lookup_case_insensitive()
+{
+    Reply r = parse(ask("ELRS_RX.Local", T_A));
+    TEST_ASSERT_EQUAL(1, r.answers.size());
+    TEST_ASSERT_EQUAL(T_A, r.answers[0].type);
+    TEST_ASSERT_EQUAL(0, r.additionals.size());
+}
+
+void test_srv_brings_address()
+{
+    Reply r = parse(ask(INSTANCE, T_SRV));
+    TEST_ASSERT_EQUAL(1, r.answers.size());
+    TEST_ASSERT_EQUAL(T_SRV, r.answers[0].type);
+    TEST_ASSERT_EQUAL(1, r.additionals.size());
+    TEST_ASSERT_EQUAL(T_A, r.additionals[0].type);
+}
+
+void test_txt_only()
+{
+    Reply r = parse(ask(INSTANCE, T_TXT));
+    TEST_ASSERT_EQUAL(1, r.answers.size());
+    TEST_ASSERT_EQUAL(T_TXT, r.answers[0].type);
+    TEST_ASSERT_EQUAL(0, r.additionals.size());
+}
+
+void test_any_on_instance()
+{
+    Reply r = parse(ask(INSTANCE, T_ANY));
+    TEST_ASSERT_EQUAL(2, r.answers.size());
+    TEST_ASSERT_NOT_NULL(find(r.answers, T_SRV));
+    TEST_ASSERT_NOT_NULL(find(r.answers, T_TXT));
+    TEST_ASSERT_EQUAL(1, r.additionals.size());
+    TEST_ASSERT_EQUAL(T_A, r.additionals[0].type);
+}
+
+void test_service_enumeration()
+{
+    Reply r = parse(ask("_services._dns-sd._udp.local", T_PTR));
+    TEST_ASSERT_EQUAL(1, r.answers.size());
+    TEST_ASSERT_EQUAL_STRING("_http._tcp.local", rdataName(r.answers[0]).c_str());
+    TEST_ASSERT_EQUAL(0, r.additionals.size());
+}
+
+void test_compressed_second_question()
+{
+    // q1 is the full service name, q2 points back at its "local" label
+    size_t o = header(pkt, 2);
+    size_t localAt = o + 6 + 5; // past "_http" and "_tcp"
+    o = question(pkt, o, "_http._tcp.local", T_PTR);
+    o += putName(pkt + o, "_services._dns-sd._udp") - 1; // drop the root label
+    pkt[o++] = 0xC0 | (localAt >> 8);
+    pkt[o++] = localAt;
+    pkt[o++] = 0;
+    pkt[o++] = T_PTR;
+    pkt[o++] = 0;
+    pkt[o++] = 1;
+    Reply r = parse(mdns->testHandle(pkt, o, out, sizeof(out)));
+    TEST_ASSERT_EQUAL(2, r.answers.size());
+    TEST_ASSERT_EQUAL(3, r.additionals.size());
+}
+
+void test_wrong_type_ignored()
+{
+    TEST_ASSERT_EQUAL(0, ask("elrs_rx.local", T_SRV));
+    TEST_ASSERT_EQUAL(0, ask("_http._tcp.local", T_A));
+}
+
+void test_other_names_ignored()
+{
+    TEST_ASSERT_EQUAL(0, ask("elrs_tx.local", T_A));
+    TEST_ASSERT_EQUAL(0, ask("_ssh._tcp.local", T_PTR));
+    TEST_ASSERT_EQUAL(0, ask("elrs_rx.local.extra", T_A));
+}
+
+void test_responses_ignored()
+{
+    size_t len = question(pkt, header(pkt, 1, true), "elrs_rx.local", T_A);
+    TEST_ASSERT_EQUAL(0, mdns->testHandle(pkt, len, out, sizeof(out)));
+}
+
+void test_truncated_packets()
+{
+    size_t len = question(pkt, header(pkt, 1), "elrs_rx.local", T_A);
+    for (size_t cut = 0; cut < len; cut++)
+    {
+        TEST_ASSERT_EQUAL(0, mdns->testHandle(pkt, cut, out, sizeof(out)));
+    }
+}
+
+void test_pointer_loop()
+{
+    size_t o = header(pkt, 1);
+    pkt[o++] = 0xC0; // points at itself
+    pkt[o++] = 12;
+    pkt[o++] = 0;
+    pkt[o++] = T_A;
+    pkt[o++] = 0;
+    pkt[o++] = 1;
+    TEST_ASSERT_EQUAL(0, mdns->testHandle(pkt, o, out, sizeof(out)));
+}
+
+void test_long_txt_capped()
+{
+    delete mdns;
+    mdns = new MiniMDNS("elrs_rx", 80);
+    static char big[300];
+    memset(big, 'x', sizeof(big) - 1);
+    big[sizeof(big) - 1] = 0;
+    mdns->addTxt("k", big);
+    Reply r = parse(ask(INSTANCE, T_TXT));
+    std::vector<std::string> items = txtItems(r.answers[0]);
+    TEST_ASSERT_EQUAL(1, items.size());
+    TEST_ASSERT_EQUAL(255, items[0].size());
+    TEST_ASSERT_EQUAL_STRING_LEN("k=xxx", items[0].c_str(), 5);
+    makeResponder();
+}
+
+void test_arena_full()
+{
+    delete mdns;
+    mdns = new MiniMDNS("elrs_rx", 80);
+    static char big[MiniMDNS::ARENA];
+    memset(big, 'y', sizeof(big) - 1);
+    big[sizeof(big) - 1] = 0;
+    TEST_ASSERT_NULL(mdns->store(big)); // the instance name is already in there
+    TEST_ASSERT_NOT_NULL(mdns->store("fits"));
+    makeResponder();
+}
+
+int main(int argc, char **argv)
+{
+    makeResponder();
+    UNITY_BEGIN();
+    RUN_TEST(test_instance_name);
+    RUN_TEST(test_announce_has_everything);
+    RUN_TEST(test_goodbye_zero_ttl);
+    RUN_TEST(test_service_browse);
+    RUN_TEST(test_host_lookup_case_insensitive);
+    RUN_TEST(test_srv_brings_address);
+    RUN_TEST(test_txt_only);
+    RUN_TEST(test_any_on_instance);
+    RUN_TEST(test_service_enumeration);
+    RUN_TEST(test_compressed_second_question);
+    RUN_TEST(test_wrong_type_ignored);
+    RUN_TEST(test_other_names_ignored);
+    RUN_TEST(test_responses_ignored);
+    RUN_TEST(test_truncated_packets);
+    RUN_TEST(test_pointer_loop);
+    RUN_TEST(test_long_txt_capped);
+    RUN_TEST(test_arena_full);
+    UNITY_END();
+    return 0;
+}


### PR DESCRIPTION
LEAmDNS is 19.7k of flash and all we ask of it is one hostname, one `_http._tcp` service and seven TXT records. Replaced it with `MiniMDNS`, ~500 lines in `lib/MDNS`, which answers A/PTR/SRV/TXT plus the service enumeration and nothing else, which is exactly what the configurator reads. ~17k off the 8285, ESP32 keeps ESPmDNS.

Devices still key off the service instance label and get found by IP exactly as they do now. 17 native tests in `test_mdns`.

Also fixes the 8285 TX advertising `type=rx`. Overlaps #3769.
