### PR TITLE
Fix ESP8266 RX losing its binding when changing packet rates

### DIFF
--- a/src/lib/LQCALC/LQCALC.h
+++ b/src/lib/LQCALC/LQCALC.h
@@ -2,6 +2,17 @@
 
 #include <stdint.h>
 
+// These accessors are called from IRAM interrupt handlers. ICACHE_RAM_ATTR alone is not
+// enough: GCC silently drops the section attribute for COMDAT template members, so the
+// out-of-line copies link into IROM, and an ISR that calls one during a flash erase (when
+// the flash window is unmapped) faults with Exception(0). Forcing them inline means the
+// IRAM caller contains the code and never reaches into flash.
+#if defined(__GNUC__)
+  #define LQCALC_ALWAYS_INLINE __attribute__((always_inline)) inline
+#else
+  #define LQCALC_ALWAYS_INLINE inline
+#endif
+
 template <uint8_t N>
 class LQCALC
 {
@@ -12,7 +23,7 @@ public:
     }
 
     /* Set the bit for the current period to true and update the running LQ */
-    void ICACHE_RAM_ATTR add()
+    void ICACHE_RAM_ATTR LQCALC_ALWAYS_INLINE add()
     {
         if (currentIsSet())
             return;
@@ -21,7 +32,7 @@ public:
     }
 
     /* Start a new period */
-    void ICACHE_RAM_ATTR inc()
+    void ICACHE_RAM_ATTR LQCALC_ALWAYS_INLINE inc()
     {
         // Increment the counter by shifting one bit higher
         // If we've shifted out all the bits, move to next idx
@@ -50,7 +61,7 @@ public:
     }
 
     /* Return the current running total of bits set, in percent */
-    uint8_t ICACHE_RAM_ATTR getLQ() const
+    uint8_t ICACHE_RAM_ATTR LQCALC_ALWAYS_INLINE getLQ() const
     {
         return (uint32_t)LQ * 100U / count;
     }
@@ -93,7 +104,7 @@ public:
     }
 
     /*  Return true if the current period was add()ed */
-    bool ICACHE_RAM_ATTR currentIsSet() const
+    bool ICACHE_RAM_ATTR LQCALC_ALWAYS_INLINE currentIsSet() const
     {
         return LQArray[index] & LQmask;
     }

--- a/src/lib/elrs_eeprom/elrs_eeprom.cpp
+++ b/src/lib/elrs_eeprom/elrs_eeprom.cpp
@@ -38,7 +38,24 @@ ELRS_EEPROM::WriteByte(const uint32_t address, const uint8_t value)
 void
 ELRS_EEPROM::Commit()
 {
-    if (!EEPROM.commit())
+#if defined(PLATFORM_ESP8266)
+    // EEPROM.commit() erases a flash sector, and the flash window is unmapped for the
+    // duration. Any interrupt that reaches code living in IROM therefore fetches garbage
+    // and dies with Exception(0) IllegalInstruction, abandoning the erase and leaving the
+    // config sector invalid -- which zeroes the UID and drops the receiver into binding
+    // mode. The ISRs themselves are IRAM, but callees such as LQCALC's accessors are not:
+    // GCC silently drops the section attribute for those COMDAT template members, so they
+    // link into .text/IROM. Observed faulting in LQCALC<100>::currentIsSet() and in
+    // hardware_pin(), i.e. more than one callee is affected, so mask here rather than
+    // chase individual functions. A sector erase is tens of milliseconds and every caller
+    // has already stopped the link, so blocking interrupts across it is safe.
+    noInterrupts();
+#endif
+    const bool ok = EEPROM.commit();
+#if defined(PLATFORM_ESP8266)
+    interrupts();
+#endif
+    if (!ok)
     {
       ERRLN("EEPROM commit failed");
     }


### PR DESCRIPTION
When using traditional binding (no binding phrase), the receiver will sometimes lose its bind and drop into bind mode on its own after a packet rate change. It isn't every time — sometimes it survives a dozen rate changes, sometimes it goes on the second one — which is what made it hard to pin down.

I hit it while testing packet rates and antenna modes for link stability on a 900 MHz setup. I kept having to re-bind partway through a test run. My first assumption was that I'd worn out or damaged the flash on that particular receiver, or that my transmitter was at fault. So I tried a second receiver of a different hardware revision (v1.2.1 instead of v1.1) — and it did exactly the same thing, which ruled the hardware out.

The other clue was that binding itself would sometimes fail the same way: the receiver would accept the bind and go to a slow blink, then a moment later drop straight back into bind mode. That turned out to be the same bug on a different code path.

To see what the receiver was actually doing, I rebuilt its firmware with -DDEBUG_LOG and watched the serial output while changing rates. That caught it in the act — an Exception (0) crash, and on the next boot the config came back with a zeroed UID.